### PR TITLE
Return a parameter from compiled Rust however it is named

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1294,7 +1294,9 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 emit_bare_i64(&let_node.value)
                     .or_else(|| emit_mir_expr(&let_node.value, emit_ctx))?
             } else {
-                emit_mir_expr(&let_node.value, emit_ctx)?
+                // The binding is an owning position — see
+                // [`emit_mir_binding_value`].
+                emit_mir_binding_value(&let_node.value, emit_ctx)?
             };
             let body = emit_mir_expr(&let_node.body, emit_ctx)?;
             if let_node.binding_name.is_empty() {
@@ -2582,20 +2584,56 @@ pub(super) fn emit_mir_fn_body(
 /// call argument, a match arm and a TCO base-case return. Two shapes reach
 /// it needing the wrapper, because `emit_mir_expr` renders both bare: a
 /// read of a borrowed param (`&T` against a by-value return type) and a
-/// field access through one (a move out of a shared reference). Mirror of
-/// HIR's `emit_body_expr_plan_with_options` `Leaf`/`Expr` arms.
+/// field read through one at any depth (a move out of a shared reference).
 fn emit_mir_tail_value(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
     let code = emit_mir_expr(expr, ctx)?;
     if local_of(&expr.node).is_some() {
         return Some(mir_maybe_clone(code, &expr.node, ctx));
     }
-    if let MirExpr::Project(p) = &expr.node
-        && let Some(local) = local_of(&p.node.base.node)
-        && ctx.is_borrowed_param(&local.name)
-    {
-        return Some(format!("{}.clone()", code));
+    Some(mir_own_borrowed_read(code, &expr.node, ctx))
+}
+
+/// Emit a `let` binding's value as an OWNED value when it reads a borrowed
+/// param.
+///
+/// Naming an intermediate is not supposed to change what a function may do
+/// with it: `p.y` in return position and `y = p.y` then `y` are the same
+/// program. `emit_mir_expr` renders a binding value raw, so the second one
+/// used to bind `&T` (or move a field out of a shared reference) and the
+/// generated project would not build. The binding is an owning position for
+/// the same reason the tail is — the name outlives the expression that
+/// produced it — so it goes through the same materialisation step.
+fn emit_mir_binding_value(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
+    let code = emit_mir_expr(expr, ctx)?;
+    Some(mir_own_borrowed_read(code, &expr.node, ctx))
+}
+
+/// Materialise an owned value from a read that bottoms out in a borrowed
+/// param, leaving every other expression untouched.
+///
+/// The base chain is walked to its ROOT local rather than checked one level
+/// down: `s.piece.kind` is behind the same shared reference `s.piece` is, so
+/// a depth-1 rule leaves every nested read raw. Anything whose root is not a
+/// borrowed param — a call result, a constructor, an owned local — already
+/// owns what it produces and is returned verbatim, which is also what keeps
+/// this from double-cloning an argument (`mir_clone_arg` runs inside
+/// `emit_mir_expr`, on the arguments, never on the whole call).
+fn mir_own_borrowed_read(code: String, expr: &MirExpr, ctx: &MirEmitCtx<'_>) -> String {
+    match mir_projection_root_local(expr) {
+        Some(local) if ctx.is_borrowed_param(&local.name) => mir_maybe_clone(code, expr, ctx),
+        _ => code,
     }
-    Some(code)
+}
+
+/// The local a chain of field reads bottoms out in: `p` for `p`, and `s` for
+/// both `s.piece` and `s.piece.kind`. `None` for anything else — a call, a
+/// constructor, an index, a literal — which owns its result already.
+fn mir_projection_root_local(expr: &MirExpr) -> Option<&MirLocal> {
+    match expr {
+        MirExpr::Local(_) => local_of(expr),
+        MirExpr::Project(p) => mir_projection_root_local(&p.node.base.node),
+        _ => None,
+    }
 }
 
 /// Emit a non-TCO body's tail value as a bare `i64` expression. The tail
@@ -2635,11 +2673,16 @@ fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
 }
 
 /// Emit a top-level `Let` chain as flat Rust statement lines: each
-/// binding becomes `let {name} = {value};` (value rendered raw, no clone
-/// wrapper), one per line, 4-space indented and `\n`-joined, terminated
-/// by the chain's final expression on its own line. That final expression
-/// is the fn's tail, so it goes through [`emit_mir_tail_value`] — a
-/// statement chain ending in one of its own params returns it by value.
+/// binding becomes `let {name} = {value};`, one per line, 4-space
+/// indented and `\n`-joined, terminated by the chain's final expression
+/// on its own line.
+///
+/// Both the binding value and the final expression are owning positions,
+/// so each goes through its materialisation step —
+/// [`emit_mir_binding_value`] and [`emit_mir_tail_value`]. A chain that
+/// ends in one of its own params returns it by value, and one that names
+/// a param (or a field read through one) part-way through owns what it
+/// named.
 ///
 /// The chain is the run of directly-nested `Let` nodes: each one emits
 /// its statement line and continues into its body until a body that
@@ -2656,7 +2699,7 @@ fn emit_mir_let_chain_flat(
     let mut lines: Vec<String> = Vec::new();
     let mut current = let_node;
     loop {
-        let value = emit_mir_expr(&current.value, ctx)?;
+        let value = emit_mir_binding_value(&current.value, ctx)?;
         if current.binding_name.is_empty() {
             // Discarded intermediate (`Stmt::Expr` at non-tail position,
             // or a `_ = effect()` discard binding). No source ident to
@@ -5613,6 +5656,118 @@ mod tests {
         assert_eq!(
             emit,
             "    crate::cancel_checkpoint();\n    aver_rt::AverInt::from_i64(1);\n    let g = aver_rt::AverInt::from_i64(2);\n    g"
+        );
+    }
+
+    // ── Owning positions over a borrowed param ──────────────────────
+    //
+    // A borrowed param is `&T` in the signature, so every position that
+    // has to hand back an owned value materialises one. The differential
+    // suite proves the emitted project builds and agrees with the VM;
+    // these are the same rules at walker resolution, cheap enough to run
+    // on every `cargo test`.
+
+    /// A read of the named local (`last_use`, so nothing but the borrow
+    /// policy can ask for a clone).
+    fn read(name: &str, slot: u32) -> Spanned<MirExpr> {
+        span(MirExpr::Local(span(MirLocal {
+            slot: LocalId(slot),
+            last_use: true,
+            name: name.to_string(),
+        })))
+    }
+
+    /// `base.field`.
+    fn project(base: Spanned<MirExpr>, field: &str) -> Spanned<MirExpr> {
+        span(MirExpr::Project(span(crate::ir::mir::MirProject {
+            base: Box::new(base),
+            field: field.to_string(),
+        })))
+    }
+
+    /// A policy whose only borrowed param is `name`.
+    fn borrowed_param_policy(name: &str) -> MirFnEmitPolicy {
+        let mut policy = MirFnEmitPolicy::empty();
+        policy.borrowed_params.insert(name.to_string());
+        policy
+    }
+
+    /// A ctx over `policy` — the borrow-field plumbing of `empty_ctx`
+    /// with a real `borrowed_params` set behind it.
+    fn ctx_over(policy: &MirFnEmitPolicy) -> MirEmitCtx<'_> {
+        use std::sync::OnceLock;
+        static SYMBOLS: OnceLock<SymbolTable> = OnceLock::new();
+        static PREFIXES: OnceLock<HashSet<String>> = OnceLock::new();
+        static BUILTINS: OnceLock<Vec<String>> = OnceLock::new();
+        MirEmitCtx {
+            symbol_table: SYMBOLS.get_or_init(SymbolTable::default),
+            module_prefixes: PREFIXES.get_or_init(HashSet::new),
+            codegen: None,
+            local_types: &policy.local_types,
+            rc_wrapped: &policy.rc_wrapped,
+            borrowed_params: &policy.borrowed_params,
+            owned_params: &policy.owned_params,
+            current_module_scope: policy.current_module_scope.as_deref(),
+            mir_builtins: BUILTINS.get_or_init(Vec::new),
+            bare: &policy.bare,
+            try_err_to_string: false,
+        }
+    }
+
+    #[test]
+    fn tail_field_read_through_a_borrowed_param_clones_at_any_depth() {
+        // `s.piece.kind` is behind the same shared reference `s.piece` is,
+        // so a rule that only looks one level down leaves the nested read
+        // raw and rustc rejects the move out of `&S`.
+        let policy = borrowed_param_policy("s");
+        let ctx = ctx_over(&policy);
+        let one = project(read("s", 0), "piece");
+        assert_eq!(
+            emit_mir_fn_body(&one, &ctx).expect("depth-1 tail emits"),
+            "    crate::cancel_checkpoint();\n    s.piece.clone()"
+        );
+        let two = project(project(read("s", 0), "piece"), "kind");
+        assert_eq!(
+            emit_mir_fn_body(&two, &ctx).expect("depth-2 tail emits"),
+            "    crate::cancel_checkpoint();\n    s.piece.kind.clone()"
+        );
+    }
+
+    #[test]
+    fn let_binding_of_a_borrowed_param_read_owns_what_it_names() {
+        // Naming the value does not change what the fn may do with it:
+        // `kept = outcome` then `kept` has to return by value exactly as
+        // `outcome` alone does, and `k = s.piece.kind` has to own the
+        // field it named.
+        let policy = borrowed_param_policy("s");
+        let ctx = ctx_over(&policy);
+        let body = let_chain(
+            ("kept", read("s", 0)),
+            ("k", project(project(read("s", 0), "piece"), "kind")),
+            read("kept", 1),
+        );
+        assert_eq!(
+            emit_mir_fn_body(&body, &ctx).expect("binding chain emits"),
+            "    crate::cancel_checkpoint();\n    let kept = s.clone();\n    let k = s.piece.kind.clone();\n    kept"
+        );
+    }
+
+    #[test]
+    fn owning_positions_leave_a_non_borrowed_read_alone() {
+        // The rule keys on the ROOT local being a borrowed param. A read
+        // rooted anywhere else — here a param the policy does not borrow —
+        // already owns its result and must stay verbatim, which is what
+        // keeps the emitted bytes of every other fn unchanged.
+        let policy = borrowed_param_policy("other");
+        let ctx = ctx_over(&policy);
+        let body = let_chain(
+            ("kept", read("s", 0)),
+            ("k", project(project(read("s", 0), "piece"), "kind")),
+            project(read("s", 0), "tag"),
+        );
+        assert_eq!(
+            emit_mir_fn_body(&body, &ctx).expect("binding chain emits"),
+            "    crate::cancel_checkpoint();\n    let kept = s;\n    let k = s.piece.kind;\n    s.tag"
         );
     }
 

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -2585,6 +2585,19 @@ pub(super) fn emit_mir_fn_body(
 /// it needing the wrapper, because `emit_mir_expr` renders both bare: a
 /// read of a borrowed param (`&T` against a by-value return type) and a
 /// field read through one at any depth (a move out of a shared reference).
+///
+/// The tail applies a WIDER rule than [`emit_mir_binding_value`] does, and
+/// the difference is deliberate rather than incidental: a bare `Local` tail
+/// goes through the full [`mir_maybe_clone`] policy, which also covers an
+/// `rc_wrapped` local (`(*x).clone()`) and a non-last-use owned local
+/// (`x.clone()`) — neither of which is a borrowed-param read. Only the
+/// non-`Local` shapes fall back to the narrow root-of-a-projection rule.
+/// The extra reach is inert today (`rc_wrapped` is populated only on the
+/// TCO paths, and a top-level tail read is by definition a last use), which
+/// is why the binding position was not widened to match: it would change no
+/// emitted byte and would cost a second policy to keep honest. A future
+/// merge of the TCO and non-TCO policies would make the difference live, so
+/// widen the binding rule at the same time if that ever happens.
 fn emit_mir_tail_value(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
     let code = emit_mir_expr(expr, ctx)?;
     if local_of(&expr.node).is_some() {
@@ -2593,16 +2606,38 @@ fn emit_mir_tail_value(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<
     Some(mir_own_borrowed_read(code, &expr.node, ctx))
 }
 
-/// Emit a `let` binding's value as an OWNED value when it reads a borrowed
-/// param.
+/// Emit a `let` binding's value as an OWNED value when it reads a BORROWED
+/// PARAM — and only then.
 ///
-/// Naming an intermediate is not supposed to change what a function may do
+/// Naming a read of a borrowed param does not change what a function may do
 /// with it: `p.y` in return position and `y = p.y` then `y` are the same
 /// program. `emit_mir_expr` renders a binding value raw, so the second one
 /// used to bind `&T` (or move a field out of a shared reference) and the
 /// generated project would not build. The binding is an owning position for
 /// the same reason the tail is — the name outlives the expression that
 /// produced it — so it goes through the same materialisation step.
+///
+/// KNOWN GAP (pre-existing, not closed here): the rule fires only when
+/// [`mir_projection_root_local`] bottoms out in a borrowed param. A binding
+/// whose value is an OWNED local — a plain `let`, or an `own_param`-
+/// graduated by-value collection param — is still emitted as a raw move, so
+/// naming it and then reading the original does change what the fn may do:
+///
+/// ```text
+/// fn twice(n: Int) -> Int
+///     b = Vector.new(n, 1)
+///     a = b
+///     Vector.len(a) + Vector.len(b)
+/// ```
+///
+/// emits `let a = b;` and rustc rejects `b.len()` after it (E0382). The wide
+/// rule would close it for free — [`mir_maybe_clone`] emits `.clone()` for a
+/// local read that is not `last_use`, which is exactly this shape, and
+/// [`emit_mir_tail_value`] already uses it for a bare `Local` tail. It is
+/// left alone because widening here changes emitted bytes for every fn that
+/// names a live local, and the corpus has no instance of the shape
+/// (`examples/` and `self_hosted/` contain no bare `name = name` binding).
+/// Close it together with the tail/binding rule merge, not on its own.
 fn emit_mir_binding_value(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
     let code = emit_mir_expr(expr, ctx)?;
     Some(mir_own_borrowed_read(code, &expr.node, ctx))
@@ -5666,6 +5701,22 @@ mod tests {
     // suite proves the emitted project builds and agrees with the VM;
     // these are the same rules at walker resolution, cheap enough to run
     // on every `cargo test`.
+    //
+    // WHAT THESE CAN AND CANNOT PIN. They run against `ctx_over`, which
+    // is NOT the ctx production uses: production always goes through
+    // `MirEmitCtx::for_fn` with `codegen: Some(ctx)` and the fn's params
+    // in `local_types`, while `ctx_over` leaves `codegen` `None` and
+    // takes `local_types` from an empty policy. That is sound today
+    // because the three rules under test — `mir_projection_root_local`,
+    // `mir_own_borrowed_read` and the `mir_maybe_clone` path they reach
+    // — read neither field. It stops being sound the moment either
+    // owning position starts consulting a rule that does: the nearest
+    // one is `mir_clone_arg`'s Copy-field elision, whose
+    // `mir_attr_result_is_copy` returns `false` whenever `codegen` is
+    // `None` or the base type is missing from `local_types`. Route the
+    // binding or the tail through that and these tests stay green while
+    // the emitted bytes change. The net that would see it is the
+    // build-and-run differential, not this module.
 
     /// A read of the named local (`last_use`, so nothing but the borrow
     /// policy can ask for a clone).
@@ -5693,7 +5744,9 @@ mod tests {
     }
 
     /// A ctx over `policy` — the borrow-field plumbing of `empty_ctx`
-    /// with a real `borrowed_params` set behind it.
+    /// with a real `borrowed_params` set behind it. `codegen` stays
+    /// `None` and `local_types` stays empty; see the section note above
+    /// for what that costs.
     fn ctx_over(policy: &MirFnEmitPolicy) -> MirEmitCtx<'_> {
         use std::sync::OnceLock;
         static SYMBOLS: OnceLock<SymbolTable> = OnceLock::new();

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -2527,9 +2527,8 @@ fn mir_subject_is_borrowed_param(subject: &MirExpr, emit_ctx: &MirEmitCtx<'_>) -
 /// construct anywhere in the tree), the signal for the caller to emit a
 /// hard codegen diagnostic.
 ///
-/// One return-position detail: a field access (`Project`) on a borrowed
-/// param in tail/return position needs `.clone()` to produce an owned
-/// value (`emit_mir_expr` emits `obj.field` without it).
+/// The tail expression is a return position, so it goes through
+/// [`emit_mir_tail_value`] to materialise an owned value.
 ///
 /// A top-level `Let` chain (the MIR shape a `Block` body with `let`
 /// bindings lowers to) is emitted as flat statement lines —
@@ -2572,17 +2571,31 @@ pub(super) fn emit_mir_fn_body(
     // `Box` nodes. So the default emit below renders the boxed-return tail
     // correctly without a codegen-side boxing pass.
 
-    let mut code = emit_mir_expr(body, emit_ctx)?;
-    // Return-position field access on a borrowed param → clone for
-    // an owned result. Mirror of HIR's
-    // `emit_body_expr_plan_with_options` `Leaf`/`Expr` arms.
-    if let MirExpr::Project(p) = &body.node
-        && let Some(local) = local_of(&p.node.base.node)
-        && emit_ctx.is_borrowed_param(&local.name)
-    {
-        code = format!("{}.clone()", code);
-    }
+    let code = emit_mir_tail_value(body, emit_ctx)?;
     Some(format!("    crate::cancel_checkpoint();\n    {}", code))
+}
+
+/// Emit a fn body's tail expression as an OWNED value.
+///
+/// The tail is a return position, so whatever lands there has to own what
+/// it hands back — the same rule [`mir_maybe_clone`] already applies to a
+/// call argument, a match arm and a TCO base-case return. Two shapes reach
+/// it needing the wrapper, because `emit_mir_expr` renders both bare: a
+/// read of a borrowed param (`&T` against a by-value return type) and a
+/// field access through one (a move out of a shared reference). Mirror of
+/// HIR's `emit_body_expr_plan_with_options` `Leaf`/`Expr` arms.
+fn emit_mir_tail_value(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Option<String> {
+    let code = emit_mir_expr(expr, ctx)?;
+    if local_of(&expr.node).is_some() {
+        return Some(mir_maybe_clone(code, &expr.node, ctx));
+    }
+    if let MirExpr::Project(p) = &expr.node
+        && let Some(local) = local_of(&p.node.base.node)
+        && ctx.is_borrowed_param(&local.name)
+    {
+        return Some(format!("{}.clone()", code));
+    }
+    Some(code)
 }
 
 /// Emit a non-TCO body's tail value as a bare `i64` expression. The tail
@@ -2624,7 +2637,9 @@ fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
 /// Emit a top-level `Let` chain as flat Rust statement lines: each
 /// binding becomes `let {name} = {value};` (value rendered raw, no clone
 /// wrapper), one per line, 4-space indented and `\n`-joined, terminated
-/// by the chain's final expression rendered raw on its own line.
+/// by the chain's final expression on its own line. That final expression
+/// is the fn's tail, so it goes through [`emit_mir_tail_value`] — a
+/// statement chain ending in one of its own params returns it by value.
 ///
 /// The chain is the run of directly-nested `Let` nodes: each one emits
 /// its statement line and continues into its body until a body that
@@ -2672,7 +2687,7 @@ fn emit_mir_let_chain_flat(
                 {
                     bare
                 } else {
-                    emit_mir_expr(&current.body, ctx)?
+                    emit_mir_tail_value(&current.body, ctx)?
                 };
                 lines.push(final_expr);
                 break;

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1028,25 +1028,54 @@ fn main() -> Unit
     );
 }
 
-/// The cleanup-wrapper shape from the field: do the thing that must happen
-/// either way, then hand back the outcome you were given. The parameter is no
-/// longer the whole body — it is the last line of a statement chain — and that
-/// chain's final expression is a second owning position that never materialised
-/// an owned value, so `closeAfter` emitted `&Result<…>` against a by-value
-/// return type. A field read through a borrowed param on the same line is the
-/// move-out-of-a-reference sibling of the same gap.
+/// A parameter that reaches the return slot through something other than
+/// being the whole body. Three positions in one program, because the fix for
+/// one of them does not cover the other two:
 ///
-/// The third shape is the ownership guard: `tagged` writes a key into a map it
-/// was given while the caller keeps using the original. Materialising the owned
-/// value with a `.clone()` keeps the two maps separate; handing the callee the
-/// caller's value instead would let the write land in `original` — invisible to
-/// the build, visible only as a divergence from the VM here.
+/// - the last line of a statement chain (`closeAfter`, the cleanup-wrapper
+///   shape from the issue, and `yAfter`, the field read through a borrowed
+///   param on that same line);
+/// - a NAME the parameter was bound to (`kept = outcome` then `kept`, and
+///   `y = p.y` then `y`) — giving the value a name does not change what the
+///   function may do with it, but the binding used to be rendered raw, so
+///   `kept` was a `&Result<…>` and `y` was a move out of a shared reference;
+/// - a field read more than one level deep (`s.piece.kind`), in the tail and
+///   bound to a name and as the last line after an effect — `s.piece` is
+///   behind the same shared reference `s` is, so a rule that only looks one
+///   level down leaves every nested read raw.
+///
+/// The build is the primary detector for this class — the issue is a project
+/// that does not compile — and the stdout comparison against the VM is what
+/// catches materialising the WRONG value once it does compile.
+///
+/// `tagged` is a different guard and exercises none of the tail/binding code:
+/// the caller keeps using a map it passed to a callee that adds a key, and the
+/// two stay separate because `Map.set` emits `m.clone().insert_owned(…)` — the
+/// argument itself is passed as a plain `&original` borrow. It is kept because
+/// that separation IS invisible to the build (a callee writing into the
+/// caller's map compiles fine) and only shows up as a divergence from the VM,
+/// so it is the one shape here that the stdout comparison, not rustc, decides.
+///
+/// `shifted` is the mirror of that on the new path: it NAMES the borrowed
+/// param before building a changed copy from the name, so the caller's
+/// `origin` and the returned `moved` must differ by exactly one.
 #[test]
-fn rust_param_returned_after_an_effect_builds_and_matches_vm() {
+fn rust_param_returned_via_a_name_or_a_nested_field_builds_and_matches_vm() {
     let src = r#"module CloseAfter
-    intent = "A parameter handed back after an effect, and a map the caller keeps using"
+    intent = "A parameter handed back through a name, a nested field or a statement chain"
     depends []
     effects [Console.print]
+
+record Kind
+    label: String
+
+record Piece
+    kind: Kind
+    size: Int
+
+record Slot
+    piece: Piece
+    tag: Int
 
 record Point
     x: Int
@@ -1064,6 +1093,36 @@ fn yAfter(label: String, p: Point) -> Int
     _printed = Console.print(label)
     p.y
 
+fn keptOutcome(outcome: Result<Int, String>) -> Result<Int, String>
+    ? "Bind the parameter to a name, then hand the name back."
+    kept = outcome
+    kept
+
+fn keptY(p: Point) -> Int
+    ? "Bind a field read to a name, then hand the name back."
+    y = p.y
+    y
+
+fn nestedTail(s: Slot) -> Kind
+    ? "Hand back a field two levels down."
+    s.piece.kind
+
+fn nestedNamed(s: Slot) -> Kind
+    ? "Bind a field two levels down to a name, then hand the name back."
+    k = s.piece.kind
+    k
+
+fn nestedAfter(label: String, s: Slot) -> Kind
+    ? "Print the label, then hand back a field two levels down."
+    ! [Console.print]
+    _printed = Console.print(label)
+    s.piece.kind
+
+fn shifted(p: Point) -> Point
+    ? "Name the point, then build a changed copy from the name."
+    kept = p
+    Point(x = kept.x + 1, y = kept.y)
+
 fn tagged(m: Map<String, Int>) -> Map<String, Int>
     ? "Add a key and hand the map back."
     Map.set(m, "b", 2)
@@ -1078,24 +1137,40 @@ verify shown
     shown(Result.Ok(1)) => "1"
     shown(Result.Err("e")) => "e"
 
+fn slot() -> Slot
+    ? "One nested record to read through."
+    Slot(piece = Piece(kind = Kind(label = "axe"), size = 3), tag = 7)
+
+verify slot
+    slot().tag => 7
+
 fn main() -> Unit
     ? "Print each shape so a divergence shows as a diff, not a pass."
     ! [Console.print]
     Console.print(shown(closeAfter("closing", Result.Ok(1))))
     Console.print(String.fromInt(yAfter("point", Point(x = 4, y = 5))))
+    Console.print(shown(keptOutcome(Result.Ok(2))))
+    Console.print(String.fromInt(keptY(Point(x = 4, y = 6))))
+    Console.print(nestedTail(slot()).label)
+    Console.print(nestedNamed(slot()).label)
+    Console.print(nestedAfter("nested", slot()).label)
+    origin = Point(x = 10, y = 20)
+    moved = shifted(origin)
+    Console.print("{origin.x} {moved.x}")
     original = {"a" => 1}
     grown = tagged(original)
     Console.print(String.fromInt(Map.len(original)))
     Console.print(String.fromInt(Map.len(grown)))
 "#;
-    // `original` still has one key after `tagged` added one to its own copy.
-    let expected = "closing\n1\npoint\n5\n1\n2";
+    // `origin` is unchanged by `shifted`, and `original` still has one key
+    // after `tagged` added one to its own copy.
+    let expected = "closing\n1\npoint\n5\n2\n6\naxe\naxe\nnested\naxe\n10 11\n1\n2";
     let vm = run_vm_inline("close_after", src).expect("vm run");
     let rust = build_run_rust_inline("close_after", src).expect("rust compile + cargo build + run");
-    assert_eq!(vm, expected, "VM cleanup-wrapper contract changed");
+    assert_eq!(vm, expected, "VM contract for these shapes changed");
     assert_eq!(
         rust, vm,
-        "Rust diverged from the VM on a parameter handed back after an effect"
+        "Rust diverged from the VM on a parameter returned through a name or a nested field"
     );
 }
 

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1056,9 +1056,21 @@ fn main() -> Unit
 /// caller's map compiles fine) and only shows up as a divergence from the VM,
 /// so it is the one shape here that the stdout comparison, not rustc, decides.
 ///
-/// `shifted` is the mirror of that on the new path: it NAMES the borrowed
-/// param before building a changed copy from the name, so the caller's
-/// `origin` and the returned `moved` must differ by exactly one.
+/// `shifted` is a PARITY WITNESS, not a guard, and the caption says so
+/// because the honest accounting matters more than the extra shape: it
+/// NAMES the borrowed param and then reads fields through the name, but it
+/// cannot go red either way. Pre-fix the emitter wrote `let kept = p;`,
+/// which binds `&Point`, and `kept.x` / `kept.y` autoderef through the
+/// shared reference — measured: that project builds and prints `10 11`
+/// unchanged. And no emission can make `origin` differ, because
+/// `Point(x = …, y = …)` allocates a fresh record and Aver never writes
+/// through the `&T`. It is here to show the new binding path carries a
+/// record read through a name end-to-end without disturbing the caller.
+///
+/// The shapes that actually go red before the fix are `keptOutcome`
+/// (E0308: `&Result<…>` returned where `Result<…>` is expected), `keptY`
+/// (E0507: move out of `p.y`) and `nestedNamed` (E0507: move out of
+/// `s.piece.kind`) — three rustc errors in one build.
 #[test]
 fn rust_param_returned_via_a_name_or_a_nested_field_builds_and_matches_vm() {
     let src = r#"module CloseAfter

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -888,6 +888,217 @@ fn main() -> Unit
     );
 }
 
+/// A parameter handed straight back, once per parameter type. Params of a
+/// collection / sum / product / tuple type are emitted as `&T` while the
+/// return type stays by value, so the fn's tail has to materialise an owned
+/// value — the same `.clone()` a match arm or a call argument already gets.
+/// The tail was the one owning position that never asked for it, so
+/// `passthrough(x) = x` emitted `&T` where `T` was expected and the generated
+/// project would not build at all (`Result`, `Option`, a sum type, a record, a
+/// tuple and a `List` all failed; `String`, `Int`, `Float`, `Bool` and the
+/// `own_param`-graduated `Vector` / `Map` built because they are already
+/// owned). Every shape sits in one program, so a backend that materialises too
+/// little fails the build and one that materialises the wrong value diverges
+/// from the VM.
+#[test]
+fn rust_passthrough_param_of_every_type_builds_and_matches_vm() {
+    let src = r#"module Passthrough
+    intent = "One passthrough fn per parameter type, so every borrow shape is exercised"
+    depends []
+    effects [Console.print]
+
+type Colour
+    Red
+    Green(Int)
+
+record Point
+    x: Int
+    y: Int
+
+fn passResult(v: Result<Int, String>) -> Result<Int, String>
+    ? "Hand back exactly what was given."
+    v
+
+fn passOption(v: Option<Int>) -> Option<Int>
+    ? "Hand back exactly what was given."
+    v
+
+fn passColour(v: Colour) -> Colour
+    ? "Hand back exactly what was given."
+    v
+
+fn passPoint(v: Point) -> Point
+    ? "Hand back exactly what was given."
+    v
+
+fn passTuple(v: Tuple<Int, String>) -> Tuple<Int, String>
+    ? "Hand back exactly what was given."
+    v
+
+fn passList(v: List<Int>) -> List<Int>
+    ? "Hand back exactly what was given."
+    v
+
+fn passVector(v: Vector<Int>) -> Vector<Int>
+    ? "Hand back exactly what was given."
+    v
+
+fn passMap(v: Map<String, Int>) -> Map<String, Int>
+    ? "Hand back exactly what was given."
+    v
+
+fn passString(v: String) -> String
+    ? "Hand back exactly what was given."
+    v
+
+fn passInt(v: Int) -> Int
+    ? "Hand back exactly what was given."
+    v
+
+fn passFloat(v: Float) -> Float
+    ? "Hand back exactly what was given."
+    v
+
+fn passBool(v: Bool) -> Bool
+    ? "Hand back exactly what was given."
+    v
+
+fn showResult(v: Result<Int, String>) -> String
+    ? "Render it."
+    match v
+        Result.Ok(n) -> String.fromInt(n)
+        Result.Err(e) -> e
+
+verify showResult
+    showResult(Result.Ok(1)) => "1"
+    showResult(Result.Err("e")) => "e"
+
+fn showOption(v: Option<Int>) -> String
+    ? "Render it."
+    match v
+        Option.Some(n) -> String.fromInt(n)
+        Option.None -> "none"
+
+verify showOption
+    showOption(Option.Some(2)) => "2"
+    showOption(Option.None) => "none"
+
+fn showColour(v: Colour) -> String
+    ? "Render it."
+    match v
+        Colour.Red -> "red"
+        Colour.Green(n) -> "green {n}"
+
+verify showColour
+    showColour(Colour.Red) => "red"
+    showColour(Colour.Green(3)) => "green 3"
+
+fn showTuple(v: Tuple<Int, String>) -> String
+    ? "Render it."
+    match v
+        (n, s) -> "{n}{s}"
+
+verify showTuple
+    showTuple((6, "t")) => "6t"
+
+fn main() -> Unit
+    ? "Print every passthrough so a divergence shows as a diff, not a pass."
+    ! [Console.print]
+    Console.print(showResult(passResult(Result.Ok(1))))
+    Console.print(showOption(passOption(Option.Some(2))))
+    Console.print(showColour(passColour(Colour.Green(3))))
+    Console.print(String.fromInt(passPoint(Point(x = 4, y = 5)).y))
+    Console.print(showTuple(passTuple((6, "t"))))
+    Console.print(String.fromInt(List.len(passList([7, 8]))))
+    Console.print(String.fromInt(Vector.len(passVector(Vector.new(3, 0)))))
+    Console.print(String.fromInt(Map.len(passMap({"a" => 9}))))
+    Console.print(passString("s"))
+    Console.print(String.fromInt(passInt(10)))
+    Console.print("{passFloat(1.5)}")
+    Console.print("{passBool(true)}")
+"#;
+    let expected = "1\n2\ngreen 3\n5\n6t\n2\n3\n1\ns\n10\n1.5\ntrue";
+    let vm = run_vm_inline("passthrough_param", src).expect("vm run");
+    let rust =
+        build_run_rust_inline("passthrough_param", src).expect("rust compile + cargo build + run");
+    assert_eq!(vm, expected, "VM passthrough contract changed");
+    assert_eq!(
+        rust, vm,
+        "Rust passthrough of a borrowed param diverged from the VM"
+    );
+}
+
+/// The cleanup-wrapper shape from the field: do the thing that must happen
+/// either way, then hand back the outcome you were given. The parameter is no
+/// longer the whole body — it is the last line of a statement chain — and that
+/// chain's final expression is a second owning position that never materialised
+/// an owned value, so `closeAfter` emitted `&Result<…>` against a by-value
+/// return type. A field read through a borrowed param on the same line is the
+/// move-out-of-a-reference sibling of the same gap.
+///
+/// The third shape is the ownership guard: `tagged` writes a key into a map it
+/// was given while the caller keeps using the original. Materialising the owned
+/// value with a `.clone()` keeps the two maps separate; handing the callee the
+/// caller's value instead would let the write land in `original` — invisible to
+/// the build, visible only as a divergence from the VM here.
+#[test]
+fn rust_param_returned_after_an_effect_builds_and_matches_vm() {
+    let src = r#"module CloseAfter
+    intent = "A parameter handed back after an effect, and a map the caller keeps using"
+    depends []
+    effects [Console.print]
+
+record Point
+    x: Int
+    y: Int
+
+fn closeAfter(label: String, outcome: Result<Int, String>) -> Result<Int, String>
+    ? "Always print the label, whatever the session did."
+    ! [Console.print]
+    _printed = Console.print(label)
+    outcome
+
+fn yAfter(label: String, p: Point) -> Int
+    ? "Print the label, then hand back a field of the point."
+    ! [Console.print]
+    _printed = Console.print(label)
+    p.y
+
+fn tagged(m: Map<String, Int>) -> Map<String, Int>
+    ? "Add a key and hand the map back."
+    Map.set(m, "b", 2)
+
+fn shown(v: Result<Int, String>) -> String
+    ? "Render it."
+    match v
+        Result.Ok(n) -> String.fromInt(n)
+        Result.Err(e) -> e
+
+verify shown
+    shown(Result.Ok(1)) => "1"
+    shown(Result.Err("e")) => "e"
+
+fn main() -> Unit
+    ? "Print each shape so a divergence shows as a diff, not a pass."
+    ! [Console.print]
+    Console.print(shown(closeAfter("closing", Result.Ok(1))))
+    Console.print(String.fromInt(yAfter("point", Point(x = 4, y = 5))))
+    original = {"a" => 1}
+    grown = tagged(original)
+    Console.print(String.fromInt(Map.len(original)))
+    Console.print(String.fromInt(Map.len(grown)))
+"#;
+    // `original` still has one key after `tagged` added one to its own copy.
+    let expected = "closing\n1\npoint\n5\n1\n2";
+    let vm = run_vm_inline("close_after", src).expect("vm run");
+    let rust = build_run_rust_inline("close_after", src).expect("rust compile + cargo build + run");
+    assert_eq!(vm, expected, "VM cleanup-wrapper contract changed");
+    assert_eq!(
+        rust, vm,
+        "Rust diverged from the VM on a parameter handed back after an effect"
+    );
+}
+
 // ─── Mode (b): deny-policy ──────────────────────────────────────────────
 
 /// A Disk-write program. `__PATH__` is substituted with the real

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -1067,10 +1067,14 @@ fn main() -> Unit
 /// through the `&T`. It is here to show the new binding path carries a
 /// record read through a name end-to-end without disturbing the caller.
 ///
-/// The shapes that actually go red before the fix are `keptOutcome`
-/// (E0308: `&Result<…>` returned where `Result<…>` is expected), `keptY`
-/// (E0507: move out of `p.y`) and `nestedNamed` (E0507: move out of
-/// `s.piece.kind`) — three rustc errors in one build.
+/// The shapes that actually go red are the other seven. Against the base
+/// commit this program fails to build with seven rustc errors: `closeAfter`
+/// and `keptOutcome` E0308 (`&Result<…>` where `Result<…>` is expected),
+/// `yAfter` and `keptY` E0507 (move out of `p.y`), `nestedTail`,
+/// `nestedNamed` and `nestedAfter` E0507 (move out of `s.piece.kind`).
+/// Three of those seven — `keptOutcome`, `keptY`, `nestedNamed` — are the
+/// binding position specifically: reverting only the binding call sites,
+/// with the tail rule left in place, still fails with exactly those three.
 #[test]
 fn rust_param_returned_via_a_name_or_a_nested_field_builds_and_matches_vm() {
     let src = r#"module CloseAfter


### PR DESCRIPTION
`aver check` passed and `aver run` gave the right answer, but `aver compile --target rust` produced a project that would not build for a function that hands one of its own parameters back.

## What was broken

A parameter of a collection, sum, product or tuple type is emitted as `&T` while the return type stays by value. Every owning position in a function body already asks the emitter to materialise an owned value from such a parameter — a call argument, a match arm, an `if`/`else` branch, a tail-call base-case return all go through the same `.clone()` step. Two positions never asked, and one asked only for the shallowest shape.

**The return slot.** The function's own tail did not ask, so the parameter arrived at the return slot still borrowed:

- the parameter as the whole body (`fn passthrough(outcome: Result<Int, String>) -> Result<Int, String> = outcome`) — `&T` against a by-value return type;
- the parameter as the last line of a statement chain — the cleanup-wrapper shape from the issue, `_closed = Tcp.close(connection)` then `outcome`;
- a field read through such a parameter on that last line (`p.y`) — a move out of a shared reference.

**A name the parameter was bound to.** A `let` binding's value was rendered raw, so giving the value a name changed what the function was allowed to do with it. `kept = outcome` then `kept` reproduced the same `E0308` as the version without the name, and `y = p.y` then `y` reproduced the same `E0507` one line earlier.

**A field read more than one level deep.** The field rule only looked one level down, so `s.piece.kind` through a borrowed parameter stayed raw and moved out of a shared reference — in the tail, in a binding, and as the last line of a chain. The nested base `s.piece` is behind the same shared reference `s` is.

Mapping the class across parameter types: `Result`, `Option`, a sum type, a record, a tuple and a `List` all failed to build. `String`, `Int`, `Float` and `Bool` built because they are passed by value in the first place, and `Vector` / `Map` built because the ownership analysis had already proved those particular parameters uniquely owned and graduated them to by-value.

## The fix

One rule, added at the binding position and at the tail:

> Walk the base chain of a read to its **root local**. If that root is a borrowed parameter, materialise an owned value with the existing `mir_maybe_clone` step — the same one a call argument and a match arm already get.

`emit_mir_tail_value` applies it to the tail (the body expression and the final line of a flattened statement chain); `emit_mir_binding_value` applies it to a `let` binding's value (both the flat statement-chain form and the inline block-expression form). Walking to the root is what makes it depth-independent: `p`, `s.piece` and `s.piece.kind` all resolve to the same root.

Anything whose root is not a borrowed parameter — a call result, a constructor, an owned local — is returned verbatim. That is what keeps this from double-cloning an argument: the argument clone runs *inside* `emit_mir_expr`, on the arguments, never on the whole call.

This is a clone on the emission path only. Ownership analysis is untouched: the parameter is still `&T` in the signature, so a callee can never write through to a value its caller still holds.

### Two honest qualifications on that rule

**The tail applies a wider rule than the binding does.** `emit_mir_tail_value` short-circuits on a bare `Local` and routes it through the full `mir_maybe_clone` policy, which also covers an `rc_wrapped` local (`(*x).clone()`) and a non-last-use owned local (`x.clone()`) — neither of which is a borrowed-parameter read. Only the non-`Local` shapes fall back to the narrow root-of-a-projection rule. The extra reach is inert today: `rc_wrapped` is populated only on the tail-call paths, and a top-level tail read is by definition a last use. The binding was not widened to match because it would change no emitted byte and would cost a second policy to keep honest. Both function doc comments now say this, so a later merge of the tail-call and non-tail-call policies does not widen one side by accident.

**The rule does not close the naming case in general, and that is pre-existing.** It fires only when the read bottoms out in a *borrowed* parameter. A binding whose value is an owned local is still a raw move:

```
fn twice(n: Int) -> Int
    b = Vector.new(n, 1)
    a = b
    Vector.len(a) + Vector.len(b)
```

emits `let a = b;` and rustc rejects `b.len()` after it (`E0382`). Naming the value did change what the function may do with it. The same is not reachable through a graduated by-value *parameter*, because the ownership pass never graduates a parameter whose alias is read while the parameter is still live — verified: the borrowed-parameter version of the program above emits `let a = v.clone();` and builds. The wide rule would close the owned-local case for free, but widening changes emitted bytes for every function that names a live local, and the corpus has no instance of the shape (`examples/` and `self_hosted/` contain no bare `name = name` binding). The gap is recorded on `emit_mir_binding_value` with the shape that hits it, to be closed together with the tail/binding rule merge rather than on its own.

## How it is tested

Two tests in the Rust codegen differential suite, which compiles, `cargo build`s, runs the binary and compares stdout with the VM:

- `rust_passthrough_param_of_every_type_builds_and_matches_vm` — one passthrough function per parameter type (`Result`, `Option`, sum type, record, tuple, `List`, `Vector`, `Map`, `String`, `Int`, `Float`, `Bool`) in a single program.
- `rust_param_returned_via_a_name_or_a_nested_field_builds_and_matches_vm` — the cleanup-wrapper shape, the field read through a borrowed parameter, the two let-bound shapes (`kept = outcome` then `kept`, `y = p.y` then `y`), and a two-level read `s.piece.kind` in the tail / bound to a name / as the last line after an effect.

On the base commit that second test's project fails to build with **seven** rustc errors: `closeAfter` and `keptOutcome` `E0308` (`&Result<…>` where `Result<…>` is expected), `yAfter` and `keptY` `E0507` (move out of `p.y`), and `nestedTail`, `nestedNamed`, `nestedAfter` `E0507` (move out of `s.piece.kind`). Three of the seven — `keptOutcome`, `keptY`, `nestedNamed` — are the binding position specifically: reverting only the binding call sites, with the tail rule left in place, still fails with exactly those three.

The program carries two further shapes that are **witnesses, not guards**, and the test captions now say so:

- `tagged` — a map the caller keeps using while a callee adds a key to it. Invisible to the build (a callee writing into the caller's map compiles fine) and decided only by the stdout comparison. The emitted argument really is a plain `&original` borrow.
- `shifted` — a record parameter named before a changed copy is built from the name. It cannot go red either way. Before the fix the emitter wrote `let kept = p;`, binding `&Point`, and `kept.x` / `kept.y` dereference through the shared reference — measured: that project builds and prints `10 11`, the same answer. And no emission can make the caller's `origin` differ, because `Point(x = …, y = …)` allocates a fresh record and Aver never writes through the `&T`. It shows the binding path carries a record read through a name end-to-end without disturbing the caller; it does not detect anything.

Three walker unit tests run the same rules in milliseconds on every `cargo test`, so the class does not depend on a suite that does real `cargo build`s: `tail_field_read_through_a_borrowed_param_clones_at_any_depth`, `let_binding_of_a_borrowed_param_read_owns_what_it_names`, and `owning_positions_leave_a_non_borrowed_read_alone` (the guard that the rule keys on the root being borrowed, which is why every other function's emitted bytes are unchanged).

They run the same *rules*, not the same *context*. Their `ctx_over` helper leaves `codegen` as `None` and `local_types` empty, while production always goes through `MirEmitCtx::for_fn` with a real codegen context and the function's parameters in `local_types`. That is sound today because none of the three rules under test reads either field. It stops being sound the moment an owning position starts consulting one that does — the nearest is `mir_clone_arg`'s Copy-field elision, whose `mir_attr_result_is_copy` returns `false` whenever `codegen` is `None` or the base type is missing from `local_types`. Route the binding or the tail through that and these three stay green while the emitted bytes change. The build-and-run differential is the only net here that sees the production context. The limit is written into the test module.

## What each net can and cannot see

Two emitted-bytes sweeps, run by emitting Rust with a binary built from the base commit and a binary built from this branch and diffing the output trees:

- **Regenerating the self-hosted compiler** (`aver compile self_hosted/main.av --target rust …`, the `release.py` invocation): byte-identical. It is a no-drift check and **it could not have caught any of this** — the self-hosted compiler never names a parameter this way, so the shape has zero occurrences in ~26k lines of Aver.
- **Every example** (104 that the compiler accepts, 9 refused for unrelated reasons on both binaries): 103 byte-identical, **one changed**, and the change is one line — `let p = state.player;` → `let p = state.player.clone();` in `examples/games/doom/main.av`. That is the whole corpus footprint of this class.

So neither sweep is evidence that the class is closed; they are evidence the change is confined to it. The class evidence is the differential test and the unit tests above.

For the same reason there is no corpus example to add to a build net: the only example in the tree with this shape is Doom, and Doom is multi-module. It still does not build on the Rust backend after this change, for a **separate, pre-existing** reason — a cross-module record type is emitted as a bare `Level_Room` with no such name in scope (`E0425`, ten times, identical before and after this change). The `E0507` on `state.player` is gone. That leaves Doom one unrelated bug away from being the first game example on the Rust backend; worth its own issue rather than a caption here.

Two nets cited in earlier discussion that genuinely cannot see this class, stated plainly: `RUST_REGRESSION_CORPUS` is seven `examples/core` files, none of which has the shape; and `alias_soundness.rs` never invokes the Rust backend at all — it is a VM-side net for the alias-slot pass.

## Known follow-ups

- The owned-local naming case above (`E0382`), documented on `emit_mir_binding_value` and not closed here.
- Doom's cross-module `E0425`, pre-existing and unrelated.

Fixes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)
