### PR TITLE
Pin that a call result never grants ownership of a caller's collection

### DIFF
--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -498,7 +498,13 @@ fn uniquely_owned(
             }
             // User-fn / fn-value / intrinsic results may alias an arg
             // (the RULE-2 gap) — never provably owned without a
-            // returns-fresh analysis (deferred).
+            // returns-fresh analysis (deferred). Answering `true` here
+            // lets a callee mutate a collection its caller still holds:
+            // the `*_keeps_the_callers_{map,vector}_intact` tests in
+            // `tests/rust_codegen_differential.rs` feed a call result
+            // straight into another call's argument and read the
+            // caller's own collection back afterwards, which is the
+            // shape that turns red.
             MirCallee::Fn(_) | MirCallee::LocalSlot { .. } | MirCallee::Intrinsic(_) => false,
         },
         // A live (last-use), owned slot read.

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -499,12 +499,37 @@ fn uniquely_owned(
             // User-fn / fn-value / intrinsic results may alias an arg
             // (the RULE-2 gap) — never provably owned without a
             // returns-fresh analysis (deferred). Answering `true` here
-            // lets a callee mutate a collection its caller still holds:
-            // the `*_keeps_the_callers_{map,vector}_intact` tests in
-            // `tests/rust_codegen_differential.rs` feed a call result
-            // straight into another call's argument and read the
-            // caller's own collection back afterwards, which is the
-            // shape that turns red.
+            // lets a callee mutate a collection its caller still holds.
+            //
+            // Two of the three constructors reach this arm from real
+            // source with a collection result, and each is pinned
+            // SEPARATELY in `tests/own_param_graduation.rs` — relaxing
+            // one alone leaves the other test green:
+            //
+            // - `Fn`: a named user function.
+            //   `named_fn_call_result_argument_keeps_the_param_flagged`,
+            //   plus the behavioural
+            //   `rust_fn_result_argument_keeps_the_callers_map_intact`
+            //   in `tests/rust_codegen_differential.rs`.
+            // - `LocalSlot`: a first-class fn value read out of a slot,
+            //   which this pass cannot see through at all.
+            //   `fn_value_call_result_argument_keeps_the_param_flagged`,
+            //   plus the behavioural
+            //   `fn_value_result_argument_is_not_mutated_in_place` in
+            //   `tests/own_param_soundness.rs`.
+            //
+            // `Intrinsic` has no pin because it cannot be reached with a
+            // collection: the deforestation intrinsics return a String,
+            // an Int or a buffer handle (`BufNew` / `BufAppend` /
+            // `BufAppendSepUnlessFirst` / `BufFinalize` / `ToStr` /
+            // `IntDivEuclid` / `IntModEuclid`), never a Vector or Map, so
+            // such a call is never the argument of an alias-prone param.
+            //
+            // The pinned shapes all feed a call result STRAIGHT into
+            // another call's argument and read the caller's own
+            // collection back afterwards. Going through a `let` first
+            // would settle the question on the binding rules instead —
+            // the argument would be a `MirExpr::Local`, not a `Call`.
             MirCallee::Fn(_) | MirCallee::LocalSlot { .. } | MirCallee::Intrinsic(_) => false,
         },
         // A live (last-use), owned slot read.

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -509,6 +509,8 @@ fn uniquely_owned(
             // - `Fn`: a named user function.
             //   `named_fn_call_result_argument_keeps_the_param_flagged`,
             //   plus the behavioural
+            //   `own_param_soundness::named_fn_result_argument_is_not_mutated_in_place`
+            //   and the end-to-end
             //   `rust_fn_result_argument_keeps_the_callers_map_intact`
             //   in `tests/rust_codegen_differential.rs`.
             // - `LocalSlot`: a first-class fn value read out of a slot,
@@ -519,11 +521,13 @@ fn uniquely_owned(
             //   `tests/own_param_soundness.rs`.
             //
             // `Intrinsic` has no pin because it cannot be reached with a
-            // collection: the deforestation intrinsics return a String,
-            // an Int or a buffer handle (`BufNew` / `BufAppend` /
-            // `BufAppendSepUnlessFirst` / `BufFinalize` / `ToStr` /
-            // `IntDivEuclid` / `IntModEuclid`), never a Vector or Map, so
-            // such a call is never the argument of an alias-prone param.
+            // collection: no member of `BuiltinIntrinsic` returns one.
+            // The full set today is `BufNew` / `BufAppend` /
+            // `BufAppendSepUnlessFirst` / `BufFinalize` (a buffer handle),
+            // `ToStr` (a String), and `IntDivEuclid` / `IntModEuclid` /
+            // `BitsShiftLeft` / `BitsShiftRight` / `BitsLow` (all
+            // `(Int, Int) -> Int`) — never a Vector or Map, so such a call
+            // is never the argument of an alias-prone param.
             //
             // The pinned shapes all feed a call result STRAIGHT into
             // another call's argument and read the caller's own

--- a/tests/own_param_graduation.rs
+++ b/tests/own_param_graduation.rs
@@ -238,3 +238,94 @@ fn main() -> Int
         "param stored as a collection element/value arg must stay flagged"
     );
 }
