### PR TITLE
Fuse loops written as a driver and a step function

### DIFF
--- a/src/ir/buffer_build/driver_step.rs
+++ b/src/ir/buffer_build/driver_step.rs
@@ -1,0 +1,1243 @@
+//! The same loop, written as two functions.
+//!
+//! Real parser code writes a collecting loop as a pair: a DRIVER that
+//! matches and terminates, and a STEP companion that does one unit of
+//! work and recurses back into the driver — the docstrings in the code
+//! that motivated this stage say why: the accumulator form keeps the
+//! recursion in tail position, and splitting the step out keeps each
+//! match arm on one line.
+//!
+//! ```aver
+//! fn parseAll(records: List<String>, acc: List<Change>) -> Result<List<Change>, String>
+//!     match records
+//!         [] -> Result.Ok(List.reverse(acc))
+//!         [head, ..tail] -> parseNext(head, tail, acc)
+//!
+//! fn parseNext(head: String, tail: List<String>, acc: List<Change>) -> Result<List<Change>, String>
+//!     parsed = parseOne(head)?
+//!     parseAll(tail, List.prepend(parsed, acc))
+//! ```
+//!
+//! The single-function spelling of that loop fuses today; the pair never
+//! reaches candidacy, because the recognisers in [`super::list_build`]
+//! read one body at a time and the append lives in the other one. This
+//! stage closes that gap by INLINING the step into the driver before
+//! candidacy, so the existing recognisers judge the merged loop with
+//! zero changes to their guards.
+//!
+//! The inline is deliberately narrow. A step is inlined only when:
+//!
+//! - it has EXACTLY ONE call site in the whole module, the tail call in
+//!   the driver — a step called from anywhere else is shared code, not
+//!   the idiom;
+//! - the module cannot be called around: the step must not be visible
+//!   outside the module (`exposes` list, or the `_` convention). The
+//!   pass sees one module at a time, so a step some other module could
+//!   call is a step whose call sites this walk cannot count — decline
+//!   rather than guess;
+//! - it declares no effects. The inline moves the step's statements
+//!   into the driver's branch structure, which reshapes the trace an
+//!   effectful body would record;
+//! - it does not recurse into itself — the idiom recurses into the
+//!   DRIVER, and a self-recursive step is its own loop.
+//!
+//! Binder hygiene is mechanical rather than argued per-case: every name
+//! the step's body binds is renamed into the guarded `__stp` namespace
+//! (fresh per inline, so a chain of inlines cannot capture across
+//! rounds), parameters are substituted only when the argument is a bare
+//! identifier or a literal — anything else is bound first, in argument
+//! order, so evaluation order is the call's — and a step whose body
+//! reads a name the driver re-binds anywhere is declined outright.
+//! This family has already shipped binder-capture bugs; the rules here
+//! prefer a lost fusion over a wrong answer, every time.
+//!
+//! The inline happens on a COPY of the driver's body, and the copy is
+//! committed only when the merged loop then actually fuses — the same
+//! candidacy walk and variant build the main pass runs, plus at least
+//! one call site that starts the accumulator empty. A pair that would
+//! not fuse keeps both its functions exactly as written; there is no
+//! inline-without-payoff residue. The step itself is never edited or
+//! removed: its verify blocks and any future callers keep the function
+//! they named.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use super::list_build::{
+    ListBuildShape, build_collected_variant, builder_namespace_taken, list_build_acc_of,
+    try_rewrite_list_build_site,
+};
+use super::*;
+use crate::ast::TopLevel;
+
+/// The namespace every binder this stage synthesizes lives in. Fresh
+/// names are `__stp<k>_<name>` with `k` unique per inline, so no two
+/// inlines — including two rounds into the same driver — can collide.
+/// A program that binds any name starting with this prefix takes the
+/// stage away for the whole module: the check is on the prefix, so it
+/// covers every `k` at once.
+pub(super) const STEP_PREFIX: &str = "__stp";
+
+/// Why the driver-and-step normalization left a pair alone.
+///
+/// Reported per driver so `--explain-passes` can say which pair stayed
+/// two functions and what about it stopped the inline. A driver whose
+/// merged loop then failed candidacy is reported with the recogniser's
+/// own reason instead — that is the more precise fact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PairDecline {
+    /// The step is visible outside this module, so callers this walk
+    /// cannot see may exist and the call-site count below cannot be
+    /// trusted.
+    StepVisible,
+    /// The step has more than one call site, or is referenced as a
+    /// value — it is shared code, not this driver's step.
+    StepShared,
+    /// The step declares effects; inlining would reshape its trace.
+    StepEffects,
+    /// The step recurses into itself instead of only into the driver.
+    StepSelfRecursive,
+    /// The step's body binds names the mechanical rename cannot carry:
+    /// a binder that shadows a parameter, a top-level name, or a name
+    /// that does not start lowercase — or its statements are not the
+    /// binding-then-answer shape the encoding knows.
+    StepShape,
+    /// The step reads a name the driver binds, so the inlined body
+    /// would read the driver's binder instead of what the step meant.
+    Capture,
+    /// The `__stp` namespace or the `<fn>__collected` variant name is
+    /// already bound in this program.
+    NameTaken,
+    /// The merged loop is a collecting loop, but no call site starts
+    /// its accumulator empty — nothing would move, so nothing is
+    /// committed.
+    NoCallSite,
+}
+
+impl PairDecline {
+    /// One-line explanation, rendered by `--explain-passes`.
+    pub(super) const fn reason(self) -> &'static str {
+        match self {
+            Self::StepVisible => "the step fn is visible outside this module",
+            Self::StepShared => "the step fn has more than one call site",
+            Self::StepEffects => "the step fn declares effects",
+            Self::StepSelfRecursive => "the step fn recurses into itself",
+            Self::StepShape => "the step fn's body is not a shape the inline can carry",
+            Self::Capture => "the step fn reads a name the driver binds",
+            Self::NameTaken => "the __stp namespace or the __collected variant name is taken",
+            Self::NoCallSite => "no call site starts the merged loop's accumulator empty",
+        }
+    }
+}
+
+/// How many rounds of step-inlining one driver may take. Robin's
+/// deepest chain is driver → step → step — three functions, two rounds.
+/// The bound exists so a shape nobody has imagined cannot spin; it is
+/// not a budget anyone is expected to reach.
+const MAX_ROUNDS: usize = 8;
+
+/// Is there a driver-and-step pair here at all? Read-only twin of the
+/// detection below, for callers that must decide whether to COPY a
+/// module before running the pass — same contract as
+/// [`super::has_list_build_shape`], which calls this.
+pub(super) fn has_driver_step_shape(items: &[TopLevel]) -> bool {
+    crate::ir::chars_fusion::fn_defs(items).any(|fd| is_driver_shaped(fd, items))
+}
+
+/// Run the normalization: find every driver whose self-recursive tail
+/// path goes through inlinable step companions, inline them on a copy,
+/// and commit the copy only when the merged loop fuses. Records what it
+/// did — and what it declined — on the pass report.
+pub(super) fn run_driver_step_normalize(items: &mut [TopLevel], report: &mut ListBuildPassReport) {
+    let drivers: Vec<String> = crate::ir::chars_fusion::fn_defs(items)
+        .filter(|fd| is_driver_shaped(fd, items))
+        .map(|fd| fd.name.clone())
+        .collect();
+    if drivers.is_empty() {
+        return;
+    }
+
+    // Every fact below is computed against the PRISTINE module, before
+    // any driver's body is committed: reference counts, visibility,
+    // binder sets. An inline never edits a step and never adds a call,
+    // so the pristine answers stay true for every driver in turn.
+    let taken = crate::ir::chars_fusion::taken_names(items);
+    let stp_taken = taken.iter().any(|n| n.starts_with(STEP_PREFIX));
+    let exposes: Option<Vec<String>> =
+        crate::visibility::effective_exposes(items).map(|e| e.to_vec());
+    let top_level = top_level_names(items);
+    let facts = StepFacts {
+        items: items.to_vec(),
+        taken,
+        exposes,
+        top_level,
+    };
+
+    for driver_name in drivers {
+        let fd = crate::ir::chars_fusion::fn_defs(&facts.items)
+            .find(|fd| fd.name == driver_name)
+            .expect("driver came from this item list");
+        let outcome = if stp_taken {
+            Err(PairDecline::NameTaken.reason())
+        } else {
+            build_and_validate(fd, &facts)
+        };
+        match outcome {
+            Ok((body, steps)) => {
+                let committed = crate::ir::chars_fusion::fn_defs_mut(items)
+                    .find(|fd| fd.name == driver_name)
+                    .expect("driver came from this item list");
+                committed.body = Arc::new(body);
+                report.pair_inlined_by_fn.insert(driver_name, steps);
+            }
+            Err(reason) => {
+                report.pair_declined.insert(driver_name, reason);
+            }
+        }
+    }
+}
+
+/// The pristine-module facts every step check reads.
+struct StepFacts {
+    items: Vec<TopLevel>,
+    taken: HashSet<String>,
+    exposes: Option<Vec<String>>,
+    top_level: HashSet<String>,
+}
+
+/// Inline the driver's step chain on a copy and validate that the
+/// merged loop fuses. Returns the body to commit and the steps that
+/// went into it, or the reason the pair keeps its two functions.
+fn build_and_validate(
+    fd: &FnDef,
+    facts: &StepFacts,
+) -> Result<(FnBody, Vec<String>), &'static str> {
+    let mut body = fd.body.as_ref().clone();
+    let mut steps: Vec<String> = Vec::new();
+    let driver_bound = bound_names_of(fd);
+
+    for round in 0..MAX_ROUNDS {
+        let Some(target) = first_companion_target(&body, &fd.name) else {
+            break;
+        };
+        // A tail call's target is a fn of this module by construction —
+        // the TCO pass only marks calls between SCC members — but a
+        // shape that breaks the assumption costs a fusion, never a
+        // panic.
+        let Some(step) = crate::ir::chars_fusion::fn_defs(&facts.items).find(|s| s.name == target)
+        else {
+            return Err(PairDecline::StepShape.reason());
+        };
+        check_step_conditions(step, facts).map_err(PairDecline::reason)?;
+        let inlined = inline_step_at(&mut body, step, &driver_bound, &facts.top_level, round)
+            .map_err(PairDecline::reason)?;
+        if !inlined {
+            // The walk saw the target but the replacement did not land —
+            // a shape mismatch this stage does not know. Leave the pair.
+            return Err(PairDecline::StepShape.reason());
+        }
+        steps.push(target);
+    }
+    if steps.is_empty() || first_companion_target(&body, &fd.name).is_some() {
+        // Either nothing was inlined, or the round budget ran out with
+        // companions still in the tail path — both mean the merged body
+        // is not the single loop candidacy expects.
+        return Err(PairDecline::StepShape.reason());
+    }
+
+    // The merged loop must now clear exactly the bars the main pass
+    // holds it to — candidacy, the variant build, the names — plus one
+    // call site that starts the accumulator empty, so the commit is
+    // never an inline without a payoff.
+    let mut merged = fd.clone();
+    merged.body = Arc::new(body);
+    let Some(acc) = list_build_acc_of(&merged) else {
+        return Err(PairDecline::StepShape.reason());
+    };
+    let new_name = format!("{}{}", fd.name, super::list_build::COLLECTED_SUFFIX);
+    if builder_namespace_taken(&facts.taken) || facts.taken.contains(&new_name) {
+        return Err(PairDecline::NameTaken.reason());
+    }
+    let (_, kind) = build_collected_variant(&merged, &acc, &new_name).map_err(|d| d.reason())?;
+
+    let mut accepted: HashMap<String, (String, ListBuildShape)> = HashMap::new();
+    accepted.insert(fd.name.clone(), (new_name, ListBuildShape { acc, kind }));
+    let has_site = crate::ir::chars_fusion::fn_defs(&facts.items).any(|other| {
+        let body = if other.name == fd.name {
+            merged.body.as_ref()
+        } else {
+            other.body.as_ref()
+        };
+        body.stmts().iter().any(|stmt| {
+            expr_has_rewritable_site(crate::ir::chars_fusion::stmt_expr(stmt), &accepted)
+        })
+    });
+    if !has_site {
+        return Err(PairDecline::NoCallSite.reason());
+    }
+
+    let FnBody::Block(_) = merged.body.as_ref();
+    Ok((merged.body.as_ref().clone(), steps))
+}
+
+/// Every condition a step must clear before its body travels.
+fn check_step_conditions(step: &FnDef, facts: &StepFacts) -> Result<(), PairDecline> {
+    if crate::visibility::is_exposed(&step.name, facts.exposes.as_deref()) {
+        return Err(PairDecline::StepVisible);
+    }
+    if !step.effects.is_empty() {
+        return Err(PairDecline::StepEffects);
+    }
+    if references_in_fn(step, &step.name) > 0 {
+        return Err(PairDecline::StepSelfRecursive);
+    }
+    let refs: usize = crate::ir::chars_fusion::fn_defs(&facts.items)
+        .map(|fd| references_in_fn(fd, &step.name))
+        .sum();
+    if refs != 1 {
+        return Err(PairDecline::StepShared);
+    }
+    Ok(())
+}
+
+/// A fn is driver-shaped when it has an accumulator-position `List`
+/// parameter and its tail path runs through a companion whose chain
+/// tail-calls back into it with a `List.prepend` in that accumulator's
+/// position — the orientation that tells the driver of a pair from its
+/// step, which sees the same mutual recursion from the other side.
+fn is_driver_shaped(fd: &FnDef, items: &[TopLevel]) -> bool {
+    let Some((acc_idx, _)) = rightmost_list_param(fd) else {
+        return false;
+    };
+    let mut queue: Vec<String> = Vec::new();
+    for stmt in fd.body.stmts() {
+        walk_tail_calls(crate::ir::chars_fusion::stmt_expr(stmt), &mut |data| {
+            if data.target != fd.name {
+                queue.push(data.target.clone());
+            }
+        });
+    }
+    if queue.is_empty() {
+        return false;
+    }
+    // Follow the companion chain's tail calls, looking for the append
+    // aimed back at this fn. Bounded by the visited set: each fn is
+    // walked once.
+    let mut visited: HashSet<String> = HashSet::new();
+    while let Some(name) = queue.pop() {
+        if name == fd.name || !visited.insert(name.clone()) {
+            continue;
+        }
+        let Some(step) = crate::ir::chars_fusion::fn_defs(items).find(|s| s.name == name) else {
+            continue;
+        };
+        let mut found_append = false;
+        for stmt in step.body.stmts() {
+            walk_tail_calls(crate::ir::chars_fusion::stmt_expr(stmt), &mut |data| {
+                if data.target == fd.name {
+                    if let Some(arg) = data.args.get(acc_idx)
+                        && is_prepend_to_some_ident(&arg.node)
+                    {
+                        found_append = true;
+                    }
+                } else if data.target != step.name {
+                    queue.push(data.target.clone());
+                }
+            });
+        }
+        if found_append {
+            return true;
+        }
+    }
+    false
+}
+
+/// Is `expr` `List.prepend(<anything>, <some identifier>)` — the append
+/// shape with the accumulator's identity left to the real recogniser?
+fn is_prepend_to_some_ident(expr: &Expr) -> bool {
+    let Expr::FnCall(callee, args) = expr else {
+        return false;
+    };
+    is_dotted_ident(&callee.node, "List", "prepend")
+        && args.len() == 2
+        && matches!(&args[1].node, Expr::Ident(_))
+}
+
+/// The rightmost `List<…>` parameter — the same accumulator rule the
+/// recognisers use.
+fn rightmost_list_param(fd: &FnDef) -> Option<(usize, String)> {
+    fd.params
+        .iter()
+        .enumerate()
+        .rfind(|(_, (_, ty))| is_list_type_str(ty))
+        .map(|(i, (name, _))| (i, name.clone()))
+}
+
+/// The first tail call in `body` whose target is another fn — the
+/// companion the next round inlines. Preorder, so the answer is
+/// deterministic. Every `TailCall` node is in tail position by the TCO
+/// pass's construction, so a full walk and a tail-position walk find
+/// the same set.
+fn first_companion_target(body: &FnBody, self_name: &str) -> Option<String> {
+    for stmt in body.stmts() {
+        let mut found: Option<String> = None;
+        walk_tail_calls(crate::ir::chars_fusion::stmt_expr(stmt), &mut |data| {
+            if found.is_none() && data.target != self_name {
+                found = Some(data.target.clone());
+            }
+        });
+        if found.is_some() {
+            return found;
+        }
+    }
+    None
+}
+
+/// Visit every `TailCall` under `expr`, preorder.
+fn walk_tail_calls(expr: &Spanned<Expr>, f: &mut impl FnMut(&TailCallData)) {
+    if let Expr::TailCall(data) = &expr.node {
+        f(data);
+    }
+    crate::ir::chars_fusion::walk_children(expr, &mut |child| walk_tail_calls(child, f));
+}
+
+/// How many times `fd`'s body references `name` — identifier reads plus
+/// tail-call targets, which the identifier count cannot see because a
+/// target is a string on the node rather than an `Ident` under it.
+fn references_in_fn(fd: &FnDef, name: &str) -> usize {
+    fd.body
+        .stmts()
+        .iter()
+        .map(|stmt| {
+            let expr = crate::ir::chars_fusion::stmt_expr(stmt);
+            count_ident_reads(&expr.node, name) + count_tail_targets(expr, name)
+        })
+        .sum()
+}
+
+/// How many `TailCall` nodes under `expr` target `name`.
+fn count_tail_targets(expr: &Spanned<Expr>, name: &str) -> usize {
+    let mut count = 0usize;
+    walk_tail_calls(expr, &mut |data| {
+        if data.target == name {
+            count += 1;
+        }
+    });
+    count
+}
+
+/// Every top-level name in the program — fns, types, program-level
+/// bindings. A step binder that shadows one of these is a binder whose
+/// reads the mechanical rename cannot tell from reads of the top-level
+/// thing, so such steps are declined.
+fn top_level_names(items: &[TopLevel]) -> HashSet<String> {
+    items
+        .iter()
+        .filter_map(|it| match it {
+            TopLevel::FnDef(fd) => Some(fd.name.clone()),
+            TopLevel::TypeDef(
+                crate::ast::TypeDef::Sum { name, .. } | crate::ast::TypeDef::Product { name, .. },
+            ) => Some(name.clone()),
+            TopLevel::Stmt(Stmt::Binding(name, _, _)) => Some(name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Every name `fd` binds anywhere — parameters, statement bindings,
+/// pattern binders. The capture check reads this program-wide rather
+/// than scope-by-scope: a lost fusion is acceptable, a captured read is
+/// not, and one set is one answer.
+fn bound_names_of(fd: &FnDef) -> HashSet<String> {
+    let mut out: HashSet<String> = fd.params.iter().map(|(n, _)| n.clone()).collect();
+    for stmt in fd.body.stmts() {
+        if let Stmt::Binding(name, _, _) = stmt {
+            out.insert(name.clone());
+        }
+        collect_pattern_binders_into(crate::ir::chars_fusion::stmt_expr(stmt), &mut out);
+    }
+    out
+}
+
+/// Every name a pattern under `expr` binds.
+fn collect_pattern_binders_into(expr: &Spanned<Expr>, out: &mut HashSet<String>) {
+    if let Expr::Match { arms, .. } = &expr.node {
+        for arm in arms {
+            collect_binders_of_pattern(&arm.pattern, out);
+        }
+    }
+    crate::ir::chars_fusion::walk_children(expr, &mut |child| {
+        collect_pattern_binders_into(child, out);
+    });
+}
+
+fn collect_binders_of_pattern(pattern: &Pattern, out: &mut HashSet<String>) {
+    match pattern {
+        Pattern::Wildcard | Pattern::Literal(_) | Pattern::EmptyList => {}
+        Pattern::Ident(n) => {
+            out.insert(n.clone());
+        }
+        Pattern::Cons(head, tail) => {
+            out.insert(head.clone());
+            out.insert(tail.clone());
+        }
+        Pattern::Tuple(items) => items
+            .iter()
+            .for_each(|p| collect_binders_of_pattern(p, out)),
+        Pattern::Constructor(_, bindings) => out.extend(bindings.iter().cloned()),
+    }
+}
+
+/// Find the one tail call to `step` in `body` and replace it with the
+/// step's inlined body. Returns whether a replacement landed.
+fn inline_step_at(
+    body: &mut FnBody,
+    step: &FnDef,
+    driver_bound: &HashSet<String>,
+    top_level: &HashSet<String>,
+    round: usize,
+) -> Result<bool, PairDecline> {
+    // Build the replacement first, so a decline leaves the body copy
+    // exactly as it was.
+    let mut done = false;
+    let mut outcome: Result<(), PairDecline> = Ok(());
+    for stmt in body.stmts_mut() {
+        replace_step_call(
+            crate::ir::chars_fusion::stmt_expr_mut(stmt),
+            step,
+            driver_bound,
+            top_level,
+            round,
+            &mut done,
+            &mut outcome,
+        );
+    }
+    outcome.map(|()| done)
+}
+
+/// Depth-first hunt for `TailCall(step)`, replacing the first one found.
+#[allow(clippy::too_many_arguments)]
+fn replace_step_call(
+    expr: &mut Spanned<Expr>,
+    step: &FnDef,
+    driver_bound: &HashSet<String>,
+    top_level: &HashSet<String>,
+    round: usize,
+    done: &mut bool,
+    outcome: &mut Result<(), PairDecline>,
+) {
+    if *done || outcome.is_err() {
+        return;
+    }
+    if let Expr::TailCall(data) = &expr.node
+        && data.target == step.name
+    {
+        match encode_step_body(step, &data.args, driver_bound, top_level, round) {
+            Ok(inlined) => {
+                *expr = inlined;
+                *done = true;
+            }
+            Err(decline) => *outcome = Err(decline),
+        }
+        return;
+    }
+    crate::ir::chars_fusion::walk_children_mut(expr, &mut |child| {
+        replace_step_call(child, step, driver_bound, top_level, round, done, outcome);
+    });
+}
+
+/// The step's body as one expression, hygienically renamed and with the
+/// call's arguments substituted in — the whole inline, or the reason it
+/// cannot be done.
+fn encode_step_body(
+    step: &FnDef,
+    args: &[Spanned<Expr>],
+    driver_bound: &HashSet<String>,
+    top_level: &HashSet<String>,
+    round: usize,
+) -> Result<Spanned<Expr>, PairDecline> {
+    if args.len() != step.params.len() {
+        return Err(PairDecline::StepShape);
+    }
+
+    // The step's own binders, checked against everything the mechanical
+    // rename relies on: distinct from the parameters (a shadowed
+    // parameter would make substitution rewrite the shadow's reads),
+    // distinct from top-level names (a read above the binder would be
+    // renamed with it), and lowercase (an uppercase name could be a
+    // namespace or constructor read the rename must not touch).
+    let mut binders: HashSet<String> = HashSet::new();
+    for stmt in step.body.stmts() {
+        if let Stmt::Binding(name, _, _) = stmt {
+            binders.insert(name.clone());
+        }
+        collect_pattern_binders_into(crate::ir::chars_fusion::stmt_expr(stmt), &mut binders);
+    }
+    let params: HashSet<&str> = step.params.iter().map(|(n, _)| n.as_str()).collect();
+    for binder in &binders {
+        let lowercase_start = binder
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_lowercase() || c == '_');
+        if params.contains(binder.as_str()) || top_level.contains(binder) || !lowercase_start {
+            return Err(PairDecline::StepShape);
+        }
+    }
+
+    // Capture: a name the step reads that is neither its parameter nor
+    // its binder resolves at top level — unless the driver binds it, in
+    // which case the inlined read would resolve to the driver's binder
+    // instead. Tail-call targets ride along for the same reason.
+    let mut free: HashSet<String> = HashSet::new();
+    for stmt in step.body.stmts() {
+        collect_free_names(
+            crate::ir::chars_fusion::stmt_expr(stmt),
+            &binders,
+            &params,
+            &mut free,
+        );
+    }
+    if free.iter().any(|name| driver_bound.contains(name)) {
+        return Err(PairDecline::Capture);
+    }
+
+    // The body travels as a copy: rename the binders, substitute the
+    // parameters, then fold the statements into one expression.
+    let FnBody::Block(stmts) = step.body.as_ref();
+    let mut stmts = stmts.clone();
+    let Some(Stmt::Expr(_)) = stmts.last() else {
+        return Err(PairDecline::StepShape);
+    };
+
+    let rename: HashMap<String, String> = binders
+        .iter()
+        .map(|n| (n.clone(), format!("{STEP_PREFIX}{round}_{n}")))
+        .collect();
+    for stmt in stmts.iter_mut() {
+        if let Stmt::Binding(name, _, _) = stmt
+            && let Some(fresh) = rename.get(name)
+        {
+            *name = fresh.clone();
+        }
+        rename_names(crate::ir::chars_fusion::stmt_expr_mut(stmt), &rename);
+    }
+
+    // Parameters: a bare identifier or a literal substitutes directly —
+    // its reads are pure and cannot change between the call and the
+    // read. Anything else is bound first, in argument order, so
+    // whatever the argument computes happens exactly once and exactly
+    // where the call evaluated it.
+    let mut bound_args: Vec<(String, Spanned<Expr>)> = Vec::new();
+    for (idx, ((param, _), arg)) in step.params.iter().zip(args.iter()).enumerate() {
+        match &arg.node {
+            Expr::Ident(_) | Expr::Literal(_) => {
+                for stmt in stmts.iter_mut() {
+                    substitute_reads(crate::ir::chars_fusion::stmt_expr_mut(stmt), param, arg);
+                }
+            }
+            _ => {
+                let fresh = format!("{STEP_PREFIX}{round}_p{idx}");
+                let read = sp_at(arg.line, Expr::Ident(fresh.clone()));
+                if let Some(ty) = arg.ty() {
+                    read.set_ty(ty.clone());
+                }
+                for stmt in stmts.iter_mut() {
+                    substitute_reads(crate::ir::chars_fusion::stmt_expr_mut(stmt), param, &read);
+                }
+                bound_args.push((fresh, arg.clone()));
+            }
+        }
+    }
+
+    // Fold the statements into one expression, back to front: each
+    // binding becomes a single-arm match on its value — the let-in this
+    // AST spells as an irrefutable match — and a bare statement, which
+    // a pure body can only have as a value it then ignores, binds to a
+    // wildcard.
+    let Some(Stmt::Expr(mut expr)) = stmts.pop() else {
+        unreachable!("the last statement was checked above");
+    };
+    for stmt in stmts.into_iter().rev() {
+        expr = match stmt {
+            Stmt::Binding(name, _, value) => bind_over(value, Pattern::Ident(name), expr),
+            Stmt::Expr(value) => bind_over(value, Pattern::Wildcard, expr),
+        };
+    }
+    for (fresh, arg) in bound_args.into_iter().rev() {
+        expr = bind_over(arg, Pattern::Ident(fresh), expr);
+    }
+    Ok(expr)
+}
+
+/// `match <value> { <pattern> -> <body> }` — the let-in encoding.
+/// Carries the body's type: the match answers what its only arm does.
+fn bind_over(value: Spanned<Expr>, pattern: Pattern, body: Spanned<Expr>) -> Spanned<Expr> {
+    let line = value.line;
+    let ty = body.ty().cloned();
+    let arm = MatchArm::new(pattern, body);
+    let out = sp_at(
+        line,
+        Expr::Match {
+            subject: Box::new(value),
+            arms: vec![arm],
+        },
+    );
+    if let Some(ty) = ty {
+        out.set_ty(ty);
+    }
+    out
+}
+
+/// Every name read under `expr` that is neither a parameter nor a
+/// binder of the step — the names that must still mean their top-level
+/// thing after the move. Tail-call targets are included: they are fn
+/// references spelled as strings.
+fn collect_free_names(
+    expr: &Spanned<Expr>,
+    binders: &HashSet<String>,
+    params: &HashSet<&str>,
+    out: &mut HashSet<String>,
+) {
+    match &expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. }
+            if !binders.contains(n) && !params.contains(n.as_str()) =>
+        {
+            out.insert(n.clone());
+        }
+        Expr::TailCall(data) => {
+            out.insert(data.target.clone());
+        }
+        _ => {}
+    }
+    crate::ir::chars_fusion::walk_children(expr, &mut |child| {
+        collect_free_names(child, binders, params, out);
+    });
+}
+
+/// Rename every identifier read and pattern binder whose name is in the
+/// map. Statement-binding names are the caller's half — they are not
+/// expressions.
+fn rename_names(expr: &mut Spanned<Expr>, rename: &HashMap<String, String>) {
+    match &mut expr.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => {
+            if let Some(fresh) = rename.get(n) {
+                *n = fresh.clone();
+            }
+        }
+        Expr::Match { arms, .. } => {
+            for arm in arms.iter_mut() {
+                rename_pattern(&mut arm.pattern, rename);
+            }
+        }
+        _ => {}
+    }
+    crate::ir::chars_fusion::walk_children_mut(expr, &mut |child| rename_names(child, rename));
+}
+
+fn rename_pattern(pattern: &mut Pattern, rename: &HashMap<String, String>) {
+    match pattern {
+        Pattern::Wildcard | Pattern::Literal(_) | Pattern::EmptyList => {}
+        Pattern::Ident(n) => {
+            if let Some(fresh) = rename.get(n) {
+                *n = fresh.clone();
+            }
+        }
+        Pattern::Cons(head, tail) => {
+            if let Some(fresh) = rename.get(head) {
+                *head = fresh.clone();
+            }
+            if let Some(fresh) = rename.get(tail) {
+                *tail = fresh.clone();
+            }
+        }
+        Pattern::Tuple(items) => items.iter_mut().for_each(|p| rename_pattern(p, rename)),
+        Pattern::Constructor(_, bindings) => {
+            for b in bindings.iter_mut() {
+                if let Some(fresh) = rename.get(b) {
+                    *b = fresh.clone();
+                }
+            }
+        }
+    }
+}
+
+/// Replace every read of `param` with the argument expression. Patterns
+/// never bind `param` here — a step whose body shadows a parameter was
+/// declined before this runs — so every `Ident(param)` is the read.
+fn substitute_reads(expr: &mut Spanned<Expr>, param: &str, arg: &Spanned<Expr>) {
+    if let Expr::Ident(n) = &expr.node
+        && n == param
+    {
+        *expr = arg.clone();
+        return;
+    }
+    crate::ir::chars_fusion::walk_children_mut(expr, &mut |child| {
+        substitute_reads(child, param, arg);
+    });
+}
+
+/// Does any expression under `expr` match a rewritable call site of an
+/// accepted loop? Read-only twin of the site rewrite, used to prove the
+/// commit will have a payoff.
+fn expr_has_rewritable_site(
+    expr: &Spanned<Expr>,
+    accepted: &HashMap<String, (String, ListBuildShape)>,
+) -> bool {
+    if try_rewrite_list_build_site(expr, accepted).is_some() {
+        return true;
+    }
+    let mut found = false;
+    crate::ir::chars_fusion::walk_children(expr, &mut |child| {
+        found = found || expr_has_rewritable_site(child, accepted);
+    });
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse, tail-call-convert, and run the list-build pass — the
+    /// same prefix of the pipeline the pass sees in production.
+    fn pass_on(source: &str) -> super::super::list_build::ListBuildPassReport {
+        let mut items = crate::source::parse_source(source).expect("fixture parses");
+        crate::tco::transform_program(&mut items);
+        super::super::list_build::run_list_build_pass(&mut items)
+    }
+
+    /// The canonical pair, parameterized so the matrix tests below can
+    /// vary the step's binder name and where the binder sits. The step
+    /// works through a binding, so the inline has a statement to carry.
+    fn pair_program(binder: &str, binder_in_pattern: bool) -> String {
+        let step_body = if binder_in_pattern {
+            format!(
+                "    match Option.Some(sh * 2)\n        Option.Some({binder}) -> drive(st, List.prepend({binder}, sacc))\n        Option.None -> []"
+            )
+        } else {
+            format!("    {binder} = sh * 2\n    drive(st, List.prepend({binder}, sacc))")
+        };
+        format!(
+            r#"module Pairs
+    intent = "Driver-and-step fixture."
+    exposes [entry]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(sh: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+{step_body}
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#
+        )
+    }
+
+    #[test]
+    fn the_canonical_pair_fuses() {
+        let report = pass_on(&pair_program("v", false));
+        assert_eq!(
+            report.pair_inlined_by_fn.get("drive"),
+            Some(&vec!["step".to_string()]),
+            "the step is inlined into the driver: {report:?}"
+        );
+        assert_eq!(report.builder_fns, vec!["drive".to_string()]);
+        assert_eq!(report.rewrites, 1, "the entry call site moves");
+        assert!(report.pair_declined.is_empty());
+    }
+
+    /// The bare-name identity class recurs in this family, so hygiene
+    /// is asserted as an ORDER-CONTROLLED MATRIX over binder positions
+    /// rather than a single case: every name the driver already owns,
+    /// in both binder positions the step can put it in. Every cell must
+    /// fuse — the mechanical rename makes the collision unspellable —
+    /// and the answers for the same collisions are pinned end-to-end in
+    /// `tests/driver_step_pairs.rs`.
+    #[test]
+    fn step_binders_colliding_with_driver_names_fuse_in_every_position() {
+        // xs / acc: the driver's params. h / t: the driver's pattern
+        // binders, bound BETWEEN the driver's head and the inline
+        // point. v: the no-collision control.
+        for binder in ["xs", "acc", "h", "t", "v"] {
+            for in_pattern in [false, true] {
+                let report = pass_on(&pair_program(binder, in_pattern));
+                assert!(
+                    report.pair_inlined_by_fn.contains_key("drive"),
+                    "binder {binder:?} (in_pattern: {in_pattern}) must not block the \
+                     inline: {report:?}"
+                );
+                assert_eq!(
+                    report.builder_fns,
+                    vec!["drive".to_string()],
+                    "binder {binder:?} (in_pattern: {in_pattern}) must fuse"
+                );
+            }
+        }
+    }
+
+    /// A step binder that shadows one of the step's own parameters:
+    /// substitution would rewrite the shadow's reads, so the pair is
+    /// declined — in both binder positions.
+    #[test]
+    fn a_step_binder_shadowing_a_step_param_declines_in_every_position() {
+        for binder in ["sh", "st", "sacc"] {
+            for in_pattern in [false, true] {
+                // The binder wears one of the step's own param names,
+                // shadowing it for everything underneath.
+                let report = pass_on(&pair_program(binder, in_pattern));
+                assert_eq!(
+                    report.pair_declined.get("drive").copied(),
+                    Some(PairDecline::StepShape.reason()),
+                    "binder {binder:?} (in_pattern: {in_pattern}): {report:?}"
+                );
+                assert!(report.pair_inlined_by_fn.is_empty());
+            }
+        }
+    }
+
+    /// A step binder that shares a top-level fn's name: reads before
+    /// the binder would be renamed with it, so the pair is declined.
+    #[test]
+    fn a_step_binder_named_like_a_top_level_fn_declines() {
+        let report = pass_on(&pair_program("entry", false));
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepShape.reason()),
+            "{report:?}"
+        );
+    }
+
+    /// The step reads a top-level fn the driver re-binds — inlined, the
+    /// read would resolve to the driver's binder. Declined, and the
+    /// matrix runs the driver's binder through both of its positions.
+    #[test]
+    fn a_step_reading_a_name_the_driver_binds_declines_in_every_position() {
+        for driver_arm in [
+            // The colliding name bound by the driver's own cons pattern.
+            "        [scale, ..t] -> step(scale, t, acc)",
+            // The colliding name bound by a nested pattern around the call.
+            "        [h, ..t] -> match Int.div(h, 1)\n            Result.Ok(scale) -> step(scale, t, acc)\n            Result.Err(msg) -> acc",
+        ] {
+            let source = format!(
+                r#"module Capture
+    intent = "The step reads scale; the driver binds it."
+    exposes [entry]
+
+fn scale(n: Int) -> Int
+    n * 10
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+{driver_arm}
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    drive(t, List.prepend(scale(h), acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#
+            );
+            let report = pass_on(&source);
+            assert_eq!(
+                report.pair_declined.get("drive").copied(),
+                Some(PairDecline::Capture.reason()),
+                "arm {driver_arm:?}: {report:?}"
+            );
+            assert!(report.pair_inlined_by_fn.is_empty());
+        }
+    }
+
+    /// The same program with the driver binder renamed is the control:
+    /// nothing is captured, and the pair fuses.
+    #[test]
+    fn the_capture_control_with_a_fresh_driver_binder_fuses() {
+        let source = r#"module CaptureControl
+    intent = "The step reads scale; the driver does not bind it."
+    exposes [entry]
+
+fn scale(n: Int) -> Int
+    n * 10
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    drive(t, List.prepend(scale(h), acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#;
+        let report = pass_on(source);
+        assert!(
+            report.pair_inlined_by_fn.contains_key("drive"),
+            "{report:?}"
+        );
+    }
+
+    /// A second call site for the step — the decline the idiom's
+    /// one-call-site condition exists for.
+    #[test]
+    fn a_step_with_a_second_call_site_declines() {
+        let source = r#"module SharedStep
+    intent = "The step is also called from another fn."
+    exposes [entry, other]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    drive(t, List.prepend(h * 2, acc))
+
+fn other(h: Int) -> List<Int>
+    step(h, [], [])
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#;
+        let report = pass_on(source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepShared.reason()),
+            "{report:?}"
+        );
+        assert!(report.synthesized.is_empty(), "nothing fuses: {report:?}");
+    }
+
+    /// A step the module exposes is API surface; callers this pass
+    /// cannot see may exist, so the call-site count cannot be trusted.
+    #[test]
+    fn an_exposed_step_declines() {
+        let source = pair_program("v", false).replace("exposes [entry]", "exposes [entry, step]");
+        let report = pass_on(&source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepVisible.reason()),
+            "{report:?}"
+        );
+    }
+
+    /// No module declaration means no exposes list, and the default
+    /// rule makes every fn visible — same decline, other spelling.
+    #[test]
+    fn a_pair_in_a_module_without_an_exposes_list_declines() {
+        let source = pair_program("v", false).replace(
+            "module Pairs\n    intent = \"Driver-and-step fixture.\"\n    exposes [entry]\n\n",
+            "",
+        );
+        let report = pass_on(&source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepVisible.reason()),
+            "{report:?}"
+        );
+    }
+
+    /// An effectful step would have its trace reshaped by the move.
+    #[test]
+    fn an_effectful_step_declines() {
+        let source = r#"module EffectfulStep
+    intent = "The step prints as it works."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ! [Console.print]
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    ! [Console.print]
+    Console.print("{h}")
+    drive(t, List.prepend(h * 2, acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ! [Console.print]
+    drive(xs, [])
+"#;
+        let report = pass_on(source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepEffects.reason()),
+            "{report:?}"
+        );
+    }
+
+    /// A self-recursive step is its own loop, not this driver's step.
+    #[test]
+    fn a_self_recursive_step_declines() {
+        let source = r#"module SelfStep
+    intent = "The step recurses into itself before the driver."
+    exposes [entry]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    match h > 100
+        true -> step(h - 100, t, acc)
+        false -> drive(t, List.prepend(h, acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#;
+        let report = pass_on(source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepSelfRecursive.reason()),
+            "{report:?}"
+        );
+    }
+
+    /// A program that binds into the `__stp` namespace takes the stage
+    /// away — the fresh names must be unspellable by the program.
+    #[test]
+    fn a_program_binding_into_the_step_namespace_declines() {
+        let source =
+            pair_program("v", false).replace("    v = sh * 2", "    __stp0_v = 1\n    v = sh * 2");
+        let report = pass_on(&source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::NameTaken.reason()),
+            "{report:?}"
+        );
+    }
+
+    /// A pair whose merged loop would not fuse — the step reads the
+    /// accumulator beside the append — is left untouched, with the
+    /// recogniser's own reason on the report.
+    #[test]
+    fn a_pair_whose_merged_loop_cannot_fuse_is_left_untouched() {
+        let source = pair_program("v", false).replace(
+            "    drive(st, List.prepend(v, sacc))",
+            "    drive(st, List.prepend(v + List.len(sacc), sacc))",
+        );
+        let report = pass_on(&source);
+        assert!(
+            report.pair_inlined_by_fn.is_empty(),
+            "no commit without a fusion: {report:?}"
+        );
+        assert!(
+            report.pair_declined.contains_key("drive"),
+            "the pair is reported: {report:?}"
+        );
+        assert!(report.synthesized.is_empty());
+    }
+
+    /// A pair with no empty-started call site fuses to nothing, so
+    /// nothing is committed.
+    #[test]
+    fn a_pair_nobody_calls_with_an_empty_accumulator_is_left_untouched() {
+        let source = pair_program("v", false).replace("    drive(xs, [])", "    drive(xs, [9])");
+        let report = pass_on(&source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::NoCallSite.reason()),
+            "{report:?}"
+        );
+        assert!(report.pair_inlined_by_fn.is_empty());
+    }
+
+    /// A three-fn chain — driver, step, step — inlines both, in order.
+    #[test]
+    fn a_driver_step_step_chain_inlines_both() {
+        let source = r#"module Chain
+    intent = "Driver, step, and the step's own step."
+    exposes [entry]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> stepOne(h, t, acc)
+
+fn stepOne(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    v = h * 2
+    stepTwo(v, t, acc)
+
+fn stepTwo(v: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    drive(t, List.prepend(v + 1, acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#;
+        let report = pass_on(source);
+        assert_eq!(
+            report.pair_inlined_by_fn.get("drive"),
+            Some(&vec!["stepOne".to_string(), "stepTwo".to_string()]),
+            "{report:?}"
+        );
+        assert_eq!(report.builder_fns, vec!["drive".to_string()]);
+    }
+
+    /// The record-constructor terminator, driven through a pair: the
+    /// reverse lands inside a field, the other fields are ordinary
+    /// reads, and the merged loop fuses.
+    #[test]
+    fn a_pair_with_a_record_constructor_terminator_fuses() {
+        let source = r#"module RecordExit
+    intent = "The exit wraps the reverse in a record field."
+    exposes [entry]
+
+record Gathered
+    items: List<Int>
+    seen: Int
+
+fn drive(xs: List<Int>, seen: Int, acc: List<Int>) -> Gathered
+    match xs
+        [] -> Gathered(items = List.reverse(acc), seen = seen)
+        [h, ..t] -> step(h, t, seen, acc)
+
+fn step(h: Int, t: List<Int>, seen: Int, acc: List<Int>) -> Gathered
+    drive(t, seen + 1, List.prepend(h * 2, acc))
+
+fn entry(xs: List<Int>) -> Gathered
+    drive(xs, 0, [])
+"#;
+        let report = pass_on(source);
+        assert!(
+            report.pair_inlined_by_fn.contains_key("drive"),
+            "{report:?}"
+        );
+        assert_eq!(report.builder_fns, vec!["drive".to_string()]);
+    }
+
+    /// A record-constructor exit whose OTHER field reads the
+    /// accumulator is two reads on one path — the discipline the
+    /// occurs-check enforces — so the merged loop declines and nothing
+    /// is committed.
+    #[test]
+    fn a_record_exit_whose_other_field_reads_the_accumulator_declines() {
+        let source = r#"module RecordLeak
+    intent = "A second field reads the accumulator."
+    exposes [entry]
+
+record Gathered
+    items: List<Int>
+    seen: Int
+
+fn drive(xs: List<Int>, acc: List<Int>) -> Gathered
+    match xs
+        [] -> Gathered(items = List.reverse(acc), seen = List.len(acc))
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> Gathered
+    drive(t, List.prepend(h * 2, acc))
+
+fn entry(xs: List<Int>) -> Gathered
+    drive(xs, [])
+"#;
+        let report = pass_on(source);
+        assert!(report.pair_inlined_by_fn.is_empty(), "{report:?}");
+        assert!(report.synthesized.is_empty(), "{report:?}");
+        assert!(report.pair_declined.contains_key("drive"), "{report:?}");
+    }
+}

--- a/src/ir/buffer_build/driver_step.rs
+++ b/src/ir/buffer_build/driver_step.rs
@@ -46,10 +46,10 @@
 //! - it does not recurse into itself — the idiom recurses into the
 //!   DRIVER, and a self-recursive step is its own loop.
 //!
-//! Binder hygiene is mechanical rather than argued per-case: every name
-//! the step's body binds is renamed into the guarded `__stp` namespace
-//! (fresh per inline, so a chain of inlines cannot capture across
-//! rounds), parameters are substituted only when the argument is a bare
+//! Binder hygiene is mechanical rather than argued per-case: every
+//! name this stage synthesizes — binder renames and argument binders
+//! alike — comes from ONE allocator, so no two are ever equal.
+//! Parameters are substituted only when the argument is a bare
 //! identifier or a literal — anything else is bound first, in argument
 //! order, so evaluation order is the call's — and a step whose body
 //! reads a name the driver re-binds anywhere is declined outright.
@@ -79,13 +79,37 @@ use super::list_build::{
 use super::*;
 use crate::ast::TopLevel;
 
-/// The namespace every binder this stage synthesizes lives in. Fresh
-/// names are `__stp<k>_<name>` with `k` unique per inline, so no two
-/// inlines — including two rounds into the same driver — can collide.
-/// A program that binds any name starting with this prefix takes the
-/// stage away for the whole module: the check is on the prefix, so it
-/// covers every `k` at once.
+/// The namespace every name this stage synthesizes lives in. The
+/// names are `__stp<n>` with `n` handed out by [`FreshNames`] — one
+/// allocator per driver build, shared by binder renames and argument
+/// binders across every inline round — so no two synthesized names
+/// are ever equal, by construction. A program that binds any name
+/// starting with this prefix takes the stage away for the whole
+/// module: the check is on the prefix, so it covers every `n` at
+/// once.
 pub(super) const STEP_PREFIX: &str = "__stp";
+
+/// The single fresh-name allocator behind every name this stage
+/// synthesizes. One monotone counter: two allocations can never be
+/// equal BY CONSTRUCTION, with no second namespace to reason about.
+/// This replaced two overlapping hand-rolled schemes (`__stp<k>_<name>`
+/// binder renames beside `__stp<k>_p<idx>` argument binders), where a
+/// step binder literally named `p0` renamed to exactly the fresh name
+/// minted for the bound argument at index 0 and shadowed it.
+#[derive(Default)]
+struct FreshNames {
+    next: usize,
+}
+
+impl FreshNames {
+    /// The next name. No other call on this allocator has returned it
+    /// or ever will.
+    fn next_name(&mut self) -> String {
+        let n = self.next;
+        self.next += 1;
+        format!("{STEP_PREFIX}{n}")
+    }
+}
 
 /// Why the driver-and-step normalization left a pair alone.
 ///
@@ -224,8 +248,11 @@ fn build_and_validate(
     let mut body = fd.body.as_ref().clone();
     let mut steps: Vec<String> = Vec::new();
     let driver_bound = bound_names_of(fd);
+    // One allocator for the whole build: every synthesized name in
+    // every round comes from here, so no two are ever equal.
+    let mut fresh = FreshNames::default();
 
-    for round in 0..MAX_ROUNDS {
+    for _ in 0..MAX_ROUNDS {
         let Some(target) = first_companion_target(&body, &fd.name) else {
             break;
         };
@@ -238,7 +265,7 @@ fn build_and_validate(
             return Err(PairDecline::StepShape.reason());
         };
         check_step_conditions(step, facts).map_err(PairDecline::reason)?;
-        let inlined = inline_step_at(&mut body, step, &driver_bound, &facts.top_level, round)
+        let inlined = inline_step_at(&mut body, step, &driver_bound, &facts.top_level, &mut fresh)
             .map_err(PairDecline::reason)?;
         if !inlined {
             // The walk saw the target but the replacement did not land —
@@ -567,7 +594,7 @@ fn inline_step_at(
     step: &FnDef,
     driver_bound: &HashSet<String>,
     top_level: &HashSet<String>,
-    round: usize,
+    fresh: &mut FreshNames,
 ) -> Result<bool, PairDecline> {
     // Build the replacement first, so a decline leaves the body copy
     // exactly as it was.
@@ -579,7 +606,7 @@ fn inline_step_at(
             step,
             driver_bound,
             top_level,
-            round,
+            fresh,
             &mut done,
             &mut outcome,
         );
@@ -594,7 +621,7 @@ fn replace_step_call(
     step: &FnDef,
     driver_bound: &HashSet<String>,
     top_level: &HashSet<String>,
-    round: usize,
+    fresh: &mut FreshNames,
     done: &mut bool,
     outcome: &mut Result<(), PairDecline>,
 ) {
@@ -604,7 +631,7 @@ fn replace_step_call(
     if let Expr::TailCall(data) = &expr.node
         && data.target == step.name
     {
-        match encode_step_body(step, &data.args, driver_bound, top_level, round) {
+        match encode_step_body(step, &data.args, driver_bound, top_level, fresh) {
             Ok(inlined) => {
                 *expr = inlined;
                 *done = true;
@@ -614,7 +641,7 @@ fn replace_step_call(
         return;
     }
     crate::ir::chars_fusion::walk_children_mut(expr, &mut |child| {
-        replace_step_call(child, step, driver_bound, top_level, round, done, outcome);
+        replace_step_call(child, step, driver_bound, top_level, fresh, done, outcome);
     });
 }
 
@@ -626,7 +653,7 @@ fn encode_step_body(
     args: &[Spanned<Expr>],
     driver_bound: &HashSet<String>,
     top_level: &HashSet<String>,
-    round: usize,
+    fresh: &mut FreshNames,
 ) -> Result<Spanned<Expr>, PairDecline> {
     if args.len() != step.params.len() {
         return Err(PairDecline::StepShape);
@@ -681,9 +708,15 @@ fn encode_step_body(
         return Err(PairDecline::StepShape);
     };
 
-    let rename: HashMap<String, String> = binders
-        .iter()
-        .map(|n| (n.clone(), format!("{STEP_PREFIX}{round}_{n}")))
+    // The rename map's keys are the step's original binder names;
+    // every output comes from the one allocator. Allocation walks the
+    // binders in sorted order so the synthesized names are
+    // deterministic across runs — the set's own order is not.
+    let mut ordered: Vec<String> = binders.iter().cloned().collect();
+    ordered.sort();
+    let rename: HashMap<String, String> = ordered
+        .into_iter()
+        .map(|n| (n, fresh.next_name()))
         .collect();
     for stmt in stmts.iter_mut() {
         if let Stmt::Binding(name, _, _) = stmt
@@ -710,16 +743,20 @@ fn encode_step_body(
     // the cross-backend differential.
     let mut bound_args: Vec<(String, Spanned<Expr>)> = Vec::new();
     let mut subst: HashMap<String, Spanned<Expr>> = HashMap::new();
-    for (idx, ((param, _), arg)) in step.params.iter().zip(args.iter()).enumerate() {
+    for ((param, _), arg) in step.params.iter().zip(args.iter()) {
         let replacement = match &arg.node {
             Expr::Ident(_) | Expr::Literal(_) => arg.clone(),
             _ => {
-                let fresh = format!("{STEP_PREFIX}{round}_p{idx}");
-                let read = sp_at(arg.line, Expr::Ident(fresh.clone()));
+                // The argument binder comes from the same allocator as
+                // the binder renames above, so no binder rename can
+                // spell it — the shadow a `p<idx>`-shaped second
+                // namespace let a step binder cast.
+                let name = fresh.next_name();
+                let read = sp_at(arg.line, Expr::Ident(name.clone()));
                 if let Some(ty) = arg.ty() {
                     read.set_ty(ty.clone());
                 }
-                bound_args.push((fresh, arg.clone()));
+                bound_args.push((name, arg.clone()));
                 read
             }
         };
@@ -1036,6 +1073,69 @@ fn entry(xs: List<Int>) -> List<Int>
                 report.builder_fns,
                 vec!["drive".to_string()],
                 "arguments ({first:?}, {second:?}) (bound: {bound:?}) must fuse"
+            );
+        }
+    }
+
+    /// One cell of the P-BINDER matrix: the step's binder is spelled
+    /// like the index-derived half of a synthesized argument name
+    /// (`p0`, `p1`), and the step reads both parameters again after
+    /// the binding, so a collision between synthesized names changes
+    /// the answer instead of hiding.
+    fn p_binder_program(binder: &str, bound: (bool, bool)) -> String {
+        let arg1 = if bound.0 { "x + 0" } else { "x" };
+        let arg2 = if bound.1 { "y + 0" } else { "y" };
+        format!(
+            r#"module PBinderMatrix
+    intent = "P-binder collision fixture."
+    exposes [entry]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [x, ..t] -> match t
+            [] -> List.reverse(acc)
+            [y, ..t2] -> step({arg1}, {arg2}, t2, acc)
+
+fn step(sa: Int, sb: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    {binder} = sa + sb
+    drive(st, List.prepend({binder} * 10 + sa + sb, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#
+        )
+    }
+
+    /// The P-BINDER axis of the hygiene matrix: a step binder spelled
+    /// like the index-derived half of a synthesized argument name,
+    /// with the argument at that index substituted, bound, and bound
+    /// at the OTHER index. Every synthesized name comes from one
+    /// allocator, so the spelling cannot collide with the name minted
+    /// for the bound argument and every cell fuses; the running
+    /// answers for the same cells are pinned end-to-end in
+    /// `tests/driver_step_pairs.rs`.
+    #[test]
+    fn step_binders_spelled_like_argument_indices_fuse_in_every_cell() {
+        let cells: &[(&str, (bool, bool))] = &[
+            ("p0", (false, false)),
+            ("p0", (true, false)),
+            ("p0", (false, true)),
+            ("p1", (false, false)),
+            ("p1", (false, true)),
+            ("p1", (true, false)),
+        ];
+        for (binder, bound) in cells {
+            let report = pass_on(&p_binder_program(binder, *bound));
+            assert_eq!(
+                report.pair_inlined_by_fn.get("drive"),
+                Some(&vec!["step".to_string()]),
+                "binder {binder:?} (bound: {bound:?}) must not block the inline: {report:?}"
+            );
+            assert_eq!(
+                report.builder_fns,
+                vec!["drive".to_string()],
+                "binder {binder:?} (bound: {bound:?}) must fuse"
             );
         }
     }

--- a/src/ir/buffer_build/driver_step.rs
+++ b/src/ir/buffer_build/driver_step.rs
@@ -31,7 +31,10 @@
 //!   the driver — a step called from anywhere else is shared code, not
 //!   the idiom. The census walks every expression-bearing top-level
 //!   item, verify blocks and top-level statements included, so the
-//!   condition means what it says;
+//!   condition means what it says. The one carve-out is the step's own
+//!   verify block: the step is never edited or removed, so its spec
+//!   keeps the exact function it names — those calls are not a second
+//!   consumer;
 //! - the module cannot be called around: the step must not be visible
 //!   outside the module (`exposes` list, or the `_` convention). The
 //!   pass sees one module at a time, so a step some other module could
@@ -434,9 +437,17 @@ fn references_in_expr(expr: &Spanned<Expr>, name: &str) -> usize {
 /// are documentation strings (`DecisionImpact`), so a call cannot be
 /// spelled there — and the module header, type defs, and capability
 /// declarations have no expression positions at all.
+///
+/// One carve-out, from this stage's own contract: the step is never
+/// edited or removed, so a verify block ON THE STEP ITSELF keeps the
+/// exact function it specifies — its calls are the spec's, not a
+/// second consumer's, and real corpora verify their step fns directly.
+/// A step called from any OTHER verify block is shared code and
+/// declines like any other extra call site.
 fn references_in_top_level(item: &TopLevel, name: &str) -> usize {
     match item {
         TopLevel::FnDef(fd) => references_in_fn(fd, name),
+        TopLevel::Verify(vb) if vb.fn_name == name => 0,
         TopLevel::Verify(vb) => {
             let in_domain = |given: &crate::ast::VerifyGiven| match &given.domain {
                 crate::ast::VerifyGivenDomain::Explicit(values) => values
@@ -1133,11 +1144,13 @@ fn entry(xs: List<Int>) -> List<Int>
 
     /// The one-call-site condition claims the WHOLE MODULE, so a
     /// second call in a verify block counts: the census walks every
-    /// expression-bearing top-level item, not just fn bodies.
+    /// expression-bearing top-level item, not just fn bodies. Here the
+    /// extra call lives in ANOTHER fn's verify block — a second
+    /// consumer of the step, spelled in spec position.
     #[test]
     fn a_step_called_again_from_a_verify_block_declines() {
         let source = format!(
-            "{}\nverify step\n    step(2, [1], []) => [4, 2]\n",
+            "{}\nverify entry\n    entry([2]) => step(2, [], [])\n",
             pair_program("v", false)
         );
         let report = pass_on(&source);
@@ -1147,6 +1160,24 @@ fn entry(xs: List<Int>) -> List<Int>
             "{report:?}"
         );
         assert!(report.pair_inlined_by_fn.is_empty());
+    }
+
+    /// The carve-out: a verify block ON THE STEP ITSELF is the step's
+    /// spec, and the step it names is never edited or removed — so the
+    /// pair still fuses. Real corpora verify their step fns directly;
+    /// counting the spec as a second consumer would turn this stage
+    /// off exactly where it was built to fire.
+    #[test]
+    fn a_verify_block_on_the_step_itself_does_not_block_the_inline() {
+        let source = format!(
+            "{}\nverify step\n    step(2, [1], []) => [4, 2]\n",
+            pair_program("v", false)
+        );
+        let report = pass_on(&source);
+        assert!(
+            report.pair_inlined_by_fn.contains_key("drive"),
+            "{report:?}"
+        );
     }
 
     /// The control for the verify-block census: a verify block on the

--- a/src/ir/buffer_build/driver_step.rs
+++ b/src/ir/buffer_build/driver_step.rs
@@ -29,7 +29,9 @@
 //!
 //! - it has EXACTLY ONE call site in the whole module, the tail call in
 //!   the driver — a step called from anywhere else is shared code, not
-//!   the idiom;
+//!   the idiom. The census walks every expression-bearing top-level
+//!   item, verify blocks and top-level statements included, so the
+//!   condition means what it says;
 //! - the module cannot be called around: the step must not be visible
 //!   outside the module (`exposes` list, or the `_` convention). The
 //!   pass sees one module at a time, so a step some other module could
@@ -48,8 +50,12 @@
 //! identifier or a literal — anything else is bound first, in argument
 //! order, so evaluation order is the call's — and a step whose body
 //! reads a name the driver re-binds anywhere is declined outright.
-//! This family has already shipped binder-capture bugs; the rules here
-//! prefer a lost fusion over a wrong answer, every time.
+//! Substitution is SIMULTANEOUS: one walk, from a complete
+//! param-to-argument map, never descending into what it inserts — an
+//! argument identifier spelled like another parameter of the step must
+//! not be captured by that parameter's substitution. This family has
+//! already shipped binder-capture bugs; the rules here prefer a lost
+//! fusion over a wrong answer, every time.
 //!
 //! The inline happens on a COPY of the driver's body, and the copy is
 //! committed only when the merged loop then actually fuses — the same
@@ -291,8 +297,10 @@ fn check_step_conditions(step: &FnDef, facts: &StepFacts) -> Result<(), PairDecl
     if references_in_fn(step, &step.name) > 0 {
         return Err(PairDecline::StepSelfRecursive);
     }
-    let refs: usize = crate::ir::chars_fusion::fn_defs(&facts.items)
-        .map(|fd| references_in_fn(fd, &step.name))
+    let refs: usize = facts
+        .items
+        .iter()
+        .map(|item| references_in_top_level(item, &step.name))
         .sum();
     if refs != 1 {
         return Err(PairDecline::StepShared);
@@ -408,11 +416,64 @@ fn references_in_fn(fd: &FnDef, name: &str) -> usize {
     fd.body
         .stmts()
         .iter()
-        .map(|stmt| {
-            let expr = crate::ir::chars_fusion::stmt_expr(stmt);
-            count_ident_reads(&expr.node, name) + count_tail_targets(expr, name)
-        })
+        .map(|stmt| references_in_expr(crate::ir::chars_fusion::stmt_expr(stmt), name))
         .sum()
+}
+
+fn references_in_expr(expr: &Spanned<Expr>, name: &str) -> usize {
+    count_ident_reads(&expr.node, name) + count_tail_targets(expr, name)
+}
+
+/// How many times any top-level item references `name` — the
+/// module-wide census behind the one-call-site condition. The claim is
+/// "exactly one call site in the whole module", so the census walks
+/// every place an expression can live, not just fn bodies: verify
+/// blocks (cases, per-case givens, and the law form's template,
+/// `when`, sample guards, and explicit given domains) and top-level
+/// statements. Decision blocks carry no expressions — their impacts
+/// are documentation strings (`DecisionImpact`), so a call cannot be
+/// spelled there — and the module header, type defs, and capability
+/// declarations have no expression positions at all.
+fn references_in_top_level(item: &TopLevel, name: &str) -> usize {
+    match item {
+        TopLevel::FnDef(fd) => references_in_fn(fd, name),
+        TopLevel::Verify(vb) => {
+            let in_domain = |given: &crate::ast::VerifyGiven| match &given.domain {
+                crate::ast::VerifyGivenDomain::Explicit(values) => values
+                    .iter()
+                    .map(|v| references_in_expr(v, name))
+                    .sum::<usize>(),
+                crate::ast::VerifyGivenDomain::IntRange { .. } => 0,
+            };
+            let mut refs: usize = vb
+                .cases
+                .iter()
+                .flat_map(|(lhs, rhs)| [lhs, rhs])
+                .chain(vb.case_givens.iter().flatten().map(|(_, value)| value))
+                .map(|e| references_in_expr(e, name))
+                .sum();
+            refs += vb.cases_givens.iter().map(in_domain).sum::<usize>();
+            if let crate::ast::VerifyKind::Law(law) = &vb.kind {
+                refs += references_in_expr(&law.lhs, name) + references_in_expr(&law.rhs, name);
+                refs += law
+                    .when
+                    .as_ref()
+                    .map_or(0, |when| references_in_expr(when, name));
+                refs += law
+                    .sample_guards
+                    .iter()
+                    .map(|g| references_in_expr(g, name))
+                    .sum::<usize>();
+                refs += law.givens.iter().map(in_domain).sum::<usize>();
+            }
+            refs
+        }
+        TopLevel::Stmt(stmt) => references_in_expr(crate::ir::chars_fusion::stmt_expr(stmt), name),
+        TopLevel::Module(_)
+        | TopLevel::Decision(_)
+        | TopLevel::TypeDef(_)
+        | TopLevel::Capability(_) => 0,
+    }
 }
 
 /// How many `TailCall` nodes under `expr` target `name`.
@@ -626,27 +687,35 @@ fn encode_step_body(
     // its reads are pure and cannot change between the call and the
     // read. Anything else is bound first, in argument order, so
     // whatever the argument computes happens exactly once and exactly
-    // where the call evaluated it.
+    // where the call evaluated it. The map is built COMPLETE before any
+    // rewriting and applied in ONE walk — substitution must be
+    // SIMULTANEOUS, because a call-site argument may itself be spelled
+    // like another parameter of the step. Substituting one parameter at
+    // a time re-visited the identifiers just inserted for the earlier
+    // parameters, so an argument spelled like a LATER parameter was
+    // rewritten again by that parameter's pass: `step(b, c, t2, acc)`
+    // against params `(a, b, st, sacc)` turned `a*10 + b` into
+    // `c*10 + c` — the same wrong answer on both backends, invisible to
+    // the cross-backend differential.
     let mut bound_args: Vec<(String, Spanned<Expr>)> = Vec::new();
+    let mut subst: HashMap<String, Spanned<Expr>> = HashMap::new();
     for (idx, ((param, _), arg)) in step.params.iter().zip(args.iter()).enumerate() {
-        match &arg.node {
-            Expr::Ident(_) | Expr::Literal(_) => {
-                for stmt in stmts.iter_mut() {
-                    substitute_reads(crate::ir::chars_fusion::stmt_expr_mut(stmt), param, arg);
-                }
-            }
+        let replacement = match &arg.node {
+            Expr::Ident(_) | Expr::Literal(_) => arg.clone(),
             _ => {
                 let fresh = format!("{STEP_PREFIX}{round}_p{idx}");
                 let read = sp_at(arg.line, Expr::Ident(fresh.clone()));
                 if let Some(ty) = arg.ty() {
                     read.set_ty(ty.clone());
                 }
-                for stmt in stmts.iter_mut() {
-                    substitute_reads(crate::ir::chars_fusion::stmt_expr_mut(stmt), param, &read);
-                }
                 bound_args.push((fresh, arg.clone()));
+                read
             }
-        }
+        };
+        subst.insert(param.clone(), replacement);
+    }
+    for stmt in stmts.iter_mut() {
+        substitute_reads(crate::ir::chars_fusion::stmt_expr_mut(stmt), &subst);
     }
 
     // Fold the statements into one expression, back to front: each
@@ -761,18 +830,23 @@ fn rename_pattern(pattern: &mut Pattern, rename: &HashMap<String, String>) {
     }
 }
 
-/// Replace every read of `param` with the argument expression. Patterns
-/// never bind `param` here — a step whose body shadows a parameter was
-/// declined before this runs — so every `Ident(param)` is the read.
-fn substitute_reads(expr: &mut Spanned<Expr>, param: &str, arg: &Spanned<Expr>) {
+/// Replace every parameter read with its argument expression — all
+/// parameters SIMULTANEOUSLY, from one complete map. A replacement is
+/// inserted and never descended into, so an argument identifier
+/// spelled like another parameter of the step cannot be rewritten by
+/// that parameter's substitution — the capture the sequential
+/// per-parameter walk this replaced committed. Patterns never bind a
+/// parameter here — a step whose body shadows a parameter was declined
+/// before this runs — so every `Ident(param)` is the read.
+fn substitute_reads(expr: &mut Spanned<Expr>, subst: &HashMap<String, Spanned<Expr>>) {
     if let Expr::Ident(n) = &expr.node
-        && n == param
+        && let Some(arg) = subst.get(n)
     {
         *expr = arg.clone();
         return;
     }
     crate::ir::chars_fusion::walk_children_mut(expr, &mut |child| {
-        substitute_reads(child, param, arg);
+        substitute_reads(child, subst);
     });
 }
 
@@ -877,6 +951,84 @@ fn entry(xs: List<Int>) -> List<Int>
         }
     }
 
+    /// One cell of the ARGUMENT-SPELLING matrix: the driver peels two
+    /// elements per round, so its call site has two value arguments to
+    /// dress in another parameter's name. The bound flags wrap an
+    /// argument in `+ 0`, pushing it off the substituted path onto the
+    /// bound-args path.
+    fn argument_program(first: &str, second: &str, bound: (bool, bool)) -> String {
+        let arg1 = if bound.0 {
+            format!("{first} + 0")
+        } else {
+            first.to_string()
+        };
+        let arg2 = if bound.1 {
+            format!("{second} + 0")
+        } else {
+            second.to_string()
+        };
+        format!(
+            r#"module ArgMatrix
+    intent = "Argument-spelling fixture."
+    exposes [entry]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [{first}, ..t] -> match t
+            [] -> List.reverse(acc)
+            [{second}, ..t2] -> step({arg1}, {arg2}, t2, acc)
+
+fn step(sa: Int, sb: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    v = sa * 10 + sb
+    drive(st, List.prepend(v, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#
+        )
+    }
+
+    /// The ARGUMENT/PARAMETER axis, order-controlled like the binder
+    /// matrix: a call-site argument spelled like an earlier parameter,
+    /// a later one, the same one, and a step binder — each on the
+    /// substituted path and on the bound-args path. Substitution is
+    /// simultaneous, so every cell fuses; the later-param spelling is
+    /// the cell sequential substitution silently got wrong (the
+    /// end-to-end answers for all cells are pinned in
+    /// `tests/driver_step_pairs.rs`).
+    #[test]
+    fn call_site_arguments_spelled_like_step_names_fuse_in_every_cell() {
+        let cells: &[(&str, &str, (bool, bool))] = &[
+            // Like a LATER param: sb (the step's second) worn by arg 1.
+            ("sb", "y", (false, false)),
+            ("sb", "y", (true, false)),
+            // Like an EARLIER param: sa worn by arg 2.
+            ("x", "sa", (false, false)),
+            ("x", "sa", (false, true)),
+            // Like the SAME param: sa worn by its own argument.
+            ("sa", "y", (false, false)),
+            ("sa", "y", (true, false)),
+            // Like a STEP BINDER: v is the step's own binding.
+            ("v", "y", (false, false)),
+            ("v", "y", (true, false)),
+        ];
+        for (first, second, bound) in cells {
+            let report = pass_on(&argument_program(first, second, *bound));
+            assert_eq!(
+                report.pair_inlined_by_fn.get("drive"),
+                Some(&vec!["step".to_string()]),
+                "arguments ({first:?}, {second:?}) (bound: {bound:?}) must not block \
+                 the inline: {report:?}"
+            );
+            assert_eq!(
+                report.builder_fns,
+                vec!["drive".to_string()],
+                "arguments ({first:?}, {second:?}) (bound: {bound:?}) must fuse"
+            );
+        }
+    }
+
     /// A step binder that shadows one of the step's own parameters:
     /// substitution would rewrite the shadow's reads, so the pair is
     /// declined — in both binder positions.
@@ -975,6 +1127,51 @@ fn entry(xs: List<Int>) -> List<Int>
         let report = pass_on(source);
         assert!(
             report.pair_inlined_by_fn.contains_key("drive"),
+            "{report:?}"
+        );
+    }
+
+    /// The one-call-site condition claims the WHOLE MODULE, so a
+    /// second call in a verify block counts: the census walks every
+    /// expression-bearing top-level item, not just fn bodies.
+    #[test]
+    fn a_step_called_again_from_a_verify_block_declines() {
+        let source = format!(
+            "{}\nverify step\n    step(2, [1], []) => [4, 2]\n",
+            pair_program("v", false)
+        );
+        let report = pass_on(&source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepShared.reason()),
+            "{report:?}"
+        );
+        assert!(report.pair_inlined_by_fn.is_empty());
+    }
+
+    /// The control for the verify-block census: a verify block on the
+    /// DRIVER references only the driver, so the pair still fuses.
+    #[test]
+    fn a_verify_block_on_the_driver_does_not_block_the_inline() {
+        let source = format!(
+            "{}\nverify drive\n    drive([3], []) => [6]\n",
+            pair_program("v", false)
+        );
+        let report = pass_on(&source);
+        assert!(
+            report.pair_inlined_by_fn.contains_key("drive"),
+            "{report:?}"
+        );
+    }
+
+    /// A top-level statement calling the step is a call site too.
+    #[test]
+    fn a_step_called_again_from_a_top_level_statement_declines() {
+        let source = format!("{}\nwarm = step(2, [1], [])\n", pair_program("v", false));
+        let report = pass_on(&source);
+        assert_eq!(
+            report.pair_declined.get("drive").copied(),
+            Some(PairDecline::StepShared.reason()),
             "{report:?}"
         );
     }

--- a/src/ir/buffer_build/list_build.rs
+++ b/src/ir/buffer_build/list_build.rs
@@ -149,6 +149,13 @@ impl ListBuildDecline {
 /// assert on without parsing prose.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ListBuildPassReport {
+    /// Drivers whose step companions were inlined ahead of candidacy —
+    /// the driver-and-step normalization — with the steps in inline
+    /// order. Alphabetised by driver. See [`super::driver_step`].
+    pub pair_inlined_by_fn: std::collections::BTreeMap<String, Vec<String>>,
+    /// Driver-and-step pairs the normalization looked at and turned
+    /// down, with the reason. Alphabetised by driver.
+    pub pair_declined: std::collections::BTreeMap<String, &'static str>,
     /// Call sites moved from `<fn>(…, [])` onto a collected variant.
     pub rewrites: usize,
     /// Names of the synthesized `<fn>__collected` variants appended to
@@ -177,7 +184,7 @@ pub struct ListBuildPassReport {
 
 /// Suffix distinguishing the synthesized variant from the loop it was
 /// built from.
-const COLLECTED_SUFFIX: &str = "__collected";
+pub(super) const COLLECTED_SUFFIX: &str = "__collected";
 
 /// Prefixes of every intrinsic and binder this pass emits — the list
 /// builder's, and the byte builder's the byte-sink retarget below
@@ -207,20 +214,19 @@ const BUILDER_INTRINSICS: [&str; 3] = ["__lst_new", "__lst_push", "__lst_finaliz
 /// on one function, and this is the order that lets them.
 pub fn run_list_build_pass(items: &mut Vec<TopLevel>) -> ListBuildPassReport {
     let mut report = ListBuildPassReport::default();
+    // The driver-and-step normalization first: a loop written as a pair
+    // becomes the single fn the candidacy walk below knows how to read.
+    // It commits only bodies whose merged loop it has already proven
+    // will fuse, so everything after this line treats them like any
+    // other candidate.
+    super::driver_step::run_driver_step_normalize(items, &mut report);
     let candidates: Vec<(String, ListBuildAcc)> = list_build_candidates(items);
     if candidates.is_empty() {
         return report;
     }
 
     let taken = crate::ir::chars_fusion::taken_names(items);
-    // One name in the program's own binders is enough to take the
-    // namespace away from every loop at once: the intrinsics are emitted
-    // by name, and a name that means something else anywhere it is in
-    // scope is a name this pass cannot spell.
-    let namespace_taken = taken.iter().any(|name| {
-        BUILDER_PREFIXES.iter().any(|p| name.starts_with(p))
-            || BUILDER_INTRINSICS.contains(&name.as_str())
-    });
+    let namespace_taken = builder_namespace_taken(&taken);
 
     let mut accepted: HashMap<String, (String, ListBuildShape)> = HashMap::new();
     let mut variants: Vec<FnDef> = Vec::new();
@@ -287,12 +293,27 @@ pub fn run_list_build_pass(items: &mut Vec<TopLevel>) -> ListBuildPassReport {
     report
 }
 
+/// One name in the program's own binders is enough to take the builder
+/// namespace away from every loop at once: the intrinsics are emitted
+/// by name, and a name that means something else anywhere it is in
+/// scope is a name this pass cannot spell. Shared with the
+/// driver-and-step normalization, which must decline a pair the main
+/// pass would then refuse to fuse.
+pub(super) fn builder_namespace_taken(taken: &std::collections::HashSet<String>) -> bool {
+    taken.iter().any(|name| {
+        BUILDER_PREFIXES.iter().any(|p| name.starts_with(p))
+            || BUILDER_INTRINSICS.contains(&name.as_str())
+    })
+}
+
 /// Is there a collecting loop here at all? Read-only, so a caller that
 /// has to decide whether to COPY a module before running the pass can
 /// ask first — the VM re-parses every dependency and re-runs the pass on
-/// its own copy.
+/// its own copy. A driver-and-step pair counts: the normalization would
+/// merge it into exactly such a loop.
 pub fn has_list_build_shape(items: &[TopLevel]) -> bool {
     crate::ir::chars_fusion::fn_defs(items).any(|fd| list_build_acc_of(fd).is_some())
+        || super::driver_step::has_driver_step_shape(items)
 }
 
 /// Every fn that looks like a collecting loop, paired with the
@@ -319,7 +340,7 @@ fn list_build_candidates(items: &[TopLevel]) -> Vec<(String, ListBuildAcc)> {
 /// The accumulator is the RIGHTMOST `List<…>` parameter, the same rule
 /// the joined builders use above and for the same reason: a list-driven
 /// loop takes its input first and threads its answer last.
-fn list_build_acc_of(fd: &FnDef) -> Option<ListBuildAcc> {
+pub(super) fn list_build_acc_of(fd: &FnDef) -> Option<ListBuildAcc> {
     let (idx, name, ty) = fd
         .params
         .iter()
@@ -374,7 +395,7 @@ struct AccUses {
 /// conclusion than the rewrite it is supposed to be guarding: the walk
 /// either replaces every read of the accumulator with the builder form
 /// that stands for it, or it stops and the copy is thrown away.
-fn build_collected_variant(
+pub(super) fn build_collected_variant(
     fd: &FnDef,
     acc: &ListBuildAcc,
     new_name: &str,
@@ -1701,7 +1722,7 @@ fn rewrite_list_build_sites(
 /// reverses; the builder produces the forward list, so only a call site
 /// wearing that reverse can be moved — a bare one asked for the elements
 /// backwards and still gets them.
-fn try_rewrite_list_build_site(
+pub(super) fn try_rewrite_list_build_site(
     expr: &Spanned<Expr>,
     accepted: &HashMap<String, (String, ListBuildShape)>,
 ) -> Option<(String, Spanned<Expr>)> {

--- a/src/ir/buffer_build/mod.rs
+++ b/src/ir/buffer_build/mod.rs
@@ -1322,6 +1322,7 @@ fn build_buffered_variant(fd: &FnDef, shape: &BufferBuildShape) -> Option<FnDef>
 /// accumulator is the answer rather than something `String.join`
 /// consumes. Built on the recognisers above, which is why it is a
 /// sibling rather than a module of its own.
+mod driver_step;
 mod list_build;
 
 #[cfg(test)]

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4008,6 +4008,7 @@ fn dep_fusion_reports(items: &[TopLevel], module_root: &str) -> Vec<DepFusion> {
             || !chars_fusion.declined.is_empty()
             || list_build.rewrites > 0
             || !list_build.declined.is_empty()
+            || !list_build.pair_declined.is_empty()
         {
             out.push(DepFusion {
                 prefix: m.dep_name,
@@ -4141,6 +4142,17 @@ fn merge_dep_list_build(diagnostics: &mut [aver::ir::PassDiagnostic], dep_report
             }
             for (fn_name, reason) in &dep.declined {
                 entry.declined.insert(format!("{prefix}.{fn_name}"), reason);
+            }
+            for (driver, steps) in &dep.pair_inlined_by_fn {
+                entry.pair_inlined_by_fn.insert(
+                    format!("{prefix}.{driver}"),
+                    steps.iter().map(|s| format!("{prefix}.{s}")).collect(),
+                );
+            }
+            for (fn_name, reason) in &dep.pair_declined {
+                entry
+                    .pair_declined
+                    .insert(format!("{prefix}.{fn_name}"), reason);
             }
             for (fn_name, reason) in &dep.byte_declined {
                 entry
@@ -4555,11 +4567,22 @@ fn render_pass_diagnostics(diags: &[aver::ir::pipeline::PassDiagnostic]) -> Stri
                     }
                     out.push_str(&format!("  • {DEFORESTING_TARGETS_NOTE}\n"));
                 }
+                for (driver, steps) in &r.pair_inlined_by_fn {
+                    out.push_str(&format!(
+                        "  • {driver} absorbed its step fn(s) {} before candidacy\n",
+                        steps.join(", ")
+                    ));
+                }
                 // Same reason the chars-fusion declines are unconditional:
                 // a loop the recogniser stopped seeing is what this
                 // diagnostic exists to surface.
                 for (fn_name, reason) in &r.declined {
                     out.push_str(&format!("  • declined {fn_name}: {reason}\n"));
+                }
+                for (fn_name, reason) in &r.pair_declined {
+                    out.push_str(&format!(
+                        "  • declined the step inline for {fn_name}: {reason}\n"
+                    ));
                 }
                 for (fn_name, reason) in &r.byte_declined {
                     out.push_str(&format!(
@@ -4858,15 +4881,35 @@ fn render_pass_diagnostics_json(diags: &[aver::ir::pipeline::PassDiagnostic]) ->
                     byte_declined.push_str(&format!("{}:{}", json_str(k), json_str(v)));
                 }
                 byte_declined.push('}');
+                let mut pair_inlined = String::from("{");
+                for (j, (k, v)) in r.pair_inlined_by_fn.iter().enumerate() {
+                    if j > 0 {
+                        pair_inlined.push(',');
+                    }
+                    pair_inlined.push_str(&format!("{}:{}", json_str(k), json_str_array(v)));
+                }
+                pair_inlined.push('}');
+                let mut pair_declined = String::from("{");
+                for (j, (k, v)) in r.pair_declined.iter().enumerate() {
+                    if j > 0 {
+                        pair_declined.push(',');
+                    }
+                    pair_declined.push_str(&format!("{}:{}", json_str(k), json_str(v)));
+                }
+                pair_declined.push('}');
                 out.push_str(&format!(
                     "{{\"rewrites\":{},\"synthesized\":{},\"loop_fns\":{},\
-                     \"rewrites_by_fn\":{},\"declined\":{},\"byte_retargets\":{},\
+                     \"rewrites_by_fn\":{},\"declined\":{},\
+                     \"pair_inlined_by_fn\":{},\"pair_declined\":{},\
+                     \"byte_retargets\":{},\
                      \"byte_fns\":{},\"byte_declined\":{},\"targets\":{}}}",
                     r.rewrites,
                     json_str_array(&r.synthesized),
                     json_str_array(&r.builder_fns),
                     by_fn,
                     declined,
+                    pair_inlined,
+                    pair_declined,
                     r.byte_retargets,
                     json_str_array(&r.byte_fns),
                     byte_declined,

--- a/tests/driver_step_pairs.rs
+++ b/tests/driver_step_pairs.rs
@@ -12,6 +12,13 @@
 //! one really fuses) are pinned in the unit tests beside the pass; what
 //! this file adds is the running answer.
 //!
+//! The second axis is ARGUMENT SPELLING: a call-site argument dressed
+//! in another step parameter's name — earlier, later, the same one, a
+//! step binder — on both the substituted and the bound-args path. The
+//! later-param spelling was a shipped silent-wrong answer (sequential
+//! substitution re-visited the identifiers it had just inserted), so
+//! this axis, too, is a matrix and not a single case.
+//!
 //! The declined half pins the answers of the pairs the normalization
 //! must leave alone: a step with a second call site, a step that reads
 //! a name the driver binds (the capture witness — inlined, its helper
@@ -102,6 +109,171 @@ fn the_hygiene_matrix_keeps_the_pairs_answer_in_every_cell() {
             );
         }
     }
+}
+
+/// One cell of the ARGUMENT-SPELLING matrix: the driver peels two
+/// elements per round, so the step has two value parameters and the
+/// call site can dress either argument in another parameter's name.
+/// `first`/`second` name the driver's element binders — the spellings
+/// the call-site arguments wear — and the bound flags wrap an argument
+/// in `+ 0`, pushing it off the substituted path onto the bound-args
+/// path.
+fn argument_matrix_program(
+    first: &str,
+    second: &str,
+    bound_first: bool,
+    bound_second: bool,
+) -> String {
+    let arg1 = if bound_first {
+        format!("{first} + 0")
+    } else {
+        first.to_string()
+    };
+    let arg2 = if bound_second {
+        format!("{second} + 0")
+    } else {
+        second.to_string()
+    };
+    format!(
+        r#"module ArgumentMatrix
+    intent =
+        "One cell of the argument-spelling matrix."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver: peels two elements, then hands the pair to the step."
+    match xs
+        [] -> List.reverse(acc)
+        [{first}, ..t] -> match t
+            [] -> List.reverse(acc)
+            [{second}, ..t2] -> step({arg1}, {arg2}, t2, acc)
+
+fn step(sa: Int, sb: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    ? "Step: combine the pair as sa*10 + sb, then back into the driver."
+    v = sa * 10 + sb
+    drive(st, List.prepend(v, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{{head}}/{{render(tail)}}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{{render(entry([1, 2, 3, 4]))}}")
+"#
+    )
+}
+
+/// The argument/parameter axis of the hygiene matrix: a call-site
+/// argument spelled like an EARLIER step parameter, like a LATER one,
+/// like the SAME one, and like a STEP BINDER — each on the substituted
+/// path (bare identifier) and on the bound-args path (`+ 0` around the
+/// same identifier). Substituting one parameter at a time captured the
+/// later-param spelling: the identifiers just inserted for the earlier
+/// parameter were re-visited by the later parameter's pass, and
+/// `[1, 2, 3, 4]` answered `22/44/` instead of `12/34/` — silently, on
+/// both backends. Every cell must answer what the unfused pair
+/// answers.
+#[test]
+fn the_argument_spelling_matrix_keeps_the_pairs_answer_in_every_cell() {
+    let cells: &[(&str, &str, bool, bool)] = &[
+        // Argument spelled like a LATER param: sb is the step's second
+        // parameter, worn by the FIRST argument. The silent-wrong cell.
+        ("sb", "y", false, false),
+        ("sb", "y", true, false),
+        // Like an EARLIER param: sa worn by the second argument.
+        ("x", "sa", false, false),
+        ("x", "sa", false, true),
+        // Like the SAME param: sa worn by its own argument.
+        ("sa", "y", false, false),
+        ("sa", "y", true, false),
+        // Like a STEP BINDER: v is the step's own statement binding.
+        ("v", "y", false, false),
+        ("v", "y", true, false),
+    ];
+    for (first, second, bound_first, bound_second) in cells {
+        let out = run_program(
+            &format!("argmatrix_{first}_{second}_{bound_first}_{bound_second}"),
+            &argument_matrix_program(first, second, *bound_first, *bound_second),
+        );
+        assert_eq!(
+            out, "12/34/",
+            "arguments ({first:?}, {second:?}) (bound: {bound_first}, {bound_second}) \
+             changed the answer"
+        );
+    }
+}
+
+/// The silent-wrong shape as a fused-vs-unfused differential: the same
+/// program with the step private (fuses) and with the step exposed
+/// (declines, so the pair runs as written). Both must answer `12/34/`
+/// — the cross-backend differential cannot catch this class, because
+/// the VM and the generated Rust agree on the wrong answer.
+#[test]
+fn a_pairwise_combine_answers_the_same_fused_and_unfused() {
+    let fused = argument_matrix_program("sb", "y", false, false);
+    let unfused = fused.replace("exposes [entry]", "exposes [entry, step]");
+    assert_eq!(
+        run_program("pairwise_fused", &fused),
+        "12/34/",
+        "the fused pair changed the answer"
+    );
+    assert_eq!(
+        run_program("pairwise_unfused", &unfused),
+        "12/34/",
+        "the declined control changed the answer"
+    );
+}
+
+/// The typed manifestation of the same capture: the driver's cons
+/// binder wears the step's LIST parameter's name and is passed as the
+/// first argument. Sequential substitution rewrote the inserted
+/// identifier to the list argument, and a well-typed program was
+/// rejected with "cannot multiply List and Int" blaming the user's
+/// correct line. It must compile and keep the pair's answer.
+#[test]
+fn a_driver_binder_spelled_like_the_steps_list_param_compiles_and_answers() {
+    let out = run_program(
+        "typed_manifestation",
+        r#"module TypedManifestation
+    intent =
+        "The driver's cons binder wears the step's List param name."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver whose cons binder wears the step's second param name."
+    match xs
+        [] -> List.reverse(acc)
+        [st, ..t] -> step(st, t, acc)
+
+fn step(sh: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    ? "Step: double the head, back into the driver."
+    drive(st, List.prepend(sh * 2, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{head}/{render(tail)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{render(entry([1, 2, 3]))}")
+"#,
+    );
+    assert_eq!(out, "2/4/6/");
 }
 
 /// The capture witness: the step reads the top-level `scale`, and the

--- a/tests/driver_step_pairs.rs
+++ b/tests/driver_step_pairs.rs
@@ -1,0 +1,241 @@
+//! A collecting loop written as a driver and a step companion must
+//! answer exactly what the pair answered before the pass could merge
+//! it — whether the pair fuses or declines.
+//!
+//! The fused half is the hygiene matrix. This family's shipped bugs
+//! were binder/naming holes, and that class RECURS, so the matrix is
+//! order-controlled over binder POSITIONS rather than a single case:
+//! every name the driver already owns, worn by the step's binder in
+//! each position the step can put it — a statement binding before the
+//! recursion, and a pattern binder around it. Every cell must keep the
+//! pair's answer. The report-level facts for the same cells (that each
+//! one really fuses) are pinned in the unit tests beside the pass; what
+//! this file adds is the running answer.
+//!
+//! The declined half pins the answers of the pairs the normalization
+//! must leave alone: a step with a second call site, a step that reads
+//! a name the driver binds (the capture witness — inlined, its helper
+//! call would resolve to the driver's binder), and an effectful step
+//! (inlined, its trace would change shape).
+
+use std::process::Command;
+
+fn run_program(name: &str, source: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join(format!("{name}.av"));
+    std::fs::write(&entry, source).expect("write entry");
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("run")
+        .arg(&entry)
+        .output()
+        .expect("invoke aver");
+    assert!(
+        output.status.success(),
+        "aver run {name} failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// One cell of the hygiene matrix: the step's binder wears `binder`,
+/// either as a statement binding before the recursion or as a pattern
+/// binder around it.
+fn matrix_program(binder: &str, binder_in_pattern: bool) -> String {
+    let step_body = if binder_in_pattern {
+        format!(
+            "    match Option.Some(sh * 2)\n        Option.Some({binder}) -> drive(st, List.prepend({binder}, sacc))\n        Option.None -> []"
+        )
+    } else {
+        format!("    {binder} = sh * 2\n    drive(st, List.prepend({binder}, sacc))")
+    };
+    format!(
+        r#"module PairMatrix
+    intent =
+        "One cell of the driver-and-step hygiene matrix."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver: matches and terminates."
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(sh: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    ? "Step: one doubled element, then back into the driver."
+{step_body}
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{{head}}/{{render(tail)}}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{{render(entry([1, 2, 3]))}}")
+"#
+    )
+}
+
+/// Every cell of the matrix answers what the unfused pair answers:
+/// doubles, in traversal order. The binder axis runs through the
+/// driver's own names — its params, and the pattern binders that stand
+/// BETWEEN the driver's head and the inline point — plus a fresh
+/// control; the position axis runs through both places a step can bind.
+#[test]
+fn the_hygiene_matrix_keeps_the_pairs_answer_in_every_cell() {
+    for binder in ["xs", "acc", "h", "t", "v"] {
+        for in_pattern in [false, true] {
+            let out = run_program(
+                &format!("matrix_{binder}_{in_pattern}"),
+                &matrix_program(binder, in_pattern),
+            );
+            assert_eq!(
+                out, "2/4/6/",
+                "binder {binder:?} (in_pattern: {in_pattern}) changed the answer"
+            );
+        }
+    }
+}
+
+/// The capture witness: the step reads the top-level `scale`, and the
+/// driver's cons pattern re-binds that name around the call site.
+/// Inlined, the step's `scale(h)` would read the driver's binder — an
+/// integer — instead of the function. The pair must decline and keep
+/// its answer.
+#[test]
+fn a_step_reading_a_name_the_driver_binds_keeps_the_pairs_answer() {
+    let out = run_program(
+        "capture_witness",
+        r#"module CaptureWitness
+    intent =
+        "The step reads scale; the driver binds scale around the call."
+    exposes [entry]
+    effects [Console.print]
+
+fn scale(n: Int) -> Int
+    ? "The function the step means when it says scale."
+    n * 10
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver whose cons pattern re-binds the helper's name."
+    match xs
+        [] -> List.reverse(acc)
+        [scale, ..t] -> step(scale, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Step: scale one element, then back into the driver."
+    drive(t, List.prepend(scale(h), acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{head}/{render(tail)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{render(entry([1, 2]))}")
+"#,
+    );
+    assert_eq!(out, "10/20/");
+}
+
+/// A step with a second call site is shared code; both callers must
+/// keep their answers, including the one that starts mid-loop.
+#[test]
+fn a_step_with_a_second_call_site_keeps_both_answers() {
+    let out = run_program(
+        "shared_step",
+        r#"module SharedStep
+    intent =
+        "The same step called by its driver and by another fn."
+    exposes [entry, other]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver: matches and terminates."
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Step: one doubled element, then back into the driver."
+    drive(t, List.prepend(h * 2, acc))
+
+fn other(h: Int) -> List<Int>
+    ? "The second caller, entering the loop through the step."
+    step(h, [7], [])
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{head}/{render(tail)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{render(entry([1, 2]))} {render(other(3))}")
+"#,
+    );
+    assert_eq!(out, "2/4/ 6/14/");
+}
+
+/// An effectful step's prints are its trace; the pair must decline and
+/// keep printing one line per element, in loop order, before the
+/// answer.
+#[test]
+fn an_effectful_step_keeps_its_print_order() {
+    let out = run_program(
+        "effectful_step",
+        r#"module EffectfulStep
+    intent =
+        "The step prints each element as it works."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver: matches and terminates."
+    ! [Console.print]
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Step: print, double, back into the driver."
+    ! [Console.print]
+    Console.print("saw {h}")
+    drive(t, List.prepend(h * 2, acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    ! [Console.print]
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{head}/{render(tail)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{render(entry([1, 2]))}")
+"#,
+    );
+    assert_eq!(out, "saw 1\nsaw 2\n2/4/");
+}

--- a/tests/driver_step_pairs.rs
+++ b/tests/driver_step_pairs.rs
@@ -25,6 +25,8 @@
 //! call would resolve to the driver's binder), and an effectful step
 //! (inlined, its trace would change shape).
 
+use std::collections::HashMap;
+use std::path::Path;
 use std::process::Command;
 
 fn run_program(name: &str, source: &str) -> String {
@@ -229,6 +231,236 @@ fn a_pairwise_combine_answers_the_same_fused_and_unfused() {
         run_program("pairwise_unfused", &unfused),
         "12/34/",
         "the declined control changed the answer"
+    );
+}
+
+/// One cell of the P-BINDER matrix: the step's binder is literally
+/// spelled like the index-derived half of a synthesized name (`p0`,
+/// `p1`), while the argument at that index rides either the
+/// substituted path (bare identifier) or the bound-args path (`+ 0`
+/// around it). The step reads BOTH parameters again after the
+/// binding, so a synthesized binder shadowing a synthesized argument
+/// name changes the answer instead of hiding.
+fn p_binder_matrix_program(binder: &str, bound_first: bool, bound_second: bool) -> String {
+    let arg1 = if bound_first { "x + 0" } else { "x" };
+    let arg2 = if bound_second { "y + 0" } else { "y" };
+    format!(
+        r#"module PBinderMatrix
+    intent =
+        "One cell of the p-binder collision matrix."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver: peels two elements, then hands the pair to the step."
+    match xs
+        [] -> List.reverse(acc)
+        [x, ..t] -> match t
+            [] -> List.reverse(acc)
+            [y, ..t2] -> step({arg1}, {arg2}, t2, acc)
+
+fn step(sa: Int, sb: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    ? "Step: bind an index-spelled name, then read both params again."
+    {binder} = sa + sb
+    drive(st, List.prepend({binder} * 10 + sa + sb, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{{head}}/{{render(tail)}}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{{render(entry([1, 2, 3, 4]))}}")
+"#
+    )
+}
+
+/// The THIRD capture cell of this family, as a matrix: a step binder
+/// spelled like the index-derived half of a name the inline
+/// synthesizes for a compound argument. Under the two-namespace
+/// naming this pass shipped with (`__stp<k>_<name>` binder renames
+/// beside `__stp<k>_p<idx>` argument binders), a binder literally
+/// named `p0` whose index-0 argument rode the bound-args path renamed
+/// to EXACTLY the fresh argument binder's name and SHADOWED it — both
+/// backends agreed on the wrong answer. Names now come from one
+/// allocator, so the collision is unspellable; every cell must answer
+/// what the unfused pair answers.
+#[test]
+fn the_p_binder_matrix_keeps_the_pairs_answer_in_every_cell() {
+    let cells: &[(&str, bool, bool)] = &[
+        // Binder p0 with the index-0 argument substituted (control),
+        // bound at index 0 (the shipped collision), and bound at the
+        // OTHER index (cross-index control).
+        ("p0", false, false),
+        ("p0", true, false),
+        ("p0", false, true),
+        // Binder p1, same three paths; the collision is at index 1.
+        ("p1", false, false),
+        ("p1", false, true),
+        ("p1", true, false),
+    ];
+    for (binder, bound_first, bound_second) in cells {
+        let out = run_program(
+            &format!("pbinder_{binder}_{bound_first}_{bound_second}"),
+            &p_binder_matrix_program(binder, *bound_first, *bound_second),
+        );
+        assert_eq!(
+            out, "33/77/",
+            "binder {binder:?} (bound: {bound_first}, {bound_second}) changed the answer"
+        );
+    }
+}
+
+/// The single-element spelling of the same collision, as a
+/// fused-vs-unfused differential: the step binds `p0` from its value
+/// parameter and then reads the parameter AGAIN beside it, while the
+/// driver's call site wraps the index-0 argument in `+ 0` so it rides
+/// the bound-args path. With the step private the pair fuses; with
+/// the step exposed it declines and runs as written. Both must answer
+/// `(h + 1) * h` per element — the shadowed spelling answered
+/// `(h + 1) * (h + 1)` (`4/9/16/`) on both backends.
+fn p_zero_shadow_program() -> String {
+    r#"module PZeroShadow
+    intent =
+        "A step binder spelled like the synthesized name of its bound argument."
+    exposes [entry]
+    effects [Console.print]
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver: matches and terminates."
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h + 0, t, acc)
+
+fn step(sh: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    ? "Step: bind p0 from the param, then read the param again."
+    p0 = sh + 1
+    drive(st, List.prepend(p0 * sh, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    ? "Start the loop with an empty accumulator."
+    drive(xs, [])
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{head}/{render(tail)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{render(entry([1, 2, 3]))}")
+"#
+    .to_string()
+}
+
+#[test]
+fn a_step_binder_spelled_like_a_synthesized_argument_binder_keeps_the_pairs_answer() {
+    let fused = p_zero_shadow_program();
+    let unfused = fused.replace("exposes [entry]", "exposes [entry, step]");
+    assert_eq!(
+        run_program("pzero_fused", &fused),
+        "2/6/12/",
+        "the fused pair changed the answer"
+    );
+    assert_eq!(
+        run_program("pzero_unfused", &unfused),
+        "2/6/12/",
+        "the declined control changed the answer"
+    );
+}
+
+/// Every name bound by a `let` in ONE emitted Rust function that
+/// lives in the stage's synthesized namespace, with how many times it
+/// is bound there. The scope is one function because the fused body
+/// is legitimately emitted twice — once in the driver, once in the
+/// synthesized `__collected` variant — and those are different
+/// scopes; a shadow is two bindings of one name in the SAME function.
+fn synthesized_let_counts(fn_source: &str) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut rest = fn_source;
+    while let Some(pos) = rest.find("let ") {
+        rest = &rest[pos + 4..];
+        let after = rest.strip_prefix("mut ").unwrap_or(rest);
+        let name: String = after
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if name.starts_with("__stp") {
+            *counts.entry(name).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+/// Every `.rs` file under `dir`, concatenated.
+fn rust_sources_under(dir: &Path) -> String {
+    let mut out = String::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in std::fs::read_dir(&d).expect("read emitted project dir") {
+            let path = entry.expect("emitted project entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push_str(&std::fs::read_to_string(&path).expect("read emitted source"));
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
+/// The shadow, seen in the artifact instead of the answer: the
+/// emitted Rust for the fused collision program must never bind one
+/// synthesized name twice. The shipped bug's receipt was
+/// `let __stp0_p0 = h; let __stp0_p0 = __stp0_p0.add(1)` verbatim —
+/// two allocations from two namespaces agreeing on one spelling. The
+/// scan also requires at least one synthesized binding, so a pair
+/// that silently stopped fusing cannot pass this test by absence.
+#[test]
+fn the_emitted_rust_never_binds_one_synthesized_name_twice() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("pzero.av");
+    std::fs::write(&entry, p_zero_shadow_program()).expect("write entry");
+    let project = dir.path().join("project");
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("compile")
+        .arg(&entry)
+        .arg("--target")
+        .arg("rust")
+        .arg("--name")
+        .arg("pzero")
+        .arg("-o")
+        .arg(&project)
+        .output()
+        .expect("invoke aver compile");
+    assert!(
+        output.status.success(),
+        "aver compile --target rust failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let source = rust_sources_under(&project);
+    let mut seen_any = false;
+    for fn_source in source.split("fn ").skip(1) {
+        let counts = synthesized_let_counts(fn_source);
+        seen_any = seen_any || !counts.is_empty();
+        let doubled: Vec<(&String, &usize)> = counts.iter().filter(|(_, n)| **n > 1).collect();
+        assert!(
+            doubled.is_empty(),
+            "a synthesized name is bound more than once in one emitted fn: {doubled:?}"
+        );
+    }
+    assert!(
+        seen_any,
+        "the fused body binds at least one synthesized name; none found — did the pair fuse?"
     );
 }
 

--- a/tests/explain_passes_spec.rs
+++ b/tests/explain_passes_spec.rs
@@ -790,6 +790,73 @@ fn main() -> Int
     assert_eq!(data["targets"][1], "vm");
 }
 
+/// The driver-and-step half of the same report: a pair whose step was
+/// inlined ahead of candidacy is listed with its steps, and a pair the
+/// normalization turned down carries the reason as a field. Both facts
+/// exist so a pair that quietly stops fusing is a diff in CI, not a
+/// silence.
+#[test]
+fn list_build_pass_reports_the_driver_step_pairs() {
+    let json = run_explain_passes(
+        r#"
+module Pairs
+    intent = "one pair that fuses and one whose step is shared"
+    exposes [entry, sharedEntry, sharedOther]
+    depends []
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    v = h * 2
+    drive(t, List.prepend(v, acc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+
+fn sharedAll(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> sharedOne(h, t, acc)
+
+fn sharedOne(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    sharedAll(t, List.prepend(h * 3, acc))
+
+fn sharedEntry(xs: List<Int>) -> List<Int>
+    sharedAll(xs, [])
+
+fn sharedOther(h: Int) -> List<Int>
+    sharedOne(h, [], [])
+
+fn main() -> Int
+    List.len(entry([1, 2])) + List.len(sharedEntry([3])) + List.len(sharedOther(4))
+"#,
+    );
+    let data = json["passes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["stage"] == "list_build")
+        .expect("list_build stage is reported")["data"]
+        .clone();
+    assert_eq!(data["pair_inlined_by_fn"]["drive"][0], "step");
+    assert_eq!(data["loop_fns"][0], "drive");
+    assert_eq!(
+        data["pair_declined"]["sharedAll"],
+        "the step fn has more than one call site"
+    );
+    assert!(
+        data["synthesized"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|s| s != "sharedAll__collected"),
+        "a declined pair must not fuse: {data}"
+    );
+}
+
 /// The byte-sink half of the same report. A collected loop whose only
 /// reader is the standard library's `fromList` is retargeted to the
 /// byte builder — and one whose result is read twice is turned down,

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -661,12 +661,17 @@ fn main() -> Unit
 /// read of an integer — declined, answer pinned. `trimAll`/
 /// `keepUnlessLast` is the exact two-match nesting depth of the code
 /// that motivated the stage: the step carries its own exit arm beside
-/// the arm that recurses back into the driver.
+/// the arm that recurses back into the driver. `pairAll`/`pairOne` is
+/// the argument-spelling witness: the driver's first cons binder wears
+/// the step's SECOND parameter's name, so a substitution that walks
+/// one parameter at a time rewrites the identifiers it just inserted —
+/// both backends then agree on the wrong answer, which is why this
+/// case pins the exact answer and not just backend parity.
 #[test]
 fn rust_driver_step_pairs_match_vm() {
     let src = r#"module DriverStepDifferential
     intent = "Every driver-and-step shape in one program, for cross-backend agreement"
-    exposes [decoded, gatherAll, sharedEntry, sharedOther, entryCaptured, trimAll]
+    exposes [decoded, gatherAll, sharedEntry, sharedOther, entryCaptured, trimAll, pairAll]
     effects [Console.print]
 
 fn readAll(bytes: List<Int>, acc: List<Int>) -> Result<List<Int>, String>
@@ -755,6 +760,18 @@ fn keepUnlessLast(head: String, tail: List<String>, acc: List<String>) -> List<S
         [] -> List.reverse(acc)
         [next, ..rest] -> trimAll(tail, List.prepend(head, acc))
 
+fn pairAll(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver of the pairwise pair: peels two, the first binder wears the step's second param name."
+    match xs
+        [] -> List.reverse(acc)
+        [b, ..t] -> match t
+            [] -> List.reverse(acc)
+            [c, ..t2] -> pairOne(b, c, t2, acc)
+
+fn pairOne(a: Int, b: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    ? "Step of the pairwise pair: combine the pair as a*10 + b."
+    pairAll(st, List.prepend(a * 10 + b, sacc))
+
 fn render(values: List<Int>) -> String
     ? "Print a list with no accumulator of its own."
     match values
@@ -770,6 +787,7 @@ fn main() -> Unit
     Console.print("{render(sharedEntry([1, 2]))} {render(sharedOther(5))}")
     Console.print("{render(entryCaptured([1, 2]))}")
     Console.print("[{String.join(trimAll(["a", "b", "c"], []), "-")}] [{String.join(trimAll(["x"], []), "-")}]")
+    Console.print("{render(pairAll([1, 2, 3, 4], []))}")
 "#;
     // The fallible pair doubles until it meets a nine, whose error is
     // the whole answer. The record pair adds the running count to each
@@ -777,12 +795,15 @@ fn main() -> Unit
     // ways it is entered — through the driver, and mid-flight through
     // the step with a seeded accumulator. The captured pair scales by
     // ten, which only the TOP-LEVEL scale does. The two-match pair
-    // drops the last element, and a lone element leaves nothing.
+    // drops the last element, and a lone element leaves nothing. The
+    // pairwise pair combines each pair as tens-digit/units-digit — the
+    // answer sequential substitution turned into 22/44.
     let expected = "2/4/6/ nine\n\
                     5/7/9/ 3\n\
                     3/6/ 4/15/6/\n\
                     10/20/\n\
-                    [a-b] []";
+                    [a-b] []\n\
+                    12/34/";
     let vm = run_vm_inline("driver_step", src).expect("vm run");
     let rust = build_run_rust_inline("driver_step", src).expect("rust compile + cargo build + run");
     assert_eq!(vm, expected, "VM driver-and-step contract changed");

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -640,6 +640,158 @@ fn main() -> Unit
     );
 }
 
+/// The driver-and-step normalization, on the shapes where the two
+/// backends could disagree — every fused pair here goes through the
+/// inline (renamed binders, substituted arguments, a statement folded
+/// into the driver's branch structure) and then through the same
+/// builder rewrite the single-fn loops take, so a hygiene slip shows up
+/// as a wrong list rather than a missed optimization. One test, one
+/// build: the five shapes the mechanism is specified against, in one
+/// program.
+///
+/// `readAll`/`readNext` is the fallible reader — the step's `?` moves
+/// into the driver's arm and the error exits must keep their meaning.
+/// `gatherAll`/`gatherOne` terminates inside a record constructor, so
+/// the finalize lands in a field while the other fields stay ordinary
+/// reads. `sharedAll`/`sharedOne` must DECLINE — the step has a second
+/// caller that enters the loop mid-flight, and both callers' answers
+/// are pinned. `capturedAll`/`capturedOne` is the hygiene witness: the
+/// step reads the top-level `scale` and the driver re-binds that name
+/// around the call site, so an inline would turn the helper call into a
+/// read of an integer — declined, answer pinned. `trimAll`/
+/// `keepUnlessLast` is the exact two-match nesting depth of the code
+/// that motivated the stage: the step carries its own exit arm beside
+/// the arm that recurses back into the driver.
+#[test]
+fn rust_driver_step_pairs_match_vm() {
+    let src = r#"module DriverStepDifferential
+    intent = "Every driver-and-step shape in one program, for cross-backend agreement"
+    exposes [decoded, gatherAll, sharedEntry, sharedOther, entryCaptured, trimAll]
+    effects [Console.print]
+
+fn readAll(bytes: List<Int>, acc: List<Int>) -> Result<List<Int>, String>
+    ? "Driver of the fallible pair: matches and terminates with a Result."
+    match bytes
+        [] -> Result.Ok(List.reverse(acc))
+        [h, ..t] -> readNext(h, t, acc)
+
+fn readNext(h: Int, t: List<Int>, acc: List<Int>) -> Result<List<Int>, String>
+    ? "Step of the fallible pair: one checked unit, then back into the driver."
+    v = checked(h)?
+    readAll(t, List.prepend(v, acc))
+
+fn checked(h: Int) -> Result<Int, String>
+    ? "Reject nines, double the rest."
+    match h == 9
+        true -> Result.Err("nine")
+        false -> Result.Ok(h * 2)
+
+fn decoded(bytes: List<Int>) -> String
+    ? "Either the parsed list or the message that says why not."
+    match readAll(bytes, [])
+        Result.Ok(values) -> render(values)
+        Result.Err(message) -> message
+
+record Gathered
+    items: List<Int>
+    seen: Int
+
+fn gatherAll(xs: List<Int>, seen: Int, acc: List<Int>) -> Gathered
+    ? "Driver of the record pair: the exit wraps the reverse in a field."
+    match xs
+        [] -> Gathered(items = List.reverse(acc), seen = seen)
+        [h, ..t] -> gatherOne(h, t, seen, acc)
+
+fn gatherOne(h: Int, t: List<Int>, seen: Int, acc: List<Int>) -> Gathered
+    ? "Step of the record pair: one summed element, then back into the driver."
+    g = h + seen
+    gatherAll(t, seen + 1, List.prepend(g, acc))
+
+fn sharedAll(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver whose step is shared — this pair must keep both functions."
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> sharedOne(h, t, acc)
+
+fn sharedOne(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Step with a second caller, so it is shared code rather than the idiom."
+    sharedAll(t, List.prepend(h * 3, acc))
+
+fn sharedEntry(xs: List<Int>) -> List<Int>
+    ? "The driver's own caller."
+    sharedAll(xs, [])
+
+fn sharedOther(h: Int) -> List<Int>
+    ? "The second caller, entering the loop through the step mid-flight."
+    sharedOne(h, [2], [4])
+
+fn scale(n: Int) -> Int
+    ? "The function the captured step means when it says scale."
+    n * 10
+
+fn capturedAll(xs: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Driver whose cons pattern re-binds the helper's name around the call."
+    match xs
+        [] -> List.reverse(acc)
+        [scale, ..t] -> capturedOne(scale, t, acc)
+
+fn capturedOne(h: Int, t: List<Int>, acc: List<Int>) -> List<Int>
+    ? "Step that reads the top-level scale — the capture witness."
+    capturedAll(t, List.prepend(scale(h), acc))
+
+fn entryCaptured(xs: List<Int>) -> List<Int>
+    ? "Start the captured pair with an empty accumulator."
+    capturedAll(xs, [])
+
+fn trimAll(parts: List<String>, acc: List<String>) -> List<String>
+    ? "Driver of the two-match pair: everything but the final element."
+    match parts
+        [] -> List.reverse(acc)
+        [head, ..tail] -> keepUnlessLast(head, tail, acc)
+
+fn keepUnlessLast(head: String, tail: List<String>, acc: List<String>) -> List<String>
+    ? "Step with its own exit arm beside the arm that recurses back."
+    match tail
+        [] -> List.reverse(acc)
+        [next, ..rest] -> trimAll(tail, List.prepend(head, acc))
+
+fn render(values: List<Int>) -> String
+    ? "Print a list with no accumulator of its own."
+    match values
+        [] -> ""
+        [head, ..tail] -> "{head}/{render(tail)}"
+
+fn main() -> Unit
+    ? "Print every shape so a backend that drifts shows a diff, not a pass."
+    ! [Console.print]
+    Console.print("{decoded([1, 2, 3])} {decoded([1, 9, 3])}")
+    g = gatherAll([5, 6, 7], 0, [])
+    Console.print("{render(g.items)} {g.seen}")
+    Console.print("{render(sharedEntry([1, 2]))} {render(sharedOther(5))}")
+    Console.print("{render(entryCaptured([1, 2]))}")
+    Console.print("[{String.join(trimAll(["a", "b", "c"], []), "-")}] [{String.join(trimAll(["x"], []), "-")}]")
+"#;
+    // The fallible pair doubles until it meets a nine, whose error is
+    // the whole answer. The record pair adds the running count to each
+    // element and reports how many it saw. The shared pair answers both
+    // ways it is entered — through the driver, and mid-flight through
+    // the step with a seeded accumulator. The captured pair scales by
+    // ten, which only the TOP-LEVEL scale does. The two-match pair
+    // drops the last element, and a lone element leaves nothing.
+    let expected = "2/4/6/ nine\n\
+                    5/7/9/ 3\n\
+                    3/6/ 4/15/6/\n\
+                    10/20/\n\
+                    [a-b] []";
+    let vm = run_vm_inline("driver_step", src).expect("vm run");
+    let rust = build_run_rust_inline("driver_step", src).expect("rust compile + cargo build + run");
+    assert_eq!(vm, expected, "VM driver-and-step contract changed");
+    assert_eq!(
+        rust, expected,
+        "Rust driver-and-step fusion diverged from the VM"
+    );
+}
+
 /// The byte sink, on the shapes where the two backends could disagree —
 /// and against the answers the UNFUSED pair gives, since the whole
 /// program carries a word-for-word copy of the standard library's


### PR DESCRIPTION
Closes #944.

Real parser code writes a collecting loop as two functions: a driver that matches and terminates, and a step companion that does one unit of work and recurses back into the driver. The docstrings in the code that motivated this say why — the accumulator form keeps the recursion in tail position. The single-function spelling of the same loop fuses today; the pair reached zero candidacy, because the list-build recognisers read one body at a time and the append lives in the other one.

## Mechanism

A normalization stage inside the builder-rewrite family (`src/ir/buffer_build/driver_step.rs`) inlines the step into the driver **before candidacy**, then lets the existing recognisers judge the merged loop with zero changes to their guards. The inline fires only when the step:

- has **exactly one call site** in the whole module. The census walks every expression-bearing top-level item — fn bodies (identifier reads and tail-call targets), verify blocks (cases, per-case givens, and the law form's template, `when`, sample guards, and explicit given domains), and top-level statements — so the condition means what it says. The one carve-out is the step's **own** verify block: the step is never edited or removed, so its spec keeps the exact function it names and is not a second consumer. Decision blocks carry no expressions (their impacts are documentation strings), so a call cannot be spelled there;
- is **not visible outside the module** — checked with the visibility module's own rule, so a missing `exposes` list (every fn public by default) declines rather than guesses about callers the pass cannot see;
- declares **no effects** (the move would reshape an effectful body's trace);
- does **not recurse into itself** (the idiom recurses into the driver).

Binder hygiene is mechanical, not argued per-case: **every name this stage synthesizes — binder renames and argument binders alike — comes from one fresh-name allocator**, a single monotone counter per driver build handing out `__stp<n>`, so no two synthesized names are ever equal by construction — no reasoning about name grammar required. The rename map's keys stay the step's original binder names; only the allocated outputs come from the counter. Arguments substitute only when they are bare identifiers or literals and are bound in call order otherwise (the let-in this AST spells as a single-arm match); a step that reads a name the driver binds anywhere is declined outright. Substitution is **simultaneous**: the complete parameter-to-argument map is built before any rewriting and applied in one walk that never descends into what it inserts, so a call-site argument spelled like another parameter of the step cannot be captured by that parameter's substitution. A step whose binder shadows its own parameter or a top-level name is declined too — the rename cannot carry those. The inline happens on a copy, committed only when the merged loop passes the same candidacy walk and variant build the main pass runs **and** at least one call site starts the accumulator empty — no inline-without-payoff residue. The step itself is never edited or removed, so its verify blocks and outside callers keep the function they named.

Chains inline round by round: driver → step → step is two rounds, which is exactly the shape the transaction input/output decoders take.

Record-constructor exits (`SomeRecord(items = List.reverse(acc), other = x)`) turn out to already satisfy the recogniser's single-read ride-through discipline — the finalize lands inside the field, any other field reading the accumulator is a second read and declines. That behavior is now pinned by unit tests and by the cross-backend differential rather than left to luck.

`--explain-passes` gains `pair_inlined_by_fn` and `pair_declined` on the list-build report (text + JSON, folded across dependency modules), so a pair that quietly stops fusing is a CI diff, not a silence.

## Review rounds: two criticals, two minors — all repaired

**Critical (silent wrong answer, both backends).** The first version substituted parameters one at a time, so the identifiers just inserted for an earlier parameter were re-visited by a later parameter's pass. A driver that peels two elements per round and passes `step(b, c, t2, acc)` against params `(a, b, st, sacc)` turned the step's `a * 10 + b` into `c * 10 + c`: `[1, 2, 3, 4]` answered `22/44/` instead of `12/34/`, and the VM and the generated Rust **agreed on the wrong answer**, so cross-backend parity could not see it. The same capture had a typed manifestation: a driver cons binder spelled like the step's `List` parameter, passed as the first argument, made a well-typed program fail with `Type error: cannot multiply List and Int` on the user's correct line. Both were reproduced red before the fix (`22/44/` and the type error, verbatim), the substitution was made simultaneous, and both now answer `12/34/` and `2/4/6/`. Fault injection: reintroducing the sequential walk locally turns the new differential red with exactly `22/44/`; restoring the fix turns it green.

**Minor 1 (call-site census).** The "exactly one call site module-wide" scan read only fn bodies. It now walks every expression-bearing top-level item (see Mechanism); a second call in another fn's verify block or in a top-level statement declines the pair, with tests for both and for the two controls (a verify block on the driver, and the carve-out for the step's own spec).

**Minor 2 (corpus numbers re-taken after the fix).** See the next section — the counts and pair lists below are from the fixed build.
**Second round — a third capture cell (silent wrong answer, both backends).** The pass synthesized names in two overlapping namespaces: step binders renamed to `__stp<k>_<name>` while compound arguments got fresh binders `__stp<k>_p<idx>`. A step binder literally named `p<idx>`, when the argument at index `idx` rode the bound-args path, renamed to exactly the fresh argument binder's name and **shadowed it**: a driver arm `[h, ..t] -> step(h + 0, t, acc)` against a step that binds `p0 = sh + 1` and answers `p0 * sh` fused to `(h + 1)^2` — `4/9/16/` where the pair answers `2/6/12/` — and the emitted Rust contained `let __stp0_p0 = h; let __stp0_p0 = __stp0_p0.add(1)` verbatim. Both backends agreed on the wrong answer, so cross-backend parity could not see this one either. Third capture bug from hand-rolled name spelling, so the repair replaced the mechanism instead of patching the grammar: one allocator (see Mechanism), leaving no second namespace to collide with. Reproduced red before the fix (`4/9/16/` on the differential, `35/81/` on the matrix cell, and the double `let` found by the emitted-Rust scan); fault injection restoring the two-namespace naming turns the differential red with exactly `4/9/16/`, and the allocator turns it green. New tests: a p-binder answer matrix (binder `p0`/`p1` against substituted and bound argument paths, every cell `33/77/`), the fused-vs-declined differential for the shadow spelling (`2/6/12/` both), a per-function double-binding scan over the emitted Rust that also requires at least one synthesized binding (a pair that silently stopped fusing cannot pass by absence), and the report-level matrix beside the pass. Corpus spot-check after the change: `main.av` `--explain-passes` is unchanged — 25 rewrites, the same 12 pairs (the synthesized names are internal).

## Deltas on the real codebase (n1bor/btc-listener, verification only) — re-taken after the fix

| program | fused collecting loops before | after (fixed build) |
|---|---|---|
| `main.av` | 13 | **25** |
| `audit.av` | 10 | **22** |

Twelve pairs fuse, including both three-function chains:

`Infra.Store.parseAll`+`parseNext`, `Infra.Store.recordPartsFor`+`nextRecord`, `Infra.Store.deletePartsFor`+`nextTombstone`, `Domain.Block.nextTransactions`+`oneTransaction`, `Domain.Block.headersInto`+`oneHeader`, `Domain.Block.leavesFrom`+`nextLeaf`, `Domain.Transaction.countWitnesses`+`countOne` (record-constructor exit), `Domain.Transaction.readInputsInto`+`readOneInput`+`inputFrom`, `Domain.Transaction.readOutputsInto`+`readOneOutput`+`outputFrom` (record exits behind `Result.Ok`), `Domain.Message.stripZerosInto`+`keepUnlessZero`, `Domain.Text.dropLast`+`keepUnlessLast` (the two-match nesting), `Domain.Segment.decodedFrom`+`nextBlock`.

Still declining, honestly:

- `Domain.Block.pairsOf` — its inner step `onePair` genuinely has two call sites (both arms of `pairWith` call it), reported as "the step fn has more than one call site".
- `Domain.Block.advance` — its companion `locatorInto` is also called directly by the locator entry fn, so it too has more than one call site; independently, the loop reads `List.len(acc)` while collecting, which is outside the family's linearity discipline regardless of pairing.
- `Domain.Inventory.collect`, `Domain.Dns.collect`, `Infra.Prune.locationsBelow`, `Infra.Download.idsAt` — a different class: the append is **conditional**, threaded through a helper (`keepIfTx(...)`, `dropped(...)`, `prependId(...)?`) in the accumulator position instead of a `List.prepend` on the back edge. The recogniser has no maybe-append form; these are not the driver/step idiom and are not touched.

**Does any fused pair pass a bare identifier spelled like a later step parameter?** No — checked call site by call site. Every bare-identifier argument in the twelve pairs is spelled either like the **same-position** parameter (`nextTombstone(head, tail, acc)` against params `(head, tail, acc)`; `readOneInput(remaining, rest, acc, consumed)` against identical params; likewise `parseNext`, `nextRecord`, `oneHeader`, `oneTransaction`, `nextLeaf`, `keepUnlessZero`, `keepUnlessLast`, `nextBlock`, `countOne`) or like no parameter at all, and the compound arguments in the chain calls (`inputFrom(remaining, List.take(rest, 32), index, script.value, script.rest, acc, ...)`, `outputFrom(...)`) ride the bound-args path. Same-position spelling substitutes identically under either order, so the corpus was not corrupted by the sequential bug — but it sat one parameter reorder away from the trap, which is exactly the axis the new matrix pins.

Corpus verification on the fixed build: `aver verify audit.av --module-root . --deps` — 20 files, 293 blocks, **801/801** cases; `aver verify main.av --module-root . --deps` — 32 files, 419 blocks, **1106/1106**; the whole repository (`aver verify . --module-root . --deps`) — 325 files, 4368 blocks, **11842/11842**, 0 failed. The generated Rust project for `main.av` builds with zero errors.

## Red receipts

The fallible driver/step fixture, compiled before the change: `list_build` report `{"rewrites": 0, "declined": {}}` — invisible to the pass, not even a decline. After: `{"rewrites": 1, "synthesized": ["readAll__collected"], "pair_inlined_by_fn": {"readAll": ["readNext"]}}`. The same zero-candidacy baseline is what the stored corpus reports show for all sixteen pair-shaped spine loops.

From the review round, recorded before the repair: the fused pairwise probe answered `22/44/` against the unfused control's `12/34/`; the typed probe failed with `Type error [line 15]: cannot multiply List and Int`; the census tests found the pair fusing despite a second call in a verify block and in a top-level statement.

## Timing (bounded, release, VM)

Self-contained fixture, the canonical pair over 200 000 elements, 15 iterations: fused p50 **42.55 ms** vs declined-variant p50 **76.30 ms** (~1.8×).

## Tests

- `src/ir/buffer_build/driver_step.rs` unit tests: report-level facts, including an **order-controlled matrix over binder positions** — every driver-owned name worn by the step's binder, as a statement binding and as a pattern binder — plus an **argument-spelling matrix** and a **p-binder matrix** (a step binder spelled like the index-derived half of a synthesized argument name, against substituted and bound argument paths) (a call-site argument spelled like an earlier parameter, a later one, the same one, and a step binder, each on the substituted and the bound-args path), every decline reason, and the census tests (second call in a verify block or a top-level statement declines; a verify block on the driver or on the step itself does not).
- `tests/driver_step_pairs.rs`: both matrices pinned as running answers on the VM (`12/34/` in every argument-spelling cell), the fused-vs-unfused differential for the pairwise shape, the typed manifestation (`2/4/6/`), the capture witness, the shared step (both entry points), and the effectful step's print order.
- `tests/rust_codegen_differential.rs::rust_driver_step_pairs_match_vm`: six shapes in one program on both backends — fallible reader pair with `?`, record-constructor terminator pair, a step with a second caller (must decline, both callers pinned), the capture hygiene witness (must decline), the exact two-match nesting depth, and the pairwise argument-spelling witness pinned to its exact answer (parity alone cannot catch a bug both backends share).
- `tests/explain_passes_spec.rs`: the new report fields surface in the JSON.
- Suites run green: family unit tests (74), the three decline suites, `rust_codegen_differential` (41), `stdlib_spec`, `proof_snapshot_seam`, `explain_passes_spec`, `driver_step_pairs`; `cargo fmt --check` and both CI clippy lanes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

