### PR TITLE
Apply `[[check.suppress]]` consistently across path spellings and commands

### DIFF
--- a/.claude/commands/aver-tooling.md
+++ b/.claude/commands/aver-tooling.md
@@ -337,3 +337,10 @@ Disk path patterns have deliberately small, explicit semantics:
 | `**` | Invalid; use `./**` or `/**` to state the intended boundary |
 
 An empty pattern, unsupported `*` placement, or a `..`-rooted pattern is also a config-load error. An absent `paths` key or `paths = []` keeps the existing allow-all behavior. Matching is string-only: Aver normalizes `.` and `..` in the caller-supplied path without resolving it against the working directory or touching the filesystem. A project-relative pattern therefore does not admit an absolute spelling of the same in-project file.
+
+`[[check.suppress]]` rules in detail:
+
+- `files` globs match the file's path **relative to the module root**, so a leading `./` is insignificant on either side and every spelling of the same file (`aver check domain/version.av`, `aver check ./domain/version.av`, `aver check .`, an absolute path, or a dependency pulled in by `--deps`) honours the same rule. A rule with no `files` key applies everywhere.
+- `aver check` and `aver audit` apply the same rules. Both print how many warnings a file's waivers removed.
+- Suppression applies to warnings only. It can never hide an `error[...]`, a verify failure, or the `needs-format` result, so a waiver can never change a command's exit code.
+- A rule that removes nothing during a whole-directory run (`aver check .`, `aver audit .`) is reported on stderr, telling you whether its globs matched no checked file at all or matched files whose warning no longer fires. Single-file runs stay quiet, since they legitimately never exercise rules scoped to other paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 - **Disk allowlists now honor explicit project and filesystem roots.** `paths = ["./**"]` now allows relative paths inside the project and denies absolute paths outside it, while `/` and `/**` allow absolute paths from the filesystem root. Bare `**`, empty entries, unsupported glob spellings, and `..`-rooted paths are rejected when `aver.toml` loads, as are non-matching `*`/`**` host entries and `**` environment-key entries.
 - **Lean proof exports preserve `?` error propagation inside nested expressions.** Proofs can now rely on calls, operators, interpolation, bindings, and match arms returning the original `Result.Err` instead of continuing with a default value.
+- **`[[check.suppress]]` no longer depends on how you spell the path.** A waiver written for `domain/version.av` now applies to `aver check .`, `aver check ./domain/version.av`, the absolute path, and dependency modules under `--deps --module-root .` — previously only some spellings matched. A glob may itself be written with a leading `./`. `aver audit` honours the same waivers as `aver check`, and reports how many warnings they removed; as a consequence it now also stops on a malformed `aver.toml` instead of ignoring it. Suppression still applies to warnings only and can never hide an error or a verify failure.
+- **A `[[check.suppress]]` rule that waives nothing now says so.** Whole-directory runs of `aver check` and `aver audit` report on stderr any rule that removed no warning, distinguishing a glob that matched no checked file from one whose warning no longer fires. Exit codes are unchanged.
 
 ## 0.28.0 "Oktet" — 2026-08-10
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -342,3 +342,10 @@ Disk path patterns have deliberately small, explicit semantics:
 | `**` | Invalid; use `./**` or `/**` to state the intended boundary |
 
 An empty pattern, unsupported `*` placement, or a `..`-rooted pattern is also a config-load error. An absent `paths` key or `paths = []` keeps the existing allow-all behavior. Matching is string-only: Aver normalizes `.` and `..` in the caller-supplied path without resolving it against the working directory or touching the filesystem. A project-relative pattern therefore does not admit an absolute spelling of the same in-project file.
+
+`[[check.suppress]]` rules in detail:
+
+- `files` globs match the file's path **relative to the module root**, so a leading `./` is insignificant on either side and every spelling of the same file (`aver check domain/version.av`, `aver check ./domain/version.av`, `aver check .`, an absolute path, or a dependency pulled in by `--deps`) honours the same rule. A rule with no `files` key applies everywhere.
+- `aver check` and `aver audit` apply the same rules. Both print how many warnings a file's waivers removed.
+- Suppression applies to warnings only. It can never hide an `error[...]`, a verify failure, or the `needs-format` result, so a waiver can never change a command's exit code.
+- A rule that removes nothing during a whole-directory run (`aver check .`, `aver audit .`) is reported on stderr, telling you whether its globs matched no checked file at all or matched files whose warning no longer fires. Single-file runs stay quiet, since they legitimately never exercise rules scoped to other paths.

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,10 +227,31 @@ impl ProjectConfig {
     /// Returns `true` if a diagnostic with the given `slug` at `file_path`
     /// is suppressed by any `[[check.suppress]]` rule.
     pub fn is_check_suppressed(&self, slug: &str, file_path: &str) -> bool {
-        self.check_suppressions.iter().any(|s| {
-            s.slug == slug
-                && (s.files.is_empty() || s.files.iter().any(|g| glob_matches(file_path, g)))
-        })
+        (0..self.check_suppressions.len())
+            .any(|idx| self.check_suppression_applies(idx, slug, file_path))
+    }
+
+    /// Whether the rule at `idx` waives `slug` for `file_path`. Callers that
+    /// report on waiver hygiene need to know *which* rules did the work, not
+    /// just that some rule did.
+    pub fn check_suppression_applies(&self, idx: usize, slug: &str, file_path: &str) -> bool {
+        match self.check_suppressions.get(idx) {
+            Some(rule) => rule.slug == slug && self.suppression_covers_file(idx, file_path),
+            None => false,
+        }
+    }
+
+    /// Whether the rule at `idx` covers `file_path` by its file globs alone,
+    /// ignoring the slug. A rule with no globs covers every file. This is what
+    /// separates "the waiver points at a path nothing in the run touched" from
+    /// "the file was checked and the warning it waives no longer fires".
+    pub fn suppression_covers_file(&self, idx: usize, file_path: &str) -> bool {
+        match self.check_suppressions.get(idx) {
+            Some(rule) => {
+                rule.files.is_empty() || rule.files.iter().any(|g| glob_matches(file_path, g))
+            }
+            None => false,
+        }
     }
 
     /// Check whether an HTTP call to `url_str` is allowed by the policy.
@@ -690,13 +711,27 @@ fn parse_check_suppressions(table: &toml::Table) -> Result<Vec<CheckSuppression>
     Ok(suppressions)
 }
 
