### PR TITLE
Refuse fabricated intrinsics in the wasm-gc backend instead of skipping them

### DIFF
--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -1058,11 +1058,25 @@ pub(crate) fn emit_mir_expr(
                         emit_bits_counted_value(func, op, &call.args, slots, ctx, &helper)?;
                         return Ok(Some(true));
                     }
-                    // Mirror of `emit_expr`'s `Intrinsic` arm: route the
-                    // bare intrinsic name through the registered-builtin
-                    // fast path. (Buffer intrinsics aren't produced on the
-                    // wasm-gc path — it skips `buffer_build` — so this is
-                    // effectively unreachable; kept for parity.)
+                    // Route the bare intrinsic name through the
+                    // registered-builtin fast path — this serves the
+                    // discharged Euclidean pair when bignum is off
+                    // (`__int_div_euclid` / `__int_mod_euclid` are
+                    // registered wasm helpers).
+                    //
+                    // Anything unregistered is a fabricated intrinsic
+                    // from a fusion pass (`__buf_*`, `__str_*`,
+                    // `__lst_*`, `__to_str`) that only the VM and the
+                    // Rust codegen can lower; the wasm-gc pipeline
+                    // excludes those passes, so one showing up here
+                    // means the exclusion regressed. REFUSE instead of
+                    // falling through to `Ok(None)`: that fallback
+                    // would ship a trap stub for a fn whose call sites
+                    // the pass rewrote — a silent miscompile, not a
+                    // compile error. (`refuse_fabricated_intrinsics` in
+                    // `module.rs` already surfaces the named error
+                    // before any body emit; this arm is the same
+                    // refusal at the seam the hole was recorded on.)
                     match ctx.fn_map.builtins.get(intr.name()) {
                         Some(&wasm_idx) => {
                             if emit_mir_args_then_call(func, &call.args, slots, ctx, wasm_idx)?
@@ -1072,7 +1086,13 @@ pub(crate) fn emit_mir_expr(
                             }
                             Ok(Some(aver_type_str_of(expr).trim() != "Unit"))
                         }
-                        None => Ok(None),
+                        None => Err(WasmGcError::Validation(format!(
+                            "the fabricated intrinsic `{}` reached the wasm-gc emitter; \
+                             the wasm-gc family does not lower fabricated intrinsics — \
+                             the pass that synthesized this call must stay excluded on \
+                             this path",
+                            intr.name()
+                        ))),
                     }
                 }
                 // First-class local-slot call: dispatch the `Fn`-param

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -467,6 +467,12 @@ pub(super) fn emit_module_with(
         )
     };
 
+    // Fabricated-intrinsic refusal — before any body is emitted, so a
+    // fusion pass that leaked through the pipeline's exclusion flags is
+    // a compile error naming the intrinsic, not a module whose
+    // rewritten call sites trap at runtime.
+    refuse_fabricated_intrinsics(&mir_program)?;
+
     // Lazy caller_fn name registry — populated during user-fn body
     // emit by `emit_caller_fn_idx` call sites. Threaded into every
     // `emit_fn_body` call via `EmitCtx::caller_fn_collector`. The
