### PR TITLE
Charge oracle call indices in evaluation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 - **Every rejected operator now names the function that replaces it.** Writing `a ^ b` reported `Unknown character: '^'`, which tells you nothing about `Bits.xor` — so a deliberate design choice read as a gap. `^`, `&`, `&&`, `|`, `||`, `~`, `%`, `<<` and `>>` now each report what they are and what to use instead, carrying the `rejected-operator` slug and a repair that spells out the call. `/` on `Int` already did this and is unchanged. Nested generics (`Map<String, List<Int>>`) and ordinary comparisons are unaffected — the shift diagnostic only fires on two adjacent `<` or `>` in operator position, which a type annotation never reaches.
 
+### Fixed
+
+- **A law over an effect call nested inside another effect call's arguments is provable again.** `Random.int(1, Random.int(2, 6))` ran one way and exported a proof about the other: the run charges the inner read the first oracle index and the outer read the second, but the export numbered them the other way round. Nothing said so. The law that matched the run passed `aver verify` and then `aver proof --check` refuted it in Lean, while the law that matched the export failed `verify` — so a correct program was simply unprovable and each tool pointed at the other. Oracle indices are now assigned in evaluation order on both sides. Laws that only read effects one at a time, or read them in separate statements, were never affected and their exported proofs are unchanged.
+
 ### Changed
 
 - **A module named `Bits` can no longer define a function named `and`, `or`, `xor`, `not`, `shiftLeft`, `shiftRight` or `low`.** This is the existing rule for every builtin namespace — a module named `Bool` has never been able to define `fn and` — now extended to seven more names. A project-local `Bits` module still shadows the namespace for any *other* function name; only a direct collision is rejected, with the same "already defined in this module" diagnostic.

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -4250,3 +4250,57 @@ verify a law aAdvances
         "a clique reaching a sub-parser with no universal advance law must decline"
     );
 }
+
+#[test]
+fn generative_call_nested_in_args_gets_the_higher_oracle_index() {
+    // Regression — the lifted proof must charge oracle call indices in the
+    // order the VM charges them.
+    //
+    // The VM evaluates a call's arguments eagerly and only then takes its
+    // oracle coordinates (`dispatch_oracle_stub` receives already-evaluated
+    // args and calls `take_oracle_coordinates()` afterwards), so a generative
+    // call nested inside the arguments consumes the LOWER index. Pre-fix the
+    // lifter did the opposite: it claimed its own counter before lifting its
+    // arguments, so `Random.int(1, Random.int(2, 6))` exported as
+    // `rnd path 0 1 (rnd path 1 2 6)` while the run answered as
+    // `rnd path 1 1 (rnd path 0 2 6)`.
+    //
+    // The inversion was invisible at both ends and fail-closed in both
+    // directions: the law that held at runtime exported a theorem
+    // `native_decide` refutes, and the law matching the export failed
+    // `verify`. A correct program was simply unprovable. See the VM half of
+    // this invariant in tests/regression_oracle_counter_order.rs.
+    let mut ctx = ctx_from_source(
+        r#"module CounterOrder
+    intent = "Oracle indices must be charged in evaluation order."
+    effects [Random]
+
+fn indexStub(path: BranchPath, n: Int, min: Int, max: Int) -> Int
+    ? "Returns the call index so the oracle coordinate is observable."
+    n
+
+fn nested() -> Int
+    ? "Outer Random.int whose upper bound is itself a Random.int."
+    ! [Random.int]
+    Random.int(1, Random.int(2, 6))
+
+verify nested law indexOrder
+    given rnd: Random.int = [indexStub]
+    nested() => 1
+"#,
+        "counter_order",
+    );
+    let out = transpile(&mut ctx);
+    let lean = generated_lean_file(&out);
+
+    assert!(
+        lean.contains("rnd_Random_int path 1 1 (rnd_Random_int path 0 2 6)"),
+        "the nested generative call must take index 0 and the surrounding one index 1, \
+         matching the VM's eager argument evaluation; emitted body was:\n{lean}"
+    );
+    assert!(
+        !lean.contains("rnd_Random_int path 0 1 (rnd_Random_int path 1 2 6)"),
+        "inverted oracle indices are back — the lifter is claiming its counter before \
+         lifting its own arguments again"
+    );
+}

