### PR TITLE
Key VM arena record types by module identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 ### Fixed
 
 - **Disk allowlists now honor explicit project and filesystem roots.** `paths = ["./**"]` now allows relative paths inside the project and denies absolute paths outside it, while `/` and `/**` allow absolute paths from the filesystem root. Bare `**`, empty entries, unsupported glob spellings, and `..`-rooted paths are rejected when `aver.toml` loads, as are non-matching `*`/`**` host entries and `**` environment-key entries.
+- **The VM keeps same-named record types from different modules distinct.** A private dependency record can no longer corrupt the field layout of an entry-module record with the same bare name.
 - **Lean proof exports preserve `?` error propagation inside nested expressions.** Proofs can now rely on calls, operators, interpolation, bindings, and match arms returning the original `Result.Err` instead of continuing with a default value.
 
 ## 0.28.0 "Oktet" — 2026-08-10

--- a/aver-memory/src/arena.rs
+++ b/aver-memory/src/arena.rs
@@ -13,6 +13,7 @@ impl<T: ArenaTypes> Arena<T> {
             scratch_stable: Vec::new(),
             peak_usage: ArenaUsage::default(),
             alloc_space: AllocSpace::Young,
+            type_keys: Vec::new(),
             type_names: Vec::new(),
             type_field_names: Vec::new(),
             type_variant_names: Vec::new(),
@@ -39,6 +40,7 @@ impl<T: ArenaTypes> Arena<T> {
             scratch_stable: Vec::new(),
             peak_usage: ArenaUsage::default(),
             alloc_space: AllocSpace::Young,
+            type_keys: self.type_keys.clone(),
             type_names: self.type_names.clone(),
             type_field_names: self.type_field_names.clone(),
             type_variant_names: self.type_variant_names.clone(),
@@ -631,8 +633,19 @@ impl<T: ArenaTypes> Arena<T> {
     // -- Type registry -----------------------------------------------------
 
     pub fn register_record_type(&mut self, name: &str, field_names: Vec<String>) -> u32 {
-        let id = self.type_names.len() as u32;
-        self.type_names.push(String::from(name));
+        self.register_record_type_keyed(name, name, field_names)
+    }
+
+    pub fn register_record_type_keyed(
+        &mut self,
+        key: &str,
+        display: &str,
+        field_names: Vec<String>,
+    ) -> u32 {
+        let id = self.type_keys.len() as u32;
+        self.type_keys.push(String::from(key));
+        self.type_names.push(String::from(display));
+        debug_assert_eq!(self.type_keys.len(), self.type_names.len());
         self.type_field_names.push(field_names);
         self.type_variant_names.push(Vec::new());
         self.type_variant_ctor_ids.push(Vec::new());
@@ -640,8 +653,19 @@ impl<T: ArenaTypes> Arena<T> {
     }
 
     pub fn register_sum_type(&mut self, name: &str, variant_names: Vec<String>) -> u32 {
-        let id = self.type_names.len() as u32;
-        self.type_names.push(String::from(name));
+        self.register_sum_type_keyed(name, name, variant_names)
+    }
+
+    pub fn register_sum_type_keyed(
+        &mut self,
+        key: &str,
+        display: &str,
+        variant_names: Vec<String>,
+    ) -> u32 {
+        let id = self.type_keys.len() as u32;
+        self.type_keys.push(String::from(key));
+        self.type_names.push(String::from(display));
+        debug_assert_eq!(self.type_keys.len(), self.type_names.len());
         self.type_field_names.push(Vec::new());
         let ctor_ids: Vec<u32> = (0..variant_names.len())
             .map(|variant_idx| {
@@ -684,7 +708,7 @@ impl<T: ArenaTypes> Arena<T> {
     }
 
     pub fn find_type_id(&self, name: &str) -> Option<u32> {
-        self.type_names
+        self.type_keys
             .iter()
             .position(|n| n == name)
             .map(|i| i as u32)

--- a/aver-memory/src/lib.rs
+++ b/aver-memory/src/lib.rs
@@ -1218,13 +1218,18 @@ pub struct Arena<T: ArenaTypes> {
     scratch_stable: Vec<u32>,
     peak_usage: ArenaUsage,
     alloc_space: AllocSpace,
+    /// Canonical lookup keys consulted by `find_type_id`: bare for entry and
+    /// builtin types, and module-qualified for dependency types. Kept in
+    /// lockstep with `type_names`.
+    pub type_keys: Vec<String>,
+    /// Source-facing display spellings used by value conversion and rendering.
     pub type_names: Vec<String>,
     pub type_field_names: Vec<Vec<String>>,
     pub type_variant_names: Vec<Vec<String>>,
     pub type_variant_ctor_ids: Vec<Vec<u32>>,
     pub ctor_to_type_variant: Vec<(u32, u16)>,
     pub symbol_entries: Vec<ArenaSymbol<T>>,
-    /// Qualified-name aliases for types (e.g. "Data.Shape" → type_id for "Shape").
+    /// Fallback aliases for types (e.g. bare "Shape" → type_id for "Data.Shape").
     pub type_aliases: Vec<(String, u32)>,
 }
 

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -233,7 +233,7 @@ fn compile_program_inner(
                     }
                 }
                 // VM-specific: register type symbols
-                compiler.register_type_in_symbols(td, arena)?;
+                compiler.register_type_in_symbols(td, None, arena)?;
             }
             _ => {}
         }
@@ -427,24 +427,22 @@ impl ProgramCompiler {
         crate::ir::pipeline::tco(&mut mod_items);
         crate::ir::pipeline::resolve(&mut mod_items);
 
-        // Register types in Arena with qualified aliases.
+        // Dependency types use qualified canonical keys. Their bare display
+        // spellings remain fallback aliases for the Value/JSON boundary.
         for mt in visibility::collect_module_types(&mod_items) {
-            let type_id = match &mt.kind {
-                visibility::ModuleTypeKind::Record { field_names } => {
-                    arena.register_record_type(&mt.bare_name, field_names.clone())
-                }
-                visibility::ModuleTypeKind::Sum { variant_names } => {
-                    arena.register_sum_type(&mt.bare_name, variant_names.clone())
-                }
-            };
-            arena.register_type_alias(
-                &visibility::qualified_name(dep_name, &mt.bare_name),
-                type_id,
-            );
+            let qualified = visibility::qualified_name(dep_name, &mt.bare_name);
+            let type_id =
+                match &mt.kind {
+                    visibility::ModuleTypeKind::Record { field_names } => arena
+                        .register_record_type_keyed(&qualified, &mt.bare_name, field_names.clone()),
+                    visibility::ModuleTypeKind::Sum { variant_names } => arena
+                        .register_sum_type_keyed(&qualified, &mt.bare_name, variant_names.clone()),
+                };
+            arena.register_type_alias(&mt.bare_name, type_id);
         }
         for item in &mod_items {
             if let TopLevel::TypeDef(td) = item {
-                self.register_type_in_symbols(td, arena)?;
+                self.register_type_in_symbols(td, Some(dep_name), arena)?;
             }
         }
 
@@ -609,14 +607,22 @@ impl ProgramCompiler {
     fn register_type_in_symbols(
         &mut self,
         td: &TypeDef,
+        scope: Option<&str>,
         arena: &Arena,
     ) -> Result<(), CompileError> {
+        let name = match td {
+            TypeDef::Product { name, .. } | TypeDef::Sum { name, .. } => name,
+        };
+        let arena_name = match scope {
+            Some(module) => visibility::qualified_name(module, name),
+            None => name.to_string(),
+        };
         match td {
             TypeDef::Product { name, fields, .. } => {
                 self.symbols.intern_namespace_path(name)?;
                 let type_id = arena
-                    .find_type_id(name)
-                    .expect("type already registered in Arena");
+                    .find_type_id(&arena_name)
+                    .unwrap_or_else(|| panic!("type `{arena_name}` already registered in Arena"));
                 let field_symbol_ids: Vec<u32> = fields
                     .iter()
                     .map(|(field_name, _)| self.symbols.intern_name(field_name))
@@ -626,8 +632,8 @@ impl ProgramCompiler {
             TypeDef::Sum { name, variants, .. } => {
                 let type_symbol_id = self.symbols.intern_namespace_path(name)?;
                 let type_id = arena
-                    .find_type_id(name)
-                    .expect("type already registered in Arena");
+                    .find_type_id(&arena_name)
+                    .unwrap_or_else(|| panic!("type `{arena_name}` already registered in Arena"));
                 for (variant_id, variant) in variants.iter().enumerate() {
                     let ctor_id = arena
                         .find_ctor_id(type_id, variant_id as u16)

--- a/tests/vm_arena_type_identity.rs
+++ b/tests/vm_arena_type_identity.rs
@@ -1,0 +1,242 @@
+//! VM arena identity regressions for records that share a bare name across modules.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use aver::codegen::ModuleInfo;
+use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::nan_value::{Arena, NanValue, NanValueConvert};
+use aver::source::{LoadedModule, parse_source};
+use aver::value::Value;
+use aver::vm;
+
+const LEFT_SRC: &str = r#"module Left
+    intent = "Dependency with a private Box record."
+    exposes [mk]
+    effects []
+
+record Box
+    b: Int
+    a: Int
+
+fn mk() -> Int
+    ? "Read the private Box."
+    Box(b = 9, a = 8).a
+"#;
+
+const ENTRY_SRC: &str = r#"module Main
+    intent = "Entry with its own Box record."
+    depends [Left]
+    exposes [main]
+    effects [Console.print]
+
+record Box
+    a: Int
+    b: Int
+
+fn probe() -> Int
+    ? "Read both fields from the entry Box."
+    x = Box(a = 111, b = 222)
+    x.a * 1000 + x.b
+
+verify probe
+    probe() => 111222
+
+fn main() -> Unit
+    ? "Print the probe result."
+    ! [Console.print]
+    Console.print("{probe()}")
+"#;
+
+const WIDER_ENTRY_SRC: &str = r#"module Main
+    intent = "Entry with a wider Box record."
+    depends [Left]
+    effects []
+
+record Box
+    a: Int
+    b: Int
+    c: Int
+
+fn probe() -> Int
+    x = Box(a = 1, b = 2, c = 3)
+    x.c
+"#;
+
+const DEP_ONLY_ENTRY_SRC: &str = r#"module Main
+    intent = "Entry that uses the dependency Box through Left.mk."
+    depends [Left]
+    effects []
+
+fn probe() -> Int
+    Left.mk()
+"#;
+
+struct CompiledFixture {
+    code: vm::CodeStore,
+    globals: Vec<NanValue>,
+    arena: Arena,
+}
+
+fn compile_fixture(entry_source: &str) -> CompiledFixture {
+    let mut entry_items = parse_source(entry_source).expect("entry parse");
+    let loaded = vec![LoadedModule {
+        dep_name: "Left".to_string(),
+        items: parse_source(LEFT_SRC).expect("Left parse"),
+        path: PathBuf::from("left.av"),
+    }];
+    let modules: Vec<ModuleInfo> = loaded.iter().map(ModuleInfo::from_loaded).collect();
+    let result = pipeline::run(
+        &mut entry_items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
+            run_build_symbols: true,
+            dep_modules: &modules,
+            ..Default::default()
+        },
+    );
+    let typecheck = result.typecheck.as_ref().expect("typecheck result");
+    assert!(
+        typecheck.errors.is_empty(),
+        "fixture should typecheck: {:?}",
+        typecheck.errors
+    );
+
+    let mut arena = Arena::new();
+    vm::register_service_types(&mut arena);
+    let (code, globals) = vm::compile_program_with_loaded_modules(
+        &result.resolved_items,
+        &result.symbol_table,
+        &mut arena,
+        loaded,
+        "<test>",
+        result.analysis.as_ref(),
+    )
+    .expect("compile fixture");
+
+    CompiledFixture {
+        code,
+        globals,
+        arena,
+    }
+}
+
+fn run_probe(entry_source: &str) -> (Value, Arena) {
+    let CompiledFixture {
+        code,
+        globals,
+        arena,
+    } = compile_fixture(entry_source);
+    let mut machine = vm::VM::new(code, globals, arena);
+    machine.run_top_level().expect("run top level");
+    let result = machine
+        .run_named_function("probe", &[])
+        .expect("run probe")
+        .to_value(&machine.arena);
+    (result, machine.arena)
+}
+
+fn write_cli_fixture() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("create fixture directory");
+    std::fs::write(dir.path().join("left.av"), LEFT_SRC).expect("write left.av");
+    std::fs::write(dir.path().join("main.av"), ENTRY_SRC).expect("write main.av");
+    dir
+}
+
+fn run_cli(dir: &Path, subcommand: &str, self_host: bool) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aver"));
+    command.arg(subcommand);
+    if self_host {
+        command.arg("--self-host");
+    }
+    command
+        .arg(dir.join("main.av"))
+        .arg("--module-root")
+        .arg(dir)
+        .output()
+        .unwrap_or_else(|error| panic!("spawn `aver {subcommand}`: {error}"))
+}
+
+fn assert_success(output: &Output, command: &str) {
+    assert!(
+        output.status.success(),
+        "`{command}` failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn arena_keys_entry_and_dep_records_separately() {
+    let fixture = compile_fixture(ENTRY_SRC);
+    let entry_id = fixture.arena.find_type_id("Box").expect("entry Box");
+    let dep_id = fixture
+        .arena
+        .find_type_id("Left.Box")
+        .expect("dependency Left.Box");
+
+    assert_ne!(entry_id, dep_id);
+    assert_eq!(fixture.arena.get_field_names(entry_id), ["a", "b"]);
+    assert_eq!(fixture.arena.get_field_names(dep_id), ["b", "a"]);
+    assert_eq!(fixture.arena.get_type_name(entry_id), "Box");
+    assert_eq!(fixture.arena.get_type_name(dep_id), "Box");
+}
+
+#[test]
+fn vm_reads_entry_record_fields_when_a_dep_shadows_the_bare_name() {
+    let (result, _) = run_probe(ENTRY_SRC);
+    assert_eq!(result, Value::int(111222));
+}
+
+#[test]
+fn vm_does_not_read_out_of_bounds_when_the_entry_record_is_wider() {
+    let (result, _) = run_probe(WIDER_ENTRY_SRC);
+    assert_eq!(result, Value::int(3));
+}
+
+#[test]
+fn vm_matches_self_host_on_shadowed_record_layout() {
+    let dir = write_cli_fixture();
+    let vm = run_cli(dir.path(), "run", false);
+    let self_host = run_cli(dir.path(), "run", true);
+    assert_success(&vm, "aver run");
+    assert_success(&self_host, "aver run --self-host");
+
+    let vm_stdout = String::from_utf8_lossy(&vm.stdout).trim().to_string();
+    let self_host_stdout = String::from_utf8_lossy(&self_host.stdout)
+        .trim()
+        .to_string();
+    assert_eq!(self_host_stdout, "111222");
+    assert_eq!(vm_stdout, self_host_stdout);
+}
+
+#[test]
+fn verify_passes_for_shadowed_record_layout() {
+    let dir = write_cli_fixture();
+    let output = run_cli(dir.path(), "verify", false);
+    assert_success(&output, "aver verify");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("1/1"),
+        "unexpected verify output:\n{stdout}"
+    );
+}
+
+#[test]
+fn dep_only_record_still_resolves_by_bare_name() {
+    let fixture = compile_fixture(DEP_ONLY_ENTRY_SRC);
+    assert_eq!(
+        fixture.arena.find_type_id("Box"),
+        fixture.arena.find_type_id("Left.Box"),
+        "the dependency record's bare display spelling remains a fallback alias"
+    );
+
+    let mut machine = vm::VM::new(fixture.code, fixture.globals, fixture.arena);
+    machine.run_top_level().expect("run top level");
+    let result = machine
+        .run_named_function("probe", &[])
+        .expect("run probe")
+        .to_value(&machine.arena);
+    assert_eq!(result, Value::int(8));
+}


### PR DESCRIPTION
Closes #820.

The VM arena registered record types under their bare name, so two modules that happened to name a record the same thing shared one layout entry. The first registration won and the other module's field order was silently reinterpreted.

The checker stamps both types correctly — this is the downstream, name-keyed half of the identity problem, not a checker defect.

## Reproduction

A dependency whose `Box` is private and never referenced from the entry:

```aver
# left.av
record Box
    b: Int
    a: Int

# main.av
record Box
    a: Int
    b: Int

fn probe() -> Str
    x = Box(a = 111, b = 222)
    "a={x.a} b={x.b}"
```

Before: `aver check` clean, `aver run` printed `a=222 b=111`, and `aver verify` failed with `actual: a=222 b=111`. Confirmed silent on a build with debug assertions off as well, so this was a wrong answer in the configuration users ship, not a debug-only artefact.

After: `a=111 b=222`, and the verify block passes.

## What changed

Arena registrations are keyed on module identity, with the bare spelling demoted to an alias consulted on a miss. Display names are unchanged deliberately: making the qualified name the display name would rewrite `"type": "Bytes"` to `"type": "Bytes.Bytes"` in every effect recording and every `repr`, breaking existing replay files for a cosmetic gain unrelated to this defect. The diff is behaviour-neutral except for the collision case.

## Tests

A new `tests/vm_arena_type_identity.rs`, including a cross-backend differential that runs the same program through the VM and through `--self-host`, which never touches the arena and is therefore an independent oracle. Six tests, all passing.

## Not fixed here

The same collision on sum types trips an internal assertion in `intern_variant_ctor` and is tracked separately as #830. This change does not repair it: the two colliding constructors move from "same type id, different variant id" to "different type id", and the assertion still fires. Verified after the fix — the reproduction still reports mismatched constructors, now with distinct type ids. `src/vm/symbol.rs` is untouched.

## Release note

`aver-memory` gains public surface while the root manifest pins `=0.2.13`. The workspace uses a path dependency so nothing breaks at build time, but the next release run needs a patch bump.
