### PR TITLE
Cover map iteration order in the compiled Rust differential suite

### DIFF
--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -713,6 +713,89 @@ fn main() -> Unit
 }
 
 #[test]
+fn rust_map_iteration_order_matches_vm() {
+    // A map iterates sorted by key on every read: `Map.keys`, `Map.values`
+    // and `Map.entries` must agree with each other and with the VM. The
+    // compiled backend used to walk `HashMap::values()` bare while `keys`
+    // and `entries` beside it sorted, so the value order changed per process
+    // and `zip(keys, values)` stopped matching `entries` — inside ONE
+    // backend, on one run. Six string keys make an accidental agreement a
+    // 1-in-720 event, and the zip-vs-entries line catches it without any
+    // cross-run comparison. The integer-keyed map pins the comparator:
+    // numeric order, not the printed digits that would put 10 before 2.
+    let src = r#"module MapOrderDifferential
+    intent = "Every map iteration read in one program, for cross-backend agreement"
+    effects [Console.print]
+
+fn stringKeyed() -> Map<String, Int>
+    ? "Six keys inserted deliberately out of key order."
+    m0 = Map.set({}, "z", 1)
+    m1 = Map.set(m0, "a", 2)
+    m2 = Map.set(m1, "m", 3)
+    m3 = Map.set(m2, "k", 4)
+    m4 = Map.set(m3, "e", 5)
+    Map.set(m4, "t", 6)
+
+fn intKeyed() -> Map<Int, String>
+    ? "Keys whose numeric order differs from their printed order."
+    m0 = Map.set({}, 10, "ten")
+    m1 = Map.set(m0, 2, "two")
+    Map.set(m1, 33, "lot")
+
+fn joinStrings(xs: List<String>) -> String
+    ? "Joins strings with a comma separator."
+    match xs
+        [] -> ""
+        [x, ..rest] -> match rest
+            [] -> x
+            _ -> "{x},{joinStrings(rest)}"
+
+fn joinInts(xs: List<Int>) -> String
+    ? "Joins integers with a comma separator."
+    match xs
+        [] -> ""
+        [x, ..rest] -> match rest
+            [] -> "{x}"
+            _ -> "{x},{joinInts(rest)}"
+
+fn pairText(p: Tuple<String, Int>) -> String
+    ? "Renders one key-value pair."
+    match p
+        (k, v) -> "{k}={v}"
+
+fn joinPairs(xs: List<Tuple<String, Int>>) -> String
+    ? "Joins key-value pairs with a comma separator."
+    match xs
+        [] -> ""
+        [p, ..rest] -> match rest
+            [] -> pairText(p)
+            _ -> "{pairText(p)},{joinPairs(rest)}"
+
+fn main() -> Unit
+    ? "Print every read so a backend that drifts shows a diff, not a pass."
+    ! [Console.print]
+    Console.print(joinStrings(Map.keys(stringKeyed())))
+    Console.print(joinInts(Map.values(stringKeyed())))
+    Console.print(joinPairs(Map.entries(stringKeyed())))
+    Console.print(joinPairs(List.zip(Map.keys(stringKeyed()), Map.values(stringKeyed()))))
+    Console.print(joinInts(Map.keys(intKeyed())))
+    Console.print(joinStrings(Map.values(intKeyed())))
+"#;
+    // Lines 3 and 4 are the correspondence check: zip(keys, values) must BE
+    // entries, or `keys[i]` no longer names the key of `values[i]`.
+    let expected = "a,e,k,m,t,z\n2,5,4,3,6,1\na=2,e=5,k=4,m=3,t=6,z=1\na=2,e=5,k=4,m=3,t=6,z=1\n2,10,33\ntwo,ten,lot";
+
+    let vm = run_vm_inline("map_iteration_order", src).expect("vm run");
+    let rust = build_run_rust_inline("map_iteration_order", src)
+        .expect("rust compile + cargo build + run");
+    assert_eq!(vm, expected, "VM map iteration order changed");
+    assert_eq!(
+        rust, expected,
+        "Rust map iteration diverged from the VM — a map read stopped sorting by key"
+    );
+}
+
+#[test]
 fn rust_try_in_argument_position_matches_vm() {
     // `?` inside an argument returns from the function whose body contains it,
     // and the Rust backend gets this from `?` on a real `Result`. The VM reaches


### PR DESCRIPTION
## What

Adds a VM-versus-compiled-Rust differential test for map iteration order to `tests/rust_codegen_differential.rs`. One program builds a six-key `Map<String, Int>` inserted deliberately out of key order and a `Map<Int, String>` whose numeric key order differs from its printed order, then prints `Map.keys`, `Map.values`, `Map.entries`, and `List.zip(Map.keys(m), Map.values(m))`. The test runs it on the VM and as a compiled Rust binary and asserts both print one expected text.

## Why

The compiled Rust backend used to lower `Map.values` to a bare hash-map walk while `Map.keys` and `Map.entries` beside it sorted by key, so the value order changed from process to process and `keys[i]` no longer named the key of `values[i]` — inside one backend, on one run. That lowering was fixed on main in #874 together with the VM comparator and the proof model, so this PR changes no compiler code. What #874 did not add is coverage in the differential harness itself: before this PR, `tests/rust_codegen_differential.rs` never read any of the three map readers, and no test compiled an integer-keyed map through the direct Rust codegen path at all (the self-host round trip can only model string keys). This is the net that was missing when the bug shipped.

## Red receipt

The fix already being on main, the test was proven load-bearing by temporarily reinstating the old bare-values lowering in `src/codegen/rust/from_mir.rs` and running it once:

```
assertion `left == right` failed: Rust map iteration diverged from the VM — a map read stopped sorting by key
  left: "a,e,k,m,t,z\n5,1,4,2,3,6\na=2,e=5,k=4,m=3,t=6,z=1\na=2,e=5,k=4,m=6,t=3,z=1\n2,10,33\nten,lot,two"
 right: "a,e,k,m,t,z\n2,5,4,3,6,1\na=2,e=5,k=4,m=3,t=6,z=1\na=2,e=5,k=4,m=3,t=6,z=1\n2,10,33\ntwo,ten,lot"
```

Line 2 is `Map.values` in hash order, line 4 is the zip pairing `m` with `6` and `t` with `3` while `Map.entries` on line 3 says `m=3, t=6` — the broken correspondence, caught deterministically in a single run (six keys make an accidental sorted hash order a 1-in-720 event). The injected lowering was then reverted; the committed diff touches only the test file.

## Sibling sweep (Rust backend only)

- `Map.keys` / `Map.values` / `Map.entries` in `src/codegen/rust/from_mir.rs` all sort by key; `Map.fromList`, `Map.get`, `Map.set`, `Map.has`, `Map.remove`, `Map.len` are order-blind. The language has no fold or forEach builtins over maps, so these are all the map iteration lowerings.
- `aver-rt` display and `Hash` for maps both sort keys, consistent with the readers.
- Replay recording (`src/codegen/rust/replay.rs`) serialises a map by walking raw hash order, but the session JSON is read back structurally into a map, so no iteration order is observable through it.

## Known cross-backend divergence (context, unchanged here)

The wasm-gc backend still returns hash-bucket order for map iteration; the exported proof trust header carries an explicit carve-out for it since #874. Whether and how that backend converges on the canonical order is a design decision that rests with the project owner and is deliberately not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
