### PR TITLE
Retry the CI downloads that fail on a transient 503

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -150,16 +150,31 @@ jobs:
           fi
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
+      - name: Cache wasm-tools
+        id: cache-wasm-tools
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/wasm-tools
+          key: wasm-tools-${{ runner.os }}-1.246.2
+
       - name: Install wasm-tools
-        # Only the decode differential suite shells out to `wasm-tools print`
-        # (tools/certkit/decode_ref.py); harmless to install for the others.
-        if: matrix.suite == 'cert_decode_spec'
+        # Retrying was not enough on its own: a run burned all six attempts
+        # over ninety seconds against a releases CDN that stayed down for
+        # longer than that. A pinned binary does not need re-fetching every
+        # run, so the cache above removes the download from the common path
+        # and the retry only covers a genuine cache miss.
+        if: steps.cache-wasm-tools.outputs.cache-hit != 'true'
         run: |
+          mkdir -p "$HOME/.local/bin"
           curl -sSfL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o /tmp/wasm-tools.tar.gz \
             https://github.com/bytecodealliance/wasm-tools/releases/download/v1.246.2/wasm-tools-1.246.2-x86_64-linux.tar.gz
           tar -xzf /tmp/wasm-tools.tar.gz -C /tmp
-          sudo mv /tmp/wasm-tools-1.246.2-x86_64-linux/wasm-tools /usr/local/bin/wasm-tools
-          wasm-tools --version
+          mv /tmp/wasm-tools-1.246.2-x86_64-linux/wasm-tools "$HOME/.local/bin/wasm-tools"
+
+      - name: Put wasm-tools on PATH
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/wasm-tools" --version
 
       - name: Verify pinned `lake` reachable
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,8 @@ jobs:
         env:
           BINARYEN_VERSION: version_129
         run: |
-          curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" -o binaryen.tar.gz
+          curl -fsSL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
+            "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" -o binaryen.tar.gz
           tar -xzf binaryen.tar.gz
           echo "$PWD/binaryen-${BINARYEN_VERSION}/bin" >> "$GITHUB_PATH"
           test -x "$PWD/binaryen-${BINARYEN_VERSION}/bin/wasm-merge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,17 +129,33 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Cache binaryen
+        id: cache-binaryen
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/binaryen
+          key: binaryen-${{ runner.os }}-version_129
+
       - name: Install WASM tools
+        # A pinned release does not change between runs, so the download only
+        # has to happen on a cache miss. Retrying alone was not enough: one run
+        # spent all six attempts against a releases CDN that was down for
+        # longer than the retry window.
         env:
           BINARYEN_VERSION: version_129
         run: |
-          curl -fsSL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
-            "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" -o binaryen.tar.gz
-          tar -xzf binaryen.tar.gz
-          echo "$PWD/binaryen-${BINARYEN_VERSION}/bin" >> "$GITHUB_PATH"
-          test -x "$PWD/binaryen-${BINARYEN_VERSION}/bin/wasm-merge"
-          test -x "$PWD/binaryen-${BINARYEN_VERSION}/bin/wasm-opt"
-          test -x "$PWD/binaryen-${BINARYEN_VERSION}/bin/wasm-metadce"
+          if [ ! -x "$HOME/.local/binaryen/bin/wasm-opt" ]; then
+            curl -fsSL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
+              "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-x86_64-linux.tar.gz" -o binaryen.tar.gz
+            tar -xzf binaryen.tar.gz
+            mkdir -p "$HOME/.local"
+            rm -rf "$HOME/.local/binaryen"
+            mv "binaryen-${BINARYEN_VERSION}" "$HOME/.local/binaryen"
+          fi
+          echo "$HOME/.local/binaryen/bin" >> "$GITHUB_PATH"
+          test -x "$HOME/.local/binaryen/bin/wasm-merge"
+          test -x "$HOME/.local/binaryen/bin/wasm-opt"
+          test -x "$HOME/.local/binaryen/bin/wasm-metadce"
 
       - name: Clippy (wasm + wasip2)
         run: cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -55,9 +55,21 @@ jobs:
         # a different `lean-toolchain` still trigger elan to fetch the
         # matching version on first `lake build`.
         run: |
