### PR TITLE
Remove the Str alias for String

### DIFF
--- a/.claude/commands/aver-tooling.md
+++ b/.claude/commands/aver-tooling.md
@@ -43,7 +43,7 @@ It fails on:
 
 It is not a coverage tool.
 
-`--wasm-gc` (0.17.3+) executes the same cases via the wasm-gc backend instead of the VM — cross-target check that catches divergence between VM and wasm-gc codegen on equality. The host decodes a single Bool per case (wasm-gc lowers `==` per-type via eq_helpers natively). Failure diagnostics show the actual runtime value for primitive return types (Int/Float/Bool/Str). Trace projections (`.trace.*`), classified-effect Oracle stubs (`given X: Time = stub`), and case bodies mentioning `BranchPath` are rejected upfront with a pointer back to VM verify — those features depend on namespace-value dispatch and runtime override that the wasm-gc backend doesn't have yet.
+`--wasm-gc` (0.17.3+) executes the same cases via the wasm-gc backend instead of the VM — cross-target check that catches divergence between VM and wasm-gc codegen on equality. The host decodes a single Bool per case (wasm-gc lowers `==` per-type via eq_helpers natively). Failure diagnostics show the actual runtime value for primitive return types (Int/Float/Bool/String). Trace projections (`.trace.*`), classified-effect Oracle stubs (`given X: Time = stub`), and case bodies mentioning `BranchPath` are rejected upfront with a pointer back to VM verify — those features depend on namespace-value dispatch and runtime override that the wasm-gc backend doesn't have yet.
 
 ### Format
 

--- a/.claude/commands/aver.md
+++ b/.claude/commands/aver.md
@@ -37,7 +37,7 @@ xs: List<Int> = []
 
 ### Types
 