@@ -6247,6 +6253,171 @@ fn discover_builtins_in_expr(
 /// full-tree walk shape `own_param.rs::visit_children` uses; built
 /// here standalone so module assembly doesn't depend on optimizer
 /// internals.
+/// Refuse any fabricated intrinsic the wasm-gc family cannot lower.
+///
+/// The fusion passes (`interp_lower` / `buffer_build` / `chars_fusion` /
+/// `list_build`) synthesize intrinsic calls (`__buf_*`, `__to_str`,
+/// `__str_*`, `__lst_*`) that only the VM and the Rust codegen can
+/// lower; every wasm-gc / wasip2 call site keeps those passes off via
+/// pipeline flags. If that exclusion ever regresses, the synthesized
+/// nodes reach this backend — and the failure used to be silent: the
+/// body emitter's `Intrinsic` arm fell through to the per-fn trap-stub
+/// fallback (or the type reader panicked first on a synthesized node
+/// with no type stamp) while the pass had already moved real call
+/// sites onto the rewritten variant, so the artifact shipped and
+/// trapped at runtime. This scan runs before any body is emitted so
+/// the regression surfaces as a compile error that names the
+/// intrinsic.
+///
+/// The classifying match is exhaustive on purpose (the
+/// [`crate::codegen::expr_walk`] lock): a new [`BuiltinIntrinsic`]
+/// variant fails this build until someone states whether the wasm-gc
+/// family lowers it.
+fn refuse_fabricated_intrinsics(
+    mir_program: &crate::ir::mir::MirProgram,
+) -> Result<(), WasmGcError> {
+    use crate::ir::hir::BuiltinIntrinsic;
+    use crate::ir::mir::{MirCallee, MirExpr, MirStrPart};
+
+    /// `true` ⟺ the body emitter's `MirCallee::Intrinsic` arm
+    /// (`body/from_mir/mod.rs`) has a lowering for this intrinsic.
+    fn lowered_here(intr: BuiltinIntrinsic) -> bool {
+        match intr {
+            // Resolver / const-fold discharges backed by a registered
+            // wasm helper or the bignum divmod / Bits routes.
+            BuiltinIntrinsic::IntDivEuclid
+            | BuiltinIntrinsic::IntModEuclid
+            | BuiltinIntrinsic::BitsShiftLeft
+            | BuiltinIntrinsic::BitsShiftRight
+            | BuiltinIntrinsic::BitsLow => true,
+            // Fusion-pass fabrications — VM / Rust codegen only.
+            BuiltinIntrinsic::BufNew
+            | BuiltinIntrinsic::BufAppend
+            | BuiltinIntrinsic::BufAppendSepUnlessFirst
+            | BuiltinIntrinsic::BufFinalize
+            | BuiltinIntrinsic::ToStr
+            | BuiltinIntrinsic::StrCursorEnd
+            | BuiltinIntrinsic::StrCursorHead
+            | BuiltinIntrinsic::StrCursorNext
+            | BuiltinIntrinsic::StrCode1
+            | BuiltinIntrinsic::StrCode1Lower
+            | BuiltinIntrinsic::StrCode1Upper
+            | BuiltinIntrinsic::LstNew
+            | BuiltinIntrinsic::LstPush
+            | BuiltinIntrinsic::LstFinalize => false,
+        }
+    }
+
+    fn walk(e: &MirExpr, fn_name: &str) -> Result<(), WasmGcError> {
+        match e {
+            MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => Ok(()),
+            MirExpr::Let(l) => {
+                walk(&l.node.value.node, fn_name)?;
+                walk(&l.node.body.node, fn_name)
+            }
+            MirExpr::Call(c) => {
+                if let MirCallee::Intrinsic(intr) = c.node.callee
+                    && !lowered_here(intr)
+                {
+                    return Err(WasmGcError::Validation(format!(
+                        "fn `{fn_name}` calls the fabricated intrinsic `{}`; the wasm-gc \
+                         family does not lower fabricated intrinsics — the pass that \
+                         synthesized this call must stay excluded on this path",
+                        intr.name()
+                    )));
+                }
+                for a in &c.node.args {
+                    walk(&a.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::TailCall(tc) => {
+                for a in &tc.node.args {
+                    walk(&a.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::BinOp(b) => {
+                walk(&b.node.lhs.node, fn_name)?;
+                walk(&b.node.rhs.node, fn_name)
+            }
+            MirExpr::Neg(inner)
+            | MirExpr::Try(inner)
+            | MirExpr::Return(inner)
+            | MirExpr::Box(inner)
+            | MirExpr::Unbox(inner) => walk(&inner.node, fn_name),
+            MirExpr::Match(m) => {
+                walk(&m.node.subject.node, fn_name)?;
+                for arm in &m.node.arms {
+                    walk(&arm.body.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::Construct(c) => {
+                for a in &c.node.args {
+                    walk(&a.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::RecordCreate(r) => {
+                for field in &r.node.fields {
+                    walk(&field.value.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::RecordUpdate(u) => {
+                walk(&u.node.base.node, fn_name)?;
+                for field in &u.node.updates {
+                    walk(&field.value.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::Project(p) => walk(&p.node.base.node, fn_name),
+            MirExpr::IfThenElse(ite) => {
+                walk(&ite.node.cond.node, fn_name)?;
+                walk(&ite.node.then_branch.node, fn_name)?;
+                walk(&ite.node.else_branch.node, fn_name)
+            }
+            MirExpr::List(items) | MirExpr::Tuple(items) => {
+                for i in items {
+                    walk(&i.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::MapLiteral(pairs) => {
+                for (k, v) in pairs {
+                    walk(&k.node, fn_name)?;
+                    walk(&v.node, fn_name)?;
+                }
+                Ok(())
+            }
+            MirExpr::InterpolatedStr(parts) => {
+                for p in parts {
+                    if let MirStrPart::Expr(e) = p {
+                        walk(&e.node, fn_name)?;
+                    }
+                }
+                Ok(())
+            }
+            MirExpr::IndependentProduct(ip) => {
+                for i in &ip.node.items {
+                    walk(&i.node, fn_name)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    // Deterministic fn order (sort by FnId, same as every other
+    // program-wide scan here) so the named offender is stable.
+    let mut fns: Vec<(&crate::ir::FnId, &crate::ir::mir::MirFn)> = mir_program.iter().collect();
+    fns.sort_by_key(|(id, _)| **id);
+    for (_, mir_fn) in fns {
+        walk(&mir_fn.body.node, &mir_fn.name)?;
+    }
+    Ok(())
+}
+
 fn collect_address_taken(mir_program: &crate::ir::mir::MirProgram) -> Vec<String> {
     use crate::ir::mir::{MirExpr, MirStrPart};
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -2524,3 +2524,88 @@ fn coord(x: Int, y: Int) -> Result<Coord, String>
          unique multi-field carrier's field representation and return 7"
     );
 }
+
+/// A program shaped so the chars-fusion pass fires: a linear loop over
+/// `String.chars` that the pass rewrites into a `__cursor` variant full
+/// of `__str_*` intrinsics, with the call site moved onto the variant.
+const FUSIBLE_DIGITS: &str = r#"
+module Digits
+    intent = "counts the decimal digits in a string, shaped so chars fusion fires"
+    exposes [count]
+    effects []
+
+fn digitCount(chars: List<String>, acc: Int) -> Int
+    match chars
+        [] -> acc
+        [head, ..tail] -> match head
+            "0" -> digitCount(tail, acc + 1)
+            "1" -> digitCount(tail, acc + 1)
+            _ -> digitCount(tail, acc)
+
+fn count(text: String) -> Int
+    digitCount(String.chars(text), 0)
+
+fn main() -> Int
+    count("a1b0c1")
+"#;
+
+/// The fusion passes synthesize intrinsic calls (`__str_*`, `__buf_*`,
+/// `__lst_*`) that only the VM and the Rust codegen can lower; the
+/// wasm-gc family excludes those passes via pipeline flags. If that
+/// exclusion ever regresses, the intrinsics reach this backend's
+/// emitter — and the emitter must REFUSE with a named compile error,
+/// not fall back to a trap stub that ships a module whose rewritten
+/// call sites trap at runtime (the silent-miscompile hole recorded in
+/// the change that added the list-build pass). Before the refusal
+/// existed, this fixture did not even reach that fall-through: the
+/// emitter's type reader panicked on a synthesized `__str_code1` node
+/// carrying no type stamp — an internal panic either way, never a
+/// compile error.
+#[test]
+fn a_fabricated_intrinsic_reaching_the_emitter_is_refused() {
+    // Drive the hazard for real: the exclusion flag deliberately wrong
+    // (chars fusion ON on the wasm-gc path), everything else as
+    // `compile_bytes` sets it.
+    let mut items = parse_source(FUSIBLE_DIGITS).expect("fixture parses");
+    let neutral_policy = aver::ir::NeutralAllocPolicy;
+    let result = pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            alloc_policy: Some(&neutral_policy),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            run_chars_fusion: true,
+            run_list_build: false,
+            ..Default::default()
+        },
+    );
+    if let Some(tc) = &result.typecheck
+        && !tc.errors.is_empty()
+    {
+        panic!("typecheck failed: {:?}", tc.errors);
+    }
+    let err = match compile_to_wasm_gc(&items, result.analysis.as_ref()) {
+        Err(e) => e,
+        Ok(bytes) => panic!(
+            "a fused cursor variant slipped through the wasm-gc emitter: the module \
+             compiled to {} bytes — the fabricated intrinsics fell back to a trap \
+             stub instead of being refused",
+            bytes.len()
+        ),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("fabricated intrinsic `__str_"),
+        "the refusal names the intrinsic it cannot lower: {msg}"
+    );
+    assert!(
+        msg.contains("does not lower fabricated intrinsics"),
+        "the refusal states the wasm-gc family's contract: {msg}"
+    );
+
+    // The properly-excluded path is untouched: the same program, with
+    // the fusion flags off as every wasm-gc call site sets them,
+    // compiles and answers as it always did.
+    assert_eq!(run_int(FUSIBLE_DIGITS), 3);
+}


### PR DESCRIPTION
The change that added the list-build pass (#930) recorded a known hole: the wasm-gc `Intrinsic` arm falls through to `Ok(None)` for an intrinsic it does not know, rather than refusing. The fusion passes (`interp_lower`, `buffer_build`, `chars_fusion`, `list_build`) synthesize intrinsic calls — `__buf_*`, `__to_str`, `__str_*`, `__lst_*` — that only the VM and the compiled Rust backend can lower, and the wasm-gc family relies on pipeline flags keeping those passes off. One forgotten `true` and the synthesized calls reach a backend that has no lowering for them.

## What the regression actually looks like

The new test drives it for real: the chars-fusion pass deliberately enabled on the wasm-gc path, everything else exactly as the real call sites set it. Run before the fix, the failure is not even the recorded fall-through — the emitter's type reader panics first, on the synthesized `__str_code1` node the pass rewrote a character match into, because a node synthesized after typechecking carries no type stamp:

```
thread 'a_fabricated_intrinsic_reaching_the_emitter_is_refused' panicked at src/codegen/wasm_gc/body/infer.rs:77:9:
wasm-gc emit: expression has no type — typecheck must run before codegen (Step 0 setter or
synthesised AST without set_ty); offending node: Call(... MirCall { callee: Intrinsic(StrCode1), ... })
```

Any intrinsic the type reader does not trip over first takes the recorded path instead: the `Ok(None)` fall-through quietly turns the whole function into a trap stub, while the pass has already moved real call sites onto the rewritten variant. Either way the outcome is never a compile error — an internal panic on one shape, a module that compiles and traps at runtime on the other.

## The fix

`refuse_fabricated_intrinsics` (in `module.rs`, on the one path every wasm-gc and wasip2 compile funnels through) scans the lowered program before any body is emitted. A fabricated intrinsic is now a compile error that names the function and the intrinsic and states the contract:

```
wasm-gc: validation failed — fn `digitCount` calls the fabricated intrinsic `__str_code1`;
the wasm-gc family does not lower fabricated intrinsics — the pass that synthesized this
call must stay excluded on this path
```

Running before body emit is what keeps the refusal ahead of the type-reader panic. The body emitter's own `Intrinsic` arm also refuses with the same message instead of returning `Ok(None)`, closing the hole at the seam it was recorded on. The intrinsics this backend does lower — the discharged Euclidean division and modulo pair and the counted bits operations — keep their routes, and the classifying match is exhaustive, so a future intrinsic variant fails the build until someone states whether the wasm-gc family lowers it.

The same test then compiles the same program with the passes off, exactly as every real call site sets them, and checks the answer is unchanged. Every wasm-gc / wasip2 call site was audited (`aver compile`, `aver run --wasm-gc`, the playground, the verify diagnostics, the test suites): all four passes are off everywhere, so the refusal cannot fire on a correct path.

## Known gaps, not made worse

The type-reader panic on a synthesized node without a type stamp still exists for any future construct that reaches body emit that way; the scan makes it unreachable for intrinsics, which is the only producer of such nodes today.

## Tested

`wasm_gc_spec` (69 tests, the new refusal test among them), `wasm_gc_games_differential_mir`, `cargo fmt --all -- --check`, and `cargo clippy --features wasm,wasip2 -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
