### PR TITLE
Parse capability declarations, and refuse to compile them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 - **Every rejected operator now names the function that replaces it.** Writing `a ^ b` reported `Unknown character: '^'`, which tells you nothing about `Bits.xor` — so a deliberate design choice read as a gap. `^`, `&`, `&&`, `|`, `||`, `~`, `%`, `<<` and `>>` now each report what they are and what to use instead, carrying the `rejected-operator` slug and a repair that spells out the call. `/` on `Int` already did this and is unchanged. Nested generics (`Map<String, List<Int>>`) and ordinary comparisons are unaffected — the shift diagnostic only fires on two adjacent `<` or `>` in operator position, which a type annotation never reaches.
 
+- **Capability declarations parse, and are refused.** A module can now write `kind = capability` in its header, declare `operation` items with their signature and an indented block of `oracle` / `replay` / `hostile` / `unmodelled` fields, and declare a representation-less `opaque` type. Nothing consumes any of it yet: `check`, `verify`, `proof`, `run` and `compile` all refuse a file that declares a capability, and they refuse it whether it is the file you named, a module it depends on, or a module further down that chain.
+
+  That refusal is the point of shipping this now. Until it lands, `kind = capability` was not a parse error — the header stopped at the unknown field and the line was re-read as a top-level binding, so a capability declaration would have been silently ignored and the program compiled as if the boundary were not there. Being told "not supported yet" is the only honest answer while the rest is being built.
+
+  `capability Foo` as a standalone item is a hard error naming `kind = capability`. A capability is a kind of module, and there is exactly one way to declare one.
+
+### Changed
+
+- **An unrecognised field in a module header is now an error.** The header used to stop at the first line it did not recognise and hand that line back to the top level. A typo'd `expose [main]` therefore produced no diagnostic at all when its right-hand side happened to resolve, and a mistyped field silently did nothing. Header-shaped lines — `name = value` or `name [list]` — are now checked against the five allowed fields.
+
+  This is breaking for one shape: a top-level binding written *indented*, directly under the header, used to be accepted and now is not. The fix is to unindent it — bindings belong at column 0, outside the header — and the error says so.
+
 ### Fixed
 
 - **A map iterates in one order on the VM, in compiled Rust and in the exported proof.** `Map.keys`, `Map.values` and `Map.entries` return entries sorted by key — that part was already true when you ran a program — but `aver proof` exported a model that kept insertion order instead. A map built by writing `z`, `a`, `m` has values `[2, 3, 1]`, which is what `aver verify` reports; the exported Lean said the values were `[1, 2, 3]` and the kernel accepted it. Either tool could confirm a claim the other refuted, on the same source, on the same commit.

--- a/src/analysis/literal_refinement.rs
+++ b/src/analysis/literal_refinement.rs
@@ -305,6 +305,14 @@ pub fn discharge_sites(
                     walk(&ctx, right, &mut out);
                 }
             }
+            // A capability item carries no expressions: an operation
+            // has a signature and no body, and its `hostile` /
+            // `unmodelled` entries are bare symbol names, not calls.
+            // There is no literal to discharge, so this is a genuine
+            // no-op — named explicitly rather than folded into the
+            // arm below, so a later phase that gives operations an
+            // expression has to come back here.
+            TopLevel::Capability(_) => {}
             TopLevel::Module(_) | TopLevel::Decision(_) | TopLevel::TypeDef(_) => {}
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -515,6 +515,71 @@ pub struct Module {
     /// `Disk` admits any `Disk.*` method).
     pub effects: Option<Vec<String>>,
     pub effects_line: Option<usize>,
+    /// `kind = capability` in the module header. `None` is an
+    /// ordinary module. The value is stored verbatim and read only
+    /// by the refusal in `types::checker`; nothing downstream
+    /// branches on it yet.
+    pub kind: Option<String>,
+    pub kind_line: Option<usize>,
+}
+
+/// A declaration that only a capability module may carry. Both forms
+/// live under a single [`TopLevel`] variant on purpose: three variants
+/// would triple the match-site audit surface for no gain, and both
+/// forms are refused by the same rule today.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CapabilityItem {
+    /// `opaque ConnectionToken` — a type with no representation
+    /// anywhere. Distinct from `exposes opaque [T]`, which hides a
+    /// representation that exists inside the module.
+    Opaque { name: String, line: usize },
+    /// `operation open(host: String, port: Int) -> Result<T, E>` with
+    /// an indented block of `name = value` attributes.
+    Operation(Operation),
+}
+
+impl CapabilityItem {
+    pub fn name(&self) -> &str {
+        match self {
+            CapabilityItem::Opaque { name, .. } => name,
+            CapabilityItem::Operation(op) => &op.name,
+        }
+    }
+
+    pub fn line(&self) -> usize {
+        match self {
+            CapabilityItem::Opaque { line, .. } => *line,
+            CapabilityItem::Operation(op) => op.line,
+        }
+    }
+
+    /// The word that introduces the declaration, for diagnostics.
+    pub fn keyword(&self) -> &'static str {
+        match self {
+            CapabilityItem::Opaque { .. } => "opaque",
+            CapabilityItem::Operation(_) => "operation",
+        }
+    }
+}
+
+/// A boundary operation: a signature with no body, plus the model
+/// attributes a proof binds to. Attribute values are stored as written
+/// — no admissibility rule is applied at this stage.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Operation {
+    pub name: String,
+    pub line: usize,
+    pub params: Vec<(String, String)>,
+    pub return_type: String,
+    pub desc: Option<String>,
+    /// `oracle = <ident>`.
+    pub oracle: Option<String>,
+    /// `replay = <ident>`.
+    pub replay: Option<String>,
+    /// `hostile = [a, b]`.
+    pub hostile: Vec<String>,
+    /// `unmodelled = [a, b]`.
+    pub unmodelled: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -711,4 +776,7 @@ pub enum TopLevel {
     Decision(DecisionBlock),
     Stmt(Stmt),
     TypeDef(TypeDef),
+    /// `operation` / `opaque` — declarations that belong to a module
+    /// whose header says `kind = capability`.
+    Capability(CapabilityItem),
 }

--- a/src/ast/unparse.rs
+++ b/src/ast/unparse.rs
@@ -11,8 +11,9 @@
 use std::fmt::Write;
 
 use crate::ast::{
-    BinOp, DecisionBlock, DecisionImpact, Expr, FnDef, Literal, Module, Pattern, Spanned, Stmt,
-    StrPart, TopLevel, TypeDef, VerifyBlock, VerifyGiven, VerifyGivenDomain, VerifyKind,
+    BinOp, CapabilityItem, DecisionBlock, DecisionImpact, Expr, FnDef, Literal, Module, Pattern,
+    Spanned, Stmt, StrPart, TopLevel, TypeDef, VerifyBlock, VerifyGiven, VerifyGivenDomain,
+    VerifyKind,
 };
 
 /// Errors the unparser can surface. Caller (Phase 1 mutator) maps
@@ -85,7 +86,46 @@ fn write_top_level(out: &mut String, item: &TopLevel) -> Result<()> {
         TopLevel::Verify(vb) => write_verify(out, vb),
         TopLevel::Decision(db) => write_decision(out, db),
         TopLevel::Stmt(stmt) => write_stmt(out, stmt, 0),
+        TopLevel::Capability(item) => write_capability(out, item),
     }