+
+// ─── call results never grant ownership ─────────────────────────────────
+//
+// `uniquely_owned` answers `false` for every call whose callee is not a
+// builtin: a callee may hand back one of its own arguments, so the result
+// can share a collection the caller still holds. Two constructors reach
+// that arm from real source — `MirCallee::Fn` (a named user function) and
+// `MirCallee::LocalSlot` (a first-class fn value held in a slot) — and each
+// one needs its own pin, because a change that only relaxes one of them
+// leaves the other test green.
+//
+// Both shapes below hand a call result STRAIGHT into another call's
+// argument, never through a `let`. That is what keeps the decision on this
+// arm: a `let`-bound result is a `MirExpr::Local` at the call site, which
+// the binding rules settle long before `uniquely_owned` sees a `Call`.
+
+/// The `MirCallee::Fn` edge. `keepFirst` returns one of its two argument
+/// maps and that result is `growth`'s argument with no binding in between,
+/// while `main` reads `base` back afterwards. `growth`'s map param must
+/// stay flagged — granting it ownership lets `growth` mutate `base` in
+/// place. Behavioural twin: the
+/// `rust_fn_result_argument_keeps_the_callers_map_intact` differential.
+#[test]
+fn named_fn_call_result_argument_keeps_the_param_flagged() {
+    let src = r#"module OwnedFnResultMap
+    intent = "a helper's Map result flows straight into another call"
+    depends []
+    effects []
+
+fn keepFirst(a: Map<String, Int>, b: Map<String, Int>) -> Map<String, Int>
+    ? "returns one of its arguments, so the result shares a caller value"
+    match Map.len(a) > 0
+        true -> a
+        false -> b
+
+fn growth(m: Map<String, Int>, n: Int) -> Int
+    ? "threads the map linearly, then reports its size"
+    match n == 0
+        true -> Map.len(m)
+        false -> growth(Map.set(m, "g{n}", n), n - 1)
+
+fn main() -> Int
+    base = Map.set(Map.set({}, "a", 7), "b", 8)
+    grown = growth(keepFirst(base, {}), 4)
+    grown + Map.len(base)
+"#;
+    let program = refine(src);
+    assert!(
+        param_flagged(&program, "growth", 0),
+        "a named-fn call result must not grant ownership of the caller's map"
+    );
+}
+
+/// The `MirCallee::LocalSlot` edge — the same class through a first-class
+/// fn value. `viaValue` calls its `Fn(..)` parameter and hands the result
+/// straight to `growth` while keeping `base` live, so `growth`'s map param
+/// must stay flagged. `aliasIt` returning its own parameter is what makes a
+/// grant here observable, but the pin does not depend on which function is
+/// passed: the pass cannot see through the slot at all.
+#[test]
+fn fn_value_call_result_argument_keeps_the_param_flagged() {
+    let src = r#"module OwnedSlotResultMap
+    intent = "a fn value's Map result flows straight into another call"
+    depends []
+    effects []
+
+fn aliasIt(m: Map<String, Int>) -> Map<String, Int>
+    ? "returns its own parameter, so the result shares a caller value"
+    m
+
+fn growth(m: Map<String, Int>, n: Int) -> Int
+    ? "threads the map linearly, then reports its size"
+    match n == 0
+        true -> Map.len(m)
+        false -> growth(Map.set(m, "g{n}", n), n - 1)
+
+fn viaValue(f: Fn(Map<String, Int>) -> Map<String, Int>, base: Map<String, Int>) -> Int
+    ? "calls the fn value and hands its result straight to another call"
+    grown = growth(f(base), 4)
+    grown + Map.len(base)
+
+fn main() -> Int
+    base = Map.set(Map.set({}, "a", 7), "b", 8)
+    viaValue(aliasIt, base)
+"#;
+    let program = refine(src);
+    assert!(
+        param_flagged(&program, "growth", 0),
+        "a fn-value call result must not grant ownership of the caller's map"
+    );
+}

--- a/tests/own_param_soundness.rs
+++ b/tests/own_param_soundness.rs
@@ -891,6 +891,59 @@ fn main() -> Unit
     assert_sound("round3_live_alias_at_callsite_map", src, "7");
 }
 
