### PR TITLE
List every effect name in every build

### DIFF
--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -23,14 +23,41 @@ pub fn all_effect_names() -> Vec<&'static str> {
     out.extend_from_slice(console::DECLARED_EFFECTS);
     out.extend_from_slice(disk::DECLARED_EFFECTS);
     out.extend_from_slice(env::DECLARED_EFFECTS);
-    #[cfg(feature = "runtime-net")]
-    out.extend_from_slice(http::DECLARED_EFFECTS);
+    // The Http and Terminal names are written out literally rather than read
+    // from their modules, because those modules only exist in builds that
+    // compile the implementation in. The name list answers "what can these
+    // calls do", not "is the implementation compiled into this binary" — the
+    // second question is answered where the implementation lives, which
+    // reports "not available in this build" at the invoke site. Gating the
+    // names here made the REPL refuse an `Http.get` the type checker had just
+    // accepted. Tests check the literal copies against the modules'
+    // `DECLARED_EFFECTS` in builds that have them.
+    out.extend_from_slice(&[
+        "Http.get",
+        "Http.head",
+        "Http.delete",
+        "Http.post",
+        "Http.put",
+        "Http.patch",
+    ]);
     out.extend_from_slice(http_server::DECLARED_EFFECTS);
     out.extend_from_slice(random::DECLARED_EFFECTS);
     out.extend_from_slice(tcp::DECLARED_EFFECTS);
     out.extend_from_slice(time::DECLARED_EFFECTS);
-    #[cfg(feature = "terminal")]
-    out.extend_from_slice(terminal::DECLARED_EFFECTS);
+    out.extend_from_slice(&[
+        "Terminal.enableRawMode",
+        "Terminal.disableRawMode",
+        "Terminal.clear",
+        "Terminal.moveTo",
+        "Terminal.print",
+        "Terminal.setColor",
+        "Terminal.resetColor",
+        "Terminal.readKey",
+        "Terminal.size",
+        "Terminal.hideCursor",
+        "Terminal.showCursor",
+        "Terminal.flush",
+    ]);
     out
 }
 
@@ -46,3 +73,82 @@ pub mod tcp;
 #[cfg(feature = "terminal")]
 pub mod terminal;
 pub mod time;
+
+#[cfg(test)]
+mod tests {
+    /// Source text of `all_effect_names()`, from its signature to the closing
+    /// brace of its body. Panics if the signature moved, so the guard below
+    /// can never pass by silently matching nothing.
+    fn all_effect_names_fn_source() -> &'static str {
+        const SOURCE: &str = include_str!("mod.rs");
+        const SIGNATURE: &str = "pub fn all_effect_names() -> Vec<&'static str> {";
+
+        let start = SOURCE.find(SIGNATURE).expect(
+            "`all_effect_names()` signature not found — update this guard to match the new one",
+        );
+        let body = &SOURCE[start + SIGNATURE.len()..];
+        let mut depth = 1usize;
+        for (idx, ch) in body.char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &SOURCE[start..start + SIGNATURE.len() + idx + 1];
+                    }
+                }
+                _ => {}
+            }
+        }
+        panic!("`all_effect_names()` body has unbalanced braces");
+    }
+
+    #[test]
+    fn effect_name_list_is_the_same_in_every_build() {
+        // `all_effect_names()` answers "what can these calls do", not "is the
+        // implementation compiled into this binary". The type checker
+        // registers `Http.*` and `Terminal.*` in every build, and the REPL
+        // grants this list to the wrapper it builds around an expression the
+        // type checker already approved. When the Http entry was gated on
+        // `runtime-net`, a build without that feature accepted `Http.get(...)`
+        // at the type level and then refused it in the VM's effect check — an
+        // error about an effect the user did declare.
+        //
+        // Build-dependent behaviour belongs where the implementation lives:
+        // `invoke_nv` already returns "HTTP effects not available in this
+        // build". This is a source-shape check on purpose: it holds for every
+        // feature combination at once, including the ones no CI lane builds.
+        let source = all_effect_names_fn_source();
+        assert!(
+            !source.contains("#[cfg"),
+            "`all_effect_names()` contains a `#[cfg` attribute. The effect name list must be \
+             identical in every build — gate the implementation at the invoke site instead. \
+             Offending body:\n{source}"
+        );
+    }
+
+    /// The Http and Terminal names inside `all_effect_names()` are literal
+    /// copies, because the modules that own them only exist in builds that
+    /// compile the implementation in. In builds that do have those modules,
+    /// the copies must match them exactly.
+    #[cfg(feature = "runtime-net")]
+    #[test]
+    fn literal_http_names_match_the_module() {
+        let listed: Vec<&str> = super::all_effect_names()
+            .into_iter()
+            .filter(|n| n.starts_with("Http."))
+            .collect();
+        assert_eq!(listed, super::http::DECLARED_EFFECTS);
+    }
+
+    /// See `literal_http_names_match_the_module`.
+    #[cfg(feature = "terminal")]
+    #[test]
+    fn literal_terminal_names_match_the_module() {
+        let listed: Vec<&str> = super::all_effect_names()
+            .into_iter()
+            .filter(|n| n.starts_with("Terminal."))
+            .collect();
+        assert_eq!(listed, super::terminal::DECLARED_EFFECTS);
+    }
+}


### PR DESCRIPTION
## What

`services::all_effect_names()` gated the `Http` entry behind the `runtime-net` feature and the `Terminal` entry behind the `terminal` feature. The gates are gone: the list now reads the same in every build, with the Http and Terminal names written out literally because the modules that own them only exist in builds that compile the implementation in.

## Why

The REPL grants exactly this list to the wrapper it builds around an entered expression (`src/main/repl.rs:230-234`), on the reasoning that the type checker already approved it — but the type checker registers `Http.*` and `Terminal.*` unconditionally. So in a build without `runtime-net` (the browser playground among them), an entered `Http.get(...)` type-checked and was then refused by the VM's effect check: an error about an effect the user did declare. Fixes #882.

The name list answers "what can this call do", not "is the implementation compiled into this binary". The second question already lives at the invoke site, which keeps returning "HTTP effects not available in this build" — the same split resolved for `VmBuiltin::effects()` in 3e81cfb6.

## Receipts

- **Red**: the new source-shape test, run before the fix, failed as intended — `FAIL aver-lang services::tests::effect_name_list_is_the_same_in_every_build`, panicking with the offending body showing both `#[cfg(feature = "runtime-net")]` and `#[cfg(feature = "terminal")]` gates.
- **Green**: same test passes after the fix, plus two companion tests (`literal_http_names_match_the_module`, `literal_terminal_names_match_the_module`) that pin the literal copies to the modules' `DECLARED_EFFECTS` in builds that compile those modules, so the copies cannot drift.
- `cargo check -p aver-lang --lib --no-default-features --features playground` (the CI invocation for the no-net build) compiles clean.
- `cargo nextest run -p aver-lang --lib`: 1120 passed. `--test eval_spec --test vm_spec`: 351 passed.
- `cargo fmt --all -- --check` clean.

## Notes

- `all_effect_names()` has exactly two references in the tree: its definition and the REPL grant site. The grant site maps whatever names the list yields into spans and needs no change.
- The shape test mirrors the guard standing over `VmBuiltin::effects()` in `src/vm/builtin.rs` (same extraction helper, same rejection of `#[cfg`), for the same reason: no CI lane builds every feature combination, so only a source-shape check covers them all at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)