+}
+
+/// Round-trip for `opaque` / `operation`. An ignore arm here would
+/// silently DELETE a capability declaration from any unparse, which is
+/// the worst failure available in this file — the output would still
+/// be valid Aver, just missing the boundary.
+fn write_capability(out: &mut String, item: &CapabilityItem) -> Result<()> {
+    match item {
+        CapabilityItem::Opaque { name, .. } => {
+            writeln!(out, "opaque {name}")?;
+        }
+        CapabilityItem::Operation(op) => {
+            let params: Vec<String> = op.params.iter().map(|(n, t)| format!("{n}: {t}")).collect();
+            writeln!(
+                out,
+                "operation {}({}) -> {}",
+                op.name,
+                params.join(", "),
+                op.return_type
+            )?;
+            if let Some(desc) = &op.desc {
+                writeln!(out, "{INDENT}? {}", quote_string(desc))?;
+            }
+            if let Some(oracle) = &op.oracle {
+                writeln!(out, "{INDENT}oracle = {oracle}")?;
+            }
+            if let Some(replay) = &op.replay {
+                writeln!(out, "{INDENT}replay = {replay}")?;
+            }
+            if !op.hostile.is_empty() {
+                writeln!(out, "{INDENT}hostile = [{}]", op.hostile.join(", "))?;
+            }
+            if !op.unmodelled.is_empty() {
+                writeln!(out, "{INDENT}unmodelled = [{}]", op.unmodelled.join(", "))?;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn write_module(out: &mut String, m: &Module) -> Result<()> {
@@ -101,6 +141,9 @@ fn write_module(out: &mut String, m: &Module) -> Result<()> {
             }
             writeln!(out, "{INDENT}{INDENT}{}", quote_string(trimmed))?;
         }
+    }
+    if let Some(kind) = &m.kind {
+        writeln!(out, "{INDENT}kind = {kind}")?;
     }
     if !m.depends.is_empty() {
         writeln!(out, "{INDENT}depends [{}]", m.depends.join(", "))?;

--- a/src/checker/intent.rs
+++ b/src/checker/intent.rs
@@ -214,6 +214,13 @@ fn collect_declared_symbols(items: &[TopLevel]) -> std::collections::HashSet<Str
             TopLevel::Decision(d) => {
                 out.insert(d.name.clone());
             }
+            // Operations and the opaque token are declared names: a
+            // `? "..."` justification anywhere in the file may point at
+            // them, and omitting them makes the justification
+            // bookkeeping report a real symbol as undeclared.
+            TopLevel::Capability(item) => {
+                out.insert(item.name().to_string());
+            }
             TopLevel::Verify(_) | TopLevel::Stmt(_) => {}
         }
     }

--- a/src/codegen/program_view.rs
+++ b/src/codegen/program_view.rs
@@ -342,6 +342,8 @@ mod tests {
             intent: "Test".to_string(),
             effects: None,
             effects_line: None,
+            kind: None,
+            kind_line: None,
         })];
         let modules = vec![mk_module("A", &["walker"]), mk_module("B", &["walker"])];
         let symbol_table = SymbolTable::build(&entry_items, &modules);

--- a/src/diagnostics/classify.rs
+++ b/src/diagnostics/classify.rs
@@ -219,6 +219,19 @@ pub(crate) fn classify_type_error(msg: &str) -> TypeErrorClassification {
         return ("type-mismatch", Some(msg.to_string()), fields, repair);
     }
 
+    if msg.starts_with(crate::types::checker::CAPABILITY_UNSUPPORTED) {
+        return (
+            "capability-unsupported",
+            None,
+            Vec::new(),
+            Some(
+                "Remove the capability declaration. The grammar is accepted so the shape can be \
+                 reviewed, but no operation is registered and no boundary is enforced yet."
+                    .to_string(),
+            ),
+        );
+    }
+
     if msg.starts_with("Unknown identifier") || msg.starts_with("Unknown function") {
         return (
             "unknown-ident",

--- a/src/diagnostics/why.rs
+++ b/src/diagnostics/why.rs
@@ -263,6 +263,10 @@ fn next_toplevel_line_after(items: &[TopLevel], after_line: usize) -> Option<usi
             TopLevel::FnDef(fd) => fd.line,
             TopLevel::Verify(v) => v.line,
             TopLevel::Decision(d) => d.line,
+            // A capability item starts a block, so it bounds the span
+            // of whatever precedes it. Skipping it would let a `--why`
+            // span run past the operation and swallow the next item.
+            TopLevel::Capability(item) => item.line(),
             TopLevel::TypeDef(_) | TopLevel::Module(_) | TopLevel::Stmt(_) => continue,
         };
         if line > after_line {

--- a/src/ir/dump.rs
+++ b/src/ir/dump.rs
@@ -70,6 +70,11 @@ fn dump_top_level(item: &TopLevel, out: &mut String, analysis: Option<&AnalysisR
         TopLevel::Decision(_) => {
             writeln!(out, "decision <block>").ok();
         }
+        // A silent arm here would make `--dump-ir` lie about what the
+        // file contains — the operation would simply not appear.
+        TopLevel::Capability(item) => {
+            writeln!(out, "{} {}", item.keyword(), item.name()).ok();
+        }
     }
 }
 

--- a/src/ir/hir/resolve.rs
+++ b/src/ir/hir/resolve.rs
@@ -205,9 +205,16 @@ pub fn resolve_top_level(ctx: &ResolveCtx<'_>, item: &TopLevel) -> ResolvedTopLe
         // through with their original AST representation. They're
         // not on the runtime hot path; future PRs may promote them
         // once the proof-export passes are ready.
-        TopLevel::Verify(_) | TopLevel::Decision(_) | TopLevel::Stmt(_) | TopLevel::TypeDef(_) => {
-            ResolvedTopLevel::Passthrough(item.clone())
-        }
+        // Capability items join them: nothing registers an operation
+        // yet, so there is no `FnId` to synthesise, and the refusal in
+        // `types::checker` means no program carrying one ever reaches
+        // codegen. This is the one place where ignoring the new variant
+        // is the correct answer rather than a hole.
+        TopLevel::Verify(_)
+        | TopLevel::Decision(_)
+        | TopLevel::Stmt(_)
+        | TopLevel::TypeDef(_)
+        | TopLevel::Capability(_) => ResolvedTopLevel::Passthrough(item.clone()),
     }
 }
 

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -6,7 +6,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use colored::Colorize;
 
-use aver::ast::{Expr, FnDef, Pattern, Spanned, Stmt, TopLevel, TypeDef, VerifyKind};
+use aver::ast::{
+    CapabilityItem, Expr, FnDef, Pattern, Spanned, Stmt, TopLevel, TypeDef, VerifyKind,
+};
 use aver::checker::{CheckFinding, VerifyResult, index_decisions};
 use aver::codegen;
 use aver::codegen::ModuleInfo;