-Primitives: `Int`, `Float`, `String`, `Bool`, `Unit`
+Primitives: `Int`, `Float`, `String`, `Bool`, `Unit` — each has exactly one spelling; the string type is `String`, never abbreviated
 
 Compound:
 - `Result<T, E>`, `Option<T>`, `List<T>`, `Vector<T>`, `Map<K, V>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ## Unreleased
 
+### Changed
+
+- **Breaking: `Str` is no longer accepted as a spelling of `String`.** The string type has exactly one name, the way `Int`, `Float`, `Bool` and `Unit` each do. `Str` was an undocumented alias that `aver check` and the VM accepted but the wasm-gc backend did not, so `fn label() -> Str` checked, ran, and then failed to compile with `cannot lower type 'Str'`. Replace every `Str` in a type annotation with `String`.
+
 ### Fixed
 
 - **Type declarations are now order-independent within a file.** Record fields, sum-variant fields, and constructor parameters can name types declared later, and a local type consistently shadows a dependency exposing the same bare name, preventing dependency values from being read through an unrelated local record layout.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,7 +48,7 @@ It fails on:
 
 It is not a coverage tool.
 
-`--wasm-gc` (0.17.3+) executes the same cases via the wasm-gc backend instead of the VM — cross-target check that catches divergence between VM and wasm-gc codegen on equality. The host decodes a single Bool per case (wasm-gc lowers `==` per-type via eq_helpers natively). Failure diagnostics show the actual runtime value for primitive return types (Int/Float/Bool/Str). Trace projections (`.trace.*`), classified-effect Oracle stubs (`given X: Time = stub`), and case bodies mentioning `BranchPath` are rejected upfront with a pointer back to VM verify — those features depend on namespace-value dispatch and runtime override that the wasm-gc backend doesn't have yet.
+`--wasm-gc` (0.17.3+) executes the same cases via the wasm-gc backend instead of the VM — cross-target check that catches divergence between VM and wasm-gc codegen on equality. The host decodes a single Bool per case (wasm-gc lowers `==` per-type via eq_helpers natively). Failure diagnostics show the actual runtime value for primitive return types (Int/Float/Bool/String). Trace projections (`.trace.*`), classified-effect Oracle stubs (`given X: Time = stub`), and case bodies mentioning `BranchPath` are rejected upfront with a pointer back to VM verify — those features depend on namespace-value dispatch and runtime override that the wasm-gc backend doesn't have yet.
 
 ### Format
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -13,6 +13,8 @@ For Oracle laws and trace assertions over classified effects, see [oracle.md](or
 Primitive: `Int`, `Float`, `String`, `Bool`, `Unit`
 Compound: `Result<T, E>`, `Option<T>`, `List<T>`, `Vector<T>`, `Map<K, V>`, `(A, B, ...)`, `Fn(A) -> B`, `Fn(A) -> B ! [Effect]`
 
+Each primitive has exactly one spelling — the string type is written `String`, never abbreviated.
+
 There is no dedicated `Set` type — use `Map<T, Unit>` (see [Sets](#sets) below).
 User-defined sum types: `type Shape` → `Shape.Circle(Float)`, `Shape.Rect(Float, Float)`
 User-defined product types: `record User` → `User(name = "Alice", age = 30)`, `u.name`

--- a/docs/oracle.md
+++ b/docs/oracle.md
@@ -350,11 +350,11 @@ scenario" into "every scenario", which is not what the user wrote.
 
 **Value-side boundary sets:**
 
-- `Int`   → `0`, `1`, `-1`, `i64::MIN`, `i64::MAX`
-- `Float` → `0.0`, `1.0`, `-1.0`, `MIN`, `MAX`, `+/-Inf`, `NaN`
-- `Bool`  → both
-- `Str`   → `""`, `"a"`, 1024×`x`, `"\0"` (NUL embedded), multi-byte UTF-8
-- `Unit`  → `Unit`
+- `Int`    → `0`, `1`, `-1`, `i64::MIN`, `i64::MAX`
+- `Float`  → `0.0`, `1.0`, `-1.0`, `MIN`, `MAX`, `+/-Inf`, `NaN`
+- `Bool`   → both
+- `String` → `""`, `"a"`, 1024×`x`, `"\0"` (NUL embedded), multi-byte UTF-8
+- `Unit`   → `Unit`
 
 These augment the declared list — duplicates are dropped, so a value the
 user already wrote is not re-run.

--- a/src/codegen/cert/expr_fragment_from_mir.rs
+++ b/src/codegen/cert/expr_fragment_from_mir.rs
@@ -211,8 +211,12 @@ fn sym_ty_from_mir_name(ty: &str) -> Option<SymTy> {
         "Int" => Some(SymTy::Int),
         "Float" => Some(SymTy::Float),
         "Bool" => Some(SymTy::Bool),
-        // MIR carries the resolver type's Debug rendering: the source String
-        // type prints as `Str`.
+        // Two producers feed this function and they spell the string type
+        // differently. Signature types (`MirFn::return_type`, `MirParam::ty`)
+        // are the resolver `Type`'s Debug rendering, where `Type::Str` prints
+        // as `Str`. Record field types come from the wasm-gc registry, which
+        // keeps the annotation as written in the source — `String`. Neither
+        // arm is the removed `Str` surface alias, so neither can be dropped.
         "String" | "Str" => Some(SymTy::String),
         "" => None,
         other => {

--- a/src/codegen/lean/untranslate.rs
+++ b/src/codegen/lean/untranslate.rs
@@ -576,7 +576,7 @@ fn aver_type_name(v: &Value, ctx: &UntranslateCtx) -> Option<String> {
         return Some(match name {
             "Int" => "Int".to_string(),
             "Bool" => "Bool".to_string(),
-            "String" => "Str".to_string(),
+            "String" => "String".to_string(),
             "Nat" => match &ctx.peano {
                 Some(p) => p.type_name.clone(),
                 None => lean_dotted_to_aver("Nat"),
@@ -1088,10 +1088,32 @@ mod tests {
     }
 
     #[test]
+    fn a_lean_string_binder_names_the_aver_string_type() {
+        // A residual's given types are re-parsed as Aver type annotations when
+        // the candidate law is emitted and sample-checked, so the name here has
+        // to be a spelling the language accepts.
+        let claim = format!(
+            r#"{{"app":{{"fn":{{"const":"Eq"}},"args":[{{"const":"String"}},{{"app":{{"fn":{{"const":"f"}},"args":[{}]}}}},{}]}}}}"#,
+            var("s"),
+            var("s"),
+        );
+        let json = forall("s", r#"{"const":"String"}"#, &claim);
+        let g = untranslate_goal(&json).expect("in grammar");
+        assert_eq!(g.givens, vec![("s".to_string(), "String".to_string())]);
+        assert!(
+            crate::types::parse_type_str_strict(&g.givens[0].1).is_ok(),
+            "given type must parse as an Aver type annotation"
+        );
+    }
+
+    #[test]
     fn type_name_tokens_splits_containers() {
         assert_eq!(type_name_tokens("List<Nat>"), vec!["List", "Nat"]);
         assert_eq!(type_name_tokens("Nat"), vec!["Nat"]);
-        assert_eq!(type_name_tokens("Map<Str, Int>"), vec!["Map", "Str", "Int"]);
+        assert_eq!(
+            type_name_tokens("Map<String, Int>"),
+            vec!["Map", "String", "Int"]
+        );
     }
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -56,7 +56,7 @@ pub fn parse_type_str_strict(s: &str) -> Result<Type, String> {
     match s {
         "Int" => Ok(Type::Int),
         "Float" => Ok(Type::Float),
-        "String" | "Str" => Ok(Type::Str),
+        "String" => Ok(Type::Str),
         "Bool" => Ok(Type::Bool),
         "Unit" => Ok(Type::Unit),
         _ => {
@@ -135,7 +135,7 @@ pub fn parse_type_str(s: &str) -> Type {
     match s {
         "Int" => Type::Int,
         "Float" => Type::Float,
-        "String" | "Str" => Type::Str,
+        "String" => Type::Str,
         "Bool" => Type::Bool,
         "Unit" => Type::Unit,
         "" => Type::Invalid,
@@ -540,6 +540,17 @@ mod tests {
         );
         // Lowercase unknown types still fail
         assert!(parse_type_str_strict("integ").is_err());
+    }
+
+    #[test]
+    fn test_str_is_not_a_spelling_of_string() {
+        // `Str` used to be an alias for `String` that only the checker and the
+        // VM knew, so a program using it failed on the wasm-gc backend. It is
+        // now an ordinary undeclared type name in both parsers.
+        assert_eq!(parse_type_str_strict("Str").unwrap(), Type::named("Str"));
+        assert_eq!(parse_type_str("Str"), Type::named("Str"));
+        assert_eq!(parse_type_str_strict("String").unwrap(), Type::Str);
+        assert_eq!(parse_type_str("String"), Type::Str);
     }
 
     #[test]

--- a/tests/self_host_qualified_variant.rs
+++ b/tests/self_host_qualified_variant.rs
@@ -44,7 +44,7 @@ fn other() -> Shade
     ? "Hand out Light."
     Shade.Light
 
-fn label(s: Shade) -> Str
+fn label(s: Shade) -> String
     ? "Name the shade from inside the owning module."
     match s
         Shade.Dark -> "in:dark"
@@ -79,7 +79,7 @@ const ENTRY_SRC: &str = r#"module Main
     exposes [main]
     effects [Console.print]
 
-fn name(s: Palette.Shade) -> Str
+fn name(s: Palette.Shade) -> String
     ? "Name the shade from outside the owning module."
     match s
         Palette.Shade.Dark -> "out:dark"
@@ -89,7 +89,7 @@ verify name
     name(Palette.Shade.Dark) => "out:dark"
     name(Palette.Shade.Light) => "out:light"
 
-fn describe(t: Palette.Tone) -> Str
+fn describe(t: Palette.Tone) -> String
     ? "Describe a tone from outside the owning module, binding its fields."
     match t
         Palette.Tone.Solid(v) -> "out:solid:{v}"
@@ -129,7 +129,7 @@ type Shade
     Dark
     Light
 
-fn name(s: Shade) -> Str
+fn name(s: Shade) -> String
     ? "Name the local shade."
     match s
         Shade.Dark -> "local:dark"
@@ -162,7 +162,7 @@ type Shade
     Dark
     Light
 
-fn localName(s: Shade) -> Str
+fn localName(s: Shade) -> String
     ? "Name the local shade."
     match s
         Shade.Dark -> "local:dark"
@@ -172,7 +172,7 @@ verify localName
     localName(Shade.Dark) => "local:dark"
     localName(Shade.Light) => "local:light"
 
-fn depName(s: Palette.Shade) -> Str
+fn depName(s: Palette.Shade) -> String
     ? "Name the dependency's shade."
     match s
         Palette.Shade.Dark -> "dep:dark"

--- a/tools/website/llms-full.txt
+++ b/tools/website/llms-full.txt
@@ -79,7 +79,7 @@ It fails on:
 
 It is not a coverage tool.
 
-`--wasm-gc` (0.17.3+) executes the same cases via the wasm-gc backend instead of the VM — cross-target check that catches divergence between VM and wasm-gc codegen on equality. The host decodes a single Bool per case (wasm-gc lowers `==` per-type via eq_helpers natively). Failure diagnostics show the actual runtime value for primitive return types (Int/Float/Bool/Str). Trace projections (`.trace.*`), classified-effect Oracle stubs (`given X: Time = stub`), and case bodies mentioning `BranchPath` are rejected upfront with a pointer back to VM verify — those features depend on namespace-value dispatch and runtime override that the wasm-gc backend doesn't have yet.
+`--wasm-gc` (0.17.3+) executes the same cases via the wasm-gc backend instead of the VM — cross-target check that catches divergence between VM and wasm-gc codegen on equality. The host decodes a single Bool per case (wasm-gc lowers `==` per-type via eq_helpers natively). Failure diagnostics show the actual runtime value for primitive return types (Int/Float/Bool/String). Trace projections (`.trace.*`), classified-effect Oracle stubs (`given X: Time = stub`), and case bodies mentioning `BranchPath` are rejected upfront with a pointer back to VM verify — those features depend on namespace-value dispatch and runtime override that the wasm-gc backend doesn't have yet.
 
 ### Format
 

--- a/tools/website/llms.txt
+++ b/tools/website/llms.txt
@@ -94,7 +94,7 @@ xs: List<Int> = []
 
 ### Types
 
-Primitives: `Int`, `Float`, `String`, `Bool`, `Unit`
+Primitives: `Int`, `Float`, `String`, `Bool`, `Unit` — each has exactly one spelling; the string type is `String`, never abbreviated
 
 Compound:
 - `Result<T, E>`, `Option<T>`, `List<T>`, `Vector<T>`, `Map<K, V>`


### PR DESCRIPTION
Closes #853.

`Str` was the only type alias in the language: `String` and `Str` both parsed to the same type, and the Lean untranslator emitted the short one. No `.av` file in the repo used it — not in `examples/`, `stdlib/`, `self_hosted/`, `projects/`, `challenges/`, `proof-corpus/`, `tests/`, `bench/` or `recordings/` — and the editor grammars and `editors/keywords.json` already listed only `String`.

`String` is now the only spelling. `docs/language.md` states that each primitive has exactly one.

## Two sites that needed judgement

**The Lean untranslator was emitting the alias** (`untranslate.rs:579`), so a proof round-trip could hand back a type name the docs never mention. Nothing consumed it: `synth_domain` declines on any string binder either way, and `lemma_calc::rebuild_givens` does not inspect type names. Latent, not contractual — it now emits `String`.

**`expr_fragment_from_mir.rs:216` keeps both arms**, and this is deliberate. The two are fed by different producers:

- `MirFn::return_type` and `MirParam::ty` are built with `format!("{:?}", …)` over the resolver `Type` (`ir/mir/lower.rs:246`, `:231`), so `Type::Str` arrives as `"Str"`. The sibling `Option(…)` / `Result(…, …)` arms in the same function are Debug renderings too, which is the tell.
- Record field types come from the wasm-gc registry, which preserves the source annotation and so supplies `"String"`.

Neither is the surface alias, and dropping either would have broken a live path silently. The comment there now names which producer supplies which.

## What a stale `Str` says now

```
error[type-error]: Function 'label': body returns String but declared return type is Str
  6 | fn label() -> Str
    |               ^^^  declared Str
  8 |     "hello"
    |     ^^^^^^^  returns String
