### PR TITLE
Derive the classified-effect list the diagnostic prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **The error that lists which effects `verify law` can cover now lists all of them.** Writing a law over an effect outside the proof subset reports what that subset contains — and the sentence naming it was maintained by hand and had fallen thirteen effects behind, among them `Terminal.size`, `Env.set`, `Tcp.connect` and every byte-carrying `Tcp` method. `Terminal.size` was missing while `examples/formal/terminal_size_snapshot.av` shipped as a worked example of proving over it, so the diagnostic told you a supported effect was unsupported. The list is now derived from the same table the checker enforces, and grouped by namespace, so it cannot fall behind again.
+
 - **A law over an effect call nested inside another effect call's arguments is provable again.** `Random.int(1, Random.int(2, 6))` ran one way and exported a proof about the other: the run charges the inner read the first oracle index and the outer read the second, but the export numbered them the other way round. Nothing said so. The law that matched the run passed `aver verify` and then `aver proof --check` refuted it in Lean, while the law that matched the export failed `verify` — so a correct program was simply unprovable and each tool pointed at the other. Oracle indices are now assigned in evaluation order on both sides. Laws that only read effects one at a time, or read them in separate statements, were never affected and their exported proofs are unchanged.
 
 ### Changed

--- a/src/types/checker/effect_classification.rs
+++ b/src/types/checker/effect_classification.rs
@@ -21,7 +21,16 @@
 //! - Rejection diagnostics for unclassified effects.
 //!
 //! Source of runtime signatures: `src/services/*.rs` and `docs/services.md`.
-//! Keep this table synchronized with the real built-ins.
+//!
+//! The parameter and return types below are cross-checked against the
+//! signatures `builtins.rs` actually registers — see
+//! `every_classified_entry_matches_the_registered_builtin_signature`. The
+//! agreement used to rest on a comment asking the reader to keep the two in
+//! sync, and that had already failed: `Console.print` carried a printable type
+//! variable here for twelve minor releases after 0.16 gave it a plain string.
+//! What is still hand-authored, and cannot be derived, is the DIMENSION —
+//! `FnSig` records no such thing, so adding an effect to `builtins.rs` still
+//! means deciding here how a proof is allowed to model it.
 
 use super::super::Type;
 use crate::types::branch_path;