+/// The call-result class through a NAMED USER FUNCTION
+/// (`MirCallee::Fn`). Apart from the fn-value sibling below, every test in
+/// this file binds a call result to a local before it is used again, which
+/// settles ownership on the binding rules; here `keepFirst(base, {})` is
+/// `growth`'s argument directly, so the decision rests on the call-result
+/// arm of `uniquely_owned`. `keepFirst` hands one of its arguments straight
+/// back, so granting ownership lets `growth` empty the caller's map:
+/// correct = `6 2/7`, corruption surfaces as `6 0/-1`.
+///
+/// The VM twin of the structural
+/// `own_param_graduation::named_fn_call_result_argument_keeps_the_param_flagged`
+/// and of the end-to-end
+/// `rust_codegen_differential::rust_fn_result_argument_keeps_the_callers_map_intact`.
+/// It exists so this edge keeps a cheap observable witness even if the
+/// build-and-run differential ever moves to the full tier — the
+/// compiled-Rust leg of that differential cannot go red for this class
+/// anyway, because aver-rt collections are copy-on-write.
+#[test]
+fn named_fn_result_argument_is_not_mutated_in_place() {
+    let src = r#"module OwnedFnResultMap
+    intent = "a helper's map result flows straight into another call"
+    depends []
+    effects [Console.print]
+
+fn keepFirst(a: Map<String, Int>, b: Map<String, Int>) -> Map<String, Int>
+    ? "returns one of its arguments — the result shares the caller's map"
+    match Map.len(a) > 0
+        true -> a
+        false -> b
+
+fn growth(m: Map<String, Int>, n: Int) -> Int
+    ? "threads the map linearly, then reports its size"
+    match n == 0
+        true -> Map.len(m)
+        false -> growth(Map.set(m, "g{n}", n), n - 1)
+
+fn render(m: Map<String, Int>) -> String
+    ? "size plus the value under a"
+    "{Map.len(m)}/{Option.withDefault(Map.get(m, "a"), 0 - 1)}"
+
+fn run() -> String
+    ? "the named fn's result is the next call's argument; base is read after"
+    base = Map.set(Map.set({}, "a", 7), "b", 8)
+    grown = growth(keepFirst(base, {}), 4)
+    "{grown} {render(base)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(run())
+"#;
+    assert_sound("named_fn_result_arg", src, "6 2/7");
+}
+
 /// The call-result class through a FIRST-CLASS FN VALUE. Every other test
 /// in this file binds a call result to a local before it is used again,
 /// which settles ownership on the binding rules; here `f(base)` is

--- a/tests/own_param_soundness.rs
+++ b/tests/own_param_soundness.rs
@@ -890,3 +890,49 @@ fn main() -> Unit
 "#;
     assert_sound("round3_live_alias_at_callsite_map", src, "7");
 }
+
+/// The call-result class through a FIRST-CLASS FN VALUE. Every other test
+/// in this file binds a call result to a local before it is used again,
+/// which settles ownership on the binding rules; here `f(base)` is
+/// `growth`'s argument directly, so the decision rests on the call-result
+/// arm of `uniquely_owned` — and the callee is a `Fn(..)` parameter read
+/// out of a slot (`MirCallee::LocalSlot`), which the pass cannot see
+/// through at all. `aliasIt` hands `base` straight back, so granting
+/// ownership lets `growth` empty the caller's map: correct = `6 2/7`,
+/// corruption surfaces as `6 0/-1`.
+#[test]
+fn fn_value_result_argument_is_not_mutated_in_place() {
+    let src = r#"module ViaValue
+    intent = "a fn value's map result flows straight into another call"
+    depends []
+    effects [Console.print]
+
+fn aliasIt(m: Map<String, Int>) -> Map<String, Int>
+    ? "returns its own parameter — the result shares the caller's map"
+    m
+
+fn growth(m: Map<String, Int>, n: Int) -> Int
+    ? "threads the map linearly, then reports its size"
+    match n == 0
+        true -> Map.len(m)
+        false -> growth(Map.set(m, "g{n}", n), n - 1)
+
+fn render(m: Map<String, Int>) -> String
+    ? "size plus the value under a"
+    "{Map.len(m)}/{Option.withDefault(Map.get(m, "a"), 0 - 1)}"
+
+fn viaValue(f: Fn(Map<String, Int>) -> Map<String, Int>, base: Map<String, Int>) -> String
+    ? "the fn value's result is the next call's argument; base is read after"
+    grown = growth(f(base), 4)
+    "{grown} {render(base)}"
+
+fn run() -> String
+    base = Map.set(Map.set({}, "a", 7), "b", 8)
+    viaValue(aliasIt, base)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(run())
+"#;
+    assert_sound("fn_value_result_arg", src, "6 2/7");
+}

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -847,6 +847,170 @@ fn main() -> Unit
     );
 }
 