```

Parameter, binding-annotation and record-field positions each give the same shape. All fail `aver check`.

## A gap this surfaced but does not close

`Str` now behaves exactly like any other undeclared type name — `Str` and `Wibble` are indistinguishable in every position. That includes two positions where **neither** is caught:

- a phantom type used only against itself (`fn twice(s: Str) -> Str`, never confronted with a real string) passes `aver check` and only fails on wasm-gc;
- `given s: Str = ["a", "b"]` in a law passes both `aver check` and `aver verify`.

`parse_type_str_strict` accepts any capitalised identifier as `Type::named(s)`, so an unknown name never reaches an unknown-type path. The principled fix is to resolve `Type::Named` against declared types, which touches every undeclared-name diagnostic across return types, parameters, bindings, record fields and law givens — filed separately rather than smuggled in here. Special-casing the literal string `"Str"` in the parser was rejected: it bakes a deny-list of a removed alias into the parser and would make `record Str` — legal today, like any capitalised name — unwritable.

## Verification

- `cargo fmt --all --check` clean; clippy clean at `-D warnings` for the workspace, for `aver-lang --lib --bin aver`, and again with `--features wasm,wasip2`.
- `cargo nextest run --workspace`: 2651 passed, 0 failed.
- `cargo nextest run -p aver-lang --lib --features wasm,wasip2`: 1060 passed.
- Full wasm + wasip2 lane list, all 32 named binaries at `PROPTEST_CASES=64`: 466 passed, 0 failed.
- Behaviour probe: `-> String` checks, runs on the VM and runs under `--wasm-gc`, matching pre-change behaviour; `-> Str` exits 1 at `aver check`.

New tests land in existing files (`types::tests::test_str_is_not_a_spelling_of_string`, `untranslate::tests::a_lean_string_binder_names_the_aver_string_type`), so the hand-maintained wasm test-name list in `.github/workflows/ci.yml` is untouched.