@@ -728,6 +730,28 @@ fn collect_used_exposes_for_importer(
     for item in items {
         match item {
             TopLevel::Module(_) | TopLevel::Decision(_) => {}
+            // An operation's parameter and return annotations name real
+            // types, and those types can come from a dependency. An
+            // ignore arm here would report a genuinely used expose as
+            // unused.
+            TopLevel::Capability(cap) => {
+                if let CapabilityItem::Operation(op) = cap {
+                    for (_, type_name) in &op.params {
+                        mark_type_annotation(
+                            type_name,
+                            dep_targets,
+                            &unique_type_owner,
+                            &mut used_by_target,
+                        );
+                    }
+                    mark_type_annotation(
+                        &op.return_type,
+                        dep_targets,
+                        &unique_type_owner,
+                        &mut used_by_target,
+                    );
+                }
+            }
             TopLevel::FnDef(fd) => {
                 for (_, type_name) in &fd.params {
                     mark_type_annotation(

--- a/src/parser/capability.rs
+++ b/src/parser/capability.rs
@@ -63,6 +63,12 @@ impl Parser {
                 self.skip_newlines();
             }
 
+            // Repeats are tracked by name rather than by "did the value
+            // change", so `hostile = []` followed by `hostile = [a]` is
+            // caught too — an emptied list is still a value someone
+            // wrote, and last-write-wins would drop the first silently.
+            let mut seen: Vec<String> = Vec::new();
+
             while !self.is_dedent() && !self.is_eof() {
                 if self.is_newline() {
                     self.advance();
@@ -80,21 +86,26 @@ impl Parser {
                 };
 
                 self.expect_exact(&TokenKind::Assign)?;
+                if seen.contains(&field_name) {
+                    return Err(ParseError::Error {
+                        msg: format!("Duplicate operation field '{}'", field_name),
+                        line: field_line,
+                        col: 1,
+                    });
+                }
+                seen.push(field_name.clone());
+
                 match field_name.as_str() {
                     "oracle" => {
-                        Self::reject_repeat(&oracle.is_some(), "oracle", field_line)?;
                         oracle = Some(self.parse_attribute_ident("oracle")?);
                     }
                     "replay" => {
-                        Self::reject_repeat(&replay.is_some(), "replay", field_line)?;
                         replay = Some(self.parse_attribute_ident("replay")?);
                     }
                     "hostile" => {
-                        Self::reject_repeat(&!hostile.is_empty(), "hostile", field_line)?;
                         hostile = self.parse_bracket_ident_list()?;
                     }
                     "unmodelled" => {
-                        Self::reject_repeat(&!unmodelled.is_empty(), "unmodelled", field_line)?;
                         unmodelled = self.parse_bracket_ident_list()?;
                     }
                     // The arm that makes a typo'd attribute impossible
@@ -170,16 +181,5 @@ impl Parser {
         };
         self.skip_newlines();
         Ok(value)
-    }
-
-    fn reject_repeat(already_set: &bool, field: &str, line: usize) -> Result<(), ParseError> {
-        if *already_set {
-            return Err(ParseError::Error {
-                msg: format!("Duplicate operation field '{}'", field),
-                line,
-                col: 1,
-            });
-        }
-        Ok(())
     }
 }

--- a/src/parser/capability.rs
+++ b/src/parser/capability.rs
@@ -1,0 +1,185 @@
+//! Grammar for the two declarations only a capability module carries:
+//! `operation` (a signature with no body, plus model attributes) and
+//! `opaque NAME` (a type with no representation).
+//!
+//! Both words are CONTEXTUAL. Neither is in the lexer's keyword table,
+//! because both are live identifiers in the corpus — `opaque` already
+//! modifies `exposes`, and nothing stops a program from binding a value
+//! called `operation`. They are recognised only in top-level item
+//! position, by `Parser::parse_top_level`.
+//!
+//! Why `operation` is not a body-less `fn`: `parse_fn` accepts a `fn`
+//! with no body, and `parse_fn_body` routes an unrecognised
+//! `name = value` line to `parse_binding`. An `oracle = generative`
+//! line under a `fn` therefore parses as an ordinary local binding and
+//! the strongest residual signal is `warning[unused-binding]` — the
+//! whole model half would become dead code that type-checks.
+
+use super::*;
+
+impl Parser {
+    /// `operation name(p: T, ...) -> R` followed by an optional
+    /// indented block: a `? "doc"` line and `name = value` attributes.
+    pub(super) fn parse_operation(&mut self) -> Result<Operation, ParseError> {
+        let line = self.current().line;
+        self.advance(); // consume the contextual `operation`
+
+        let name_tok =
+            self.expect_kind(&TokenKind::Ident(String::new()), "Expected operation name")?;
+        let name = match name_tok.kind {
+            TokenKind::Ident(s) => s,
+            _ => unreachable!(),
+        };
+
+        self.expect_exact(&TokenKind::LParen)?;
+        let params = self.parse_params()?;
+        self.expect_exact(&TokenKind::RParen)?;
+
+        let mut return_type = String::from("Unit");
+        if self.check_exact(&TokenKind::Arrow) {
+            self.advance();
+            return_type = self.parse_type()?;
+        }
+
+        self.skip_newlines();
+
+        let mut desc = None;
+        let mut oracle = None;
+        let mut replay = None;
+        let mut hostile = Vec::new();
+        let mut unmodelled = Vec::new();
+
+        if self.is_indent() {
+            self.advance(); // consume INDENT
+            self.skip_newlines();
+
+            // Optional description, same shape as `fn`'s.
+            if self.check_exact(&TokenKind::Question) {
+                self.advance();
+                let text = self
+                    .parse_inline_string_with_continuations()
+                    .map_err(|_| self.error("Expected string after '?'".to_string()))?;
+                desc = Some(text);
+                self.skip_newlines();
+            }
+
+            while !self.is_dedent() && !self.is_eof() {
+                if self.is_newline() {
+                    self.advance();
+                    continue;
+                }
+
+                let field_tok = self.expect_kind(
+                    &TokenKind::Ident(String::new()),
+                    "Expected operation field name",
+                )?;
+                let field_line = field_tok.line;
+                let field_name = match field_tok.kind {
+                    TokenKind::Ident(s) => s,
+                    _ => unreachable!(),
+                };
+
+                self.expect_exact(&TokenKind::Assign)?;
+                match field_name.as_str() {
+                    "oracle" => {
+                        Self::reject_repeat(&oracle.is_some(), "oracle", field_line)?;
+                        oracle = Some(self.parse_attribute_ident("oracle")?);
+                    }
+                    "replay" => {
+                        Self::reject_repeat(&replay.is_some(), "replay", field_line)?;
+                        replay = Some(self.parse_attribute_ident("replay")?);
+                    }
+                    "hostile" => {
+                        Self::reject_repeat(&!hostile.is_empty(), "hostile", field_line)?;
+                        hostile = self.parse_bracket_ident_list()?;
+                    }
+                    "unmodelled" => {
+                        Self::reject_repeat(&!unmodelled.is_empty(), "unmodelled", field_line)?;
+                        unmodelled = self.parse_bracket_ident_list()?;
+                    }
+                    // The arm that makes a typo'd attribute impossible
+                    // to lose. Modelled on `parse_decision`'s unknown-
+                    // field rejection.
+                    _ => {
+                        return Err(self.error(format!(
+                            "Unknown operation field '{}'. Allowed: oracle, replay, hostile, unmodelled",
+                            field_name
+                        )));
+                    }
+                }
+            }
+
+            if self.is_dedent() {
+                self.advance();
+            }
+        }
+
+        Ok(Operation {
+            name,
+            line,
+            params,
+            return_type,
+            desc,
+            oracle,
+            replay,
+            hostile,
+            unmodelled,
+        })
+    }
+
+    /// `opaque ConnectionToken` — no fields, ever. An indented block
+    /// under it is refused rather than ignored: a representation would
+    /// bind every provider to one implementation's internals.
+    pub(super) fn parse_opaque_decl(&mut self) -> Result<CapabilityItem, ParseError> {
+        let line = self.current().line;
+        self.advance(); // consume the contextual `opaque`
+
+        let name_tok = self.expect_kind(
+            &TokenKind::Ident(String::new()),
+            "Expected a type name after 'opaque'",
+        )?;
+        let name = match name_tok.kind {
+            TokenKind::Ident(s) => s,
+            _ => unreachable!(),
+        };
+
+        self.skip_newlines();
+
+        if self.is_indent() {
+            return Err(self.error(format!(
+                "An opaque capability type has no representation, so '{}' cannot have fields. \
+                 Its layout is a provider detail; naming it here would bind every provider to \
+                 one implementation's internals. Use `record {}` if you wanted an ordinary type \
+                 with hidden fields, and list it under `exposes opaque [...]`.",
+                name, name
+            )));
+        }
+
+        Ok(CapabilityItem::Opaque { name, line })
+    }
+
+    /// A single identifier on the right of an operation attribute.
+    fn parse_attribute_ident(&mut self, field: &str) -> Result<String, ParseError> {
+        let tok = self.expect_kind(
+            &TokenKind::Ident(String::new()),
+            &format!("Expected an identifier after '{} ='", field),
+        )?;
+        let value = match tok.kind {
+            TokenKind::Ident(s) => s,
+            _ => unreachable!(),
+        };
+        self.skip_newlines();
+        Ok(value)
+    }
+
+    fn reject_repeat(already_set: &bool, field: &str, line: usize) -> Result<(), ParseError> {
+        if *already_set {
+            return Err(ParseError::Error {
+                msg: format!("Duplicate operation field '{}'", field),
+                line,
+                col: 1,
+            });
+        }
+        Ok(())
+    }
+}

--- a/src/parser/core.rs
+++ b/src/parser/core.rs
@@ -199,6 +199,49 @@ impl Parser {
                     kw
                 )))
             }
+            // Three contextual words, recognised only here in item
+            // position. Without these arms all three fall through to
+            // `parse_expr` below, and because Aver has no juxtaposition
+            // `operation open` and `opaque Token` become two adjacent
+            // expression statements — a SILENT MISPARSE, not a failure.
+            //
+            // The `peek(1)` guards keep every one of them an ordinary
+            // identifier in every other position: a file that binds
+            // `operation = 1` or writes `opaque` as a bare expression
+            // still parses exactly as it did before.
+            TokenKind::Ident(s)
+                if s == "operation" && matches!(&self.peek(1).kind, TokenKind::Ident(_)) =>
+            {
+                Ok(Some(TopLevel::Capability(CapabilityItem::Operation(
+                    self.parse_operation()?,
+                ))))
+            }
+            TokenKind::Ident(s)
+                if s == "opaque" && matches!(&self.peek(1).kind, TokenKind::Ident(_)) =>
+            {
+                Ok(Some(TopLevel::Capability(self.parse_opaque_decl()?)))
+            }
+            // There is exactly one way to declare a capability, and it
+            // is not this one. A `capability Foo` block would duplicate
+            // exposes / exposes opaque / depends / visibility / name
+            // resolution that a module already supplies. Refused
+            // explicitly, because falling through would misparse it in
+            // silence.
+            TokenKind::Ident(s)
+                if s == "capability" && matches!(&self.peek(1).kind, TokenKind::Ident(_)) =>
+            {
+                let name = match &self.peek(1).kind {
+                    TokenKind::Ident(n) => n.clone(),
+                    _ => unreachable!(),
+                };
+                Err(self.error(format!(
+                    "A capability is a kind of module, not a declaration inside one. \
+                     Write `kind = capability` in the module header of '{}' instead of \
+                     `capability {}` — the module already supplies exposes, exposes opaque, \
+                     depends and name resolution.",
+                    name, name
+                )))
+            }
             TokenKind::Ident(_)
                 if matches!(&self.peek(1).kind, TokenKind::Assign | TokenKind::Colon) =>
             {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -43,6 +43,7 @@ pub struct Parser {
 pub(super) const MAX_PARSE_DEPTH: u32 = 64;
 
 mod blocks;
+mod capability;
 mod core;
 mod expr;
 mod functions;

--- a/src/parser/module.rs
+++ b/src/parser/module.rs
@@ -19,6 +19,8 @@ impl Parser {
         let mut intent = String::new();
         let mut effects = None;
         let mut effects_line = None;
+        let mut kind = None;
+        let mut kind_line = None;
 
         if self.is_indent() {
             self.advance(); // consume INDENT
@@ -52,6 +54,51 @@ impl Parser {
                             .collect();
                         effects = Some(list);
                     }
+                    // `kind = capability` — the ONLY way to declare a
+                    // capability. Contextual: `kind` stays an ordinary
+                    // identifier everywhere else, and is only read here,
+                    // in module-header field position. Shape copied from
+                    // `intent =` above, the header's other `name = value`
+                    // field.
+                    TokenKind::Ident(s) if s == "kind" => {
+                        kind_line = Some(self.current().line);
+                        self.advance(); // consume 'kind'
+                        self.expect_exact(&TokenKind::Assign)?;
+                        let value_tok = self.expect_kind(
+                            &TokenKind::Ident(String::new()),
+                            "Expected a module kind after 'kind =' (the only kind today is `capability`)",
+                        )?;
+                        kind = match value_tok.kind {
+                            TokenKind::Ident(s) => Some(s),
+                            _ => unreachable!(),
+                        };
+                    }
+                    // An unrecognised line that still has HEADER-FIELD
+                    // SHAPE — an identifier followed by `=` or `[`, the
+                    // two forms every real field takes. Breaking here
+                    // would leave the DEDENT unconsumed and hand the
+                    // line back to `parse_top_level`, where `kimd =
+                    // capability` becomes an ordinary binding; with a
+                    // resolvable right-hand side that produces no
+                    // diagnostic at all, so a mistyped field would
+                    // silently stop being a field. Refuse it, the way
+                    // `parse_decision` refuses an unknown decision
+                    // field.
+                    TokenKind::Ident(_)
+                        if matches!(
+                            &self.peek(1).kind,
+                            TokenKind::Assign | TokenKind::LBracket
+                        ) =>
+                    {
+                        return Err(self.error(format!(
+                            "Unknown module header field, found {}. Allowed: intent, kind, depends, exposes, effects",
+                            self.current().kind
+                        )));
+                    }
+                    // Anything else ends the header and is re-read as a
+                    // top-level item. An indented `fn` / `type` / block
+                    // keyword cannot be confused with a header field, so
+                    // the pre-existing shape keeps working.
                     _ => break,
                 }
                 self.skip_newlines();
@@ -72,6 +119,8 @@ impl Parser {
             intent,
             effects,
             effects_line,
+            kind,
+            kind_line,
         })
     }
 

--- a/src/parser/module.rs
+++ b/src/parser/module.rs
@@ -91,7 +91,8 @@ impl Parser {
                         ) =>
                     {
                         return Err(self.error(format!(
-                            "Unknown module header field, found {}. Allowed: intent, kind, depends, exposes, effects",
+                            "Unknown module header field, found {}. Allowed: intent, kind, depends, exposes, effects. \
+                             If you meant a top-level binding, unindent it — bindings live at column 0, outside the header.",
                             self.current().kind
                         )));
                     }

--- a/src/types/checker/check.rs
+++ b/src/types/checker/check.rs
@@ -151,6 +151,10 @@ impl TypeChecker {
                 .collect();
             sub.integrate_loaded_modules(&visible_to_sub);
             sub.build_signatures(&module.items);
+            // Same refusal the entry file gets. `proof` has no `--deps`
+            // flag, so without this a capability declared in a dependency
+            // would slip through every entry point that loads it.
+            super::reject_capability_items(&module.items, &mut sub.errors);
             sub.check_top_level_stmts(&module.items);
             sub.check_verify_blocks(&module.items);
             for item in &module.items {

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -283,15 +283,6 @@ fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCh
     }
 }
 
-/// Enforce module-level `effects [...]` declaration against per-fn effect
-/// usage. The rule:
-///
-/// - Module without `effects [...]` → legacy/mixed, no enforcement (0.13
-///   migration shim; 0.14+ may upgrade to soft warning).
-/// - Module with `effects [...]` (including `effects []` for explicit pure)
-///   → every function's `! [...]` must be covered by the module's declared
-///   surface. A namespace-level entry like `Disk` admits any `Disk.*`
-///   method; a method-level entry like `Time.now` admits only that one.
 /// The message every capability refusal carries. Kept as one constant
 /// so the three entry points cannot drift apart, and so the diagnostic
 /// classifier can key on it.
@@ -349,6 +340,15 @@ pub(crate) fn reject_capability_items(items: &[TopLevel], errors: &mut Vec<TypeE
     }
 }
 
+/// Enforce module-level `effects [...]` declaration against per-fn effect
+/// usage. The rule:
+///
+/// - Module without `effects [...]` → legacy/mixed, no enforcement (0.13
+///   migration shim; 0.14+ may upgrade to soft warning).
+/// - Module with `effects [...]` (including `effects []` for explicit pure)
+///   → every function's `! [...]` must be covered by the module's declared
+///   surface. A namespace-level entry like `Disk` admits any `Disk.*`
+///   method; a method-level entry like `Time.now` admits only that one.
 fn check_module_effect_boundary(items: &[TopLevel], errors: &mut Vec<TypeError>) {
     let Some(allowed) = items.iter().find_map(|i| match i {
         TopLevel::Module(m) => m.effects.as_ref().map(|e| (e, m)),

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -274,6 +274,7 @@ fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCh
     }
 
     check_module_effect_boundary(items, &mut checker.errors);
+    reject_capability_items(items, &mut checker.errors);
 
     TypeCheckResult {
         errors: checker.errors,
@@ -291,6 +292,63 @@ fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCh
 ///   → every function's `! [...]` must be covered by the module's declared
 ///   surface. A namespace-level entry like `Disk` admits any `Disk.*`
 ///   method; a method-level entry like `Time.now` admits only that one.
+/// The message every capability refusal carries. Kept as one constant
+/// so the three entry points cannot drift apart, and so the diagnostic
+/// classifier can key on it.
+pub(crate) const CAPABILITY_UNSUPPORTED: &str =
+    "capability declarations are parsed but not yet supported";
+
+/// Refuse any file that declares a capability.
+///
+/// The grammar landed before the semantics, and the gap between them is
+/// exactly where a false guarantee would live: a capability module that
+/// type-checks as an ordinary module would register no operations,
+/// classify no effects and enforce no boundary, while reading — to
+/// whoever wrote it — as if it did. Refusing is the only honest state
+/// until the registration phase lands.
+///
+/// Runs for the entry file from `finalize_check_result` and for every
+/// dependency from `check_loaded_module_bodies`, so a capability in a
+/// `depends`-only module is refused too. A refusal that only the entry
+/// file enforces is the entry-scoped checking gap all over again.
+pub(crate) fn reject_capability_items(items: &[TopLevel], errors: &mut Vec<TypeError>) {
+    for item in items {
+        match item {
+            TopLevel::Capability(cap) => {
+                errors.push(TypeError {
+                    message: format!(
+                        "{}: `{} {}` is recognised by the parser, but nothing registers it yet, \
+                         so the boundary it declares would not be enforced. Remove it until \
+                         capability support lands.",
+                        CAPABILITY_UNSUPPORTED,
+                        cap.keyword(),
+                        cap.name()
+                    ),
+                    line: cap.line(),
+                    col: 1,
+                    secondary: None,
+                });
+            }
+            TopLevel::Module(m) => {
+                if let Some(kind) = &m.kind {
+                    errors.push(TypeError {
+                        message: format!(
+                            "{}: module '{}' declares `kind = {}`, but nothing acts on it yet, \
+                             so the module is checked exactly like an ordinary one. Remove the \
+                             line until capability support lands.",
+                            CAPABILITY_UNSUPPORTED, m.name, kind
+                        ),
+                        line: m.kind_line.unwrap_or(m.line),
+                        col: 1,
+                        secondary: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 fn check_module_effect_boundary(items: &[TopLevel], errors: &mut Vec<TypeError>) {
     let Some(allowed) = items.iter().find_map(|i| match i {
         TopLevel::Module(m) => m.effects.as_ref().map(|e| (e, m)),

--- a/tests/capability_grammar_spec.rs
+++ b/tests/capability_grammar_spec.rs
@@ -282,6 +282,14 @@ fn duplicate_operation_field_is_a_parse_error() {
         msg.contains("Duplicate operation field 'oracle'"),
         "a repeated attribute must not silently win last-write, got: {msg}"
     );
+
+    // An emptied list is still a value someone wrote, so the repeat is
+    // tracked by field name rather than by "did the value change".
+    let msg = parse_error("operation open() -> Int\n    hostile = []\n    hostile = [a]\n");
+    assert!(
+        msg.contains("Duplicate operation field 'hostile'"),
+        "a repeat after an empty list must be caught too, got: {msg}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/capability_grammar_spec.rs
+++ b/tests/capability_grammar_spec.rs
@@ -1,0 +1,540 @@
+//! The capability grammar: `kind = capability` in a module header,
+//! `operation` and `opaque` as top-level declarations.
+//!
+//! Three properties are pinned here, and they point in different
+//! directions on purpose.
+//!
+//! 1. **The silent-misparse trap, both halves.** Before this grammar
+//!    existed, an unknown word at top level was not a parse error:
+//!    `parse_top_level` fell through to `parse_expr`, and because Aver
+//!    has no juxtaposition, `opaque Token` became two adjacent
+//!    expression statements with no diagnostic beyond an
+//!    `unknown-ident` anchored on the wrong line. `operation` and
+//!    `opaque` must now PARSE. `capability Foo` must now be a HARD
+//!    ERROR, because a capability is a kind of module and there is
+//!    exactly one way to declare one.
+//!
+//! 2. **Round-trip.** `unparse` is the only writer of `TopLevel`, so an
+//!    ignore arm there would silently delete a capability declaration
+//!    from the output — valid Aver, just missing its boundary. The
+//!    round-trip assertion below fails against any such stub.
+//!
+//! 3. **Fail-closed.** A file declaring a capability is refused by
+//!    `check`, `verify` and `proof` alike, whether the declaration is
+//!    in the entry file or in a dependency. Parsing without refusing
+//!    would be worse than a parse error: it would let someone believe
+//!    a boundary is enforced when nothing registers it.
+
+use std::fs;
+use std::process::Command;
+
+use aver::ast::*;
+use aver::lexer::Lexer;
+use aver::parser::Parser;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse(src: &str) -> Vec<TopLevel> {
+    let mut lexer = Lexer::new(src);
+    let tokens = lexer.tokenize().expect("lex failed");
+    let mut parser = Parser::new(tokens);
+    parser.parse().expect("parse failed")
+}
+
+fn parse_error(src: &str) -> String {
+    let mut lexer = Lexer::new(src);
+    let tokens = lexer.tokenize().expect("lex failed");
+    let mut parser = Parser::new(tokens);
+    parser
+        .parse()
+        .expect_err("expected a parse error")
+        .to_string()
+}
+
+fn aver_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aver")
+}
+
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("aver-capability-{tag}-{}", std::process::id()));
+    if dir.exists() {
+        fs::remove_dir_all(&dir).ok();
+    }
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// The refusal text every entry point must produce. Matches
+/// `aver::types::checker::CAPABILITY_UNSUPPORTED`.
+const REFUSAL: &str = "capability declarations are parsed but not yet supported";
+
+/// One module carrying every new grammar form at once.
+const CAPABILITY_SOURCE: &str = "\
+module Net
+    kind = capability
+    exposes [greet]
+    effects []
+
+opaque ConnectionToken
+
+operation open(host: String, port: Int) -> Result<ConnectionToken, Int>
+    ? \"Establish a stream connection.\"
+    oracle = generative
+    replay = recorded
+    hostile = [openOk, openRefused]
+
+operation send(tok: ConnectionToken, line: String) -> Result<Int, Int>
+    oracle = generativeOutput
+    replay = recorded
+    hostile = [sendOk, sendBroken]
+    unmodelled = [shutdown]
+
+fn greet(x: Int) -> Int
+    ? \"ordinary code above the boundary\"
+    x
+";
+
+// ---------------------------------------------------------------------------
+// 1a. `operation` and `opaque` PARSE — the half that must now succeed
+// ---------------------------------------------------------------------------
+
+#[test]
+fn opaque_declaration_parses_as_a_capability_item() {
+    // Before: two `TopLevel::Stmt(Expr(Ident))` items and no parse
+    // error at all — the declaration vanished into expression position.
+    let items = parse("opaque ConnectionToken\n");
+    assert_eq!(items.len(), 1, "expected exactly one item, got {items:?}");
+    assert_eq!(
+        items[0],
+        TopLevel::Capability(CapabilityItem::Opaque {
+            name: "ConnectionToken".to_string(),
+            line: 1,
+        })
+    );
+}
+
+#[test]
+fn operation_signature_and_attributes_parse() {
+    // Before: this errored at the `:` inside the parameter list —
+    // by accident, not because `operation` was rejected.
+    let items = parse(
+        "operation open(host: String, port: Int) -> Result<ConnectionToken, Int>\n\
+         \x20   ? \"Establish a stream connection.\"\n\
+         \x20   oracle = generative\n\
+         \x20   replay = recorded\n\
+         \x20   hostile = [openOk, openRefused]\n\
+         \x20   unmodelled = [shutdown]\n",
+    );
+    assert_eq!(items.len(), 1, "expected exactly one item, got {items:?}");
+    let TopLevel::Capability(CapabilityItem::Operation(op)) = &items[0] else {
+        panic!("expected a capability operation, got {:?}", items[0]);
+    };
+    assert_eq!(op.name, "open");
+    assert_eq!(
+        op.params,
+        vec![
+            ("host".to_string(), "String".to_string()),
+            ("port".to_string(), "Int".to_string()),
+        ]
+    );
+    assert_eq!(op.return_type, "Result<ConnectionToken, Int>");
+    assert_eq!(op.desc.as_deref(), Some("Establish a stream connection."));
+    assert_eq!(op.oracle.as_deref(), Some("generative"));
+    assert_eq!(op.replay.as_deref(), Some("recorded"));
+    assert_eq!(op.hostile, vec!["openOk", "openRefused"]);
+    assert_eq!(op.unmodelled, vec!["shutdown"]);
+}
+
+#[test]
+fn operation_without_an_attribute_block_parses() {
+    // `operation size() -> Int` used to error at the `->`, also by
+    // accident. Attribute admissibility is a later phase; the grammar
+    // must not invent a rule it cannot yet enforce.
+    let items = parse("operation size() -> Int\n");
+    let TopLevel::Capability(CapabilityItem::Operation(op)) = &items[0] else {
+        panic!("expected a capability operation, got {:?}", items[0]);
+    };
+    assert_eq!(op.name, "size");
+    assert!(op.params.is_empty());
+    assert_eq!(op.return_type, "Int");
+    assert_eq!(op.oracle, None);
+}
+
+#[test]
+fn kind_capability_is_a_module_header_field() {
+    let items = parse("module Net\n    kind = capability\n    exposes [greet]\n");
+    let TopLevel::Module(m) = &items[0] else {
+        panic!("expected a module, got {:?}", items[0]);
+    };
+    assert_eq!(m.kind.as_deref(), Some("capability"));
+    assert_eq!(m.kind_line, Some(2));
+    assert_eq!(m.exposes, vec!["greet"]);
+}
+
+#[test]
+fn ordinary_module_has_no_kind() {
+    let items = parse("module Net\n    exposes [greet]\n");
+    let TopLevel::Module(m) = &items[0] else {
+        panic!("expected a module, got {:?}", items[0]);
+    };
+    assert_eq!(m.kind, None);
+}
+
+// ---------------------------------------------------------------------------
+// 1b. `capability Foo` is a HARD ERROR — the half that must now fail
+// ---------------------------------------------------------------------------
+
+#[test]
+fn capability_block_at_top_level_is_a_parse_error() {
+    // Before: two bogus-span `unknown-ident`s from the typechecker and
+    // no parse error. A capability is a KIND OF MODULE; a `capability`
+    // block would duplicate exposes / depends / visibility / name
+    // resolution the module already supplies.
+    let msg = parse_error("capability Tcp\n");
+    assert!(
+        msg.contains("kind = capability"),
+        "the error must name the one way to declare a capability, got: {msg}"
+    );
+    assert!(
+        msg.contains("kind of module"),
+        "the error must say a capability is a kind of module, got: {msg}"
+    );
+    assert!(
+        msg.contains("Tcp"),
+        "the error must name the offending declaration, got: {msg}"
+    );
+}
+
+#[test]
+fn opaque_with_fields_is_a_parse_error() {
+    // An opaque capability type has no representation anywhere. A field
+    // list would enter the contract hash and bind every provider to one
+    // implementation's internals.
+    let msg = parse_error("opaque ConnectionToken\n    fd: Int\n");
+    assert!(
+        msg.contains("no representation"),
+        "expected the representation-less rule, got: {msg}"
+    );
+    assert!(
+        msg.contains("ConnectionToken"),
+        "the error must name the type, got: {msg}"
+    );
+}
+
+#[test]
+fn unknown_operation_field_is_a_parse_error() {
+    let msg = parse_error("operation open() -> Int\n    orcale = generative\n");
+    assert!(
+        msg.contains("Unknown operation field 'orcale'"),
+        "a typo'd attribute must be refused, not dropped, got: {msg}"
+    );
+    assert!(
+        msg.contains("oracle, replay, hostile, unmodelled"),
+        "the error must list the allowed fields, got: {msg}"
+    );
+}
+
+#[test]
+fn unknown_module_header_field_is_a_parse_error() {
+    // The header loop used to `break` on an unrecognised field, leaving
+    // the DEDENT unconsumed so the line was re-read at top level as an
+    // ordinary binding. A mistyped `kind` was therefore silent.
+    let msg = parse_error("module Net\n    kimd = capability\n    exposes [greet]\n");
+    assert!(
+        msg.contains("Unknown module header field"),
+        "expected a loud unknown-field error, got: {msg}"
+    );
+    assert!(
+        msg.contains("intent, kind, depends, exposes, effects"),
+        "the error must list the allowed header fields, got: {msg}"
+    );
+
+    // A typo'd bracket-list field takes the same path: `exposse [greet]`
+    // would otherwise fall through to the expression parser and become
+    // an index expression.
+    let msg = parse_error("module Net\n    exposse [greet]\n");
+    assert!(
+        msg.contains("Unknown module header field"),
+        "a mistyped bracket-list field must be refused too, got: {msg}"
+    );
+}
+
+#[test]
+fn indented_items_still_end_the_module_header() {
+    // The unknown-field error is scoped to HEADER-FIELD SHAPE — an
+    // identifier followed by `=` or `[`. An indented `fn` cannot be
+    // confused with a field, so it must still end the header and be
+    // re-read as a top-level item. `format_cmd`'s
+    // `normalizes_line_endings_and_trailing_ws` pins this shape.
+    let items = parse("module A\n    fn x() -> Int\n        1\n");
+    assert_eq!(items.len(), 2, "expected a module and a fn, got {items:?}");
+    assert!(matches!(&items[0], TopLevel::Module(m) if m.name == "A"));
+    assert!(matches!(&items[1], TopLevel::FnDef(fd) if fd.name == "x"));
+}
+
+#[test]
+fn duplicate_operation_field_is_a_parse_error() {
+    let msg =
+        parse_error("operation open() -> Int\n    oracle = generative\n    oracle = output\n");
+    assert!(
+        msg.contains("Duplicate operation field 'oracle'"),
+        "a repeated attribute must not silently win last-write, got: {msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Every new word stays CONTEXTUAL
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contextual_words_remain_ordinary_identifiers() {
+    // `replay` is a live function name in the corpus, `binding` is a
+    // live pattern binder, `output` occurs dozens of times as an
+    // identifier. None of the new words may be reserved.
+    let src = "\
+fn operation(x: Int) -> Int
+    x
+
+fn opaque(x: Int) -> Int
+    x
+
+fn capability(x: Int) -> Int
+    x
+
+fn kind(x: Int) -> Int
+    x
+
+fn replay(output: Int) -> Int
+    operation = 1
+    opaque = 2
+    capability = 3
+    kind = 4
+    output + operation + opaque + capability + kind
+";
+    let items = parse(src);
+    let names: Vec<&str> = items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::FnDef(fd) => Some(fd.name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        names,
+        vec!["operation", "opaque", "capability", "kind", "replay"],
+        "every new word must still be usable as a function name"
+    );
+    assert!(
+        !items
+            .iter()
+            .any(|i| matches!(i, TopLevel::Capability(_) | TopLevel::Module(_))),
+        "no contextual word may be promoted to a declaration outside item position"
+    );
+}
+
+#[test]
+fn contextual_words_still_bind_at_top_level() {
+    // `opaque = 1` has `Assign` at peek(1), so the guarded arms above
+    // must not claim it.
+    for word in ["operation", "opaque", "capability", "kind"] {
+        let items = parse(&format!("{word} = 1\n"));
+        assert_eq!(
+            items.len(),
+            1,
+            "`{word} = 1` must stay a single binding, got {items:?}"
+        );
+        assert!(
+            matches!(&items[0], TopLevel::Stmt(Stmt::Binding(n, _, _)) if n == word),
+            "`{word} = 1` must stay a binding, got {:?}",
+            items[0]
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Round-trip — kills any `=> Ok(())` stub in `write_top_level`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn capability_declarations_survive_unparse_and_reparse() {
+    let items = parse(CAPABILITY_SOURCE);
+
+    // The parse itself pins the item set: a dropped dispatch arm would
+    // change these counts before unparse ever runs.
+    let capability_items: Vec<&CapabilityItem> = items
+        .iter()
+        .filter_map(|i| match i {
+            TopLevel::Capability(c) => Some(c),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        capability_items.len(),
+        3,
+        "expected `opaque` + two `operation`s, got {capability_items:?}"
+    );
+    assert_eq!(
+        capability_items
+            .iter()
+            .map(|c| c.name())
+            .collect::<Vec<_>>(),
+        vec!["ConnectionToken", "open", "send"]
+    );
+
+    let text = aver::ast::unparse::unparse(&items).expect("unparse failed");
+    assert!(
+        text.contains("kind = capability"),
+        "the module kind must survive unparse:\n{text}"
+    );
+    assert!(
+        text.contains("opaque ConnectionToken"),
+        "the opaque declaration must survive unparse:\n{text}"
+    );
+    assert!(
+        text.contains("operation open(host: String, port: Int) -> Result<ConnectionToken, Int>"),
+        "the operation signature must survive unparse:\n{text}"
+    );
+    assert!(
+        text.contains("hostile = [openOk, openRefused]"),
+        "the model attributes must survive unparse:\n{text}"
+    );
+    assert!(
+        text.contains("unmodelled = [shutdown]"),
+        "`unmodelled` must survive unparse:\n{text}"
+    );
+
+    // The property that catches a partial writer: reparsing must give
+    // back an equal item list, not merely a parseable one.
+    let reparsed = parse(&text);
+    assert_eq!(
+        reparsed, items,
+        "unparse → reparse must be lossless for capability declarations"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Fail-closed: refused by check, verify AND proof
+// ---------------------------------------------------------------------------
+
+fn run(cmd: &str, dir: &std::path::Path, file: &str) -> (i32, String) {
+    let out = Command::new(aver_bin())
+        .current_dir(dir)
+        .args([cmd, "--module-root", dir.to_str().expect("utf-8 dir"), file])
+        .output()
+        .unwrap_or_else(|e| panic!("run aver {cmd}: {e}"));
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.code().unwrap_or(-1), text)
+}
+
+#[test]
+fn capability_file_is_refused_by_check_verify_and_proof() {
+    let dir = temp_dir("entry");
+    fs::write(dir.join("net.av"), CAPABILITY_SOURCE).expect("write net.av");
+
+    for cmd in ["check", "verify", "proof"] {
+        let (code, text) = run(cmd, &dir, "net.av");
+        assert_ne!(
+            code, 0,
+            "`aver {cmd}` must refuse a capability file, but exited 0:\n{text}"
+        );
+        assert!(
+            text.contains(REFUSAL),
+            "`aver {cmd}` must refuse with the capability message, got:\n{text}"
+        );
+        // Each of the four declarations is reported, not just the first
+        // one the scan happens to reach.
+        for named in [
+            "module 'Net' declares `kind = capability`",
+            "`opaque ConnectionToken`",
+            "`operation open`",
+            "`operation send`",
+        ] {
+            assert!(
+                text.contains(named),
+                "`aver {cmd}` must name {named} in its refusal, got:\n{text}"
+            );
+        }
+    }
+}
+
+#[test]
+fn capability_in_a_dependency_is_refused_by_check_verify_and_proof() {
+    // `proof` has no `--deps` flag. If the refusal only ran for the
+    // entry file, a capability declared one module away would slip
+    // through every entry point that loads it — the same shape as the
+    // entry-scoped checking gap.
+    let dir = temp_dir("dep");
+    fs::write(dir.join("Net.av"), CAPABILITY_SOURCE).expect("write Net.av");
+    fs::write(
+        dir.join("main.av"),
+        "\
+module Client
+    depends [Net]
+    exposes [go]
+    effects []
+
+fn go(x: Int) -> Int
+    ? \"calls into the dependency\"
+    Net.greet(x)
+
+verify go
+    go(1) => 1
+",
+    )
+    .expect("write main.av");
+
+    for cmd in ["check", "verify", "proof"] {
+        let (code, text) = run(cmd, &dir, "main.av");
+        assert_ne!(
+            code, 0,
+            "`aver {cmd}` must refuse a capability in a dependency, but exited 0:\n{text}"
+        );
+        assert!(
+            text.contains(REFUSAL),
+            "`aver {cmd}` must refuse the dependency's capability, got:\n{text}"
+        );
+        assert!(
+            text.contains("`operation open`"),
+            "`aver {cmd}` must reach the dependency's operations, got:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn a_module_without_a_capability_still_passes() {
+    // The refusal must not fire on ordinary code. Without this, a green
+    // suite above proves only that everything is rejected.
+    let dir = temp_dir("clean");
+    fs::write(
+        dir.join("clean.av"),
+        "\
+module Clean
+    exposes [go]
+    effects []
+
+fn go(x: Int) -> Int
+    ? \"ordinary\"
+    x
+
+verify go
+    go(1) => 1
+",
+    )
+    .expect("write clean.av");
+
+    let (code, text) = run("check", &dir, "clean.av");
+    assert_eq!(
+        code, 0,
+        "an ordinary module must still check clean:\n{text}"
+    );
+    assert!(
+        !text.contains(REFUSAL),
+        "the refusal must not fire on ordinary code:\n{text}"
+    );
+}

--- a/tests/parser_spec.rs
+++ b/tests/parser_spec.rs
@@ -187,6 +187,21 @@ fn var_keyword_is_parse_error() {
     assert!(parse_fails("var x = 42"), "'var' should be rejected");
 }
 
+#[test]
+fn capability_block_is_parse_error() {
+    // A capability is a KIND OF MODULE, declared solely by
+    // `kind = capability` in the module header. There is exactly one
+    // way to declare one, and a `capability Foo` block is not it — it
+    // would duplicate exposes, depends, visibility and name resolution
+    // the module already supplies. Before the capability grammar this
+    // fell through to expression parsing and misparsed in silence.
+    // Full coverage lives in `capability_grammar_spec.rs`.
+    assert!(
+        parse_fails("capability Tcp\n"),
+        "'capability Foo' should be rejected"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Function definitions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Grammar only. Three new forms parse; nothing is registered, no descriptor or hash is computed, and the effect classification table is untouched.

```aver
module Tcp
    kind = capability
    exposes [connect, write, close, TcpError]

opaque ConnectionToken

operation open(host: String, port: Int) -> Result<ConnectionToken, TcpError>
    ? "Establish a stream connection."
    oracle  = generative
    replay  = recorded
    hostile = [openOk, openRefused]
```

## Fail-closed is the point

A file declaring a capability is refused by `check`, `verify` and `proof` alike — for the entry file **and** for every dependency, which matters because `proof` has no `--deps` flag. Parsing without refusing would be worse than a parse error: a capability module that type-checks as an ordinary module registers no operations and enforces no boundary, while reading to its author as if it did.

```
error[capability-unsupported]: capability declarations are parsed but not yet supported:
`operation open` is recognised by the parser, but nothing registers it yet, so the
boundary it declares would not be enforced. Remove it until capability support lands.
```

The refusal lives in `finalize_check_result` (entry) and `check_loaded_module_bodies` (deps), the single choke point all three commands funnel through. `run` and `compile` inherit it. Each half is pinned by its own test, and each was fault-injected to confirm the test goes red.

## Two silent misparses closed, pointing opposite ways

An unknown word at top level was **not** a parse error: `parse_top_level` fell through to `parse_expr`, and since Aver has no juxtaposition, `opaque Token` became two adjacent expression statements.

| shape | before | after |
|---|---|---|
| `opaque ConnectionToken` | 2 bogus statements, `unknown-ident` on line 1 | parses |
| `operation open(h: String)` | errored at the `:`, by accident | parses |
| `capability Foo` | 2 bogus statements, `unknown-ident` on line 1 | hard error naming `kind = capability` |

There is exactly one way to declare a capability, and `capability Foo` is not it — a module already supplies exposes, exposes opaque, depends and name resolution.

## Contextual, never reserved

Nothing enters the lexer keyword table. `replay` is a live function name in the corpus and `output` is a common identifier, so `operation`, `opaque`, `capability` and `kind` all remain usable as function names, parameters and local bindings. Pinned by `contextual_words_remain_ordinary_identifiers`.

## Latent header defect repaired

`parse_module` used to `break` on an unrecognised field, leaving the DEDENT unconsumed so the line was re-read at top level as an ordinary binding — a mistyped `kind` with a resolvable right-hand side produced no diagnostic at all. A line with header-field shape (identifier followed by `=` or `[`) is now refused by name. Indented items still end the header, so the existing shape keeps working.

## Match sites

One `TopLevel` variant carrying both forms, not three — three would triple the audit surface for no gain. Seven matches were forced non-exhaustive by the compiler; six got real arms, and `ir/hir/resolve.rs` joins the documented passthrough set. Six hundred and seventy textual references across 112 files were audited; the rest are `if let` / `filter_map` and correctly ignore an item that phase 1 registers nothing for.

`unparse` is the highest-severity of the seven — the only writer of `TopLevel`, where an ignore arm would silently delete a declaration from a round-trip. `capability_declarations_survive_unparse_and_reparse` fails against a `_ => Ok(())` stub, which the compiler cannot catch.

## Tests

`tests/capability_grammar_spec.rs`, 17 tests. Full suite 2622 passed / 0 failed across 105 suites, plus 106 in the other workspace crates. `cargo fmt --all -- --check` and `cargo clippy --all-targets --features wasm,wasip2` clean.

Explicitly out of scope: registering operations, descriptors and hashes, the oracle x replay admissibility table, hostile profile resolution, private-operation visibility, and `aver.toml` bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TacZS7PBUhtBtKpb5iTdBw