### PR TITLE
Skip the release test run when CI already ran it on this commit

### DIFF
--- a/tools/release.py
+++ b/tools/release.py
@@ -116,6 +116,63 @@ def run(
     return subprocess.run(cmd, cwd=cwd, check=check, env=env)
 
 
+def ci_verified_head() -> tuple[bool, str]:
+    """Whether CI already ran the test suite on exactly this commit.
+
+    Only the full `cargo test` run below is skippable this way, and only when
+    every workflow that gates `main` reported success for this exact SHA. The
+    other release checks stay unconditional: they cover paths CI does not run
+    at all, which is how three wasm-gc handler-mode bugs survived from 0.16 to
+    0.17.2. Any doubt resolves to running the tests — a slow release is
+    cheaper than an unverified one.
+
+    Expect this to decline during a run of merges: the workflows cancel each
+    other in progress, so a commit that was overtaken carries `cancelled`
+    rather than `success` and the tests run. Releasing from a settled `main`
+    is what makes it fire.
+    """
+    required = {"CI", "Proof", "Certification"}
+    try:
+        head = run(
+            ["git", "rev-parse", "HEAD"], capture=True, check=True
+        ).stdout.strip()
+        upstream = run(
+            ["git", "rev-parse", "origin/main"], capture=True, check=True
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False, "cannot read git refs"
+    if head != upstream:
+        return False, "HEAD is not origin/main"
+    try:
+        raw = run(
+            [
+                "gh",
+                "run",
+                "list",
+                "--commit",
+                head,
+                "--limit",
+                "50",
+                "--json",
+                "name,conclusion,status",
+            ],
+            capture=True,
+            check=True,
+        ).stdout
+        runs = json.loads(raw)
+    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+        return False, "cannot read CI results for this commit"
+    if any(r.get("status") != "completed" for r in runs):
+        return False, "CI is still running on this commit"
+    if any(r.get("conclusion") == "failure" for r in runs):
+        return False, "CI failed on this commit"
+    succeeded = {r["name"] for r in runs if r.get("conclusion") == "success"}
+    missing = required - succeeded
+    if missing:
+        return False, f"no successful run of {', '.join(sorted(missing))}"
+    return True, f"CI green on {head[:8]}"
+
+
 def current_version() -> str:
     text = (REPO_ROOT / "Cargo.toml").read_text()
     m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
@@ -1061,8 +1118,16 @@ def verify(dry_run: bool) -> None:
     # wasip2 codegen / component-model surface was never gated by the
     # release check. Enable both (they share `wasm-compile`) so the
     # wasip2_* suites actually run.
-    print("  verify: cargo test --features wasm,wasip2", flush=True)
-    run(["cargo", "test", "--features", "wasm,wasip2"])
+    skip_tests, why = ci_verified_head()
+    if skip_tests:
+        print(
+            f"  verify: cargo test --features wasm,wasip2 — SKIPPED ({why});"
+            " every other release check below still runs",
+            flush=True,
+        )
+    else:
+        print(f"  verify: cargo test --features wasm,wasip2 ({why})", flush=True)
+        run(["cargo", "test", "--features", "wasm,wasip2"])
 
     # Bench smoke. Runs every scenario in `bench/scenarios/` end-to-end on
     # the VM target — catches pipeline / VM regressions that the unit tests


### PR DESCRIPTION
The release gate re-ran the whole test suite serially, duplicating what CI had just finished across its lanes. That step now skips when the commit being released is exactly the one CI verified.

```
verify: cargo test --features wasm,wasip2 — SKIPPED (CI green on 1565c714); every other release check below still runs
```

The guard requires all of: `HEAD` equal to `origin/main`, every workflow for that SHA completed, none failed, and a successful run of each of CI, Proof and Certification. Anything else — a detached head, an unreachable `gh`, a run still in progress, a workflow cancelled by a later push — declines and the tests run. A slow release is cheaper than an unverified one.

Worth knowing when it will not fire: during a run of merges the workflows cancel each other in progress, so an overtaken commit carries `cancelled` rather than `success`. Releasing from a settled `main` is what makes it useful. That is documented on the function rather than left to be rediscovered.

## What is deliberately not skipped

**The bench and wasm-gc handler smokes.** CI does not run them at all. The comment already in the script records why: the 0.17.2 release surfaced three compounding wasm-gc handler-mode bugs that had lived since 0.16 because that path was only ever gated by a release.

**The per-crate publish verification.** It looks like the most redundant part of a release — five crates, five builds — but it builds the *packaged* crate rather than the worktree, which is the only thing that catches a file missing from the package. Both `Cargo.toml` files here carry `include`/`exclude` lists, and the two commits immediately before 0.28.0 were `Package the embedded stdlib and WIT definitions with aver-lang` and `Package only wall sources in aver-cert`. That class has bitten twice in a week; `--no-verify` would have caught neither.

**The two release builds of the compiler.** They look like a duplicate and are not: the playground rebuild runs between them and `wasm-pack` clobbers the native binary.