-          curl -sSfL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
-            https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --default-toolchain stable
+          # `curl | sh` hides a failing curl behind a shell that succeeds on
+          # empty input, so the retry below could not see it without this.
+          set -o pipefail
+          # elan's own download of the toolchain tarball runs its own curl
+          # with no retry, so flags on the installer fetch do not cover it.
+          # A transient 503 from the releases CDN therefore failed the job
+          # outright; retry the whole install instead.
+          for attempt in 1 2 3 4; do
+            if curl -sSfL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 \
+                 https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+                 | sh -s -- -y --default-toolchain stable; then break; fi
+            if [ $attempt -eq 4 ]; then exit 1; fi
+            echo "elan install failed (attempt $attempt), retrying in 20s"
+            sleep 20
+          done
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Verify `lake` reachable

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -72,19 +72,32 @@ jobs:
           done
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
-      - name: Verify `lake` reachable
-        # The first lake/lean invocation lazily fetches the pinned toolchain
-        # from releases.lean-lang.org; that download has no built-in retry and
-        # times out on transient network blips (the same failure mode the
-        # Dafny arm already hardens against with `curl --retry`). Retry the
-        # toolchain materialization a few times before failing the job.
+      - name: Verify `lake` reachable and materialize the pinned toolchain
+        # The first lake/lean invocation lazily fetches a toolchain from
+        # releases.lean-lang.org; that download has no built-in retry and fails
+        # on transient network blips (the same failure mode the Dafny arm
+        # already hardens against with `curl --retry`).
+        #
+        # `lake --version` only warms the *default* toolchain that elan was
+        # installed with. The reserved-token probe below runs Lean at the
+        # version pinned for the certificate wall, and that one was still being
+        # fetched lazily — from inside `cargo test`, where no retry can reach
+        # it. A run died exactly there:
+        #
+        #   downloading .../lean-4.32.2-linux.tar.zst
+        #   error: [52] Server returned nothing (Empty reply from server)
+        #
+        # So warm the pinned toolchain here too, under the same retry, and read
+        # the version from the file that defines it rather than repeating it.
         run: |
+          pinned="$(cat aver-cert/assets/wall/current/lean-toolchain)"
+          echo "pinned toolchain: ${pinned}"
           for attempt in 1 2 3 4 5 6; do
-            if lake --version; then exit 0; fi
-            echo "::warning::lake/toolchain fetch failed (attempt ${attempt}/6); retrying in 15s"
+            if lake --version && elan toolchain install "${pinned}"; then exit 0; fi
+            echo "::warning::toolchain fetch failed (attempt ${attempt}/6); retrying in 15s"
             sleep 15
           done
-          echo "::error::lake unreachable after 6 attempts (toolchain download)"
+          echo "::error::toolchain unreachable after 6 attempts"
           exit 1
 
       - name: Check reserved-token snapshot against pinned Lean


### PR DESCRIPTION
Not a code change — CI only. Four jobs failed this afternoon on the same thing.

## What happened

```
curl: (22) The requested URL returned error: 503
```

Twice fetching binaryen (the `WASM` job), twice fetching elan (`Proof Export`). None of them had compiled anything yet — all four died at a tool-install step, so the failures read as "your PR is broken" while saying nothing about the PR.

I checked whether the CDN was actually down before rerunning: the same binaryen URL returned 200 three times in a row from outside CI at the same moment. Transient, not an outage. Each one still costs a full run on a pool shared across the whole repository.

## The two fixes are not the same fix

**binaryen** had no retry at all. It now carries the flags the other network steps already use.

**elan** is subtler, and worth spelling out because the step *looked* protected. The installer fetch already had `--retry 6 --retry-all-errors`. But elan then downloads the toolchain tarball with its own `curl`, no retry, and that is the one that failed:

```
info: downloading installer
curl: (22) The requested URL returned error: 503
elan: command failed: curl -sSfL https://github.com/leanprover/elan/releases/latest/download/...
```

Flags on the outer fetch never covered the inner one. So the whole install is retried instead, up to four attempts.

`set -o pipefail` comes with it: `curl | sh` reports success when curl dies and the shell reads empty input, so without it the loop could not observe the failure it exists to catch.

## Deliberately not touched

The elan install in `cert.yml` caches `~/.elan` and only reaches the network on a cache miss, and it did not fail today. Same shape, same treatment available if it starts to.