@@ -567,6 +576,48 @@ pub fn oracle_signature(method: &str) -> Option<Type> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_classified_entry_matches_the_registered_builtin_signature() {
+        // This table and `builtins.rs` describe the same effects twice: the
+        // table for the proof pipeline, `builtins.rs` for the checker. Keeping
+        // them in agreement was a comment ("Keep this table synchronized with
+        // the real built-ins") and nothing else, and it had already failed —
+        // `Console.print` carried a printable type variable here for twelve
+        // minor releases after 0.16 made it take a plain string.
+        //
+        // It survived that long because the drifted field is unreachable for
+        // output-dimension effects, so nothing downstream ever read it. The
+        // next drift need not be so lucky, hence a mechanical cross-check
+        // rather than a stricter comment.
+        let items = crate::source::parse_source(
+            "module TableCrossCheck\n    intent = \"Cross-check the classification table against the registered builtins.\"\n",
+        )
+        .expect("the cross-check module must parse");
+        let checked = super::super::run_type_check_full(&items, None);
+
+        for c in CLASSIFICATIONS {
+            let (params, ret, _) = checked.fn_sigs.get(c.method).unwrap_or_else(|| {
+                panic!(
+                    "{} is classified for proof but no builtin of that name is registered",
+                    c.method
+                )
+            });
+            let expected_params: Vec<Type> =
+                c.runtime_params.iter().copied().map(runtime_type).collect();
+            assert_eq!(
+                params, &expected_params,
+                "{} takes different parameters here than builtins.rs registers",
+                c.method
+            );
+            assert_eq!(
+                ret,
+                &runtime_type(c.runtime_return),
+                "{} returns something different here than builtins.rs registers",
+                c.method
+            );
+        }
+    }
 
     #[test]
     fn summary_names_every_classified_method() {

--- a/src/types/checker/effect_classification.rs
+++ b/src/types/checker/effect_classification.rs
@@ -58,7 +58,6 @@ pub struct EffectClassification {
 /// Converted into [`Type`] on demand via [`runtime_type`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RuntimeType {
-    FormattedValue,
     Unit,
     Int,
     Float,
@@ -89,7 +88,6 @@ pub enum RuntimeType {
 impl RuntimeType {
     fn as_type(self) -> Type {
         match self {
-            RuntimeType::FormattedValue => Type::Var("FormattedValue".to_string()),
             RuntimeType::Unit => Type::Unit,
             RuntimeType::Int => Type::Int,
             RuntimeType::Float => Type::Float,
@@ -357,19 +355,19 @@ const CLASSIFICATIONS: &[EffectClassification] = &[
     EffectClassification {
         method: "Console.print",
         dimension: EffectDimension::Output,
-        runtime_params: &[RuntimeType::FormattedValue],
+        runtime_params: &[RuntimeType::Str],
         runtime_return: RuntimeType::Unit,
     },
     EffectClassification {
         method: "Console.error",
         dimension: EffectDimension::Output,
-        runtime_params: &[RuntimeType::FormattedValue],
+        runtime_params: &[RuntimeType::Str],
         runtime_return: RuntimeType::Unit,
     },
     EffectClassification {
         method: "Console.warn",
         dimension: EffectDimension::Output,
-        runtime_params: &[RuntimeType::FormattedValue],
+        runtime_params: &[RuntimeType::Str],
         runtime_return: RuntimeType::Unit,
     },
     EffectClassification {
@@ -393,7 +391,7 @@ const CLASSIFICATIONS: &[EffectClassification] = &[
     EffectClassification {
         method: "Terminal.print",
         dimension: EffectDimension::Output,
-        runtime_params: &[RuntimeType::FormattedValue],
+        runtime_params: &[RuntimeType::Str],
         runtime_return: RuntimeType::Unit,
     },
     EffectClassification {
@@ -466,6 +464,50 @@ pub fn is_classified(method: &str) -> bool {
     classify(method).is_some()
 }
 
+/// Render the classified set as a namespace-grouped list for diagnostics:
+/// `Args.get, Console.error/.print/.readLine/.warn, Disk.appendText/…`.
+///
+/// Derived from [`CLASSIFICATIONS`] so a message that tells the user which
+/// effects the proof subset covers can never name a different set than the
+/// one the checker enforces. The hand-written version of this sentence had
+/// drifted to 34 of the 47 methods — `Terminal.size` was missing from it
+/// while `examples/formal/terminal_size_snapshot.av` demonstrated it.
+///
+/// Namespaces and methods are both sorted, so the rendering does not depend
+/// on the order of the table and cannot change when an entry is moved.
+pub fn classified_effects_summary() -> String {
+    use std::collections::BTreeMap;
+
+    let mut grouped: BTreeMap<&'static str, Vec<&'static str>> = BTreeMap::new();
+    for c in CLASSIFICATIONS {
+        let (namespace, method) = match c.method.split_once('.') {
+            Some(parts) => parts,
+            // Every classified effect is `Namespace.method`; a bare name has
+            // no namespace to group under, so it stands on its own.
+            None => (c.method, ""),
+        };
+        grouped.entry(namespace).or_default().push(method);
+    }
+
+    grouped
+        .into_iter()
+        .map(|(namespace, mut methods)| {
+            methods.sort_unstable();
+            methods.dedup();
+            let mut rendered = String::from(namespace);
+            for (index, method) in methods.iter().enumerate() {
+                if method.is_empty() {
+                    continue;
+                }
+                rendered.push_str(if index == 0 { "." } else { "/." });
+                rendered.push_str(method);
+            }
+            rendered
+        })
+        .collect::<Vec<String>>()
+        .join(", ")
+}
+
 /// Opaque types that are runtime handles (id + connection metadata),
 /// not domain-invariant smart-constructor types. These may be fabricated
 /// inside verify-trace context so that Oracle stubs can return them
@@ -525,6 +567,25 @@ pub fn oracle_signature(method: &str) -> Option<Type> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn summary_names_every_classified_method() {
+        // The diagnostic that tells a user which effects the proof subset
+        // covers is derived from this table, so it cannot name a smaller set
+        // than the checker enforces. The hand-written sentence it replaced had
+        // drifted to 34 of the 47 methods.
+        let summary = classified_effects_summary();
+        for c in CLASSIFICATIONS {
+            let (namespace, method) = c.method.split_once('.').expect("dotted effect name");
+            let grouped = format!("/.{method}");
+            let leading = format!("{namespace}.{method}");
+            assert!(
+                summary.contains(&leading) || summary.contains(&grouped),
+                "{} is classified but missing from the diagnostic summary:\n{summary}",
+                c.method
+            );
+        }
+    }
 
     #[test]
     fn classify_returns_none_for_unknown() {

--- a/src/types/checker/flow.rs
+++ b/src/types/checker/flow.rs
@@ -346,14 +346,12 @@ impl TypeChecker {
                              {effects}. These effects are ambient state, protocol/session state, modal \
                              terminal state, or higher-order callbacks and cannot be lifted to pure form. \
                              Use 'aver record' / 'aver replay' for deterministic reproduction. \
-                             Oracle v1's classified effects: Args.get, Env.get, Console.readLine, \
-                             Random.int/.float, Time.now/.unixMs/.sleep, Disk.readText/.exists/.listDir/\
-                             .writeText/.appendText/.delete/.deleteDir/.makeDir, Http.get/.head/.delete/\
-                             .post/.put/.patch, Tcp.send/.ping, Console.print/.error/.warn, \
-                             Terminal.clear/.moveTo/.print/.readKey/.hideCursor/.showCursor/.flush.",
+                             Oracle v1's classified effects: {classified}.",
                             kind_label = kind_label,
                             fn_name = vb.fn_name,
                             effects = unclassified_effects.join(", "),
+                            classified =
+                                super::effect_classification::classified_effects_summary(),
                         ),
                     );
                 }


### PR DESCRIPTION
Falls out of the effect-table mapping for #864. Independent of #867 and of any capability design — these are things that are wrong today, plus a guard so they cannot come back.

## The diagnostic had fallen thirteen effects behind

Writing a `verify law` over an effect outside the proof subset reports which effects the subset *does* cover. That sentence was written by hand, and diffing it against the table the checker enforces gives 34 of 47:

```
Env.set
Tcp.close  Tcp.connect  Tcp.readLine  Tcp.writeLine
Tcp.readBytes  Tcp.sendBytes  Tcp.writeBytes
Terminal.size  Terminal.setColor  Terminal.resetColor
Terminal.enableRawMode  Terminal.disableRawMode
```

`Terminal.size` is the sharpest one: `examples/formal/terminal_size_snapshot.av` ships as a worked example of proving over it, so the diagnostic named a supported effect as unsupported — while refusing the user's program in the same sentence.

It now renders from the table, grouped by namespace and sorted, so it depends on neither the table's order nor anyone's memory. `summary_names_every_classified_method` asserts every classified method appears.

## `FormattedValue` was dead since 0.16

`RuntimeType::FormattedValue` mapped to `Type::Var("FormattedValue")` for `Console.print`, `Console.error`, `Console.warn` and `Terminal.print` — a leftover from before `printable_var` was retired in 0.16 and those became `String`. `builtins.rs` has registered `&[Type::Str]` ever since.

It never surfaced because the field is unreachable for exactly those four rows: `oracle_signature` returns `None` for output-dimension effects before it reads any parameter, and `runtime_params` has no consumer outside the module. The other eleven output rows agree with `builtins.rs`, so this was a bounded class rather than a general problem.

## The agreement is now a test, not a request

The table's doc comment said "Keep this table synchronized with the real built-ins". That is the whole mechanism that was supposed to prevent the above, and it had already failed for twelve minor releases.

`every_classified_entry_matches_the_registered_builtin_signature` now asserts that every classified method is registered, with the same parameters and the same return type. I checked it fails rather than merely passes: flipping `Disk.exists` from `Str` to `Int` produces

```
assertion `left == right` failed: Disk.exists takes different parameters here
than builtins.rs registers
```

and reverting turns it green again.

The **dimension** stays hand-authored, because it cannot be derived — a function signature records no such thing. Adding an effect to `builtins.rs` still means deciding here how a proof may model it, and the module doc now says which half is enforced and which half is a judgement call.

## Tests

- 1003 lib
- 771 across `proof_spec` / `typechecker_spec` / `eval_spec` / `cli_diagnostic_render_spec`
- `cargo check --workspace --all-targets`: 0 errors across 8 crates — the removed variant was `pub`, so `aver-lsp` and `aver-cert` are covered

No emitted proof output changes: the diagnostic is not part of any artifact, and the four touched parameter lists are not read on any path that reaches an oracle signature.