--- a/src/types/checker/effect_lifting.rs
+++ b/src/types/checker/effect_lifting.rs
@@ -720,6 +720,17 @@ fn lift_classified_call(
                     .ok_or_else(|| LiftError::MissingOracle {
                         method: effect_name.to_string(),
                     })?;
+            // Lift the arguments BEFORE claiming this call's counter. The VM
+            // evaluates arguments eagerly and only then takes its oracle
+            // coordinates, so a generative call nested inside the arguments
+            // consumes the LOWER index and the surrounding call the higher one
+            // (`Random.int(1, Random.int(2, 6))` charges the inner read first).
+            // Claiming this call's counter first inverted the two, and the
+            // inversion is invisible: a law that holds at runtime then exports a
+            // theorem the kernel refutes, while the law matching the export
+            // fails `verify`. Same hazard the Output arm above documents, in the
+            // opposite direction.
+            let lifted_args = lift_args(args, cfg, path_expr, counter)?;
             let current_counter = *counter;
             *counter += 1;
             let path_arg = path_expr.clone();
@@ -728,7 +739,7 @@ fn lift_classified_call(
                 original.line,
             );
             let mut new_args = vec![path_arg, counter_arg];
-            new_args.extend(lift_args(args, cfg, path_expr, counter)?);
+            new_args.extend(lifted_args);
             Ok(Expr::FnCall(
                 Box::new(Spanned::new(
                     Expr::Ident(oracle_name.clone()),

--- a/tests/regression_oracle_counter_order.rs
+++ b/tests/regression_oracle_counter_order.rs
@@ -1,0 +1,67 @@
+//! Regression — the VM half of the oracle call-index ordering invariant.
+//!
+//! The VM evaluates a call's arguments eagerly and only then takes its oracle
+//! coordinates, so a generative call nested inside the arguments consumes the
+//! LOWER index and the surrounding call the higher one. The lifted proof must
+//! charge indices in that same order.
+//!
+//! Pre-fix the lifter claimed its own counter before lifting its arguments, so
+//! `Random.int(1, Random.int(2, 6))` exported as `rnd path 0 1 (rnd path 1 2 6)`
+//! while the run answered as if it were `rnd path 1 1 (rnd path 0 2 6)`. The
+//! two never agreed, and the disagreement was fail-closed in both directions:
+//! the law that held at runtime exported a theorem `native_decide` refutes, and
+//! the law matching the export failed `verify`. A correct program was simply
+//! unprovable.
+//!
+//! This test pins the runtime side. The exported side is pinned by
+//! `generative_call_nested_in_args_gets_the_higher_oracle_index` in
+//! src/codegen/lean/tests.rs — both halves have to move together or the two
+//! interpreters diverge again.
+
+use aver::diagnostics::vm_verify::run_verify_for_items_vm_with_mode;
+use aver::source::parse_source;
+use aver::verify_law::expand::ExpansionMode;
+
+/// `indexStub` returns the oracle call index it was handed, which makes the
+/// coordinate observable in the law's value. With arguments evaluated first the
+/// inner read is charged 0 and the outer read 1, so `nested()` is 1.
+const SRC: &str = r#"module CounterOrder
+    intent = "Oracle indices must be charged in evaluation order."
+    effects [Random]
+
+fn indexStub(path: BranchPath, n: Int, min: Int, max: Int) -> Int
+    ? "Returns the call index so the oracle coordinate is observable."
+    n
+
+fn nested() -> Int
+    ? "Outer Random.int whose upper bound is itself a Random.int."
+    ! [Random.int]
+    Random.int(1, Random.int(2, 6))
+
+verify nested law indexOrder
+    given rnd: Random.int = [indexStub]
+    nested() => 1
+"#;
+
+#[test]
+fn vm_charges_the_nested_generative_call_the_lower_oracle_index() {
+    let items = parse_source(SRC).unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+    let results = run_verify_for_items_vm_with_mode(
+        items,
+        None,
+        Some(env!("CARGO_MANIFEST_DIR")),
+        "regression_oracle_counter_order.av",
+        ExpansionMode::Declared,
+    )
+    .expect("verify run");
+
+    assert_eq!(results.len(), 1, "one verify block");
+    let result = &results[0];
+    assert_eq!(
+        (result.passed, result.failed),
+        (1, 0),
+        "the outer generative call must observe index 1 — if this reports actual 0, the VM \
+         started taking its oracle coordinates before evaluating arguments and the lifter's \
+         ordering (src/types/checker/effect_lifting.rs, Generative arm) has to follow"
+    );
+}


### PR DESCRIPTION
Found while mapping the effect classification tables for #864 — unrelated to that design, and independently landable.

## What was wrong

`Random.int(1, Random.int(2, 6))` ran one way and exported a proof about the other.

The VM evaluates a call's arguments before taking its oracle coordinates, so the nested read is charged index 0 and the surrounding read index 1. The lifter claimed its own counter first and lifted its arguments afterwards, producing the opposite assignment.

Reproduced with a stub that returns the call index it is handed, which makes the coordinate observable in the law's value:

```
fn indexStub(path: BranchPath, n: Int, min: Int, max: Int) -> Int
    n

fn nested() -> Int
    ! [Random.int]
    Random.int(1, Random.int(2, 6))
```

| | before | after |
|---|---|---|
| `aver verify` | `nested() = 1` | `nested() = 1` |
| emitted Lean | `rnd path 0 1 (rnd path 1 2 6)` → `0` | `rnd path 1 1 (rnd path 0 2 6)` → `1` |

## Why nothing caught it

It was fail-closed in both directions, which is why it was survivable and also why it was invisible.

Writing the law that holds at runtime (`nested() => 1`) passed `aver verify` and then failed the kernel:

```
error: Tactic `native_decide` evaluated that the proposition
  nested BranchPath.Root indexStub = 1
is false
```

Writing the law that matches the export (`nested() => 0`) failed `aver verify` instead. Neither tool can be green at the same time as the other, so no false proof was ever certified — but a correct program was simply unprovable, with each tool pointing at the other.

## The fix

The generative arm lifts its arguments before claiming its counter. That is the order the output arm directly above it already documents for the same hazard: it walks its arguments precisely so nested reads advance the counter the way the run does. The generative arm had the same flaw in the opposite direction.

## Tests

Both halves of the invariant are pinned, because they have to move together — the bug is exactly the two halves disagreeing:

- `generative_call_nested_in_args_gets_the_higher_oracle_index` (`src/codegen/lean/tests.rs`) pins the emitted index assignment.
- `tests/regression_oracle_counter_order.rs` pins the runtime one.

Green locally: 1002 lib, 766 across `proof_spec` / `typechecker_spec` / `eval_spec`. `lake` was present, so the `proof_export_builds_*` tests ran the kernel rather than skipping.

Laws that read effects one at a time, or in separate statements, were never affected and their exported proofs are byte-identical.
