### PR TITLE
Read a called name in the module whose source wrote it

### DIFF
--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -2195,7 +2195,15 @@ fn map_order_refusal(
     // contributes its body (does anything in here read iteration order? does
     // anything in here compare two maps?) and its signature (over which key
     // type?).
-    let mut pending: Vec<String> = vec![vb.fn_name.clone()];
+    //
+    // Every name in the queue carries the module whose SOURCE it was read in,
+    // which is not always the module the claim lives in: `Peek.entry` calls its
+    // own peer as a bare `hiddenValues`, and that word is a name in `Peek`'s
+    // scope. Resolving the whole cone in the claim's scope instead either found
+    // nothing and stopped the walk one hop short of the observer, or — with a
+    // same-named function in the claim's own file — walked the WRONG body and
+    // reported on a function the claim never calls.
+    let mut pending: Vec<(Option<String>, String)> = vec![(scope.clone(), vb.fn_name.clone())];
     // `vb.cases` alongside the roots, for the same reason the comparison scan
     // reads them below: a law's `lhs`/`rhs` template is never typechecked, and a
     // function handed over by name is only recognisable as one from its type.
@@ -2206,7 +2214,8 @@ fn map_order_refusal(
             .iter()
             .flat_map(|(lhs, rhs)| [lhs, rhs].into_iter()),
     ) {
-        collect_called_names(root, &mut pending);
+        // The claim's own expressions are written in the claim's module.
+        push_called_names(root, scope.as_deref(), &mut pending);
     }
     let mut seen: HashSet<String> = HashSet::new();
     let mut key_types: Vec<String> = Vec::new();
@@ -2239,13 +2248,21 @@ fn map_order_refusal(
     ) {
         collect_compared_map_key_types(root, ctx, &mut compared_keys, &mut compared_seen);
     }
-    while let Some(name) = pending.pop() {
-        if !seen.insert(name.clone()) {
-            continue;
-        }
-        let Some((owner, fd)) = reached_fn_def(ctx, &name, scope.as_deref()) else {
+    while let Some((written_in, name)) = pending.pop() {
+        let Some((owner, fd)) = reached_fn_def(ctx, &name, written_in.as_deref()) else {
             continue;
         };
+        // "Already walked this one" is keyed on the declaration the name
+        // RESOLVED to, not on the word — the same reason the type side keys on
+        // `type_def_identity`. Two modules may declare the same bare function
+        // name, and keyed on the word the first one reached claimed it: a claim
+        // that walked a map-order-free `hiddenValues` in its own file first
+        // skipped the observing `Peek.hiddenValues` as already-seen and
+        // exported, while the same claim with the two calls written the other
+        // way round was refused.
+        if !seen.insert(fn_def_identity(owner, fd)) {
+            continue;
+        }
         // A signature's annotations are written in the module that declares the
         // function, which is not always the module the claim lives in.
         for (_, param_type) in &fd.params {
@@ -2257,7 +2274,9 @@ fn map_order_refusal(
                 Stmt::Binding(_, _, expr) | Stmt::Expr(expr) => expr,
             };
             observes = observes || expr_calls_named(expr, &observers);
-            collect_called_names(expr, &mut pending);
+            // A body's call names are written in the module that declares the
+            // function, exactly like its signature's annotations above.
+            push_called_names(expr, owner, &mut pending);
             collect_compared_map_key_types(expr, ctx, &mut compared_keys, &mut compared_seen);
         }
     }
@@ -2492,13 +2511,47 @@ fn collect_map_key_types_of_type(
     }
 }
 
-/// The `FnDef` a called name refers to, resolved in the caller's scope first
-/// and then — for a dotted `Dep.helper` — under the named module's own scope,
-/// so a helper on the far side of a module boundary stays inside the cone.
+/// Queue the names an expression reaches, tagged with the module its source is
+/// written in.
+///
+/// The tag travels with the name because a bare word is only a name inside one
+/// scope, and the cone crosses module boundaries. See the queue in
+/// [`map_order_refusal`].
+fn push_called_names(
+    expr: &Spanned<Expr>,
+    written_in: Option<&str>,
+    pending: &mut Vec<(Option<String>, String)>,
+) {
+    let mut names = Vec::new();
+    collect_called_names(expr, &mut names);
+    pending.extend(
+        names
+            .into_iter()
+            .map(|name| (written_in.map(str::to_string), name)),
+    );
+}
+
+/// The identity of a function the cone reached: `Module.name`, or `name` for a
+/// function declared in the entry file.
+///
+/// The declared name alone is not an identity — two modules may declare the
+/// same one — which is why the owner travels with it. Mirrors
+/// [`type_def_identity`] on the type side, for the same reason.
+fn fn_def_identity(owner: Option<&str>, fd: &FnDef) -> String {
+    match owner {
+        Some(prefix) => format!("{prefix}.{}", fd.name),
+        None => fd.name.clone(),
+    }
+}
+
+/// The `FnDef` a called name refers to, resolved in the scope the name was
+/// written in first and then — for a dotted `Dep.helper` — under the named
+/// module's own scope, so a helper on the far side of a module boundary stays
+/// inside the cone.
 ///
 /// The module that declares the function comes back with it: its signature's
-/// annotations are written in that module's source, and that is the scope their
-/// names are read in.
+/// annotations, and the names its body calls, are written in that module's
+/// source, and that is the scope they are read in.
 fn reached_fn_def<'a>(
     ctx: &'a CodegenContext,
     name: &str,

--- a/tests/fixtures/map_order_name_collision/main.av
+++ b/tests/fixtures/map_order_name_collision/main.av
@@ -1,0 +1,28 @@
+module MapOrderNameCollision
+    intent =
+        "Two laws that reach an iteration-order observer through a namesake in another module."
+        "Each law calls a map-order-free `hiddenValues` in this file and an observing `Peek.hiddenValues` one module over; the two laws differ only in which of them is written first."
+    effects []
+    depends [Peek]
+
+fn hiddenValues(m: Map<Float, Int>) -> Int
+    ? "A map-order-free namesake: it looks one key up, it never iterates."
+    match Map.get(m, 1.0)
+        Option.Some(v) -> v
+        Option.None -> 0
+
+fn renderedThenLocal(m: Map<Float, Int>) -> String
+    ? "Reaches the other module's namesake first, this file's second."
+    "{Peek.describe(m)}-{hiddenValues(m)}"
+
+fn localThenRendered(m: Map<Float, Int>) -> String
+    ? "The same two calls, written the other way round."
+    "{hiddenValues(m)}-{Peek.describe(m)}"
+
+verify renderedThenLocal law renderedThenLocalIsWrittenOrder
+    given m: Map<Float, Int> = [{2.0 => 5, 1.0 => 3}]
+    renderedThenLocal(m) => "5-3"
+
+verify localThenRendered law localThenRenderedIsWrittenOrder
+    given m: Map<Float, Int> = [{2.0 => 5, 1.0 => 3}]
+    localThenRendered(m) => "3-5"

--- a/tests/fixtures/map_order_name_collision/peek.av
+++ b/tests/fixtures/map_order_name_collision/peek.av
@@ -1,0 +1,15 @@
+module Peek
+    intent =
+        "Reads a float-keyed map in iteration order, one bare peer call away."
+        "The peer is called by its bare name, and that word is a name in this module's scope and nowhere else."
+    effects []
+
+fn hiddenValues(m: Map<Float, Int>) -> Int
+    ? "The value the map yields first, read in iteration order."
+    match Map.values(m)
+        [x, ..__rest] -> x
+        _ -> 0
+
+fn describe(m: Map<Float, Int>) -> String
+    ? "The first value, rendered — the peer call sits inside the braces."
+    "{hiddenValues(m)}"

--- a/tests/map_iteration_order.rs
+++ b/tests/map_iteration_order.rs
@@ -25,6 +25,7 @@ const EQUALITY_FIXTURE: &str = "tests/fixtures/map_equality_unmodelled_keys.av";
 const ADT_CONTROL_FIXTURE: &str = "tests/fixtures/map_equality_adt_control.av";
 const COLLIDING_TYPE_DIR: &str = "tests/fixtures/map_equality_colliding_type";
 const CROSS_MODULE_DIR: &str = "tests/fixtures/map_order_cross_module";
+const NAME_COLLISION_DIR: &str = "tests/fixtures/map_order_name_collision";
 const COMPARISON_ORDER_DIR: &str = "tests/fixtures/map_equality_comparison_order";
 const FIELD_COLLISION_DIR: &str = "tests/fixtures/map_equality_field_collision";
 const FN_PARAM_FIXTURE: &str = "tests/fixtures/map_order_fn_param.av";
@@ -1286,6 +1287,104 @@ fn a_given_named_after_a_map_reader_is_not_refused() {
     assert!(
         stdout.contains("0 failed"),
         "the control law must hold on the VM:\n{}",
+        format_output(&verify)
+    );
+}
+
+/// A bare call to a module's own peer is read in THAT module's scope.
+///
+/// The walk crosses a module boundary by following a dotted `Peek.describe`,
+/// and then reads the names inside that body — but it resolved every one of
+/// them in the CLAIM's scope. `Peek.describe` calls its peer as a bare
+/// `hiddenValues`, which is a name in `Peek` and nowhere else, so the cone
+/// stopped one hop short of `Map.values` and both laws exported as
+/// `native_decide` theorems that `aver verify` refutes 0/2.
+///
+/// With a same-named function in the claim's own file the miss is worse than a
+/// stop: the walk resolved `hiddenValues` to the entry file's map-free
+/// namesake and reported on a function the claim never calls.
+///
+/// The call is written inside `"{…}"` on both sides of the boundary, so the
+/// descent into an interpolated segment is exercised end to end here as well.
+#[test]
+fn an_observer_behind_a_bare_peer_call_is_still_refused() {
+    let lean = emit_lean_in_dir(
+        NAME_COLLISION_DIR,
+        "main.av",
+        "aver-map-order-name-collision",
+        "MapOrderNameCollision",
+    );
+    assert!(
+        lean.contains(
+            "-- verify law renderedThenLocal.renderedThenLocalIsWrittenOrder: map iteration \
+             order is not exported"
+        ),
+        "the walk must follow a bare peer call inside the module that wrote \
+         it:\n{lean}"
+    );
+    assert!(
+        !lean.contains("native_decide"),
+        "neither law may be stated as a theorem — the VM refutes both:\n{lean}"
+    );
+}
+
+/// The verdict does not depend on WHICH same-named function the walk met
+/// first.
+///
+/// `renderedThenLocal` and `localThenRendered` are one claim written twice,
+/// differing only in the order of the two calls inside the interpolated
+/// string: the entry file's map-free `hiddenValues` and `Peek.describe`, which
+/// reaches the observing `Peek.hiddenValues`. Same runtime answer, and `aver
+/// verify` refutes both.
+///
+/// "Already walked this one" has to be keyed on the declaration the name
+/// RESOLVED to, not on the word. Keyed on the word — which is all the queue
+/// carried while this was being written — whichever `hiddenValues` the walk
+/// popped first claimed the name and the other module's was skipped as
+/// already-seen: reaching the map-free one first hid the observer, and that
+/// law exported while its mirror image was refused.
+///
+/// A test over one ordering passes on that code. This one pins both.
+#[test]
+fn the_map_order_verdict_is_the_same_whichever_namesake_came_first() {
+    let lean = emit_lean_in_dir(
+        NAME_COLLISION_DIR,
+        "main.av",
+        "aver-map-order-name-collision-order",
+        "MapOrderNameCollision",
+    );
+    for law in [
+        "renderedThenLocal.renderedThenLocalIsWrittenOrder",
+        "localThenRendered.localThenRenderedIsWrittenOrder",
+    ] {
+        assert!(
+            lean.contains(&format!(
+                "-- verify law {law}: map iteration order is not exported"
+            )),
+            "{law} reaches the same observer as its mirror image and must get \
+             the same verdict:\n{lean}"
+        );
+    }
+}
+
+/// Both name-collision laws are refuted by the VM.
+///
+/// Without this the two tests above could be satisfied by a gate that refuses
+/// everything. The claims are FALSE at runtime — that is what makes exporting
+/// them a soundness hole rather than a lost opportunity.
+#[test]
+fn the_name_collision_laws_are_refuted_by_the_vm() {
+    let verify = run_aver(&[
+        "verify",
+        &format!("{NAME_COLLISION_DIR}/main.av"),
+        "--module-root",
+        NAME_COLLISION_DIR,
+    ]);
+    let stdout = String::from_utf8_lossy(&verify.stdout);
+    assert!(
+        stdout.contains("0/2 cases passed"),
+        "both laws must FAIL on the VM — otherwise refusing them proves \
+         nothing:\n{}",
         format_output(&verify)
     );
 }


### PR DESCRIPTION
The export refusal walks the functions a claim can reach and asks whether any of them reads a map's iteration order. It followed a dotted `Peek.describe` across a module boundary — and then read the names inside that body in the *claim's* scope. A module calls its own peer by a bare name, and that word is a name in that module and nowhere else, so:

- with no namesake in the claim's file the lookup failed, the walk stopped one hop short of `Map.values`, and the claim exported;
- with a same-named function in the claim's file the lookup succeeded on the *wrong* declaration, so the gate reported on a function the claim never calls.

Both ways a law that `aver verify` refutes `0/2` came out of `aver proof` as a `native_decide` theorem.

## The fix

Each name in the cone queue now carries the module whose source it was written in, and `reached_fn_def` resolves it there. "Already walked this one" is keyed on the declaration the name **resolved to** rather than on the word, mirroring `type_def_identity` on the type side — two modules may declare the same bare function name, and keyed on the word whichever the walk popped first claimed it and the other was skipped as already-seen.

## Red-first evidence

Fixture: `tests/fixtures/map_order_name_collision/`. `Peek.describe` renders `"{hiddenValues(m)}"`, whose peer reads `Map.values`; the entry file declares a map-order-free `hiddenValues` of its own. Two laws state the same claim, differing only in which of the two calls is written first inside the interpolated string.

| | `renderedThenLocal` | `localThenRendered` |
|---|---|---|
| `aver verify` | refuted | refuted (`0/2 cases passed`) |
| `aver proof` on `origin/main` | `theorem … := by native_decide` | `theorem … := by native_decide` |
| queue carries the scope, dedup keyed on the *word* | `theorem … := by native_decide` | declined |
| this branch | declined | declined |

The middle row is why the order control is in the suite rather than a single witness: a fix that resolves the name correctly but still remembers it by its word passes a one-ordering test and leaves the hole open in the other ordering.

## Sweep of the other expression positions

Checked, and covered:

- **every `Expr` variant** — descent lives in `src/codegen/expr_walk.rs`, which has no wildcard arm and `deny(clippy::wildcard_enum_match_arm)`, so a new variant fails the build rather than opting out silently. `InterpolatedStr`, `TailCall`, map-literal entries, record fields and independent products all go through it. That landed in #889; this branch does not touch it.
- **nested interpolation** — `StrPart::Parsed` holds a full expression and the walk is transitive, so `"{…}"` inside `"{…}"` is covered by construction. The new fixture nests one across a module boundary (`"{Peek.describe(m)}-{hiddenValues(m)}"`, and `Peek.describe` is itself `"{hiddenValues(m)}"`).
- **match guards** — this AST has none: `MatchArm` is `pattern` + `body`, so there is no guard position to miss.
- **statement positions** — the cone reads both `Stmt::Binding` and `Stmt::Expr`.
- **a predicate passed by name** — `collect_fn_reference` follows any argument the typechecker stamped `Fn(..)`, covered by `an_observer_passed_in_by_name_is_still_refused`.

Named honestly rather than covered:

- `src/codegen/lean/law_auto/shared.rs` still carries two legacy scans with wildcard arms — `collect_fncall_names` and `short_call_tree_children`. They feed law-auto lemma recognition, not this refusal, so a variant they skip costs a lemma rather than exporting a refuted claim. Left alone deliberately: changing what they recognise changes which lemmas get generated, which is not this branch's business.
- The single-file shape written in the issue (`"{firstFloatValue(m)}"` with everything in one module) is already refused on `main` by #889 and pinned by `an_observer_inside_string_interpolation_is_still_refused`. What still slipped was that same shape once the interpolated call crossed a module boundary and named a peer.

## Tests

`cargo nextest run --features runtime --test map_iteration_order` — 29 → 32, all pass. `--test proof_spec --test proof_ir_diff --test cross_module_type_keys` — 306 pass, so widening the cone did not start refusing claims that were being exported before.

Fixes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
