### PR TITLE
Establish type identity before the declaration walk resolves against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **Type declarations are now order-independent within a file.** Record fields, sum-variant fields, and constructor parameters can name types declared later, and a local type consistently shadows a dependency exposing the same bare name, preventing dependency values from being read through an unrelated local record layout.
 - **Disk allowlists now honor explicit project and filesystem roots.** `paths = ["./**"]` now allows relative paths inside the project and denies absolute paths outside it, while `/` and `/**` allow absolute paths from the filesystem root. Bare `**`, empty entries, unsupported glob spellings, and `..`-rooted paths are rejected when `aver.toml` loads, as are non-matching `*`/`**` host entries and `**` environment-key entries.
 - **The VM keeps same-named record types from different modules distinct.** A private dependency record can no longer corrupt the field layout of an entry-module record with the same bare name.
 - **Lean proof exports preserve `?` error propagation inside nested expressions.** Proofs can now rely on calls, operators, interpolation, bindings, and match arms returning the original `Result.Err` instead of continuing with a default value.

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -44,6 +44,22 @@ impl TypeChecker {
             .clone()
             .or_else(|| Self::module_decl(items).map(|m| m.name.clone()))
             .unwrap_or_default();
+        // Establish every local identity before resolving member annotations so
+        // declaration order cannot change which nominal type an annotation names.
+        for item in items {
+            if let TopLevel::TypeDef(td) = item {
+                let type_name = match td {
+                    TypeDef::Sum { name, .. } | TypeDef::Product { name, .. } => name,
+                };
+                let canonical_type = canonical_name(&module_name, type_name);
+                if let Some(id) = self.type_id_for_canonical(&canonical_type) {
+                    self.mark_type_visible(id);
+                    if canonical_type != *type_name {
+                        self.merge_bare_type_alias(type_name.clone(), id);
+                    }
+                }
+            }
+        }
         for item in items {
             if let TopLevel::TypeDef(td) = item {
                 self.register_type_def_sigs(td, &module_name);
@@ -420,19 +436,7 @@ impl TypeChecker {
                     effects: vec![],
                 };
                 self.insert_fn_sig(&canonical_type, type_sig);
-                // Mark the type itself visible to the current scope —
-                // own-module types are always visible to their own
-                // module. `type_id_for_canonical` bypasses the
-                // visibility filter so we can register it.
-                if let Some(id) = self.type_id_for_canonical(&canonical_type) {
-                    self.mark_type_visible(id);
-                    // Bare alias for the type name so bodies inside the
-                    // same module can reference `Shape` and have it
-                    // resolve to its TypeId.
-                    if canonical_type != *type_name {
-                        self.merge_bare_type_alias(type_name.clone(), id);
-                    }
-                }
+                // Visibility and bare aliases are registered by build_signatures.
                 // Register each constructor with a qualified key.
                 for variant in variants {
                     let params: Vec<Type> = variant
@@ -518,12 +522,7 @@ impl TypeChecker {
                     effects: vec![],
                 };
                 self.insert_fn_sig(&canonical_type, prod_sig);
-                if let Some(id) = self.type_id_for_canonical(&canonical_type) {
-                    self.mark_type_visible(id);
-                    if canonical_type != *type_name {
-                        self.merge_bare_type_alias(type_name.clone(), id);
-                    }
-                }
+                // Visibility and bare aliases are registered by build_signatures.
                 // Register per-field types so dot-access is checked.
                 // Phase B: single entry under canonical `(Module.Type,
                 // field)` — the bare-alias mirror that pre-phase-B

--- a/tests/cross_module_type_keys.rs
+++ b/tests/cross_module_type_keys.rs
@@ -157,16 +157,18 @@ fn backend_named_type_key_routes_id_stamped_named_to_canonical() {
 }
 
 #[test]
-fn backend_named_type_key_falls_back_to_name_for_unresolved_refs() {
+/// User-source nominal types must have a typed identity; builtin and host types
+/// such as `HttpResponse` are deliberately id-less and retain the name fallback.
+fn backend_named_type_key_falls_back_to_name_for_types_with_no_typed_identity() {
     let ctx = build_three_module_ctx();
     let unresolved = Type::Named {
         id: None,
-        name: "Unknown".to_string(),
+        name: "HttpResponse".to_string(),
     };
     let key = backend_named_type_key(&ctx, &unresolved).expect("Named is Some");
     assert_eq!(
-        key, "Unknown",
-        "id: None should fall back to the source-faithful name"
+        key, "HttpResponse",
+        "types with no typed identity should fall back to the source-faithful name"
     );
 }
 

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -2642,6 +2642,186 @@ fn bad(d: Discount) -> Float
 }
 
 #[test]
+fn forward_declared_record_field_type_is_constructible() {
+    assert_no_errors(
+        r#"record Holder
+    item: Thing
+
+record Thing
+    value: Int
+
+fn value() -> Int
+    Holder(item = Thing(value = 1)).item.value
+"#,
+    );
+}
+
+#[test]
+fn forward_declared_types_resolve_at_all_three_member_sites() {
+    assert_no_errors(
+        r#"record Outer
+    items: List<Inner>
+
+type Wrapper
+    Wrap(Inner)
+    Nothing
+
+record Inner
+    value: Int
+
+fn makeOuter() -> Outer
+    Outer(items = [Inner(value = 1)])
+
+fn makeWrapper() -> Wrapper
+    Wrapper.Wrap(Inner(value = 2))
+"#,
+    );
+}
+
+#[test]
+fn type_def_order_does_not_change_the_check_result() {
+    let defs = [
+        "record Holder\n    item: Thing\n",
+        "type Wrapper\n    Wrap(Thing)\n    Nothing\n",
+        "record Thing\n    value: Int\n",
+    ];
+    for order in [
+        [0, 1, 2],
+        [0, 2, 1],
+        [1, 0, 2],
+        [1, 2, 0],
+        [2, 0, 1],
+        [2, 1, 0],
+    ] {
+        let src = format!(
+            "{}\n{}\n{}\nfn makeHolder() -> Holder\n    Holder(item = Thing(value = 1))\n\nfn makeWrapper() -> Wrapper\n    Wrapper.Wrap(Thing(value = 2))\n",
+            defs[order[0]], defs[order[1]], defs[order[2]]
+        );
+        let errs = errors(&src);
+        assert!(errs.is_empty(), "order {order:?} failed: {errs:?}");
+    }
+}
+
+#[test]
+fn dependency_module_internal_forward_reference_is_constructible() {
+    let root = temp_module_root("dep_forward_type");
+    std::fs::write(
+        root.join("Beta.av"),
+        r#"module Beta
+    exposes [Outer, Inner, mkOuter]
+    intent = "Build a forward-referencing record."
+
+record Outer
+    item: Inner
+
+record Inner
+    value: Int
+
+fn mkOuter(v: Int) -> Outer
+    Outer(item = Inner(value = v))
+"#,
+    )
+    .expect("write Beta.av failed");
+    let src = r#"module App
+    depends [Beta]
+    intent = "Use the dependency record."
+
+fn value() -> Int
+    Beta.mkOuter(3).item.value
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(errs.is_empty(), "expected no errors, got: {errs:?}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn opaque_dep_type_is_not_readable_through_a_forward_declared_local_record() {
+    let root = temp_module_root("opaque_forward_capture");
+    std::fs::write(
+        root.join("Discount.av"),
+        r#"module Discount
+    exposes [mkDiscount]
+    exposes opaque [Discount]
+    intent = "Opaque discount."
+
+record Discount
+    percent: Float
+
+fn mkDiscount(p: Float) -> Result<Discount, String>
+    Result.Ok(Discount(percent = p))
+"#,
+    )
+    .expect("write Discount.av failed");
+    let src = r#"module App
+    depends [Discount]
+    intent = "Keep dependency values opaque."
+
+record Holder
+    item: Discount
+
+record Discount
+    percent: Float
+
+fn bad() -> Float
+    match Discount.mkDiscount(50.0)
+        Result.Ok(d) -> Holder(item = d).item.percent
+        Result.Err(_) -> 0.0
+"#;
+    let errs = errors_with_base(src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Record 'Holder' field 'item'")),
+        "expected local/dependency type mismatch, got: {errs:?}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn embedded_stdlib_opaque_type_is_not_readable_through_a_forward_declared_local_record() {
+    let src = r#"module App
+    depends [Bytes]
+    intent = "Keep standard-library values opaque."
+
+record Holder
+    item: Bytes
+
+record Bytes
+    values: List<Int>
+
+fn bad() -> Int
+    match Bytes.fromHex("010203")
+        Result.Ok(b) -> List.len(Holder(item = b).item.values)
+        Result.Err(_) -> 0
+"#;
+    let errs = errors_with_base(src, env!("CARGO_MANIFEST_DIR"));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Record 'Holder' field 'item'")),
+        "expected local/stdlib type mismatch, got: {errs:?}"
+    );
+}
+
+#[test]
+fn locally_declared_type_cannot_enter_a_dependency_slot() {
+    let src = r#"module App
+    depends [Bytes]
+    intent = "Keep local values out of standard-library slots."
+
+record Bytes
+    values: List<Int>
+
+fn bad() -> String
+    Bytes.toHex(Bytes(values = [999, -1]))
+"#;
+    let errs = errors_with_base(src, env!("CARGO_MANIFEST_DIR"));
+    assert!(
+        errs.iter()
+            .any(|e| e.contains("Argument 1 of 'Bytes.toHex'")),
+        "expected dependency-slot type mismatch, got: {errs:?}"
+    );
+}
+
+#[test]
 fn opaque_type_usable_in_signatures() {
     let root = temp_module_root("opaque_sig");
     let pricing_dir = root.join("Pricing");
@@ -3262,6 +3442,61 @@ fn pick() -> Int
         errs.join("\n  ")
     );
 
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn local_type_declared_after_use_still_shadows_a_dependency_bare_name() {
+    let root = temp_module_root("local_type_shadows_dep");
+    std::fs::write(
+        root.join("Alpha.av"),
+        r#"module Alpha
+    exposes [Thing, mkThing]
+    intent = "Expose a dependency Thing."
+
+record Thing
+    tag: String
+
+fn mkThing(tag: String) -> Thing
+    Thing(tag = tag)
+"#,
+    )
+    .expect("write Alpha.av failed");
+    let local_src = r#"module App
+    depends [Alpha]
+    intent = "The local Thing shadows Alpha.Thing."
+
+record Holder
+    item: Thing
+
+record Thing
+    value: Int
+
+fn local() -> Holder
+    Holder(item = Thing(value = 1))
+"#;
+    let local_errs = errors_with_base(local_src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        local_errs.is_empty(),
+        "local construction should typecheck, got: {local_errs:?}"
+    );
+
+    let captured_src = format!(
+        "{local_src}\nfn captured() -> Holder\n    Holder(item = Alpha.mkThing(\"hello\"))\n"
+    );
+    let captured_errs = errors_with_base(&captured_src, root.to_str().expect("utf-8 temp dir"));
+    assert!(
+        captured_errs
+            .iter()
+            .any(|e| e.contains("Record 'Holder' field 'item'")),
+        "dependency value should be rejected, got: {captured_errs:?}"
+    );
+    assert!(
+        captured_errs
+            .iter()
+            .all(|e| !e.contains("Ambiguous type name 'Thing'")),
+        "local shadowing must not become ambiguity: {captured_errs:?}"
+    );
     let _ = std::fs::remove_dir_all(&root);
 }
 


### PR DESCRIPTION
Closes #818. Closes #816.

Type identity was resolved *during* the declaration walk that establishes it. `build_signatures` marked a type visible only inside its own registration call, so a member annotation naming a later sibling was canonicalised against an incomplete visibility set. Two faces, one cause.

**Fail-closed:** with no colliding name, the annotation stayed unresolved and construction was rejected with `expects T, got T` — that is #816.

**Fail-open:** when a dependency exposed the same bare name, the annotation was stamped with *that* type's identity while the field layout stayed local. A checker-clean program could read a dependency's opaque payload through a local record of the same name, `aver audit` reported zero errors, and it printed the private value.

## The fix

A pre-pass over every local `TypeDef` marks it visible before any member annotation is canonicalised, with bare-alias merging hoisted alongside for bookkeeping.

That is smaller than the issue originally described, and the correction matters. I claimed hoisting visibility alone would leave the capture intact because a dependency alias wins an ungated fallback. It does not: `resolve_type_id` tries the unqualified current-module and entry-scope lookups, both gated on visibility, *before* the ungated alias fallback. Once the local type is visible it wins outright, and the alias is never consulted. So the alias only won during the window the hoist closes.

**Shadowing is the established rule, not a new one.** Function parameters, return types and binding annotations have always had a local type shadow a dependency's same-named type — verified on the released binary. The declaration walk was the only place that disagreed, and this makes it agree. `resolved_named_type` needs no visibility gate: with the pre-pass, the member side and the return side resolve to the same local id, so the mixed-identity rejection stops firing by itself.

## Reproductions

| | before | after |
|---|---|---|
| forward-referenced record field, sum-variant field, constructor parameter | rejected, `expects T, got T` | constructs |
| dependency capture | checker-clean | rejected, local wins |
| opacity bypass on the embedded stdlib | check and audit clean, printed the private payload | rejected |
| reverse direction (local value forged into a dependency's refinement) | rejected | still rejected |

The wider-capture case that this issue reported as an out-of-bounds panic had already become a controlled runtime error on the current base, once the arena keying landed in #820. It is now rejected statically, before execution.

## Tests

Declaration-order permutation as a property across record fields, sum-variant fields and constructor parameters; a capture regression including the variant that needs no user-authored dependency (`depends [Bytes]` plus a local `record Bytes`); and the opacity invariant as a must-reject.

`tests/cross_module_type_keys.rs:160` asserted the bare-name fallback for an unresolved named type as required behaviour, using a synthetic name the symbol table never knew. It is restated around `HttpResponse`, a host type that is genuinely identity-less by design. An unresolved id on a user-source nominal type is now a resolution bug rather than a sanctioned fallback.

Full suite 2623 passed, 25 skipped. No certificate bytes, snapshots or generated files moved — checked deliberately, since this moves type stamps for member annotations.

## Residual

`expects T, got T` still appears, but only where two genuinely distinct types share a bare name — a real error rather than an ordering artefact. The message should name the declaring modules; that is a much smaller diagnostics change and belongs in its own issue.
