### PR TITLE
Four repairs: map comparison export, replayed record fields, set-shaped map export, Dafny map helpers

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -312,12 +312,12 @@ seen3 = Map.remove(seen2, "alice")
 
 `Map.set(s, k, Unit)` adds an element, `Map.has(s, k)` checks membership, `Map.remove(s, k)` removes an element, and `Map.len(s)` returns cardinality. Map literals with `Unit` values work as set literals: `{"alice" => Unit, "bob" => Unit}`.
 
-When targeting formal verification backends, the codegen automatically lowers `Map<T, Unit>` to the native set type:
+When targeting Dafny, the codegen lowers `Map<T, Unit>` to the native set type. Lean has no set type the generated project can reach, so there it stays an ordinary map:
 
 | Backend | Aver type | Target type | `Map.set(s, k, Unit)` |
 |---------|-----------|-------------|----------------------|
 | Dafny | `Map<T, Unit>` | `set<T>` | `s + {k}` |
-| Lean | `Map<T, Unit>` | `Finset T` | `AverSet.add s k` |
+| Lean | `Map<T, Unit>` | `List (T × Unit)` | `AverMap.set s k ()` |
 
 ## Common patterns
 

--- a/src/codegen/builtin_helpers.rs
+++ b/src/codegen/builtin_helpers.rs
@@ -176,11 +176,18 @@ pub const BUILTIN_HELPERS: &[BuiltinHelper] = &[
     },
     BuiltinHelper {
         key: "AverMap",
-        body_tokens: &["AverMap.", "MapGet(", "MapEntries(", "MapFromList("],
+        body_tokens: &[
+            "AverMap.",
+            "MapGet(",
+            "MapEntries(",
+            "MapKeys(",
+            "MapValues(",
+            "MapFromList(",
+        ],
         // Dafny's `MapGet` returns `Option<V>`.
         depends_on: &["OptionDatatype"],
         doc: "Map helper namespace. Lean: `AverMap.has_set_self` / `.get_set_self` / etc. \
-              Dafny: `MapGet` / `MapEntries` / `MapFromList`.",
+              Dafny: `MapGet` / `MapEntries` / `MapKeys` / `MapValues` / `MapFromList`.",
     },
     BuiltinHelper {
         key: "ProofFuel",

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -711,6 +711,17 @@ function ListDrop<T>(xs: seq<T>, n: int): seq<T> {
 }
 "#;
 
+/// The three iteration readers — `MapEntries`, `MapKeys`, `MapValues` — are
+/// declared with a signature and no body on purpose. Dafny's `map` is
+/// unordered, so there is no expression here that reproduces the runtime's
+/// key-sorted sequence; leaving them uninterpreted commits the model to
+/// nothing about the order, which makes an order-dependent law simply not
+/// provable rather than provable-and-wrong. A law that only needs the name to
+/// stand for *something* (both sides read the same sequence) still closes.
+///
+/// All three must be listed in the `AverMap` helper's `body_tokens`
+/// (`codegen::builtin_helpers`), or a program that uses only `Map.keys` gets
+/// no map helper block at all and the emitted file does not resolve.
 const DAFNY_HELPER_AVER_MAP: &str = r#"
 function MapGet<K, V>(m: map<K, V>, k: K): Option<V> {
   if k in m then Some(m[k])
@@ -718,6 +729,8 @@ function MapGet<K, V>(m: map<K, V>, k: K): Option<V> {
 }
 
 function MapEntries<K, V>(m: map<K, V>): seq<(K, V)>
+function MapKeys<K, V>(m: map<K, V>): seq<K>
+function MapValues<K, V>(m: map<K, V>): seq<V>
 function MapFromList<K, V>(entries: seq<(K, V)>): map<K, V>
   decreases |entries|
 {

--- a/src/codegen/lean/builtins.rs
+++ b/src/codegen/lean/builtins.rs
@@ -20,20 +20,19 @@ fn bits_counted(op: &str, a: &[String], message: &str) -> String {
 
 /// Try to emit a builtin call as Lean 4 code.
 /// Returns `None` if the name is not a pure builtin.
+///
+/// A set-shaped map (`Map<T, Unit>`) gets no special treatment here. It used
+/// to: `Map.set(s, k, Unit)` was intercepted and emitted as `AverSet.add s k`,
+/// with the type rendered `Finset T` and a literal as `AverSet.ofList [...]`.
+/// Nothing defined `AverSet`, and `Finset` is Mathlib, which the generated
+/// project does not depend on — so every such program exported Lean that did
+/// not build. It goes through the ordinary `AverMap` path now, which is
+/// defined, key-sorted and has the `len` the same program reaches for.
 pub fn emit_builtin_call(
     name: &str,
     args: &[Spanned<ResolvedExpr>],
     ctx: &CodegenContext,
 ) -> Option<String> {
-    use crate::codegen::common::is_unit_expr_resolved;
-
-    // Map<T, Unit> set operations: intercept before generic builtin path
-    if name == "Map.set" && args.len() == 3 && is_unit_expr_resolved(&args[2].node) {
-        let m = p(&super::expr::emit_expr(&args[0], ctx));
-        let k = p(&super::expr::emit_expr(&args[1], ctx));
-        return Some(format!("AverSet.add {} {}", m, k));
-    }
-
     let builtin = recognize_builtin(name)?;
     let a: Vec<String> = args
         .iter()

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -205,15 +205,13 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
             format!("({})", parts.join(", "))
         }
         ResolvedExpr::MapLiteral(entries) => {
+            // A set-shaped map (`Map<T, Unit>`) used to branch off here into
+            // `AverSet.ofList [...]`, which nothing defines — and it branched
+            // off BEFORE the key ordering below, so even a defined `AverSet`
+            // would have emitted a set literal in written order rather than
+            // key order. Both go away by letting it fall through.
             if entries.is_empty() {
                 "[]".to_string()
-            } else if entries
-                .iter()
-                .all(|(_, v)| crate::codegen::common::is_unit_expr_resolved(&v.node))
-            {
-                // Map<T, Unit> literal → set literal
-                let parts: Vec<String> = entries.iter().map(|(k, _)| emit_expr(k, ctx)).collect();
-                format!("AverSet.ofList [{}]", parts.join(", "))
             } else {
                 // The map model is a key-sorted association list, so a
                 // literal written out of order (`{"z" => 1, "a" => 2}`)

--- a/src/codegen/lean/types.rs
+++ b/src/codegen/lean/types.rs
@@ -60,9 +60,9 @@ pub fn type_to_lean(ty: &Type) -> String {
             let parts: Vec<String> = items.iter().map(type_to_lean).collect();
             format!("({})", parts.join(" × "))
         }
-        Type::Map(key, value) if crate::codegen::common::is_set_type(ty) => {
-            format!("Finset {}", type_to_lean_atom(key))
-        }
+        // A set-shaped map (`Map<T, Unit>`) renders as an ordinary map. It
+        // used to render as `Finset T`, which is Mathlib — not a dependency of
+        // the generated project — so the export did not build.
         Type::Map(key, value) => {
             // No direct Map in Lean core; use a list of pairs as approximation
             format!("List ({} × {})", type_to_lean(key), type_to_lean(value))

--- a/src/vm/runtime.rs
+++ b/src/vm/runtime.rs
@@ -550,6 +550,12 @@ impl VmRuntime {
         let result = match &record {
             RecordedOutcome::Value(json) => {
                 let val = json_to_value(json).map_err(VmError::runtime)?;
+                let val = realign_replayed_records(val, arena).map_err(|why| {
+                    VmError::runtime(format!(
+                        "Replay of '{}' carries a record that does not match its type: {}",
+                        builtin_name, why
+                    ))
+                })?;
                 NanValue::from_value(&val, arena)
             }
             RecordedOutcome::RuntimeError(msg) => return Err(VmError::runtime(msg.clone())),
@@ -657,4 +663,120 @@ impl VmRuntime {
 
         Ok(())
     }
+}
+
+/// Put a replayed record's values into the slots the record's type declares.
+///
+/// A recording writes a record's fields into a JSON object keyed by field
+/// name, so they come out of the file in name order. Decoding walks that
+/// object back in the same order, and `NanValue::from_value` then fills the
+/// registered type's slots BY POSITION, discarding the names it was handed.
+/// `HttpResponse` is declared `status, body, headers` but sorts `body,
+/// headers, status`, so every replayed read of `.status` returned the body.
+///
+/// It is worse than a wrong value: the slot types move with the values, so
+/// the arena's type invariant breaks behind a typechecker that already proved
+/// otherwise. `resp.status + 1` over a replayed response fails on a type the
+/// program cannot have — `Arena: expected an integer at 2 but found
+/// String("teapot")` where the read reaches the arena first — while replay
+/// itself reports the run as matched. Where every field of a record shares a
+/// type, as in `Terminal.Size`, nothing fails at all and the program simply
+/// gets the other field's value.
+///
+/// The names survive as far as `Value::Record`, so this is where they get
+/// used. Every record in the decoded value is matched against the field list
+/// the arena holds for its type. A name the type does not declare, or a
+/// declared name the recording does not carry, is a replay failure: filling
+/// the slot with whatever happened to sort into it is the bug, not the
+/// fallback. A type the arena has never seen keeps the decoded order, since
+/// `from_value` registers it from those same names and the two then agree.
+fn realign_replayed_records(value: Value, arena: &Arena) -> Result<Value, String> {
+    Ok(match value {
+        Value::Record { type_name, fields } => {
+            let mut aligned: Vec<(String, Value)> = Vec::with_capacity(fields.len());
+            for (name, field) in fields.iter() {
+                aligned.push((
+                    name.clone(),
+                    realign_replayed_records(field.clone(), arena)?,
+                ));
+            }
+            if let Some(type_id) = arena.find_type_id(&type_name) {
+                let declared = arena.get_field_names(type_id);
+                for (name, _) in &aligned {
+                    if !declared.iter().any(|d| d == name) {
+                        return Err(format!(
+                            "'{}' has no field '{}' (it declares {})",
+                            type_name,
+                            name,
+                            declared.join(", ")
+                        ));
+                    }
+                }
+                let mut in_declared_order: Vec<(String, Value)> = Vec::with_capacity(aligned.len());
+                for want in declared {
+                    let Some(idx) = aligned.iter().position(|(name, _)| name == want) else {
+                        return Err(format!(
+                            "'{}' declares a field '{}' the recording does not carry",
+                            type_name, want
+                        ));
+                    };
+                    in_declared_order.push(aligned.remove(idx));
+                }
+                aligned = in_declared_order;
+            }
+            Value::Record {
+                type_name,
+                fields: aligned.into(),
+            }
+        }
+        Value::Variant {
+            type_name,
+            variant,
+            fields,
+        } => {
+            let mut out = Vec::with_capacity(fields.len());
+            for field in fields.iter() {
+                out.push(realign_replayed_records(field.clone(), arena)?);
+            }
+            Value::Variant {
+                type_name,
+                variant,
+                fields: out.into(),
+            }
+        }
+        Value::Ok(inner) => Value::Ok(Box::new(realign_replayed_records(*inner, arena)?)),
+        Value::Err(inner) => Value::Err(Box::new(realign_replayed_records(*inner, arena)?)),
+        Value::Some(inner) => Value::Some(Box::new(realign_replayed_records(*inner, arena)?)),
+        Value::List(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                out.push(realign_replayed_records(item.clone(), arena)?);
+            }
+            Value::List(aver_rt::AverList::from_vec(out))
+        }
+        Value::Vector(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items.iter() {
+                out.push(realign_replayed_records(item.clone(), arena)?);
+            }
+            Value::Vector(aver_rt::AverVector::from_vec(out))
+        }
+        Value::Tuple(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(realign_replayed_records(item, arena)?);
+            }
+            Value::Tuple(out)
+        }
+        Value::Map(entries) => {
+            let mut out = std::collections::HashMap::with_capacity(entries.len());
+            for (key, val) in entries {
+                // A map key is a scalar in every shape a recording can carry,
+                // so only the value side can hold a record.
+                out.insert(key, realign_replayed_records(val, arena)?);
+            }
+            Value::Map(out)
+        }
+        other => other,
+    })
 }

--- a/tests/eval_spec.rs
+++ b/tests/eval_spec.rs
@@ -3401,12 +3401,19 @@ fn check() -> Bool
     /// A recorded `Http.get` returning `Ok(HttpResponse(status = 418, body =
     /// "teapot", headers = {}))`, ready to hand to `start_replay`.
     fn recorded_teapot_response() -> EffectRecord {
+        // One header, not none: an empty map is indistinguishable from
+        // several wrong answers when a test reads `.headers` back.
+        let mut headers = std::collections::HashMap::new();
+        headers.insert(
+            Value::Str("content-type".to_string()),
+            Value::Str("text/plain".to_string()),
+        );
         let outcome = value_to_json(&Value::Ok(Box::new(Value::Record {
             type_name: "HttpResponse".to_string(),
             fields: vec![
                 ("status".to_string(), Value::int(418)),
                 ("body".to_string(), Value::Str("teapot".to_string())),
-                ("headers".to_string(), Value::Map(Default::default())),
+                ("headers".to_string(), Value::Map(headers)),
             ]
             .into(),
         })))
@@ -3455,20 +3462,20 @@ fn reachedServer() -> Bool
             .expect("the recorded Http.get should have been consumed");
     }
 
-    /// KNOWN FAILURE, pre-existing and not specific to Http: a replayed record
-    /// comes back with its fields in alphabetical order rather than declared
-    /// order, because `value_to_json` writes them into a sorted object and
-    /// `NanValue::from_value` then rebuilds the record by position, ignoring
-    /// the names it was handed. `HttpResponse` is declared `status, body,
-    /// headers`, so replay hands `body` to every reader of `.status`.
+    /// A replayed record's values sit in the slots its type declares.
     ///
-    /// The same permutation hits `Tcp.Connection` (`id, host, port`) and
-    /// `Terminal.Size` (`width, height`), where the swapped fields share a
-    /// type and the wrong value is returned with no error at all.
+    /// A recording writes a record's fields into a JSON object keyed by name,
+    /// so they come back name-sorted, and rebuilding filled the type's slots
+    /// by position. `HttpResponse` is declared `status, body, headers` and
+    /// sorts `body, headers, status`, so replay handed the body to every
+    /// reader of `.status`.
     ///
-    /// Un-ignore this once records are rebuilt by field name.
+    /// All three fields are read here on purpose. Sorted order is a ROTATION
+    /// of the declared order, not a reversal, so a fix that merely undid the
+    /// sort in the other direction would land `status` correctly and still
+    /// swap `body` with `headers`. Only a rebuild keyed on the names gets all
+    /// three.
     #[test]
-    #[ignore = "replayed records come back with fields in alphabetical order; see the doc comment"]
     fn replay_mode_preserves_record_field_identity() {
         let src = r#"
 fn status() -> Int
@@ -3477,17 +3484,165 @@ fn status() -> Int
     match result
         Result.Ok(resp) -> resp.status
         Result.Err(msg) -> 0
+
+fn body() -> String
+    ! [Http.get]
+    result = Http.get("https://example.com/thing")
+    match result
+        Result.Ok(resp) -> resp.body
+        Result.Err(msg) -> "unreached"
+
+fn headerCount() -> Int
+    ! [Http.get]
+    result = Http.get("https://example.com/thing")
+    match result
+        Result.Ok(resp) -> Map.len(resp.headers)
+        Result.Err(msg) -> -1
+"#;
+        for (fn_name, expected) in [
+            ("status", Value::int(418)),
+            ("body", Value::Str("teapot".to_string())),
+            ("headerCount", Value::int(1)),
+        ] {
+            let mut machine = vm_build_with_effects(src);
+            machine.start_replay(vec![recorded_teapot_response()], true);
+            let out = machine
+                .run_named_function(fn_name, &[])
+                .expect("replaying Http.get must not reach the network path")
+                .to_value(&machine.arena);
+            assert_eq!(
+                out, expected,
+                "`.{fn_name}` must read the field the recording named, not whichever \
+                 one sorted into its slot"
+            );
+        }
+    }
+
+    /// Reading a replayed record's field returns the declared TYPE, not just
+    /// the wrong value.
+    ///
+    /// This is the sharper half of the same defect. With the values rotated,
+    /// `.status` — which the typechecker proved is an `Int` — held the body
+    /// string, so arithmetic on it failed outright (`cannot add String and
+    /// Namespace` here; an `Arena: expected an integer at 2 but found
+    /// String("teapot")` abort in the shapes that reach the arena first) while
+    /// replay itself still reported `1 replayed (1 matched)`. A record whose
+    /// fields all share a type (`Terminal.Size`, `Tcp.Connection`) has no such
+    /// alarm at all, which is why this one is worth pinning separately.
+    #[test]
+    fn replay_mode_keeps_a_record_field_at_its_declared_type() {
+        let src = r#"
+fn statusPlusOne() -> Int
+    ! [Http.get]
+    result = Http.get("https://example.com/thing")
+    match result
+        Result.Ok(resp) -> resp.status + 1
+        Result.Err(msg) -> 0
 "#;
         let mut machine = vm_build_with_effects(src);
         machine.start_replay(vec![recorded_teapot_response()], true);
         let out = machine
-            .run_named_function("status", &[])
-            .expect("replaying Http.get must not reach the network path")
+            .run_named_function("statusPlusOne", &[])
+            .expect("arithmetic on a replayed Int field must not fail on its type")
             .to_value(&machine.arena);
         assert_eq!(
             out,
-            Value::int(418),
-            "`.status` must read the recorded status, not whichever field sorted first"
+            Value::int(419),
+            "`.status` must still be the Int the typechecker proved it is"
+        );
+    }
+
+    /// The silent case: a record whose fields all share a type.
+    ///
+    /// `Terminal.Size` is declared `width, height` and sorts `height, width`,
+    /// so replay swapped them and nothing anywhere complained — a program
+    /// asking for the width of an 80x24 terminal got 24, with the run
+    /// reporting success. Nothing about the two `Int`s can catch this except
+    /// carrying the names through, which is why it is pinned next to the
+    /// `HttpResponse` probes rather than trusted to them.
+    #[test]
+    fn replay_mode_preserves_same_typed_record_fields() {
+        let src = r#"
+fn width() -> Int
+    ! [Terminal.size]
+    size = Terminal.size()
+    size.width
+"#;
+        let outcome = value_to_json(&Value::Record {
+            type_name: "Terminal.Size".to_string(),
+            fields: vec![
+                ("width".to_string(), Value::int(80)),
+                ("height".to_string(), Value::int(24)),
+            ]
+            .into(),
+        })
+        .expect("a Terminal.Size must be representable as a recorded outcome");
+        let record = EffectRecord {
+            seq: 1,
+            effect_type: "Terminal.size".to_string(),
+            args: vec![],
+            outcome: RecordedOutcome::Value(outcome),
+            caller_fn: String::new(),
+            source_line: 0,
+            group_id: None,
+            branch_path: None,
+            effect_occurrence: None,
+        };
+
+        let mut machine = vm_build_with_effects(src);
+        machine.start_replay(vec![record], true);
+        let out = machine
+            .run_named_function("width", &[])
+            .expect("replaying Terminal.size must not read the real terminal")
+            .to_value(&machine.arena);
+        assert_eq!(
+            out,
+            Value::int(80),
+            "`.width` must be the recorded width, not the height it sorts behind"
+        );
+    }
+
+    /// A recording carrying a field the type does not declare is a replay
+    /// failure, not a slot filled with whatever was closest.
+    ///
+    /// This is what stops the rebuild from being a re-sort: matching on names
+    /// only means something if a name that matches nothing is refused. The
+    /// alternative — drop it, or slot it positionally — is the original bug
+    /// with an extra step.
+    #[test]
+    fn replay_mode_rejects_a_recorded_field_the_type_does_not_declare() {
+        let src = r#"
+fn status() -> Int
+    ! [Http.get]
+    result = Http.get("https://example.com/thing")
+    match result
+        Result.Ok(resp) -> resp.status
+        Result.Err(msg) -> 0
+"#;
+        let outcome = value_to_json(&Value::Ok(Box::new(Value::Record {
+            type_name: "HttpResponse".to_string(),
+            fields: vec![
+                ("status".to_string(), Value::int(418)),
+                ("body".to_string(), Value::Str("teapot".to_string())),
+                ("headers".to_string(), Value::Map(Default::default())),
+                ("trailers".to_string(), Value::Str("nope".to_string())),
+            ]
+            .into(),
+        })))
+        .expect("the malformed response must still be representable as JSON");
+        let mut record = recorded_teapot_response();
+        record.outcome = RecordedOutcome::Value(outcome);
+
+        let mut machine = vm_build_with_effects(src);
+        machine.start_replay(vec![record], true);
+        let err = machine
+            .run_named_function("status", &[])
+            .expect_err("a recording that does not match the type must fail the replay");
+        let text = format!("{:?}", err);
+        assert!(
+            text.contains("trailers") && text.contains("HttpResponse"),
+            "the failure must name the field and the type it does not belong to, \
+             got: {text}"
         );
     }
 

--- a/tests/fixtures/map_dafny_readers.av
+++ b/tests/fixtures/map_dafny_readers.av
@@ -1,0 +1,35 @@
+module MapDafnyReaders
+    intent =
+        "Every map reader the Dafny emitter can produce has to resolve in the file it writes."
+        "`Map.keys` and `Map.values` emit `MapKeys(m)` and `MapValues(m)`; neither name was declared in the Dafny prelude and neither triggered the map helper block, so a program using only these two exported a file Dafny could not resolve."
+        "The laws here read both sequences on both sides, so they close against an uninterpreted declaration and fail loudly against a missing one."
+    effects [Console]
+
+fn keyList(m: Map<String, Int>) -> List<String>
+    ? "The map's keys, in iteration order."
+    Map.keys(m)
+
+fn valueList(m: Map<String, Int>) -> List<Int>
+    ? "The map's values, in iteration order."
+    Map.values(m)
+
+fn keyCount(m: Map<String, Int>) -> Int
+    ? "How many keys the map has, counted through the key sequence."
+    List.len(Map.keys(m))
+
+verify keyList law keysAreTheMapsKeys
+    given m: Map<String, Int> = [{"a" => 1}, {"b" => 2, "a" => 1}]
+    keyList(m) => Map.keys(m)
+
+verify valueList law valuesAreTheMapsValues
+    given m: Map<String, Int> = [{"a" => 1}, {"b" => 2, "a" => 1}]
+    valueList(m) => Map.values(m)
+
+verify keyCount law countIsTheKeySequenceLength
+    given m: Map<String, Int> = [{"a" => 1}, {"b" => 2, "a" => 1}]
+    keyCount(m) => List.len(Map.keys(m))
+
+fn main() -> Unit
+    ! [Console.print]
+    sample = {"b" => 2, "a" => 1}
+    Console.print("{List.len(keyList(sample))} {List.len(valueList(sample))}")

--- a/tests/fixtures/set_shaped_map.av
+++ b/tests/fixtures/set_shaped_map.av
@@ -1,0 +1,40 @@
+module SetShapedMap
+    intent =
+        "A set-shaped map is `Map<T, Unit>`, and its Lean export has to build."
+        "It used to render as `Finset T` with `AverSet.add` and `AverSet.ofList`, none of which the generated project can see — `Finset` is Mathlib and `AverSet` is defined nowhere at all — so every program holding a set exported Lean that failed to build."
+        "The literal below is written out of key order on purpose: the set branch ran before the key ordering, so even a defined carrier would have emitted it unsorted and made it a different value from the same set built with `Map.set`."
+    effects [Console]
+
+fn addKey(s: Map<String, Unit>, k: String) -> Map<String, Unit>
+    ? "Add a key to a set-shaped map."
+    Map.set(s, k, Unit)
+
+fn seed() -> Map<String, Unit>
+    ? "A two-element set, written out of key order."
+    {"b" => Unit, "a" => Unit}
+
+fn size(s: Map<String, Unit>) -> Int
+    ? "How many elements the set holds."
+    Map.len(s)
+
+fn seedKeys() -> List<String>
+    ? "The seed's elements, in iteration order."
+    Map.keys(seed())
+
+verify addKey
+    size(addKey(seed(), "c")) => 3
+    Map.has(addKey(seed(), "c"), "c") => true
+    size(addKey(seed(), "a")) => 2
+
+verify seedKeys
+    seedKeys() => ["a", "b"]
+
+verify addKey law addingAKeyLeavesANonEmptySet
+    given s: Map<String, Unit> = [{"a" => Unit}, {"b" => Unit, "a" => Unit}]
+    given k: String = ["a", "c"]
+    Map.len(Map.set(s, k, Unit)) >= 1 => true
+
+fn main() -> Unit
+    ! [Console.print]
+    grown = addKey(seed(), "c")
+    Console.print("{size(grown)}")

--- a/tests/proof_spec/dafny_inline.rs
+++ b/tests/proof_spec/dafny_inline.rs
@@ -230,3 +230,85 @@ fn proof_dafny_nat_accumulator_omits_when_algebra_helpers_not_citable() {
         "a Nat accumulator law whose algebra helpers are declared after it must OMIT, not error\n{summary}"
     );
 }
+
+/// A law the Dafny backend DOES export over the map readers has to reach the
+/// verifier, which means every name the emitter writes has to resolve.
+///
+/// `Map.keys` and `Map.values` emit `MapKeys(m)` / `MapValues(m)`, and neither
+/// was declared in the Dafny prelude — nor did either name trigger the map
+/// helper block, so a program using only these two got no helper block at all
+/// and the emitted file failed to resolve before a single obligation was
+/// checked. The laws in the fixture read the same sequence on both sides, so
+/// they close against a declaration with no body; what they cannot survive is
+/// a missing declaration.
+///
+/// This runs through `--check`, which shells out to `dafny verify`: a
+/// resolution failure never prints the verifier summary line, so `--check`
+/// exits before emitting JSON and this test fails on the missing JSON line.
+#[test]
+fn proof_export_of_the_dafny_map_readers_resolves_and_verifies() {
+    if Command::new("dafny").arg("--version").output().is_err() {
+        eprintln!("skipping: `dafny` not available");
+        return;
+    }
+    let out_dir = temp_output_dir("aver-map-dafny-readers");
+    let run = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+        .args([
+            "proof",
+            "tests/fixtures/map_dafny_readers.av",
+            "--backend",
+            "dafny",
+            "-o",
+            out_dir.to_str().expect("utf-8 temp path"),
+            "--check",
+            "--check-json",
+        ])
+        .output()
+        .expect("expected the `aver` binary to run");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let dfy = std::fs::read_to_string(out_dir.join("MapDafnyReaders.dfy")).unwrap_or_default();
+    let common = std::fs::read_to_string(out_dir.join("common.dfy")).unwrap_or_default();
+    let _ = std::fs::remove_dir_all(&out_dir);
+
+    // The fixture is only a test of the declarations while it actually emits
+    // the two calls; if the emitter stopped producing them this would pass
+    // saying nothing.
+    assert!(
+        dfy.contains("MapKeys(m)") && dfy.contains("MapValues(m)"),
+        "the fixture must still emit both map readers, or this test is \
+         vacuous:\n{dfy}"
+    );
+    assert!(
+        common.contains("function MapKeys<") && common.contains("function MapValues<"),
+        "both map readers the emitter writes must be declared in the helper \
+         block the file includes:\n{common}"
+    );
+
+    let json_line = stdout
+        .lines()
+        .rev()
+        .find(|l| l.starts_with('{'))
+        .unwrap_or_else(|| {
+            panic!(
+                "`aver proof --backend dafny --check --check-json` printed no JSON \
+                 summary — Dafny did not get far enough to report one, which is what \
+                 an unresolved name looks like:\n{}",
+                format_output(&run)
+            )
+        });
+    let summary: serde_json::Value =
+        serde_json::from_str(json_line).expect("expected a JSON summary line");
+    assert_eq!(
+        summary["errors"].as_u64(),
+        Some(0),
+        "the map reader laws must verify with no errors:\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "the map reader laws must verify:\n{}",
+        format_output(&run)
+    );
+}

--- a/tests/proof_spec/export_structure.rs
+++ b/tests/proof_spec/export_structure.rs
@@ -1330,3 +1330,104 @@ fn proof_export_dafny_routes_nested_error_prop_to_an_axiom() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn proof_export_of_a_set_shaped_map_builds() {
+    // Issue #884: a `Map<T, Unit>` — the set-shaped map — exported Lean that
+    // did not build. Three special cases fired on it: the type rendered as
+    // `Finset T` (Mathlib, which the generated project does not depend on),
+    // `Map.set(s, k, Unit)` emitted `AverSet.add s k`, and a literal emitted
+    // `AverSet.ofList [...]`. Nothing anywhere defined `AverSet`, so `lake
+    // build` reported `Unknown identifier 'AverSet.add'` and friends while
+    // plain `aver proof` still reported success.
+    //
+    // A fourth thing was queued behind those: the literal branch ran BEFORE
+    // the key-ordering branch added for #874, so a set literal written out of
+    // key order would have emitted unsorted even with a carrier that existed —
+    // a different value from the same set built with `Map.set`. The fixture's
+    // literal is written `{"b" => Unit, "a" => Unit}` to hold that down.
+    //
+    // All three special cases are gone; the set-shaped map goes through the
+    // ordinary `AverMap` path, which is defined, key-sorted, and has the `len`
+    // the same program reaches for.
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = temp_output_dir("aver-proof-set-shaped-map");
+
+    let mut command = Command::new(aver_bin);
+    command
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/set_shaped_map.av")
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&root);
+    let lake = Command::new("lake").arg("--version").output().is_ok();
+    if lake {
+        command
+            .arg("--check")
+            .arg("--check-json")
+            .arg("--sorry-budget")
+            .arg("0");
+    } else {
+        eprintln!("skipping the lake build: `lake` not available");
+    }
+    let output = command.output().expect("aver proof for a set-shaped map");
+    let lean =
+        std::fs::read_to_string(root.join("SetShapedMap.lean")).expect("read SetShapedMap.lean");
+
+    // The names that did not exist. `Finset` is Mathlib; `AverSet` was never
+    // written down at all.
+    for absent in ["AverSet", "Finset"] {
+        assert!(
+            !lean.contains(absent),
+            "the export must not mention `{absent}` — nothing in the generated \
+             project defines it:\n{lean}"
+        );
+    }
+    // The fixture only tests the set shape while it still holds one, and the
+    // literal only tests the ordering while it is still written out of order.
+    assert!(
+        lean.contains("def addKey (s : List (String × Unit)) (k : String)"),
+        "a set-shaped map must render as an ordinary map:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            r#"def seed  : List (String × Unit) :=
+  [("a", ()), ("b", ())]"#
+        ),
+        "a set literal written out of key order must be emitted in key order, \
+         or it is a different value from the same set built with `Map.set`:\n{lean}"
+    );
+
+    if lake {
+        let json_line = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .rev()
+            .find(|l| l.starts_with('{'))
+            .map(str::to_owned)
+            .unwrap_or_else(|| {
+                panic!(
+                    "`aver proof --check --check-json` produced no JSON line:\n{}",
+                    format_output(&output)
+                )
+            });
+        let summary: serde_json::Value =
+            serde_json::from_str(&json_line).expect("summary line parses as JSON");
+        assert_eq!(
+            summary["build_errors"].as_u64(),
+            Some(0),
+            "the exported set-shaped map must build:\n{}",
+            format_output(&output)
+        );
+        assert_eq!(
+            summary["passed"].as_bool(),
+            Some(true),
+            "the exported set-shaped map must build within a zero sorry budget:\n{}",
+            format_output(&output)
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Four repairs, one commit each. They touch disjoint files and are independently revertible.

## What is fixed

### #883 — a claim comparing maps could be certified while `aver verify` refuted it

The one that let a false statement into a certificate. The model carries a map as an association list, and that list is canonical — so list equality means what the runtime means — only for Int, String and Bool keys. Outside them `AverMap.set` appends, and two maps holding the same entries in different writing orders are equal at run time and different values in the model.

Measured on `tests/fixtures/map_equality_unmodelled_keys.av` before the fix, all three exiting 0 from `aver proof --check` with `passed: true`, zero sorries and a clean `lake build`, while `aver verify` refuted every case:

| claim | `aver verify` | `aver proof --check` |
|---|---|---|
| `a == b` over `Map<Float, Int>` | 0/1 cases passed | exit 0, `passed: true` |
| `a != b` over `Map<Tuple<Int, Int>, Int>` | 0/1 cases passed | exit 0, `passed: true` |
| `when a == b` as a law premise | 0/3 cases passed | exit 0, `passed: true` |

The third is the sharpest: the model decides the premise false and discharges the whole implication vacuously, so a law refuted on every one of its cases exported as a theorem the kernel accepted.

Such a claim is declined at export now, the same way a claim reading iteration order over the same key types already was. The refusal names the key type it could not reproduce, and both backends were already wired to the same decision, so both refuse.

It stays narrow, and the fixture holds that down from the other side: a comparison over a String-keyed map still exports, and `Map.len(m) == 0` still exports even where the map it counts is Float-keyed (`==` is homogeneous, so a scalar literal on one side settles that the pair is not a map comparison). Running every `.av` in `examples/`, `tests/fixtures/` and `stdlib/` through `aver proof` before and after gives the identical set of refusals — 8 both times — so nothing that exported yesterday stops exporting.

One consequence worth flagging for review: the declined block's comment used to open `map iteration order is not exported`, which is now only one of the two reasons it can carry. It reads `not exported` followed by the reason, and the iteration-order reasons say so themselves.

### #878 — a replayed effect result came back with its record fields in the wrong slots

A recording writes a record's fields into a JSON object keyed by name, so they come back in name order, and rebuilding filled the type's slots by position while discarding the names. `HttpResponse` is declared `status, body, headers` and sorts `body, headers, status`, so every replayed read of `.status` returned the body — with replay reporting the run as matched.

It was not only a wrong value. The types moved with the values, so a field the typechecker had proved was an `Int` came back holding a `String` and arithmetic on it failed on a type the program could not have had. Where every field shares a type, as in `Terminal.Size`, nothing failed at all: a program asking for the width of an 80x24 terminal was told 24.

Records are rebuilt against the field list the type registers now, walking through results, options, lists, vectors, tuples, maps and variants to reach nested ones. A recorded field the type does not declare, or a declared field the recording does not carry, ends the replay with a message naming both. Recording files are untouched — the schema does not change and files written by earlier versions replay unchanged.

The pinning test that was checked in ignored is enabled, and reads all three fields rather than one: name order is a rotation of declared order, not a reversal, so reading only `.status` would accept a fix that still swaps the other two.

### #884 — a set-shaped map exported Lean that did not build

`Map<T, Unit>` had three Lean special cases: the type rendered as `Finset T`, `Map.set(s, k, Unit)` emitted `AverSet.add s k`, and a literal emitted `AverSet.ofList [...]`. `Finset` is Mathlib, which the generated project does not depend on, and `AverSet` was never defined anywhere, so `lake build` stopped at `Unknown identifier 'AverSet.add'` while plain `aver proof` reported success.

All three are gone; a set-shaped map goes through the ordinary map path, which is defined, key-sorted, and has the `len` such a program reaches for. That also closes a second problem sitting behind the first: the set-literal branch ran *before* the key-ordering branch, so a set literal written out of key order would have been emitted unsorted even with a carrier that existed. The Dafny backend is unchanged — it lowers to a native `set<T>`, which Dafny actually has.

### #881 — the Dafny export of `Map.keys` or `Map.values` did not resolve

The emitter produces `MapKeys(m)` and `MapValues(m)`; the map helper block declared neither, and neither name triggered the block's inclusion, so a program using only these two got no map helpers at all and `dafny verify` stopped at `unresolved identifier: MapKeys` before checking a single obligation. Both are declared now in the shape `MapEntries` already had — a signature with no body, so the model commits to nothing about an order Dafny's unordered `map` cannot express, and an order-dependent law simply cannot be proved rather than being proved wrong.

## How the guards were checked

Every guard was run against an injected fault, then against the repair.

| guard | fault injected | RED | GREEN |
|---|---|---|---|
| `proof_export_of_the_dafny_map_readers_resolves_and_verifies` | drop the `MapKeys` declaration | `both map readers the emitter writes must be declared in the helper block the file includes` | 1 passed |
| same | drop `MapKeys(` / `MapValues(` from the helper trigger | same assertion, helper block absent from `common.dfy` | 1 passed |
| `proof_export_of_a_set_shaped_map_builds` | restore the `AverSet.add` intercept | ``the export must not mention `AverSet``` | 1 passed |
| same | restore the `Finset` type arm | ``the export must not mention `Finset``` | 1 passed |
| same | restore the unsorted set-literal branch | `a set literal written out of key order must be emitted in key order` | 1 passed |
| `replay_mode_preserves_record_field_identity` | drop the realignment call | ``left: Str("teapot"), right: Int(418)`` | 3 replay tests passed |
| `replay_mode_keeps_a_record_field_at_its_declared_type` | same | `cannot add String and Namespace` | passed, 419 |
| `replay_mode_preserves_same_typed_record_fields` | same | `left: Int(24), right: Int(80)` | passed, 80 |
| `replay_mode_rejects_a_recorded_field_the_type_does_not_declare` | same | replay succeeded instead of failing | passed |
| `a_map_comparison_over_an_unmodelled_key_is_not_exported` | delete the equality arm from the refusal | ``verify floatMapsAgree` compares maps the model cannot reproduce and must be refused, not exported` — and the emitted Lean carried `example : floatMapsAgree = false := by native_decide`, `example : tupleMapsDiffer = true := by native_decide` and the vacuous universal, with `aver proof --check` exiting 0 | 15 passed |

## Interaction between two of them

After #884, `Map<T, Unit>` falls onto the ordinary map path, so a set over an unmodelled key type is covered by the new refusal from #883. Different files, no conflict; worth knowing when reading them together.

## Tests run

`proof_spec` (246), `map_iteration_order` (14), `eval_spec` (234), `vm_spec`, `replay_proptest`, `proof_ir_diff`, `--lib` (1009). `cargo fmt --all -- --check` clean; `cargo clippy --bin aver` quiet. Debug profile throughout.

Each of the four commits compiles on its own.

## Not in here

`#877`, `#879`, `#880`, `#882`, `#862` and `#782` are untouched and stay open.
