### PR TITLE
Classify the three cursor-code intrinsics in the wasm-gc pre-emit scan

### DIFF
--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -6302,6 +6302,9 @@ fn refuse_fabricated_intrinsics(
             | BuiltinIntrinsic::StrCode1
             | BuiltinIntrinsic::StrCode1Lower
             | BuiltinIntrinsic::StrCode1Upper
+            | BuiltinIntrinsic::StrCursorCode
+            | BuiltinIntrinsic::StrFoldLower
+            | BuiltinIntrinsic::StrFoldUpper
             | BuiltinIntrinsic::LstNew
             | BuiltinIntrinsic::LstPush
             | BuiltinIntrinsic::LstFinalize => false,


### PR DESCRIPTION
Two green pull requests crossed on main: #934 added an exhaustive classification of fabricated intrinsics, #933 added three new intrinsics, and the union does not compile — the exhaustive match doing precisely its job, one merge too late. The three names join the fabricated arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)