### PR TITLE
Check hostile stub signatures against the oracle they stand in for

### DIFF
--- a/src/types/checker/hostile_effects.rs
+++ b/src/types/checker/hostile_effects.rs
@@ -721,16 +721,29 @@ mod tests {
         }
     }
 
+    fn render_signature(params: &[String], ret: &str) -> String {
+        format!("({}) -> {}", params.join(", "), ret)
+    }
+
     /// Every stub body must (a) type-check cleanly as an Aver fn, and
     /// (b) have a signature that matches what the runtime expects from
     /// an oracle for that classified effect — same parameter list as
     /// `effect_classification::oracle_signature`, same return type,
     /// same record-field shapes (Terminal.Size: width/height, not
-    /// rows/cols). Without this test, the kind of regression second-AI
-    /// caught (Terminal.Size with wrong fields, Tcp.close inheriting
-    /// Tcp.writeLine's `line` param) sneaks through the parse-only
-    /// sanity check and only surfaces when a real user runs `aver
-    /// verify --hostile` against a fn that uses that effect.
+    /// rows/cols).
+    ///
+    /// Both halves are checked here. The signature half was for a long
+    /// time a promise in this comment and nothing else: the body only
+    /// asserted each stub compiled standalone, which a `Tcp.close` stub
+    /// that inherited `Tcp.writeLine`'s `line` parameter does perfectly
+    /// well. Such a stub is rejected at the moment a user binds it in a
+    /// `given`, so the failure lands on the user running `aver verify
+    /// --hostile`, not on us.
+    ///
+    /// The roster is `classifications_for_proof_subset()`, not a list
+    /// next to the loop. The hand-written list was another copy of the
+    /// registry, and a method missing from it was not checked at all —
+    /// the guard reported success over an effect it never looked at.
     #[test]
     fn stub_bodies_typecheck_with_signature_matching_oracle_classification() {
         use crate::source::parse_source;
@@ -743,20 +756,33 @@ mod tests {
         // The method list is derived, not written down. Hand-listing it meant
         // an effect could gain profiles without ever being checked here, which
         // is the failure this test exists to prevent one level down.
-        for classification in classifications_for_proof_subset() {
-            let method = classification.method;
+        for c in classifications_for_proof_subset() {
+            let method = c.method;
             // Output effects have no oracle channel for a hostile world to
             // answer through; the injector skips them by design.
-            if matches!(classification.dimension, EffectDimension::Output) {
+            if matches!(c.dimension, EffectDimension::Output) {
                 continue;
             }
             let Some(Type::Fn(oracle_params, oracle_ret, _)) = oracle_signature(method) else {
-                panic!("{method} is not Output-dimension but has no oracle signature");
+                panic!(
+                    "{method}: classified as {:?} but has no oracle signature — \
+                     every non-Output effect binds an oracle",
+                    c.dimension
+                );
             };
+            // Compared by rendered type, because the classification table
+            // names nominals before the module graph assigns them ids while a
+            // typechecked signature carries them. Rendering is also the
+            // stricter comparison: `Type::compatible` lets `Type::Invalid`
+            // match anything and relates two id-less nominals by name suffix,
+            // so a stub declaring `Connection` would pass against an oracle
+            // taking `Tcp.Connection`.
             let want_params: Vec<String> = oracle_params.iter().map(|t| t.display()).collect();
             let want_ret = oracle_ret.display();
 
             for p in hostile_profiles_for(method) {
+                // `Bytes` is a stdlib module, so a stub that names it (as a
+                // type or to call `Bytes.fromList`) has to depend on it.
                 let depends = if p.stub_body.contains("Bytes") {
                     "    depends [Bytes]\n"
                 } else {
@@ -784,32 +810,42 @@ mod tests {
                     );
                 }
 
-                // The half the doc comment above has always promised and this
-                // test never performed: a stub that parses and typechecks can
-                // still have the wrong shape for the oracle slot it is injected
-                // into — a missing `(path, n)` prefix on a generative effect, a
-                // record with the wrong field names, a parameter inherited from
-                // a neighbouring method. Compared by rendered type, because the
-                // classification table names nominals before the module graph
-                // assigns them ids while a typechecked signature carries them.
-                let (params, ret, _) = result
-                    .fn_sigs
-                    .get(&p.stub_fn_name)
-                    .unwrap_or_else(|| panic!("{}/{}: stub fn not registered", method, p.name));
-                let got_params: Vec<String> = params.iter().map(|t| t.display()).collect();
-                assert_eq!(
-                    got_params, want_params,
-                    "{}/{}: stub takes different parameters than the oracle slot it is \
-                     injected into",
-                    method, p.name
-                );
-                assert_eq!(
-                    ret.display(),
-                    want_ret,
-                    "{}/{}: stub returns a different type than the oracle slot it is \
-                     injected into",
+                // The half the doc comment above has always promised: a stub
+                // that parses and typechecks can still have the wrong shape for
+                // the oracle slot it is injected into — a missing `(path, n)`
+                // prefix on a generative effect, a record with the wrong field
+                // names, a parameter inherited from a neighbouring method.
+                let (stub_params, stub_ret, _) =
+                    result.fn_sigs.get(&p.stub_fn_name).unwrap_or_else(|| {
+                        panic!(
+                            "{}/{}: the checker recorded no signature for stub fn '{}'",
+                            method, p.name, p.stub_fn_name
+                        )
+                    });
+                let got_params: Vec<String> = stub_params.iter().map(|t| t.display()).collect();
+                let got_ret = stub_ret.display();
+
+                assert!(
+                    got_params == want_params,
+                    "{}/{}: hostile stub takes a different parameter list than an oracle \
+                     for {} — a user binding this stub in a `given` gets a type error\n  \
+                     oracle: {}\n  stub:   {}\n\nbody:\n{}",
                     method,
-                    p.name
+                    p.name,
+                    method,
+                    render_signature(&want_params, &want_ret),
+                    render_signature(&got_params, &got_ret),
+                    p.stub_body
+                );
+                assert!(
+                    got_ret == want_ret,
+                    "{}/{}: hostile stub returns {} where an oracle for {} returns {}\n\nbody:\n{}",
+                    method,
+                    p.name,
+                    got_ret,
+                    method,
+                    want_ret,
+                    p.stub_body
                 );
             }
         }
@@ -822,20 +858,60 @@ mod tests {
     /// second skip unreachable: a method added to the classification
     /// table without profiles fails here, instead of hostile verification
     /// quietly running with that effect unmodelled.
+    ///
+    /// Non-emptiness is not enough on its own. One profile is one world,
+    /// and a sweep across one world varies nothing: the run passes, and
+    /// the pass says only that the law survived the single behaviour we
+    /// happened to write down. Two is the floor, and every effect but one
+    /// meets it.
     #[test]
-    fn every_classified_non_output_effect_ships_hostile_profiles() {
+    fn every_classified_non_output_effect_ships_enough_hostile_profiles() {
         use crate::types::checker::effect_classification::{
             EffectDimension, classifications_for_proof_subset,
         };
-        let missing: Vec<&str> = classifications_for_proof_subset()
-            .iter()
-            .filter(|c| !matches!(c.dimension, EffectDimension::Output))
-            .filter(|c| hostile_profiles_for(c.method).is_empty())
-            .map(|c| c.method)
-            .collect();
+
+        /// Fewest adversarial worlds an effect may ship.
+        const MIN_PROFILES: usize = 2;
+        /// `Tcp.connect` is the one effect that cannot reach the floor.
+        /// Its honest world would have to return `Result.Ok(<connection>)`,
+        /// and a connection handle is opaque: only a verify-trace body may
+        /// fabricate one (`effect_classification::is_verify_fabricable_handle`),
+        /// while a hostile stub is an ordinary top-level fn. So it ships the
+        /// failure world alone, and hostile verification of a fn that
+        /// connects never sees the connection succeed.
+        const SINGLE_PROFILE_EFFECTS: [&str; 1] = ["Tcp.connect"];
+
+        let mut short: Vec<String> = Vec::new();
+        for c in classifications_for_proof_subset() {
+            if matches!(c.dimension, EffectDimension::Output) {
+                continue;
+            }
+            let count = hostile_profiles_for(c.method).len();
+            let floor = if SINGLE_PROFILE_EFFECTS.contains(&c.method) {
+                1
+            } else {
+                MIN_PROFILES
+            };
+            if count < floor {
+                short.push(format!("{} ships {count}, needs {floor}", c.method));
+            }
+        }
         assert!(
-            missing.is_empty(),
-            "classified non-Output effects without hostile profiles — the injector would silently skip these during hostile verification: {missing:?}"
+            short.is_empty(),
+            "classified non-Output effects with too few hostile profiles — hostile \
+             verification would run these under fewer worlds than a sweep needs, or \
+             (at zero) skip the effect entirely: {short:?}"
         );
+
+        // A stale exemption is worse than none: it would hold an effect at
+        // one profile long after the reason expired.
+        for method in SINGLE_PROFILE_EFFECTS {
+            assert!(
+                hostile_profiles_for(method).len() < MIN_PROFILES,
+                "{method} now ships {} hostile profiles — drop it from \
+                 SINGLE_PROFILE_EFFECTS so the floor applies to it again",
+                hostile_profiles_for(method).len()
+            );
+        }
     }
 }

--- a/src/types/checker/hostile_effects.rs
+++ b/src/types/checker/hostile_effects.rs
@@ -725,6 +725,14 @@ mod tests {
         format!("({}) -> {}", params.join(", "), ret)
     }
 
+    fn render_errors(errors: &[crate::types::checker::TypeError]) -> String {
+        errors
+            .iter()
+            .map(|e| format!("  {}: {}", e.line, e.message))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// Every stub body must (a) type-check cleanly as an Aver fn, and
     /// (b) have a signature that matches what the runtime expects from
     /// an oracle for that classified effect — same parameter list as
@@ -783,6 +791,18 @@ mod tests {
             for p in hostile_profiles_for(method) {
                 // `Bytes` is a stdlib module, so a stub that names it (as a
                 // type or to call `Bytes.fromList`) has to depend on it.
+                //
+                // This prelude is NOT what the injector provides. The real
+                // injector, `vm_verify::inject_hostile_effect_stubs_for_blocks`,
+                // appends the stub straight into the user's own module and adds
+                // no dependency at all — so a user module that calls
+                // `Tcp.readBytes` without naming `Bytes` itself type-checks here
+                // and still fails under `aver verify --hostile` with `Unknown
+                // identifier Bytes`, skipping the whole file. Synthesizing the
+                // dependency keeps this test about stub signatures rather than
+                // about that separate injector defect; the defect itself is
+                // pinned by `stub_injection_typechecks_the_module_the_injector_builds`
+                // below, which is ignored until the injector is fixed.
                 let depends = if p.stub_body.contains("Bytes") {
                     "    depends [Bytes]\n"
                 } else {
@@ -800,12 +820,7 @@ mod tests {
                         "{}/{}: typecheck errors:\n{}\n\nbody:\n{}",
                         method,
                         p.name,
-                        result
-                            .errors
-                            .iter()
-                            .map(|e| format!("  {}: {}", e.line, e.message))
-                            .collect::<Vec<_>>()
-                            .join("\n"),
+                        render_errors(&result.errors),
                         p.stub_body
                     );
                 }
@@ -849,6 +864,72 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The same stubs, type-checked in the module the injector really
+    /// builds instead of the one the guard above synthesizes.
+    ///
+    /// The guard wraps each stub in a module carrying `depends [Bytes]`
+    /// whenever the body mentions `Bytes`. The injector supplies no such
+    /// thing: `vm_verify::inject_hostile_effect_stubs_for_blocks` appends
+    /// the stub bodies into the user's own module as plain
+    /// `TopLevel::FnDef` and adds no dependency at all. So the guard is
+    /// green over stubs that cannot in fact be injected, and a user module
+    /// that reads exact bytes off a connection without ever naming `Bytes`
+    /// itself passes `aver verify` and is refused by `aver verify
+    /// --hostile` with `error[1:0]: Unknown identifier 'Bytes'` — the whole
+    /// file skipped, no cases run. Writing `depends [Bytes]` into that same
+    /// file by hand makes the hostile run work.
+    ///
+    /// Ignored until the injector supplies what the stubs it injects need:
+    /// https://github.com/jasisz/aver/issues/877. Delete the `ignore` when
+    /// that lands.
+    #[test]
+    #[ignore = "the injector adds no dependency for the stubs it injects — issue #877"]
+    fn stub_injection_typechecks_the_module_the_injector_builds() {
+        use crate::checker::merge_verify_blocks;
+        use crate::diagnostics::vm_verify::inject_hostile_effect_stubs_for_blocks;
+        use crate::source::parse_source;
+        use crate::types::checker::run_type_check_full;
+
+        // An ordinary user module. It calls `Tcp.readBytes`, which the
+        // hostile profiles model, and it never spells `Bytes` anywhere.
+        let src = "module Main\n    \
+                   intent = \"Read one exact frame and classify the outcome.\"\n    \
+                   effects [Tcp]\n\n\
+                   fn frameVerdict(conn: Tcp.Connection) -> String\n    \
+                   ? \"Classify one exact-frame read.\"\n    \
+                   ! [Tcp.readBytes]\n    \
+                   match Tcp.readBytes(conn, 4)\n        \
+                   Result.Ok(_) -> \"ok\"\n        \
+                   Result.Err(_) -> \"err\"\n\n\
+                   verify frameVerdict law neverReads\n    \
+                   given conn: Tcp.Connection = \
+                   [Tcp.Connection(id = \"fake\", host = \"127.0.0.1\", port = 1)]\n    \
+                   frameVerdict(conn) => \"err\"\n";
+
+        let mut items = parse_source(src).unwrap_or_else(|e| panic!("parse: {e:?}"));
+
+        // The module is clean before injection, so anything below is the
+        // injector's doing and not a flaw in this fixture.
+        let before = run_type_check_full(&items, Some(env!("CARGO_MANIFEST_DIR")));
+        assert!(
+            before.errors.is_empty(),
+            "the fixture module must type-check on its own:\n{}",
+            render_errors(&before.errors)
+        );
+
+        let blocks = merge_verify_blocks(&items);
+        inject_hostile_effect_stubs_for_blocks(&mut items, &blocks);
+
+        let after = run_type_check_full(&items, Some(env!("CARGO_MANIFEST_DIR")));
+        assert!(
+            after.errors.is_empty(),
+            "hostile stub injection left the user's module untypecheckable — this is \
+             what a user running `aver verify --hostile` gets, and the file is skipped \
+             whole:\n{}",
+            render_errors(&after.errors)
+        );
     }
 
     /// The injector (`vm_verify::collect_effect_profile_combinations`)


### PR DESCRIPTION
Rebased onto main. The derived method roster and the comparison against `oracle_signature` landed there in #870 while this was open, so the diff is now narrower than it was: it is about what the guard says when the comparison fails, how many worlds an effect is swept through, and one thing the guard was quietly lying about.

## What changed

**The mismatch report names the stub.** The comparison itself was two `assert_eq!`s over `Vec<String>`, which prints two lists and leaves you to work out which method and which profile they belong to. It now names the method and the profile, prints the oracle signature against the stub signature on adjacent lines, and prints the stub body underneath.

Comparing by rendered type is kept on purpose. `Type::compatible` treats `Type::Invalid` as matching anything, and after `TypeId`s are erased it relates two nominals by name suffix — so it would accept a stub declaring `Connection` against an oracle taking `Tcp.Connection`. Rendering is the stricter of the two.

**Two hostile profiles per effect, not one.** One profile is one world, and a sweep across one world varies nothing. `Tcp.connect` is the single effect that cannot meet the floor and says so in place: an honest profile would have to return `Result.Ok(<connection>)`, and a connection handle is opaque — only a verify-trace body may fabricate one, while a hostile stub is an ordinary top-level function. So hostile verification of a function that connects never sees a connect succeed. The exemption is itself checked for staleness, so it cannot outlive its reason.

**The synthesized prelude now admits it is not what the injector builds.** The guard type-checks each stub inside a module it writes itself, and that module carries `depends [Bytes]` whenever the stub body mentions `Bytes`. `inject_hostile_effect_stubs_for_blocks` builds no such module — it appends the stub bodies into the user's own module and adds no dependency at all. So the guard was green over stubs that cannot in fact be injected.

Reproduced with a module that reads exact bytes off a connection and never names `Bytes` itself. `aver verify main.av` passes 1/1. `aver verify --hostile main.av`:

\`\`\`
main.av: error[1:0]: Unknown identifier 'Bytes'

1 file(s) skipped — type errors (run aver check for details):
  main.av
No verify blocks found in main.av.
\`\`\`

Line 1 of a file with nothing wrong in it, naming a module the author never wrote, whole file skipped, no cases run. Writing `depends [Bytes]` into that same file by hand makes the run work and it then reports a real law violation (3/4 passed, 1 failed).

The comment at the prelude now says this plainly, and `stub_injection_typechecks_the_module_the_injector_builds` builds what the injector really builds: parse an ordinary user module, run the real injector over it, type-check the result. It asserts the module is clean *before* injection first, so its failure can only be the injector's doing. It is ignored and pinned to #877, with the instruction to delete the ignore when that lands. Run under \`--ignored\` it reports exactly what the CLI does:

\`\`\`
hostile stub injection left the user's module untypecheckable — this is what a user
running \`aver verify --hostile\` gets, and the file is skipped whole:
  1: Unknown identifier 'Bytes'
\`\`\`

One correction to the review that prompted this: the `contains("Bytes")` substring test is not introduced here. It landed on main in #870 and is context in this diff. The substance of the objection stands and is what the comment and the ignored test address.

## Verified by breaking it

Both against the committed branch after the rebase.

- Added \`line: String\` to both \`Tcp.close\` stub bodies. Red: \`Tcp.close/normal_ok: hostile stub takes a different parameter list than an oracle for Tcp.close\`, printing \`oracle: (BranchPath, Int, Tcp.Connection) -> Result<Unit, String>\` against \`stub: (BranchPath, Int, Tcp.Connection, String) -> Result<Unit, String>\`. Reverted, green.
- With that break still in place, gated the loop by the old hand-written roster minus \`Tcp.close\`: all 7 tests passed. That is the coverage hole the derived roster closes, and it is why the roster must stay derived.
- Dropped one of the two \`Terminal.readKey\` profiles: the count guard went red with \`["Terminal.readKey ships 1, needs 2"]\`. Reverted, green.