+// ─── fn-result arguments never carry ownership ──────────────────────────
+//
+// `own_param`'s `uniquely_owned` answers `false` for the result of a user
+// fn call (the `MirCallee::Fn` arm): a callee may hand back one of its own
+// arguments, so the result can share a collection the caller still holds.
+// Every shape below feeds a call result STRAIGHT into another call's
+// argument — never through a `let`, which is what keeps the decision on
+// that arm instead of on the binding rules — while the caller keeps its own
+// handle on the same collection and reads it back AFTER the call. Granting
+// ownership there lets the callee mutate the caller's collection in place,
+// so the original changes under it. The parity assert is what catches this:
+// the compiled Rust keeps the collection's copy-on-write protection, so the
+// two backends print different answers the moment the grant is wrong.
+
+/// The `Map` half. `keepFirst` hands back one of its two argument maps, and
+/// that result is `growth`'s argument with no binding in between; `run`
+/// keeps `base` live and prints it afterwards, so an ownership grant on the
+/// call result shows up as `base` losing its entries.
+#[test]
+fn rust_fn_result_argument_keeps_the_callers_map_intact() {
+    let src = r#"module OwnedFnResultMap
+    intent = "A helper's Map result flows straight into another call while the caller keeps its own map"
+    depends []
+    effects [Console.print]
+
+fn keepFirst(a: Map<String, Int>, b: Map<String, Int>) -> Map<String, Int>
+    ? "Returns one of its arguments, so the result shares a caller value."
+    match Map.len(a) > 0
+        true -> a
+        false -> b
+
+fn growth(m: Map<String, Int>, n: Int) -> Int
+    ? "Threads the map linearly, then reports its size."
+    match n == 0
+        true -> Map.len(m)
+        false -> growth(Map.set(m, "g{n}", n), n - 1)
+
+fn render(m: Map<String, Int>) -> String
+    ? "Size plus the value under a."
+    "{Map.len(m)}/{Option.withDefault(Map.get(m, "a"), 0 - 1)}"
+
+fn run() -> String
+    ? "Pass a call result straight into another call, then read the original."
+    base = Map.set(Map.set({}, "a", 7), "b", 8)
+    grown = growth(keepFirst(base, {}), 4)
+    "{grown} {render(base)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(run())
+"#;
+    // 4 keys added to a 2-key map, and `base` still holds its own 2 entries.
+    let expected = "6 2/7";
+    let vm = run_vm_inline("own_fn_result_map", src).expect("vm run");
+    let rust = build_run_rust_inline("own_fn_result_map", src).expect("rust build+run");
+    assert_eq!(
+        vm, expected,
+        "the map the caller kept was mutated through a call result"
+    );
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from VM — a call result was treated as a uniquely-owned map"
+    );
+}
+
+/// The reported `viaHelper` shape: a one-line helper that returns
+/// `Map.set` of its own parameter, its result handed straight to the fold
+/// that grows the map. `run` reads its original map after the fold, so a
+/// fold that mutates the helper's result in place is visible as the
+/// original losing its entries.
+#[test]
+fn rust_via_helper_map_result_keeps_the_callers_map_intact() {
+    let src = r#"module ViaHelperMap
+    intent = "A helper returns Map.set of its own parameter and the result goes straight into a fold"
+    depends []
+    effects [Console.print]
+
+fn setOne(into: Map<String, String>, key: String, skip: Bool) -> Map<String, String>
+    ? "Returns a Map built from its own parameter, or the parameter itself."
+    match skip
+        true -> into
+        false -> Map.set(into, key, "v")
+
+fn fill(keys: List<String>, into: Map<String, String>) -> Map<String, String>
+    ? "Folds the keys into the map it was handed."
+    match keys
+        [] -> into
+        [head, ..tail] -> fill(tail, Map.set(into, head, "v"))
+
+fn render(m: Map<String, String>) -> String
+    ? "Size plus the value under a."
+    "{Map.len(m)}/{Option.withDefault(Map.get(m, "a"), "gone")}"
+
+fn run() -> String
+    ? "The helper result is the fold's argument; the original map is read afterwards."
+    base = Map.set(Map.set({}, "a", "0"), "b", "1")
+    grown = render(fill(["x", "y", "z"], setOne(base, "c", Map.has(base, "a"))))
+    "{grown} {render(base)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(run())
+"#;
+    // The fold sees 5 keys; `base` still holds its own 2, "a" among them.
+    let expected = "5/0 2/0";
+    let vm = run_vm_inline("via_helper_map", src).expect("vm run");
+    let rust = build_run_rust_inline("via_helper_map", src).expect("rust build+run");
+    assert_eq!(
+        vm, expected,
+        "the map the caller kept was mutated through the helper's result"
+    );
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from VM — the helper's returned map was treated as uniquely owned"
+    );
+}
+
+/// The `Vector` half of the same class — the other collection `own_param`
+/// can graduate. `keepLonger` hands back one of its argument vectors
+/// straight into `overwrite`, which writes over every position, and `run`
+/// reads position 0 of its own vector afterwards.
+#[test]
+fn rust_fn_result_argument_keeps_the_callers_vector_intact() {
+    let src = r#"module OwnedFnResultVector
+    intent = "A helper's Vector result flows straight into another call while the caller keeps its own vector"
+    depends []
+    effects [Console.print]
+
+fn keepLonger(a: Vector<Int>, b: Vector<Int>) -> Vector<Int>
+    ? "Returns one of its arguments, so the result shares a caller value."
+    match Vector.len(a) >= Vector.len(b)
+        true -> a
+        false -> b
+
+fn overwrite(v: Vector<Int>, i: Int, n: Int) -> Int
+    ? "Threads the vector linearly, writing i*i at every position."
+    match i == n
+        true -> Vector.len(v)
+        false -> overwrite(Option.withDefault(Vector.set(v, i, i * i), v), i + 1, n)
+
+fn run() -> String
+    ? "Pass a call result straight into another call, then read the original."
+    base = Option.withDefault(Vector.set(Vector.new(4, 0), 0, 7), Vector.new(4, 0))
+    touched = overwrite(keepLonger(base, Vector.new(2, 0)), 0, 4)
+    "{touched} {Option.withDefault(Vector.get(base, 0), 0 - 1)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(run())
+"#;
+    // 4 positions overwritten, and `base` still reads 7 at position 0.
+    let expected = "4 7";
+    let vm = run_vm_inline("own_fn_result_vector", src).expect("vm run");
+    let rust = build_run_rust_inline("own_fn_result_vector", src).expect("rust build+run");
+    assert_eq!(
+        vm, expected,
+        "the vector the caller kept was mutated through a call result"
+    );
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from VM — a call result was treated as a uniquely-owned vector"
+    );
+}
+
 /// Nested-tuple Int-literal match on the RUST backend. After the
 /// `Int -> AverInt` migration an `AverInt` can't be a Rust `match` pattern,
 /// so Int-literal arms lower to an if/else-if equality-guard chain. That

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -26,13 +26,20 @@
 //!
 //! ## Tiers
 //!