+/// Drop any leading `./` segments. Matching is anchored, so `./a/b.av` and
+/// `a/b.av` would otherwise be different paths to the same file.
+fn strip_dot_slash(s: &str) -> &str {
+    let mut rest = s;
+    while let Some(stripped) = rest.strip_prefix("./") {
+        rest = stripped;
+    }
+    rest
+}
+
 /// Simple glob match for file paths.
 /// Supports `**` (any path segments) and `*` (any single segment chars).
+/// A leading `./` is insignificant on both sides.
 fn glob_matches(path: &str, pattern: &str) -> bool {
     // Normalize separators
     let path = path.replace('\\', "/");
     let pattern = pattern.replace('\\', "/");
-    glob_match_recursive(path.as_bytes(), pattern.as_bytes())
+    glob_match_recursive(
+        strip_dot_slash(&path).as_bytes(),
+        strip_dot_slash(&pattern).as_bytes(),
+    )
 }
 
 fn glob_match_recursive(path: &[u8], pattern: &[u8]) -> bool {
@@ -1355,6 +1390,91 @@ reason = "Not yet ready for verify"
     fn test_glob_matches_exact() {
         assert!(glob_matches("self_hosted/eval.av", "self_hosted/eval.av"));
         assert!(!glob_matches("self_hosted/other.av", "self_hosted/eval.av"));
+    }
+
+    #[test]
+    fn test_glob_matches_leading_dot_slash_on_path() {
+        assert!(glob_matches("./self_hosted/eval.av", "self_hosted/eval.av"));
+        assert!(glob_matches("./self_hosted/eval.av", "self_hosted/**"));
+        assert!(!glob_matches("./examples/hello.av", "self_hosted/**"));
+    }
+
+    #[test]
+    fn test_glob_matches_leading_dot_slash_on_pattern() {
+        assert!(glob_matches("self_hosted/eval.av", "./self_hosted/eval.av"));
+        assert!(glob_matches("self_hosted/sub/deep.av", "./self_hosted/**"));
+    }
+
+    #[test]
+    fn test_glob_matches_leading_dot_slash_on_both() {
+        assert!(glob_matches(
+            "./self_hosted/eval.av",
+            "./self_hosted/eval.av"
+        ));
+        assert!(glob_matches("././a/b.av", "./a/b.av"));
+    }
+
+    #[test]
+    fn test_check_suppression_applies_identifies_each_rule() {
+        let toml = r#"
+[[check.suppress]]
+slug = "missing-verify"
+files = ["domain/**"]
+reason = "First rule"
+
+[[check.suppress]]
+slug = "non-tail-recursion"
+files = ["self_hosted/**"]
+reason = "Second rule"
+"#;
+        let config = ProjectConfig::parse(toml).unwrap();
+        assert!(config.check_suppression_applies(1, "non-tail-recursion", "self_hosted/eval.av"));
+        assert!(!config.check_suppression_applies(0, "non-tail-recursion", "self_hosted/eval.av"));
+        assert!(config.check_suppression_applies(0, "missing-verify", "domain/version.av"));
+        assert!(!config.check_suppression_applies(1, "missing-verify", "domain/version.av"));
+        // Out-of-range index is never a match.
+        assert!(!config.check_suppression_applies(2, "missing-verify", "domain/version.av"));
+    }
+
+    #[test]
+    fn test_overlapping_rules_both_apply() {
+        // Two rules can waive the same diagnostic. Waiver-hygiene reporting
+        // must credit both, or the narrower one looks dead.
+        let toml = r#"
+[[check.suppress]]
+slug = "non-tail-recursion"
+files = ["**"]
+reason = "Broad rule"
+
+[[check.suppress]]
+slug = "non-tail-recursion"
+files = ["self_hosted/eval.av"]
+reason = "Narrow rule"
+"#;
+        let config = ProjectConfig::parse(toml).unwrap();
+        assert!(config.check_suppression_applies(0, "non-tail-recursion", "self_hosted/eval.av"));
+        assert!(config.check_suppression_applies(1, "non-tail-recursion", "self_hosted/eval.av"));
+    }
+
+    #[test]
+    fn test_suppression_covers_file_ignores_slug() {
+        let toml = r#"
+[[check.suppress]]
+slug = "a-slug-that-never-fires"
+files = ["domain/**"]
+reason = "Scoped rule"
+
+[[check.suppress]]
+slug = "missing-verify"
+reason = "Global rule"
+"#;
+        let config = ProjectConfig::parse(toml).unwrap();
+        assert!(config.suppression_covers_file(0, "domain/version.av"));
+        assert!(config.suppression_covers_file(0, "./domain/version.av"));
+        assert!(!config.suppression_covers_file(0, "other/version.av"));
+        // No globs = covers every file.
+        assert!(config.suppression_covers_file(1, "anything/at/all.av"));
+        assert!(!config.suppression_covers_file(2, "domain/version.av"));
     }
 
     #[test]

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -991,6 +991,140 @@ pub(super) fn display_check_path(path: &str, module_root: &str) -> String {
     path.to_string()
 }
 
+/// The path key `[[check.suppress]]` globs are matched against: the file's
+/// location relative to the module root, with no leading `./`.
+///
+/// Deliberately not `display_check_path`: that one keeps whatever spelling
+/// the command line used, which is what the user should read back, but it
+/// makes the same file match a waiver under one spelling and miss it under
+/// another. Suppression must not depend on how the path was typed.
+pub(super) fn suppression_path(path: &str, module_root: &str) -> String {
+    let p = Path::new(path);
+    let root = Path::new(module_root);
+
+    if let Some(rel) = relativize_to_canonical(root, p).or_else(|| relativize_to(root, p)) {
+        return rel;
+    }
+
+    // The file may not exist on disk (or may sit outside the module root),
+    // so fall back to a purely lexical cleanup.
+    let mut lexical = PathBuf::new();
+    for component in p.components() {
+        if matches!(component, std::path::Component::CurDir) {
+            continue;
+        }
+        lexical.push(component.as_os_str());
+    }
+    if lexical.as_os_str().is_empty() {
+        path.to_string()
+    } else {
+        path_to_string(&lexical)
+    }
+}
+
+/// Per-rule bookkeeping for `[[check.suppress]]`, so a run can tell the
+/// user which waivers did nothing.
+struct SuppressionTracker {
+    /// Some checked file fell inside the rule's file globs.
+    covered: Vec<bool>,
+    /// The rule actually removed at least one diagnostic.
+    fired: Vec<bool>,
+}
+
+impl SuppressionTracker {
+    fn new(config: Option<&aver::config::ProjectConfig>) -> Self {
+        let len = config.map_or(0, |cfg| cfg.check_suppressions.len());
+        SuppressionTracker {
+            covered: vec![false; len],
+            fired: vec![false; len],
+        }
+    }
+
+    fn note_file(&mut self, config: Option<&aver::config::ProjectConfig>, key: &str) {
+        let Some(cfg) = config else {
+            return;
+        };
+        for (idx, covered) in self.covered.iter_mut().enumerate() {
+            *covered |= cfg.suppression_covers_file(idx, key);
+        }
+    }
+}
+
+/// Drop the warnings waived by `[[check.suppress]]` and return how many went.
+/// Shared by `aver check` and `aver audit` so the two commands cannot drift.
+fn apply_check_suppressions(
+    diagnostics: &mut Vec<diagnostic::Diagnostic>,
+    config: Option<&aver::config::ProjectConfig>,
+    key: &str,
+    tracker: &mut SuppressionTracker,
+) -> usize {
+    let Some(cfg) = config else {
+        return 0;
+    };
+    let before = diagnostics.len();
+    diagnostics.retain(|diag| {
+        // Warnings only. Keying on anything wider would let a waiver hide an
+        // error or a verify failure, and with it the command's exit code.
+        if !diag.is_warning() {
+            return true;
+        }
+        // Every matching rule is credited, not just the first, so an
+        // overlapping waiver is never reported as dead.
+        let mut suppressed = false;
+        for idx in 0..cfg.check_suppressions.len() {
+            if cfg.check_suppression_applies(idx, diag.slug, key) {
+                suppressed = true;
+                if let Some(fired) = tracker.fired.get_mut(idx) {
+                    *fired = true;
+                }
+            }
+        }
+        !suppressed
+    });
+    before - diagnostics.len()
+}
+
+/// Report `[[check.suppress]]` rules that removed nothing. Only meaningful
+/// when the run walked a whole directory: checking a single file legitimately
+/// leaves waivers for other paths untouched.
+///
+/// Written to stderr so `--json` stdout stays a clean stream, and never
+/// changes the exit code.
+fn report_dead_suppressions(
+    config: Option<&aver::config::ProjectConfig>,
+    tracker: &SuppressionTracker,
+    whole_tree: bool,
+) {
+    if !whole_tree {
+        return;
+    }
+    let Some(cfg) = config else {
+        return;
+    };
+    for (idx, rule) in cfg.check_suppressions.iter().enumerate() {
+        if tracker.fired.get(idx).copied().unwrap_or(false) {
+            continue;
+        }
+        let scope = if rule.files.is_empty() {
+            "every file".to_string()
+        } else {
+            rule.files.join(", ")
+        };
+        let detail = if tracker.covered.get(idx).copied().unwrap_or(false) {
+            "matched files in this run but suppressed nothing — the warning it waives no longer fires"
+        } else {
+            "matched no checked file — the path may be stale"
+        };
+        eprintln!(
+            "{} aver.toml [[check.suppress]] slug = \"{}\" (files: {}) {}",
+            "warning:".yellow(),
+            rule.slug,
+            scope,
+            detail
+        );
+    }
+}
+
 pub(super) fn cmd_run_vm(
     file: &str,
     module_root_override: Option<&str>,
@@ -1496,6 +1630,7 @@ fn run_check_for_file(
     deps: bool,
     verbose: bool,
     json: bool,
+    tracker: &mut SuppressionTracker,
 ) -> Result<bool, String> {
     let units = collect_check_units(file, module_root, deps)?;
     let _entry_module = units.first().and_then(|(_, _, items)| module_name(items));
@@ -1514,6 +1649,8 @@ fn run_check_for_file(
 
     for (idx, (path, source, items)) in units.iter().enumerate() {
         let shown_path = display_check_path(path, module_root);
+        let suppress_key = suppression_path(path, module_root);
+        tracker.note_file(config, &suppress_key);
         if !json {
             if idx > 0 {
                 println!();
@@ -1549,13 +1686,8 @@ fn run_check_for_file(
         }
 
         // --- Filter suppressed warnings ---
-        let total_before = diagnostics.len();
-        if let Some(cfg) = config {
-            diagnostics.retain(|diag| {
-                !diag.is_warning() || !cfg.is_check_suppressed(diag.slug, &shown_path)
-            });
-        }
-        let suppressed_count = total_before - diagnostics.len();
+        let suppressed_count =
+            apply_check_suppressions(&mut diagnostics, config, &suppress_key, tracker);
 
         // --- Emit ---
         if json {
@@ -1621,6 +1753,13 @@ pub(super) fn cmd_audit(path: &str, module_root_override: Option<&str>, json: bo
     use aver::diagnostics::{AnalyzeOptions, analyze_source, needs_format_diagnostic};
 
     let module_root = crate::shared::resolve_module_root(module_root_override);
+    let config = match aver::config::ProjectConfig::load_from_dir(Path::new(&module_root)) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("{}", e.red());
+            process::exit(1);
+        }
+    };
     let inputs = match resolve_av_inputs(path) {
         Ok(v) => v,
         Err(e) => {
@@ -1635,6 +1774,9 @@ pub(super) fn cmd_audit(path: &str, module_root_override: Option<&str>, json: bo
             process::exit(1);
         }
     };
+
+    let batch = Path::new(path).is_dir();
+    let mut tracker = SuppressionTracker::new(config.as_ref());
 
     let mut total_check_errors = 0usize;
     let mut total_verify_failures = 0usize;
@@ -1663,6 +1805,19 @@ pub(super) fn cmd_audit(path: &str, module_root_override: Option<&str>, json: bo
         opts.include_verify_run = true;
         opts.verify_run_hostile = hostile;
         let mut report = analyze_source(&source, &opts);
+
+        // Suppression runs before the format check on purpose: `needs-format`
+        // still increments `total_format_needed` and still forces exit 1, so
+        // letting a waiver delete the diagnostic would report a clean file
+        // that fails anyway.
+        let suppress_key = suppression_path(file, &module_root);
+        tracker.note_file(config.as_ref(), &suppress_key);
+        let suppressed_count = apply_check_suppressions(
+            &mut report.diagnostics,
+            config.as_ref(),
+            &suppress_key,
+            &mut tracker,
+        );
 
         // Format check: append needs-format diagnostic with structured
         // per-rule violations (capped at the factory's MAX_VIOLATION_REGIONS).
@@ -1706,9 +1861,11 @@ pub(super) fn cmd_audit(path: &str, module_root_override: Option<&str>, json: bo
         if json {
             println!("{}", report.to_json());
         } else {
-            render_audit_tty(&shown_path, &report, needs_format);
+            render_audit_tty(&shown_path, &report, needs_format, suppressed_count);
         }
     }
+
+    report_dead_suppressions(config.as_ref(), &tracker, batch);
 
     if json {
         println!(
@@ -1740,6 +1897,7 @@ fn render_audit_tty(
     shown_path: &str,
     report: &aver::diagnostics::AnalysisReport,
     needs_format: bool,
+    suppressed_count: usize,
 ) {
     println!();
     println!("{}", format!("Audit: {}", shown_path).cyan());
@@ -1788,6 +1946,9 @@ fn render_audit_tty(
     if needs_format {
         println!("  {} needs format", "!".yellow());
     }
+    if suppressed_count > 0 {
+        println!("  {} warning(s) suppressed by aver.toml", suppressed_count);
+    }
 }
 
 fn severity_tag(diag: &aver::diagnostics::Diagnostic) -> colored::ColoredString {
@@ -1825,6 +1986,7 @@ pub(super) fn cmd_check(
 
     let batch = Path::new(path).is_dir();
     let mut failed_files = Vec::new();
+    let mut tracker = SuppressionTracker::new(config.as_ref());
 
     for (idx, file) in inputs.iter().enumerate() {
         if !json && batch && idx > 0 {
@@ -1835,7 +1997,15 @@ pub(super) fn cmd_check(
             println!("Input: {}", display_check_path(file, &module_root).cyan());
         }
 
-        match run_check_for_file(file, &module_root, config.as_ref(), deps, verbose, json) {
+        match run_check_for_file(
+            file,
+            &module_root,
+            config.as_ref(),
+            deps,
+            verbose,
+            json,
+            &mut tracker,
+        ) {
             Ok(has_errors) => {
                 if has_errors {
                     failed_files.push(file.clone());
@@ -1847,6 +2017,8 @@ pub(super) fn cmd_check(
             }
         }
     }
+
+    report_dead_suppressions(config.as_ref(), &tracker, batch);
 
     if json {
         let passed = inputs.len().saturating_sub(failed_files.len());
@@ -9451,7 +9623,8 @@ fn load_module_recursive(
 #[cfg(test)]
 mod tests {
     use super::{
-        codegen_uses_self_host_runtime, resolve_av_inputs, validate_self_host_guest_entry_contract,
+        codegen_uses_self_host_runtime, resolve_av_inputs, suppression_path,
+        validate_self_host_guest_entry_contract,
     };
     use aver::ast::{Expr, FnBody, FnDef, Literal, Spanned, Stmt, TopLevel};
     use aver::codegen::CodegenContext;
@@ -10351,6 +10524,34 @@ Dafny program verifier finished with 158 verified, 2 errors, 12 time outs";
                 dir.join("b.av").to_string_lossy().to_string(),
                 nested.join("a.av").to_string_lossy().to_string(),
             ]
+        );
+
+        fs::remove_dir_all(&dir).expect("cleanup temp dir");
+    }
+
+    #[test]
+    fn suppression_path_strips_dot_slash_and_relativizes() {
+        let dir = temp_case_dir("suppress_key");
+        let nested = dir.join("domain");
+        fs::create_dir_all(&nested).expect("create nested dir");
+        fs::write(nested.join("version.av"), "module Version\n").expect("write version.av");
+        let root = dir.to_str().expect("utf8 path");
+
+        assert_eq!(
+            suppression_path(nested.join("version.av").to_str().expect("utf8 path"), root),
+            "domain/version.av"
+        );
+        assert_eq!(
+            suppression_path(
+                dir.join("./domain/version.av").to_str().expect("utf8 path"),
+                root
+            ),
+            "domain/version.av"
+        );
+        // No filesystem answer available: fall back to a lexical cleanup.
+        assert_eq!(
+            suppression_path("./domain/missing.av", "."),
+            "domain/missing.av"
         );
 
         fs::remove_dir_all(&dir).expect("cleanup temp dir");

--- a/tests/check_suppress_spelling_spec.rs
+++ b/tests/check_suppress_spelling_spec.rs
@@ -1,0 +1,354 @@
+//! Regression — `[[check.suppress]]` must behave the same whichever way the
+//! path was spelled on the command line, `aver audit` must honour it too, and
+//! a waiver that removes nothing must say so.
+//!
+//! Suppression used to be matched against the display path, which keeps the
+//! spelling the user typed: `aver check domain/version.av` suppressed, while
+//! `aver check .` (which walks to `./domain/version.av`) and `--module-root .`
+//! for dependency modules did not. The glob was anchored byte matching with no
+//! `./` normalisation, so the pattern side was broken symmetrically — a rule
+//! written `files = ["./domain/version.av"]` matched nothing at all.
+//! `cmd_audit` never loaded `aver.toml`, so its check leg could not be made
+//! green through project config in any spelling.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Fixture module: no `intent`, no `effects`, and no `?` description.
+/// That is exactly two `warning[check]` diagnostics plus one
+/// `warning[missing-description]` — the latter is the control that proves a
+/// waiver for `check` is targeted rather than blanket.
+const VERSION_AV: &str = "module Version\n    exposes [bump]\n\nfn bump(n: Int) -> Int\n    n + 1\n\nverify bump\n    bump(1) => 2\n";
+
+/// Entry module depending on the fixture, used for the `--deps` leg.
+const APP_AV: &str = "module App\n    depends [Domain.Version]\n    intent =\n        \"Entry point for the suppression fixture.\"\n    effects []\n\nfn next(n: Int) -> Int\n    ? \"One step forward.\"\n    Domain.Version.bump(n)\n\nverify next\n    next(1) => 2\n";
+
+/// A project rooted at a fresh temp directory, removed on drop so a failing
+/// assertion does not leave fixtures behind.
+struct Project {
+    dir: PathBuf,
+}
+
+impl Project {
+    fn new(tag: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!("aver_suppress_{tag}_{nanos}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("domain")).expect("create fixture dirs");
+        fs::write(dir.join("domain").join("version.av"), VERSION_AV).expect("write version.av");
+        Project { dir }
+    }
+
+    fn write(&self, rel: &str, contents: &str) {
+        let path = self.dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent dir");
+        }
+        fs::write(path, contents).expect("write fixture file");
+    }
+
+    fn remove(&self, rel: &str) {
+        let _ = fs::remove_file(self.dir.join(rel));
+    }
+
+    fn abs(&self, rel: &str) -> String {
+        self.dir
+            .join(rel)
+            .to_str()
+            .expect("utf8 fixture path")
+            .to_string()
+    }
+
+    /// Run `aver` from inside the project — the whole point is how the path
+    /// argument is spelled relative to the working directory.
+    fn run(&self, args: &[&str]) -> Run {
+        let out: Output = Command::new(env!("CARGO_BIN_EXE_aver"))
+            .args(args)
+            .current_dir(&self.dir)
+            .output()
+            .expect("spawn aver");
+        Run {
+            code: out.status.code(),
+            stdout: String::from_utf8_lossy(&out.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        }
+    }
+}
+
+impl Drop for Project {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+struct Run {
+    code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+impl Run {
+    fn describe(&self, label: &str) -> String {
+        format!(
+            "{label}\n--- exit: {:?}\n--- stdout:\n{}\n--- stderr:\n{}",
+            self.code, self.stdout, self.stderr
+        )
+    }
+}
+
+fn waiver_for(files: &str) -> String {
+    format!(
+        "[[check.suppress]]\nslug = \"check\"\nfiles = [{files}]\nreason = \"Fixture waiver for the suppression spelling matrix\"\n"
+    )
+}
+
+/// Defect 1 — every spelling of the same file honours the same waiver.
+#[test]
+fn suppression_applies_under_every_path_spelling() {
+    let project = Project::new("spelling");
+    project.write("aver.toml", &waiver_for("\"domain/version.av\""));
+
+    let absolute = project.abs("domain/version.av");
+    let spellings = ["domain/version.av", "./domain/version.av", ".", &absolute];
+
+    for spelling in spellings {
+        let run = project.run(&["check", spelling]);
+        assert!(
+            run.stdout.contains("warning(s) suppressed by aver.toml"),
+            "{}",
+            run.describe(&format!("`aver check {spelling}` reported no suppression"))
+        );
+        assert!(
+            !run.stdout.contains("warning[check]"),
+            "{}",
+            run.describe(&format!(
+                "`aver check {spelling}` still printed warning[check]"
+            ))
+        );
+        // The waiver names one slug; unrelated warnings must survive it.
+        assert!(
+            run.stdout.contains("warning[missing-description]"),
+            "{}",
+            run.describe(&format!(
+                "`aver check {spelling}` swallowed an unwaived warning"
+            ))
+        );
+    }
+}
+
+/// Defect 1, pattern side — a glob may itself be written with a leading `./`.
+#[test]
+fn suppression_glob_may_be_spelled_with_leading_dot_slash() {
+    let project = Project::new("dotglob");
+    project.write("aver.toml", &waiver_for("\"./domain/version.av\""));
+
+    let run = project.run(&["check", "domain/version.av"]);
+    assert!(
+        run.stdout.contains("warning(s) suppressed by aver.toml"),
+        "{}",
+        run.describe("a `./`-prefixed glob suppressed nothing")
+    );
+    assert!(
+        !run.stdout.contains("warning[check]"),
+        "{}",
+        run.describe("a `./`-prefixed glob left warning[check] in place")
+    );
+}
+
+/// Defect 1, dependency leg — `--module-root .` builds dependency paths by
+/// joining the root, so they arrive spelled `./domain/version.av`.
+#[test]
+fn deps_suppression_survives_module_root_dot() {
+    let project = Project::new("deps");
+    project.write("aver.toml", &waiver_for("\"domain/version.av\""));
+    project.write("app.av", APP_AV);
+
+    let run = project.run(&["check", "app.av", "--deps", "--module-root", "."]);
+    assert!(
+        run.stdout.contains("warning(s) suppressed by aver.toml"),
+        "{}",
+        run.describe("dependency warnings were not suppressed under --module-root .")
+    );
+    assert!(
+        !run.stdout.contains("warning[check]"),
+        "{}",
+        run.describe("dependency warning[check] survived the waiver")
+    );
+}
+
+/// Defect 2 — `aver audit` consults the same `aver.toml` as `aver check`.
+#[test]
+fn audit_honours_check_suppress() {
+    let project = Project::new("audit");
+    project.write("aver.toml", &waiver_for("\"domain/version.av\""));
+
+    let run = project.run(&["audit", "domain/version.av", "--json"]);
+    let analysis = analysis_line(&run);
+    assert!(
+        !analysis.contains("\"slug\":\"check\""),
+        "{}",
+        run.describe("audit ignored the waiver")
+    );
+    assert!(
+        analysis.contains("\"slug\":\"missing-description\""),
+        "{}",
+        run.describe("audit dropped an unwaived warning")
+    );
+
+    // Control: without the config the same run reports the warnings.
+    project.remove("aver.toml");
+    let control = project.run(&["audit", "domain/version.av", "--json"]);
+    assert!(
+        analysis_line(&control).contains("\"slug\":\"check\""),
+        "{}",
+        control.describe("control run should still report warning[check]")
+    );
+}
+
+/// Defect 2, invariant — suppression is warnings-only, so routing audit
+/// through it cannot change an exit code. A waiver naming an error slug is
+/// inert.
+#[test]
+fn audit_suppression_cannot_hide_errors() {
+    let project = Project::new("audit_error");
+    project.write(
+        "aver.toml",
+        "[[check.suppress]]\nslug = \"verify-rhs\"\nfiles = [\"**\"]\nreason = \"A waiver must not be able to hide an error\"\n",
+    );
+    project.write(
+        "domain/version.av",
+        "module Version\n    intent =\n        \"Fixture: verify case calls the target on the right side.\"\n    exposes [double]\n    effects []\n\nfn double(x: Int) -> Int\n    ? \"Doubles the input\"\n    x * 2\n\nverify double\n    double(2) => double(2)\n",
+    );
+
+    let run = project.run(&["audit", "domain/version.av", "--json"]);
+    assert!(
+        run.stdout.contains("\"slug\":\"verify-rhs\""),
+        "{}",
+        run.describe("a waiver must not remove an error diagnostic")
+    );
+    let summary = run
+        .stdout
+        .lines()
+        .find(|l| l.contains("\"kind\":\"summary\""))
+        .unwrap_or_else(|| panic!("{}", run.describe("no summary line")));
+    assert!(
+        summary.contains("\"check_errors\":1"),
+        "{}",
+        run.describe("the error must still be counted")
+    );
+    assert_eq!(
+        run.code,
+        Some(1),
+        "{}",
+        run.describe("the error must still fail the audit")
+    );
+}
+
+/// Defect 3 — a rule that removed nothing during a whole-directory run is
+/// named on stderr, without touching the exit code or the live rule.
+#[test]
+fn dead_suppress_rule_warns_on_directory_run() {
+    let project = Project::new("dead");
+    project.write(
+        "aver.toml",
+        &format!(
+            "{}\n[[check.suppress]]\nslug = \"check\"\nfiles = [\"nowhere/*.av\"]\nreason = \"Points at a path that no longer exists\"\n",
+            waiver_for("\"domain/version.av\"")
+        ),
+    );
+
+    let run = project.run(&["check", "."]);
+    assert!(
+        run.stderr.contains("check.suppress") && run.stderr.contains("nowhere/*.av"),
+        "{}",
+        run.describe("the dead rule was not reported")
+    );
+    assert!(
+        !run.stderr.contains("domain/version.av"),
+        "{}",
+        run.describe("the live rule must not be reported as dead")
+    );
+    assert_eq!(
+        run.code,
+        Some(0),
+        "{}",
+        run.describe("waiver hygiene must not change the exit code")
+    );
+}
+
+/// Defect 3, scope — checking one file legitimately leaves waivers for other
+/// paths unexercised, so the warning is reserved for directory walks.
+#[test]
+fn dead_suppress_rule_is_silent_on_single_file_run() {
+    let project = Project::new("dead_single");
+    project.write(
+        "aver.toml",
+        &format!(
+            "{}\n[[check.suppress]]\nslug = \"check\"\nfiles = [\"nowhere/*.av\"]\nreason = \"Points at a path that no longer exists\"\n",
+            waiver_for("\"domain/version.av\"")
+        ),
+    );
+
+    let run = project.run(&["check", "domain/version.av"]);
+    assert!(
+        !run.stderr.contains("check.suppress"),
+        "{}",
+        run.describe("a single-file run must not judge waivers it never exercised")
+    );
+}
+
+/// `aver audit` now loads `aver.toml`, so a malformed one stops the run
+/// instead of being silently ignored — same as `aver check` has always done.
+#[test]
+fn audit_rejects_a_malformed_config() {
+    let project = Project::new("badconfig");
+    project.write(
+        "aver.toml",
+        "[[check.suppress]]\nslug = \"check\"\nfiles = [\"domain/version.av\"]\n",
+    );
+
+    let run = project.run(&["audit", "domain/version.av"]);
+    assert_eq!(
+        run.code,
+        Some(1),
+        "{}",
+        run.describe("a malformed aver.toml must stop the audit")
+    );
+    assert!(
+        run.stderr.contains("reason"),
+        "{}",
+        run.describe("the config error must name the missing key")
+    );
+}
+
+fn analysis_line(run: &Run) -> String {
+    run.stdout
+        .lines()
+        .find(|l| l.contains("\"kind\":\"analysis\""))
+        .unwrap_or_else(|| panic!("{}", run.describe("no analysis line in audit output")))
+        .to_string()
+}
+
+/// Guard on the fixture itself: the assertions above are only meaningful if
+/// the unsuppressed file really does emit `warning[check]`.
+#[test]
+fn fixture_emits_the_warning_that_is_being_waived() {
+    let project = Project::new("fixture");
+    assert!(!Path::new(&project.abs("aver.toml")).exists());
+
+    let run = project.run(&["check", "domain/version.av"]);
+    assert!(
+        run.stdout.contains("warning[check]"),
+        "{}",
+        run.describe("fixture no longer emits warning[check]")
+    );
+    assert!(
+        !run.stdout.contains("suppressed by aver.toml"),
+        "{}",
+        run.describe("fixture must not be suppressed without a config")
+    );
+}

--- a/tools/website/llms-full.txt
+++ b/tools/website/llms-full.txt
@@ -373,3 +373,10 @@ Disk path patterns have deliberately small, explicit semantics:
 | `**` | Invalid; use `./**` or `/**` to state the intended boundary |
 
 An empty pattern, unsupported `*` placement, or a `..`-rooted pattern is also a config-load error. An absent `paths` key or `paths = []` keeps the existing allow-all behavior. Matching is string-only: Aver normalizes `.` and `..` in the caller-supplied path without resolving it against the working directory or touching the filesystem. A project-relative pattern therefore does not admit an absolute spelling of the same in-project file.
+
+`[[check.suppress]]` rules in detail:
+
+- `files` globs match the file's path **relative to the module root**, so a leading `./` is insignificant on either side and every spelling of the same file (`aver check domain/version.av`, `aver check ./domain/version.av`, `aver check .`, an absolute path, or a dependency pulled in by `--deps`) honours the same rule. A rule with no `files` key applies everywhere.
+- `aver check` and `aver audit` apply the same rules. Both print how many warnings a file's waivers removed.
+- Suppression applies to warnings only. It can never hide an `error[...]`, a verify failure, or the `needs-format` result, so a waiver can never change a command's exit code.
+- A rule that removes nothing during a whole-directory run (`aver check .`, `aver audit .`) is reported on stderr, telling you whether its globs matched no checked file at all or matched files whose warning no longer fires. Single-file runs stay quiet, since they legitimately never exercise rules scoped to other paths.


### PR DESCRIPTION
Closes #822.

Three defects made `[[check.suppress]]` unreliable. A project could write a waiver, watch it work in one invocation, and have it silently do nothing in another.

## What was wrong

**The path spelling decided whether a waiver applied.** `is_check_suppressed` was called with the display path, which keeps whatever the command line used, so walking `.` produced `./domain/version.av` and the configured glob could not match it. There is a second half the issue did not mention: the pattern side had the same problem, so `files = ["./domain/version.av"]` never matched either.

**`aver audit` never consulted the project config at all**, so its check leg was strictly noisier than `aver check` and could not be made green through aver.toml in any spelling.

**A rule matching nothing was silent**, which is how the first two stayed invisible: a waiver that had stopped applying looked exactly like one that worked.

## What changed

A new `suppression_path` computes the matching key relative to the module root, deliberately separate from `display_check_path` — the display path should keep the spelling the user typed, and `file_label` and `span.file` in `--json` output are unchanged. `glob_matches` now strips a leading `./` on both sides.

`cmd_audit` loads the project config and routes its diagnostics through the same shared helper `aver check` uses, so the two cannot drift again. The filter runs before the format check, so a waiver cannot delete a diagnostic while the format result still forces a non-zero exit.

Dead rules are reported on stderr, with two distinct messages: a rule whose globs matched no checked file, and a rule that matched files but suppressed nothing because the warning it waives no longer fires. Reporting is limited to directory runs, since a single-file run legitimately never exercises rules scoped elsewhere. It never touches the exit code.

Suppression continues to apply to warnings only, so it can never hide an error, a verify failure, or the format result.

## Verification

Measured on a real third-party project whose aver.toml carries three waivers. Before, `aver check .` showed 27 warnings the author had already written reasons for, and `aver audit` showed them in every spelling.

```
check domain/version.av    -> 0 warnings, waiver reported
check ./domain/version.av  -> 0 warnings, waiver reported
check .                    -> 0 warnings, 3 waivers reported
check <absolute path>      -> 0 warnings, 3 waivers reported
audit domain/transaction.av -> 0 verify-coverage warnings   (was 24)
```

The self-hosted project, whose aver.toml carries seven broad rules, produces no dead-waiver output at all — every rule there fires.

A falsification pass backs the tests: with the implementation stashed and only the spec kept, six of the nine new tests fail; restored, all nine pass.

## One correction to the original design

The first sketch matched rules with `position()`, first match wins. That would credit only the first of two overlapping rules waiving the same slug for the same file, and then report the narrower one as a dead waiver on every directory run — a false alarm inside the very feature this adds. It matters concretely: the self-hosted project has six rules sharing one slug with globs that can overlap. Every matching rule is now credited, and a test pins it.

## Note

`aver audit` now aborts on a malformed aver.toml where it previously ignored the file. That is intended.