-//! - **fast**: a 3-example plain-parity subset + the two critical
-//!   behavioral probes (deny-policy, record/replay). Runs on every
-//!   `cargo test` invocation. ~one cargo dep-build then seconds each.
-//! - **full**: every single-file example + the multi-module (`depends`)
-//!   examples, plain-parity only. Gated behind the `AVER_RUST_DIFF_FULL`
-//!   env var (the dep-build + per-example build is minutes of wall
-//!   time — too heavy for PR smoke). Run it with
+//! - **default**: 19 tests, run by every `cargo test` invocation. It
+//!   started as a 3-example plain-parity subset plus the two critical
+//!   behavioral probes (deny-policy, record/replay) and has since grown a
+//!   tail of single-shape regressions — each one a lowering or ownership
+//!   bug that only a real build-and-run catches. ~one cargo dep-build,
+//!   then seconds each. This tier competes for a shared CI budget, so a
+//!   new case earns its place here only when no cheaper harness can hold
+//!   the same ground, and only one shape per class.
+//! - **full**: 11 tests behind `#[ignore]`, 10 of them additionally
+//!   behind the `AVER_RUST_DIFF_FULL` env var — every single-file
+//!   example, the multi-module (`depends`) examples, and the second shape
+//!   of a class whose first shape already runs in the default tier. The
+//!   dep-build + per-example build is minutes of wall time, too heavy for
+//!   PR smoke. Run it with
 //!   `AVER_RUST_DIFF_FULL=1 cargo test --test rust_codegen_differential -- --ignored --nocapture`.
 //!
 //! ## Why this is the porting safety net, not theater
@@ -852,16 +859,31 @@ fn main() -> Unit
 // `own_param`'s `uniquely_owned` answers `false` for the result of a user
 // fn call (the `MirCallee::Fn` arm): a callee may hand back one of its own
 // arguments, so the result can share a collection the caller still holds.
-// Every shape below feeds a call result STRAIGHT into another call's
+// Both shapes below feed a call result STRAIGHT into another call's
 // argument — never through a `let`, which is what keeps the decision on
 // that arm instead of on the binding rules — while the caller keeps its own
 // handle on the same collection and reads it back AFTER the call. Granting
 // ownership there lets the callee mutate the caller's collection in place,
-// so the original changes under it. The parity assert is what catches this:
-// the compiled Rust keeps the collection's copy-on-write protection, so the
-// two backends print different answers the moment the grant is wrong.
+// so the original changes under it.
+//
+// The VM-vs-`expected` assert is the load-bearing one: the VM is where the
+// wrong grant corrupts the caller's collection, and it is checked first.
+// The compiled Rust keeps the collection's copy-on-write protection and
+// still prints the right answer, so the parity assert fires too — as a
+// consequence of the VM's answer having moved, not as an independent
+// signal. What these two tests add over the in-process pins is the
+// end-to-end path: the same program actually compiled to a Rust project,
+// built, and run.
+//
+// Cheap pins for the same class, no `cargo build` involved:
+//   - `own_param_graduation::named_fn_call_result_argument_keeps_the_param_flagged`
+//   - `own_param_graduation::fn_value_call_result_argument_keeps_the_param_flagged`
+//   - `own_param_soundness::fn_value_result_argument_is_not_mutated_in_place`
+// The `MirCallee::LocalSlot` half of the arm (a first-class fn value) is
+// covered only there — it has no build test, deliberately.
 
-/// The `Map` half. `keepFirst` hands back one of its two argument maps, and
+/// The `Map` half, and the one shape of this class that stays in the
+/// default tier. `keepFirst` hands back one of its two argument maps, and
 /// that result is `growth`'s argument with no binding in between; `run`
 /// keeps `base` live and prints it afterwards, so an ownership grant on the
 /// call result shows up as `base` losing its entries.
@@ -912,64 +934,26 @@ fn main() -> Unit
     );
 }
 
-/// The reported `viaHelper` shape: a one-line helper that returns
-/// `Map.set` of its own parameter, its result handed straight to the fold
-/// that grows the map. `run` reads its original map after the fold, so a
-/// fold that mutates the helper's result in place is visible as the
-/// original losing its entries.
-#[test]
-fn rust_via_helper_map_result_keeps_the_callers_map_intact() {
-    let src = r#"module ViaHelperMap
-    intent = "A helper returns Map.set of its own parameter and the result goes straight into a fold"
-    depends []
-    effects [Console.print]
-
-fn setOne(into: Map<String, String>, key: String, skip: Bool) -> Map<String, String>
-    ? "Returns a Map built from its own parameter, or the parameter itself."
-    match skip
-        true -> into
-        false -> Map.set(into, key, "v")
-
-fn fill(keys: List<String>, into: Map<String, String>) -> Map<String, String>
-    ? "Folds the keys into the map it was handed."
-    match keys
-        [] -> into
-        [head, ..tail] -> fill(tail, Map.set(into, head, "v"))
-
-fn render(m: Map<String, String>) -> String
-    ? "Size plus the value under a."
-    "{Map.len(m)}/{Option.withDefault(Map.get(m, "a"), "gone")}"
-
-fn run() -> String
-    ? "The helper result is the fold's argument; the original map is read afterwards."
-    base = Map.set(Map.set({}, "a", "0"), "b", "1")
-    grown = render(fill(["x", "y", "z"], setOne(base, "c", Map.has(base, "a"))))
-    "{grown} {render(base)}"
-
-fn main() -> Unit
-    ! [Console.print]
-    Console.print(run())
-"#;
-    // The fold sees 5 keys; `base` still holds its own 2, "a" among them.
-    let expected = "5/0 2/0";
-    let vm = run_vm_inline("via_helper_map", src).expect("vm run");
-    let rust = build_run_rust_inline("via_helper_map", src).expect("rust build+run");
-    assert_eq!(
-        vm, expected,
-        "the map the caller kept was mutated through the helper's result"
-    );
-    assert_eq!(
-        rust, vm,
-        "Rust diverged from VM — the helper's returned map was treated as uniquely owned"
-    );
-}
-
 /// The `Vector` half of the same class — the other collection `own_param`
 /// can graduate. `keepLonger` hands back one of its argument vectors
 /// straight into `overwrite`, which writes over every position, and `run`
 /// reads position 0 of its own vector afterwards.
+///
+/// Full tier: the `Map` sibling above already carries the class through the
+/// emitted-project path, and the cheap in-process pins cover the arm, so a
+/// second `cargo build` does not belong in the default tier.
 #[test]
+#[ignore = "full tier: cargo build wall-time; set AVER_RUST_DIFF_FULL=1 and run with --ignored"]
 fn rust_fn_result_argument_keeps_the_callers_vector_intact() {
+    if std::env::var("AVER_RUST_DIFF_FULL").is_err() {
+        eprintln!(
+            "skipping the Vector half of the call-result ownership class — \
+             set AVER_RUST_DIFF_FULL=1 (the Map half runs in the default tier, \
+             and the in-process pins in own_param_graduation cover the arm)"
+        );
+        return;
+    }
+
     let src = r#"module OwnedFnResultVector
     intent = "A helper's Vector result flows straight into another call while the caller keeps its own vector"
     depends []

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -26,20 +26,25 @@
 //!
 //! ## Tiers
 //!
-//! - **default**: 19 tests, run by every `cargo test` invocation. It
-//!   started as a 3-example plain-parity subset plus the two critical
-//!   behavioral probes (deny-policy, record/replay) and has since grown a
-//!   tail of single-shape regressions — each one a lowering or ownership
-//!   bug that only a real build-and-run catches. ~one cargo dep-build,
-//!   then seconds each. This tier competes for a shared CI budget, so a
-//!   new case earns its place here only when no cheaper harness can hold
-//!   the same ground, and only one shape per class.
-//! - **full**: 11 tests behind `#[ignore]`, 10 of them additionally
-//!   behind the `AVER_RUST_DIFF_FULL` env var — every single-file
-//!   example, the multi-module (`depends`) examples, and the second shape
-//!   of a class whose first shape already runs in the default tier. The
-//!   dep-build + per-example build is minutes of wall time, too heavy for
-//!   PR smoke. Run it with
+//! (No test counts are quoted here on purpose: they have gone stale
+//! twice, and a grep that counts them also matches this paragraph. The
+//! attribute is the tier marker — read it off the source.)
+//!
+//! - **default**: every test NOT marked `#[ignore]`, run by every `cargo
+//!   test` invocation. It started as a 3-example plain-parity subset plus
+//!   the two critical behavioral probes (deny-policy, record/replay) and
+//!   has since grown a tail of single-shape regressions — each one a
+//!   lowering or ownership bug that only a real build-and-run catches.
+//!   ~one cargo dep-build, then seconds each. This tier competes for a
+//!   shared CI budget, so a new case earns its place here only when no
+//!   cheaper harness can hold the same ground, and only one shape per
+//!   class.
+//! - **full**: every `#[ignore]`d test, each one additionally guarded by
+//!   an `AVER_RUST_DIFF_FULL` env-var check in its own body — every
+//!   single-file example, the multi-module (`depends`) examples, and the
+//!   second shape of a class whose first shape already runs in the
+//!   default tier. The dep-build + per-example build is minutes of wall
+//!   time, too heavy for PR smoke. Run it with
 //!   `AVER_RUST_DIFF_FULL=1 cargo test --test rust_codegen_differential -- --ignored --nocapture`.
 //!
 //! ## Why this is the porting safety net, not theater
@@ -866,21 +871,24 @@ fn main() -> Unit
 // ownership there lets the callee mutate the caller's collection in place,
 // so the original changes under it.
 //
-// The VM-vs-`expected` assert is the load-bearing one: the VM is where the
-// wrong grant corrupts the caller's collection, and it is checked first.
-// The compiled Rust keeps the collection's copy-on-write protection and
-// still prints the right answer, so the parity assert fires too — as a
-// consequence of the VM's answer having moved, not as an independent
-// signal. What these two tests add over the in-process pins is the
-// end-to-end path: the same program actually compiled to a Rust project,
-// built, and run.
+// The VM-vs-`expected` assert is the only one that can go red for this
+// class, and it is checked FIRST: the VM is where a wrong grant corrupts
+// the caller's collection, so under the bug that assert panics and the
+// parity assert below it is never reached. The compiled Rust keeps the
+// collection's copy-on-write protection and still prints the right answer,
+// so the parity assert carries no independent signal here — it is the
+// harness's standing shape, not this class's net. What these tests add
+// over the in-process pins is the end-to-end path: the same program
+// actually compiled to a Rust project, built, and run.
 //
 // Cheap pins for the same class, no `cargo build` involved:
 //   - `own_param_graduation::named_fn_call_result_argument_keeps_the_param_flagged`
 //   - `own_param_graduation::fn_value_call_result_argument_keeps_the_param_flagged`
+//   - `own_param_soundness::named_fn_result_argument_is_not_mutated_in_place`
 //   - `own_param_soundness::fn_value_result_argument_is_not_mutated_in_place`
-// The `MirCallee::LocalSlot` half of the arm (a first-class fn value) is
-// covered only there — it has no build test, deliberately.
+// Both halves of the arm therefore have a structural pin AND a VM-only
+// behavioural witness; the `MirCallee::LocalSlot` half (a first-class fn
+// value) has no build test on top of those, deliberately.
 
 /// The `Map` half, and the one shape of this class that stays in the
 /// default tier. `keepFirst` hands back one of its two argument maps, and


### PR DESCRIPTION
## What was uncovered

`own_param`'s `uniquely_owned` decides whether a call-site argument is a uniquely-owned collection, and it answers `false` for the result of any call that is not a builtin — a callee may hand back one of its own arguments, so the result can share a collection the caller still holds. That arm is the sole gate for a `Call`-shaped argument: the `dup` and live-alias rejections upstream of it only match `MirExpr::Local`.

Two constructors reach the arm with a collection result, and nothing in the test suite held either in place:

- `MirCallee::Fn` — a named user function.
- `MirCallee::LocalSlot` — a first-class fn value read out of a slot, which the pass cannot see through at all.

Every existing ownership test binds a call result to a local before it is used again, which settles the question on the binding rules long before the call-result arm is consulted.

`MirCallee::Intrinsic` is the third constructor on the arm and is deliberately unpinned: no member of `BuiltinIntrinsic` returns a collection. The full set is `BufNew` / `BufAppend` / `BufAppendSepUnlessFirst` / `BufFinalize` (a buffer handle), `ToStr` (a `String`), and `IntDivEuclid` / `IntModEuclid` / `BitsShiftLeft` / `BitsShiftRight` / `BitsLow` (all `(Int, Int) -> Int`). Never a `Vector` or `Map`, so such a call is never the argument of an alias-prone param.

## The tests

**Direct pins, no build** (`tests/own_param_graduation.rs`) — these run `own_param_refine` in-process and read the `aliased_slots` bit out of the refined program; milliseconds each:

- `named_fn_call_result_argument_keeps_the_param_flagged` — `keepFirst` returns one of its two argument maps and that result is `growth`'s argument with no binding in between.
- `fn_value_call_result_argument_keeps_the_param_flagged` — `viaValue` calls its `Fn(..)` parameter and hands the result straight to `growth` while keeping `base` live. The MIR is `FnId(1).call(slot(0, f).call(%1), Int(4))`, so the argument really is a `LocalSlot` call.

**Observable witness, VM only** (`tests/own_param_soundness.rs`) — each runs its program with the refinement on and off and asserts both print `6 2/7`. One `aver run` per side, no `cargo build`, about a second each:

- `named_fn_result_argument_is_not_mutated_in_place` — the named-fn edge.
- `fn_value_result_argument_is_not_mutated_in_place` — the fn-value edge.

Both edges therefore carry a structural pin *and* a cheap observable witness. That symmetry is deliberate: the compiled-Rust leg of the differential below cannot go red for this class (aver-rt collections are copy-on-write, so the built binary prints the right answer even under a wrong grant), so the build test is not a substitute for a run witness on either edge.

**Behavioural, through the emitted Rust project** (`tests/rust_codegen_differential.rs`):

- `rust_fn_result_argument_keeps_the_callers_map_intact` — default tier, the one build-and-run shape for this class.
- `rust_fn_result_argument_keeps_the_callers_vector_intact` — moved to the full tier (`#[ignore]` + `AVER_RUST_DIFF_FULL`).

## Fault-injection matrix

Each constructor was granted ownership on its own, with the other two left at `false`, and the suites re-run. Both flips were reverted; the production `match` arm is byte-identical to `main`.

| flip | `named_fn_…_keeps_the_param_flagged` | `named_fn_result_…_not_mutated_in_place` | `fn_value_…_keeps_the_param_flagged` | `fn_value_result_…_not_mutated_in_place` | other 40 |
| --- | --- | --- | --- | --- | --- |
| `Fn` → true | **RED** | **RED** | green | green | green |
| `LocalSlot` → true | green | green | **RED** | **RED** | green |

The failures:

```
named_fn_call_result_argument_keeps_the_param_flagged
  a named-fn call result must not grant ownership of the caller's map

named_fn_result_argument_is_not_mutated_in_place
  refinement ON corrupted the result
    left: "6 0/-1"   right: "6 2/7"

fn_value_call_result_argument_keeps_the_param_flagged
  a fn-value call result must not grant ownership of the caller's map

fn_value_result_argument_is_not_mutated_in_place
  refinement ON corrupted the result
    left: "6 0/-1"   right: "6 2/7"
```

`6 0/-1` is the caller's map after the callee emptied it in place — zero entries left, nothing under `a`. The same wrong grant on the named-fn edge produces the same corruption in the Map differential's VM leg.

"Other 40" is the rest of `own_param_soundness` (25), `own_param_graduation` (5), `alias_soundness` (9) and `mir_call_known_owned_regression` (1), actually run under both flips rather than argued. That the pre-existing soundness tests survive both flips is the measurement of the gap: neither edge had coverage at all.

## Why one build test, not three

The load-bearing assertion for this class is the VM-versus-expected one, and it is checked first. The wrong grant corrupts the VM's answer, so that assertion panics and the parity assertion after it is never reached. The compiled Rust keeps its copy-on-write protection and still prints the right value, so the parity assertion carries no independent signal for this class — it is the harness's standing shape, not this class's net. A build-and-run per shape therefore buys one thing over the in-process pins — the end-to-end emitted-project path — and buys it once, not three times, in a tier that competes for a shared CI budget.

So: the Map shape stays in the default tier, the Vector shape moves behind the full tier, and the `viaHelper` shape is dropped. Its distinguishing feature was a `Map.set` branch that never executed (`Map.has(base, "a")` is true, so the identity arm ran, which the expected `5/0` already showed). Making it execute removes the signal instead of adding one: with the branch live the program prints `6/0 2/0` both with and without the wrong grant, because a helper that returns `Map.set` of its parameter returns a fresh copy — the caller no longer shares it, so the fold mutating it in place is harmless. What made the shape red was the identity arm, which is exactly what the Map test already covers.

## Production change

Comments only. The arm at `src/ir/mir/optimize/own_param.rs` now names which constructor each pin covers and lists all ten `BuiltinIntrinsic` members behind the claim that `Intrinsic` cannot reach it with a collection.

In the differential harness, the tier paragraph no longer quotes test counts. It quoted them twice and they were wrong twice, because a grep that counts the `#[ignore]` attribute also matches the paragraph describing it; the paragraph now names the marker and lets the reader read the count off the source. The section comment above the call-result tests no longer credits the parity assertion with a signal it does not carry.

Part of #890 — the reported slowdown itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
