### PR TITLE
Read the pattern binder's own slot when it shadows an earlier binding

### DIFF
--- a/self_hosted/domain/resolver/core.av
+++ b/self_hosted/domain/resolver/core.av
@@ -479,9 +479,9 @@ verify resolveArms
     resolveArms([MatchArm(pattern = Pattern.PatWild, body = Expr.ExprInt(1), bindingSlots = {})], {}, []) => ([MatchArm(pattern = Pattern.PatWild, body = Expr.ExprInt(1), bindingSlots = {})], {})
 
 fn resolveOneArm(arm: MatchArm, rest: List<MatchArm>, slots: Map<String, Int>, acc: List<MatchArm>) -> Tuple<List<MatchArm>, Map<String, Int>>
-    ? "Resolve one match arm and continue."
+    ? "Resolve one match arm; continue with the ORIGINAL slots, since an arm's pattern binders are scoped to its own body. Threading the arm-extended map onward leaked binder slots into later arms and past the match, where a wrapping binding aliased them and shadowed names resolved wrong."
     match resolveArm(arm, slots)
-        (resolvedArm, mergedSlots) -> resolveArms(rest, mergedSlots, List.prepend(resolvedArm, acc))
+        (resolvedArm, _) -> resolveArms(rest, slots, List.prepend(resolvedArm, acc))
 
 verify resolveOneArm
     resolveOneArm(MatchArm(pattern = Pattern.PatWild, body = Expr.ExprInt(1), bindingSlots = {}), [], {}, []) => ([MatchArm(pattern = Pattern.PatWild, body = Expr.ExprInt(1), bindingSlots = {})], {})

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -454,7 +454,21 @@ pub struct FnResolution {
     /// Total number of local slots needed (params + bindings in body).
     pub local_count: u16,
     /// Map from local variable name → slot index in the local `Slots` frame.
+    ///
+    /// Last allocation per name wins on collision, so a pattern binder
+    /// that reuses a statement binding's spelling owns the entry.
+    /// Consumers that need a *specific* binding's slot must not go
+    /// through this map: pattern binders live in
+    /// `MatchArm::binding_slots`, statement bindings in
+    /// `stmt_binding_slots`.
     pub local_slots: std::sync::Arc<std::collections::HashMap<String, u16>>,
+    /// Slot of each fn-body statement binding, in source order —
+    /// one entry per `Stmt::Binding`, `u16::MAX` for a discarded
+    /// `_` binding (which claims no slot). This is the identity
+    /// the MIR statement-chain lowering reads; looking the slot up
+    /// by name in `local_slots` instead resolves to a later
+    /// same-named pattern binder's slot (issue #948).
+    pub stmt_binding_slots: std::sync::Arc<Vec<u16>>,
     /// Aver type per slot index. Length == `local_count`. Built post-
     /// typecheck so each entry pulls from the matching `Spanned::ty()`
     /// stamp on the producer expression, plus pattern-binding shape

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -465,9 +465,17 @@ pub struct FnResolution {
     /// Slot of each fn-body statement binding, in source order —
     /// one entry per `Stmt::Binding`, `u16::MAX` for a discarded
     /// `_` binding (which claims no slot). This is the identity
-    /// the MIR statement-chain lowering reads; looking the slot up
-    /// by name in `local_slots` instead resolves to a later
-    /// same-named pattern binder's slot (issue #948).
+    /// the MIR statement-chain lowering and the alias pass read;
+    /// looking the slot up by name in `local_slots` instead
+    /// resolves to a later same-named pattern binder's slot
+    /// (issue #948).
+    ///
+    /// CONTRACT (consumer side): zip positionally against the
+    /// body's `Stmt::Binding`s and check the list drains exactly —
+    /// a leftover means statements were added, removed, or
+    /// reordered after resolution without rebuilding this table,
+    /// and every zip may have paired a binding with a neighbor's
+    /// slot.
     pub stmt_binding_slots: std::sync::Arc<Vec<u16>>,
     /// Aver type per slot index. Length == `local_count`. Built post-
     /// typecheck so each entry pulls from the matching `Spanned::ty()`

--- a/src/codegen/lean/law_auto/homomorphism.rs
+++ b/src/codegen/lean/law_auto/homomorphism.rs
@@ -347,11 +347,15 @@ fn recognize(_vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> Option
         return None;
     }
     let (param_name, _) = subj_fd.params.first()?;
-    let param_slot = subj_fd
-        .resolution
-        .as_ref()
-        .and_then(|resolution| resolution.local_slots.get(param_name).copied())
-        .or(Some(0));
+    // Params own slots 0..N-1 in declaration order (resolver
+    // convention), so the first param is slot 0 by construction. A
+    // name lookup in `local_slots` is last-allocation-wins, so a
+    // pattern binder spelled like the param would steal the entry and
+    // the mention-check below would run against the binder's slot
+    // (issue #948's disease); the misclassification is fail-closed
+    // (the Lean kernel rejects a wrong lemma), but the check should
+    // still ask about the right slot.
+    let param_slot = Some(0u16);
 
     // Classify the subject's two arms; gate base = OP2.identity and step's head
     // operator = OP2 (the homomorphism algebra).

--- a/src/codegen/wasm_gc/body/from_mir/mod.rs
+++ b/src/codegen/wasm_gc/body/from_mir/mod.rs
@@ -722,20 +722,21 @@ pub(crate) fn emit_mir_expr(
                 ctx.int_result_raw.set(result_raw);
                 return emit_mir_expr(func, &l.body, slots, ctx);
             }
-            // Mirror of `emit_fn_body`'s `Binding` arm.
-            let slot = ctx
-                .self_local_slot(&l.binding_name)
-                .ok_or(WasmGcError::Validation(format!(
-                    "binding `{}` has no resolver slot",
-                    l.binding_name
-                )))?;
+            // Mirror of `emit_fn_body`'s `Binding` arm. The slot is the
+            // `MirLet`'s own `LocalId` — seeded by the MIR lowering from
+            // the resolver's per-statement `stmt_binding_slots`. A
+            // name-keyed `self_local_slot(&l.binding_name)` lookup here
+            // would resolve to a later same-named pattern binder's slot
+            // (last allocation wins in `local_slots`), storing the value
+            // where the body never reads it (issue #948).
+            let slot = l.binding.0;
             // ETAP-2 SLICE 2b: a bare binding slot is a raw `i64` local, so
             // its VALUE must be emitted in raw context — a boxed-path emit
             // (e.g. an `Int` literal lowering to `__aint_from_i64`) would
             // push an `$AverInt` ref into an `i64` slot (validation error).
             // The rewrite already left the value raw-rendering for a bare
             // binding (`rewrite_let_value`).
-            let value_produces = if ctx.slot_is_bare(slot as u32) {
+            let value_produces = if ctx.slot_is_bare(slot) {
                 match emit_mir_int_raw(func, &l.value, slots, ctx)? {
                     Some(p) => p,
                     None => return Ok(None),

--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -118,6 +118,7 @@ fn annotate_fn(fd: &mut FnDef) {
     let new_res = crate::ast::FnResolution {
         local_count: res.local_count,
         local_slots: res.local_slots.clone(),
+        stmt_binding_slots: res.stmt_binding_slots.clone(),
         local_slot_types: res.local_slot_types.clone(),
         aliased_slots: Arc::new(aliased),
     };

--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -79,9 +79,28 @@ fn annotate_fn(fd: &mut FnDef) {
     let body = fd.body.clone();
     let FnBody::Block(stmts) = body.as_ref();
     for _ in 0..2 {
+        // Per-statement positional identity — the same source the MIR
+        // statement-chain lowering consumes: `stmt_binding_slots` has
+        // exactly one entry per fn-body `Stmt::Binding` in source order
+        // (`u16::MAX` for `_`). Looking the slot up BY NAME in
+        // `local_slots` is the issue-#948 disease: last allocation wins
+        // in that map, so a later pattern binder spelled like the
+        // statement binding owns the entry, this pass then judges the
+        // BINDER's slot (usually a scalar → no flag) and the statement
+        // binding's own collection slot stays owned-eligible — the VM's
+        // in-place fast path then mutates an arena entry the map/vector
+        // it was extracted from still holds.
+        let mut stmt_slots = res.stmt_binding_slots.iter();
         for stmt in stmts {
-            if let Stmt::Binding(name, _, expr) = stmt {
-                let Some(&slot) = res.local_slots.get(name) else {
+            if let Stmt::Binding(_, _, expr) = stmt {
+                let slot = stmt_slots.next().copied();
+                // A discarded `_ = …` binding claims no slot and RETAINS
+                // nothing: its value is dropped on the spot, so a local
+                // flowing into it gains no second holder — skip both
+                // halves (this is also the pre-#948 behaviour, which the
+                // slot-uniqueness suite pins via its owned-grant
+                // tallies: `_ = f(m)` must not cost `m` its grant).
+                let Some(slot) = slot.filter(|&s| s != u16::MAX) else {
                     continue;
                 };
                 // Source half: flag every bare collection local whose handle
@@ -111,6 +130,18 @@ fn annotate_fn(fd: &mut FnDef) {
                 }
             }
         }
+        // Contract check (mirror of `lower_stmt_chain`): the resolver
+        // records one entry per `Stmt::Binding`, so the iterator must be
+        // drained exactly — a leftover means a pass added, removed, or
+        // reordered statement bindings without rebuilding the table,
+        // and the positional zip above stamped alias bits onto the
+        // wrong slots.
+        debug_assert!(
+            stmt_slots.next().is_none(),
+            "stmt_binding_slots not exhausted in `{}`: statement bindings and the \
+             resolver's per-statement slot table are misaligned",
+            fd.name
+        );
     }
 
     // Re-stamp the resolution. `Arc` swap keeps the rest of the
@@ -386,6 +417,68 @@ mod tests {
             .get(slot as usize)
             .copied()
             .unwrap_or(false)
+    }
+
+    /// Read the alias bit of fn `f`'s `idx`-th statement binding via the
+    /// resolver's positional `stmt_binding_slots` — the identity this
+    /// pass itself consumes. The name-keyed helper above cannot address
+    /// a statement binding whose spelling a later pattern binder reuses
+    /// (`local_slots` is last-allocation-wins), which is exactly the
+    /// case the positional read exists for.
+    fn stmt_binding_is_flagged(source: &str, f: &str, idx: usize) -> bool {
+        let mut items = parse_source(source).unwrap_or_else(|e| panic!("parse: {e}"));
+        let result = pipeline::run(
+            &mut items,
+            PipelineConfig {
+                typecheck: Some(TypecheckMode::Full { base_dir: None }),
+                ..Default::default()
+            },
+        );
+        let tc = result.typecheck.as_ref().expect("typecheck requested");
+        assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+        let fd = items
+            .iter()
+            .find_map(|i| match i {
+                TopLevel::FnDef(fd) if fd.name == f => Some(fd),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("fn {f} not found"));
+        let res = fd.resolution.as_ref().expect("resolution stamped");
+        let slot = *res
+            .stmt_binding_slots
+            .get(idx)
+            .unwrap_or_else(|| panic!("fn {f} has no statement binding #{idx}"));
+        assert_ne!(slot, u16::MAX, "statement binding #{idx} is a discard");
+        res.aliased_slots
+            .get(slot as usize)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// A statement binding that extracts a collection out of a map must
+    /// stay flagged even when a LATER pattern binder reuses its
+    /// spelling. The pass used to fetch the binding's slot by name from
+    /// `local_slots` (last allocation wins), judged the binder's Int
+    /// slot instead — never a collection, so no flag — and the
+    /// extracted vector stayed owned-eligible: the VM's in-place fast
+    /// path then mutated the arena entry the map still holds (the g6 /
+    /// g9 witnesses in `tests/vm_pattern_shadow_matrix.rs`).
+    #[test]
+    fn a_shadowed_statement_binding_of_an_extracted_collection_stays_flagged() {
+        let src = r#"
+fn main() -> Int
+    m = Map.set({}, 1, Vector.fromList([7]))
+    v = Option.withDefault(Map.get(m, 1), Vector.new(1, 0))
+    r = match Option.Some(1)
+        Option.Some(v) -> v + 1
+        Option.None -> 0
+    Vector.len(v) + r
+"#;
+        assert!(
+            stmt_binding_is_flagged(src, "main", 1),
+            "the statement binding `v` (an element extracted from `m`) lost its \
+             alias flag to the later Int pattern binder spelled `v`"
+        );
     }
 
     const FROM_LIST_BINDING: &str = r#"

--- a/src/ir/buffer_build/driver_step.rs
+++ b/src/ir/buffer_build/driver_step.rs
@@ -571,19 +571,33 @@ fn collect_pattern_binders_into(expr: &Spanned<Expr>, out: &mut HashSet<String>)
 }
 
 fn collect_binders_of_pattern(pattern: &Pattern, out: &mut HashSet<String>) {
+    // `_` is spelled inside Cons/Constructor binding lists as a plain
+    // string, but it is not a name: it binds nothing and may appear
+    // several times in one pattern. Letting it into the binder set put
+    // it in the rename map, and the rename then rewrote every `_` of a
+    // pattern to the SAME fresh name — two discards became one
+    // identifier bound twice, which the Rust emitter rejects outright
+    // (E0416) and no backend should see.
+    fn insert_binder(name: &str, out: &mut HashSet<String>) {
+        if name != "_" {
+            out.insert(name.to_string());
+        }
+    }
     match pattern {
         Pattern::Wildcard | Pattern::Literal(_) | Pattern::EmptyList => {}
-        Pattern::Ident(n) => {
-            out.insert(n.clone());
-        }
+        Pattern::Ident(n) => insert_binder(n, out),
         Pattern::Cons(head, tail) => {
-            out.insert(head.clone());
-            out.insert(tail.clone());
+            insert_binder(head, out);
+            insert_binder(tail, out);
         }
         Pattern::Tuple(items) => items
             .iter()
             .for_each(|p| collect_binders_of_pattern(p, out)),
-        Pattern::Constructor(_, bindings) => out.extend(bindings.iter().cloned()),
+        Pattern::Constructor(_, bindings) => {
+            for b in bindings {
+                insert_binder(b, out);
+            }
+        }
     }
 }
 
@@ -667,7 +681,12 @@ fn encode_step_body(
     // namespace or constructor read the rename must not touch).
     let mut binders: HashSet<String> = HashSet::new();
     for stmt in step.body.stmts() {
-        if let Stmt::Binding(name, _, _) = stmt {
+        if let Stmt::Binding(name, _, _) = stmt
+            && name != "_"
+        {
+            // `_ = e` discards its value and binds nothing — it has no
+            // name to rename (and must not put `_` into the rename map,
+            // where it would rewrite pattern discards into binders).
             binders.insert(name.clone());
         }
         collect_pattern_binders_into(crate::ir::chars_fusion::stmt_expr(stmt), &mut binders);
@@ -776,6 +795,11 @@ fn encode_step_body(
     };
     for stmt in stmts.into_iter().rev() {
         expr = match stmt {
+            // A discard binding stays a discard: `_` is not a name and
+            // was deliberately left out of the rename map above.
+            Stmt::Binding(name, _, value) if name == "_" => {
+                bind_over(value, Pattern::Wildcard, expr)
+            }
             Stmt::Binding(name, _, value) => bind_over(value, Pattern::Ident(name), expr),
             Stmt::Expr(value) => bind_over(value, Pattern::Wildcard, expr),
         };
@@ -1239,6 +1263,97 @@ fn entry(xs: List<Int>) -> List<Int>
         assert!(
             report.pair_inlined_by_fn.contains_key("drive"),
             "{report:?}"
+        );
+    }
+
+    /// Two discards in one pattern of the step must stay discards
+    /// through the inline. The binder collection once treated `_` as a
+    /// name, so the rename map rewrote BOTH `_`s of a `Two(_, _)`
+    /// pattern to the SAME fresh `__stp<n>` — one identifier bound
+    /// twice in one pattern. The VM shrugged (nothing reads the name),
+    /// but the Rust emitter faithfully printed the duplicate and rustc
+    /// rejected it (E0416) — found when regenerating the self-host,
+    /// whose resolver matches `StmtBindSlot(_, _)`.
+    #[test]
+    fn wildcards_in_the_steps_patterns_survive_the_inline_unrenamed() {
+        let source = r#"module WildcardPair
+    intent = "Two discards in one step pattern."
+    exposes [entry]
+
+type Two
+  Pair(Int, Int)
+
+fn drive(xs: List<Int>, acc: List<Int>) -> List<Int>
+    match xs
+        [] -> List.reverse(acc)
+        [h, ..t] -> step(h, t, acc)
+
+fn step(sh: Int, st: List<Int>, sacc: List<Int>) -> List<Int>
+    keep = match Two.Pair(sh, sh)
+        Two.Pair(_, _) -> sh * 2
+    drive(st, List.prepend(keep, sacc))
+
+fn entry(xs: List<Int>) -> List<Int>
+    drive(xs, [])
+"#;
+        let mut items = crate::source::parse_source(source).expect("fixture parses");
+        crate::tco::transform_program(&mut items);
+        let report = super::super::list_build::run_list_build_pass(&mut items);
+        assert!(
+            report.pair_inlined_by_fn.contains_key("drive"),
+            "the pair must fuse for this test to witness anything: {report:?}"
+        );
+
+        fn check_pattern(pattern: &Pattern) {
+            if let Pattern::Constructor(name, bindings) = pattern {
+                let mut seen: HashSet<&String> = HashSet::new();
+                for b in bindings.iter().filter(|b| *b != "_") {
+                    assert!(
+                        seen.insert(b),
+                        "`{name}` binds `{b}` twice in one pattern: {bindings:?}"
+                    );
+                }
+            }
+            if let Pattern::Tuple(items) = pattern {
+                items.iter().for_each(check_pattern);
+            }
+        }
+        fn check_expr(expr: &Spanned<Expr>) {
+            if let Expr::Match { arms, .. } = &expr.node {
+                for arm in arms {
+                    check_pattern(&arm.pattern);
+                }
+            }
+            crate::ir::chars_fusion::walk_children(expr, &mut |child| check_expr(child));
+        }
+        let mut two_wildcard_patterns = 0;
+        for item in &items {
+            if let TopLevel::FnDef(fd) = item {
+                for stmt in fd.body.stmts() {
+                    let expr = crate::ir::chars_fusion::stmt_expr(stmt);
+                    check_expr(expr);
+                    fn count_two_wild(expr: &Spanned<Expr>, count: &mut usize) {
+                        if let Expr::Match { arms, .. } = &expr.node {
+                            for arm in arms {
+                                if let Pattern::Constructor(_, bindings) = &arm.pattern
+                                    && bindings.iter().all(|b| b == "_")
+                                    && bindings.len() == 2
+                                {
+                                    *count += 1;
+                                }
+                            }
+                        }
+                        crate::ir::chars_fusion::walk_children(expr, &mut |child| {
+                            count_two_wild(child, count)
+                        });
+                    }
+                    count_two_wild(expr, &mut two_wildcard_patterns);
+                }
+            }
+        }
+        assert!(
+            two_wildcard_patterns > 0,
+            "the fused module must still contain the `Two.Pair(_, _)` discard pattern"
         );
     }
 

--- a/src/ir/escape.rs
+++ b/src/ir/escape.rs
@@ -355,8 +355,15 @@ fn rewrite_in_expr(
     // Now look at THIS node — is it an FnCall we can splice?
     if let Expr::FnCall(callee, args) = expr {
         let callee_name = match &callee.node {
+            // Only a BARE `Ident` can name an inline candidate. An
+            // `Expr::Resolved` callee is a LOCAL by construction of
+            // the resolver (only locals get slots) — a `Fn`-typed
+            // param or binder spelled like a candidate fn — so
+            // matching it against the name-keyed candidate map would
+            // splice the module fn's body over a call to whichever fn
+            // the caller actually passed (the shadowed-callee
+            // disease).
             Expr::Ident(n) => Some(n.as_str()),
-            Expr::Resolved { name, .. } => Some(name.as_str()),
             _ => None,
         };
         if let Some(name) = callee_name
@@ -1158,6 +1165,46 @@ mod tests {
         let escapes = fn_def_p("escapes", "Point", "Point", resolved("p", 0));
         let mut items = vec![TopLevel::FnDef(escapes)];
         assert_eq!(run(&mut items), 0);
+    }
+
+    /// A candidate may only match a callee that is a BARE `Ident`. An
+    /// `Expr::Resolved` callee is a LOCAL by construction of the
+    /// resolver (only locals get slots) — here a `Fn`-typed param
+    /// spelled like the candidate fn — so splicing the module fn's
+    /// body would ignore whichever fn the caller actually passed.
+    #[test]
+    fn run_skips_resolved_callee_shadowing_a_candidate() {
+        // area(p: Shape) -> Int = match p { Shape.Circle(n) -> n + 1 }
+        let arms = vec![arm_with_slots(
+            Pattern::Constructor("Shape.Circle".to_string(), vec!["n".to_string()]),
+            add(resolved("n", 1), lit_int(1)),
+            &[1],
+        )];
+        let area = fn_def_p_with_extra(
+            "area",
+            "Shape",
+            "Int",
+            match_expr(resolved("p", 0), arms),
+            &[("n", 1)],
+        );
+        // apply(p: Fn(Shape) -> Int) -> Int = p(Shape.Circle(5)) with
+        // the param RENAMED by the resolver stamp to `area` — the
+        // callee is Resolved{name: "area", slot: 0}, a local.
+        let apply = fn_def_p(
+            "apply",
+            "Fn(Shape) -> Int",
+            "Int",
+            fn_call(
+                resolved("area", 0),
+                vec![fn_call(attr(ident("Shape"), "Circle"), vec![lit_int(5)])],
+            ),
+        );
+        let mut items = vec![TopLevel::FnDef(area), TopLevel::FnDef(apply)];
+        assert_eq!(
+            run(&mut items),
+            0,
+            "a resolved (local) callee must never match the name-keyed candidate map"
+        );
     }
 
     #[test]

--- a/src/ir/escape.rs
+++ b/src/ir/escape.rs
@@ -72,8 +72,13 @@ enum InlineCandidate {
     },
     /// `f(s: Variant) -> T` whose body is `match s { Pat1(b1)->e1; … }`.
     /// At call site `f(Foo.PatN(args))` we splice arm `N`'s body with
-    /// the pattern bindings substituted. Each arm's binding slots
-    /// resolve via the resolver's `local_slots` map of `f`.
+    /// the pattern bindings substituted. Each arm's binding slots are
+    /// read from `MatchArm::binding_slots` — the per-arm table the
+    /// resolver fills in pattern order. NEVER from the name-keyed
+    /// `FnResolution.local_slots`: last allocation wins there, so two
+    /// sibling arms binding the same name would both get the last
+    /// arm's slot and the first arm's body would splice with its
+    /// binder unsubstituted (issue #948's disease).
     VariantMatch {
         /// One entry per arm. Arm pattern dotted name → (binding slots,
         /// arm body). Wildcard arms aren't included; if the dispatch
@@ -140,9 +145,17 @@ fn classify_fn(fd: &FnDef) -> Option<InlineCandidate> {
         Stmt::Expr(spanned) => spanned,
         _ => return None,
     };
-    // Param's resolver slot.
-    let resolution = fd.resolution.as_ref()?;
-    let param_slot = resolution.local_slots.get(&fd.params[0].0).copied()?;
+    // A resolution must be stamped: an unresolved body still carries
+    // bare `Ident`s that the splice would copy into the caller verbatim.
+    fd.resolution.as_ref()?;
+    // Param's resolver slot. Params own slots `0..N-1` in declaration
+    // order (`ResolverState::declare_param`), so the single param sits
+    // in slot 0 by construction. Do NOT look it up by name in
+    // `local_slots`: that map is last-allocation-wins, so a pattern
+    // binder inside the body spelled like the param steals the entry
+    // and every param-slot comparison below runs against the binder's
+    // slot instead (issue #948's disease).
+    let param_slot: u16 = 0;
     // No tail-call in body — we'd be inlining recursive reference
     // into a different fn's body if so.
     if contains_tail_call(&body.node) {
@@ -169,17 +182,21 @@ fn classify_fn(fd: &FnDef) -> Option<InlineCandidate> {
                 // Non-Constructor arm (Wildcard, Literal) — give up.
                 return None;
             };
-            // Resolve binding slots via the resolver's local_slots map.
-            // Each binding name was registered there during resolve.
-            let mut binding_slots = Vec::with_capacity(bindings.len());
-            for b in bindings {
-                if b == "_" {
-                    binding_slots.push(u16::MAX); // sentinel — discard
-                    continue;
-                }
-                let slot = resolution.local_slots.get(b).copied()?;
-                binding_slots.push(slot);
+            // Pattern binders live in `MatchArm::binding_slots` — the
+            // resolver's per-arm table, one entry per binding in
+            // pattern order, `u16::MAX` for `_`. A name lookup in
+            // `FnResolution.local_slots` here hands two sibling arms
+            // that bind the same name the LAST arm's slot (last
+            // allocation wins), so the earlier arm's body splices with
+            // its binder left unsubstituted — a dangling slot in the
+            // caller (VM slot-index panic, emitted-Rust E0425, wasm-gc
+            // validation error).
+            let slots = arm.binding_slots.get()?;
+            if slots.len() != bindings.len() {
+                // Resolver/pattern desync — refuse to classify.
+                return None;
             }
+            let binding_slots = slots.clone();
             // Arm body must not use `s` directly outside Match's
             // dispatch shape (we walk to verify).
             if !arm_body_safe(&arm.body.node, param_slot) {
@@ -712,6 +729,16 @@ mod tests {
         }
     }
 
+    /// `arm` with the resolver's per-arm `binding_slots` table filled —
+    /// what the real resolver always does. `classify_fn` reads slots
+    /// from here (never from the name-keyed fn-level map), so
+    /// VariantMatch-shape tests must populate it.
+    fn arm_with_slots(pattern: Pattern, body: Spanned<Expr>, slots: &[u16]) -> MatchArm {
+        let a = arm(pattern, body);
+        a.binding_slots.set(slots.to_vec()).expect("fresh OnceLock");
+        a
+    }
+
     /// Build a single-param fn whose body is `body_expr` (one Stmt::Expr).
     /// The single param `p` is registered at slot 0 in `local_slots`.
     fn fn_def_p(
@@ -892,13 +919,15 @@ mod tests {
         // fn unwrap(p: Option<Int>) -> Int =
         //   match p { Option.Some(v) -> v ; Option.None -> 0 }
         let arms = vec![
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.Some".to_string(), vec!["v".to_string()]),
                 resolved("v", 1),
+                &[1],
             ),
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.None".to_string(), vec![]),
                 lit_int(0),
+                &[],
             ),
         ];
         let body = match_expr(resolved("p", 0), arms);
@@ -914,14 +943,83 @@ mod tests {
         }
     }
 
+    /// Two SIBLING arms binding the same name must each keep their own
+    /// per-arm slot. The fn-level `local_slots` map is last-allocation-
+    /// wins, so a name lookup hands BOTH arms the second arm's slot —
+    /// the first arm's body then splices with its binder unsubstituted
+    /// and the dangling slot reaches the caller (VM slot-index panic,
+    /// emitted-Rust E0425, wasm-gc validation error). Slots must come
+    /// from `MatchArm::binding_slots`.
+    #[test]
+    fn classify_variant_match_sibling_arms_keep_their_own_slots() {
+        // fn eval(p: Shape) -> Int =
+        //   match p { Shape.Circle(n) -> n + 1 ; Shape.Square(n) -> n + 2 }
+        // Resolver: Circle's n → slot 1, Square's n → slot 2,
+        // local_slots["n"] = 2 (last allocation wins).
+        let arms = vec![
+            arm_with_slots(
+                Pattern::Constructor("Shape.Circle".to_string(), vec!["n".to_string()]),
+                add(resolved("n", 1), lit_int(1)),
+                &[1],
+            ),
+            arm_with_slots(
+                Pattern::Constructor("Shape.Square".to_string(), vec!["n".to_string()]),
+                add(resolved("n", 2), lit_int(2)),
+                &[2],
+            ),
+        ];
+        let body = match_expr(resolved("p", 0), arms);
+        let fd = fn_def_p_with_extra("eval", "Shape", "Int", body, &[("n", 2)]);
+        match classify_fn(&fd) {
+            Some(InlineCandidate::VariantMatch {
+                arms_by_constructor,
+            }) => {
+                assert_eq!(
+                    arms_by_constructor["Shape.Circle"].0,
+                    vec![1],
+                    "Circle's binder slot was resolved through the last-wins name map"
+                );
+                assert_eq!(arms_by_constructor["Shape.Square"].0, vec![2]);
+            }
+            other => panic!("expected VariantMatch, got {other:?}"),
+        }
+    }
+
+    /// The param's slot is positional (params own slots 0..N-1), not a
+    /// name lookup: a pattern binder inside the body spelled like the
+    /// param would otherwise steal the `local_slots` entry and every
+    /// param-slot comparison would run against the binder's slot.
+    #[test]
+    fn classify_record_access_param_slot_is_positional_not_name_keyed() {
+        // `extra` registers ("p", 3) — simulating a later binder named
+        // `p` owning the last-wins map entry.
+        let fd = fn_def_p_with_extra(
+            "getx",
+            "Point",
+            "Float",
+            attr(resolved("p", 0), "x"),
+            &[("p", 3)],
+        );
+        match classify_fn(&fd) {
+            Some(InlineCandidate::RecordAccess { param_slot, .. }) => {
+                assert_eq!(
+                    param_slot, 0,
+                    "param slot must be the positional slot 0, not the stolen map entry"
+                );
+            }
+            other => panic!("expected RecordAccess, got {other:?}"),
+        }
+    }
+
     #[test]
     fn classify_variant_match_disqualifies_wildcard_arm() {
         // Wildcard / Literal arms exit early — pass gives up to keep
         // dispatch shape uniform.
         let arms = vec![
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.Some".to_string(), vec!["v".to_string()]),
                 resolved("v", 1),
+                &[1],
             ),
             arm(Pattern::Wildcard, lit_int(0)),
         ];
@@ -935,13 +1033,15 @@ mod tests {
         // arm body refers to `p` directly (not just `v`) — bare subject
         // reference disqualifies (would mean the subject escapes).
         let arms = vec![
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.Some".to_string(), vec!["v".to_string()]),
                 resolved("p", 0),
+                &[1],
             ),
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.None".to_string(), vec![]),
                 lit_int(0),
+                &[],
             ),
         ];
         let body = match_expr(resolved("p", 0), arms);
@@ -1067,13 +1167,15 @@ mod tests {
         // After run(): main body should be `42` (the Some payload), no
         // FnCall, no Constructor wrapper.
         let arms = vec![
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.Some".to_string(), vec!["v".to_string()]),
                 resolved("v", 1),
+                &[1],
             ),
-            arm(
+            arm_with_slots(
                 Pattern::Constructor("Option.None".to_string(), vec![]),
                 lit_int(0),
+                &[],
             ),
         ];
         let unwrap = fn_def_p_with_extra(

--- a/src/ir/escape.rs
+++ b/src/ir/escape.rs
@@ -748,6 +748,7 @@ mod tests {
             resolution: Some(FnResolution {
                 local_count: (1 + extra_slots.len()) as u16,
                 local_slots: Arc::new(slots),
+                stmt_binding_slots: Arc::new(Vec::new()),
                 local_slot_types: Arc::new(vec![crate::ast::Type::Invalid; 1 + extra_slots.len()]),
                 aliased_slots: Arc::new(vec![false; 1 + extra_slots.len()]),
             }),
@@ -768,6 +769,7 @@ mod tests {
             resolution: Some(FnResolution {
                 local_count: 0,
                 local_slots: Arc::new(HashMap::new()),
+                stmt_binding_slots: Arc::new(vec![]),
                 local_slot_types: Arc::new(vec![]),
                 aliased_slots: Arc::new(vec![]),
             }),

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -21,7 +21,8 @@
 //! - `Stmt::Binding { name, value }` + `Stmt::Expr(value)` in
 //!   sequence ending in `Stmt::Expr` right-folds into nested
 //!   `MirExpr::Let { binding, value, body }` nodes.
-//! - Binding slot comes from `FnResolution.local_slots[name]`;
+//! - Binding slot comes from `FnResolution.stmt_binding_slots`
+//!   (per-statement, source order);
 //!   intermediate `Stmt::Expr` gets a fresh synthetic `LocalId`
 //!   drawn from a counter starting at `local_count`.
 //!
@@ -684,8 +685,13 @@ fn wrap<T, U>(node: T, source: &Spanned<U>) -> Spanned<T> {
 /// - The last stmt must be `Stmt::Expr`; it becomes the innermost
 ///   body of the resulting `Let` chain.
 /// - `Stmt::Binding { name, value }` uses the slot the resolver
-///   already assigned (`resolution.local_slots[name]`) as the
-///   binding's `LocalId`. Missing slot → the fn is skipped.
+///   recorded for THIS statement (`resolution.stmt_binding_slots`,
+///   source order). A name-keyed lookup in `local_slots` is wrong
+///   here: last allocation wins in that map, so a later pattern
+///   binder spelled like the statement binding would steal the
+///   slot and the `let` would write the binder's slot while every
+///   read of the statement binding hits an uninitialized one
+///   (issue #948). Missing slot entry → the fn is skipped.
 /// - `Stmt::Expr` at non-tail position is treated as a let
 ///   binding to a fresh synthetic `LocalId` so its (potentially
 ///   effectful) value still gets evaluated. The synthetic
@@ -704,15 +710,29 @@ fn lower_stmt_chain(
     };
     let mut body = lower_expr(tail_expr, program)?;
 
+    // Per-statement binding slots, aligned front-to-back with the
+    // `Binding` stmts in `stmts` (the resolver records one entry per
+    // fn-body `Stmt::Binding` in source order, `u16::MAX` for `_`).
+    // Assign each stmt its slot in a forward pass so the reverse
+    // right-fold below can consume them by position.
+    let mut binding_slot_iter = resolution.stmt_binding_slots.iter();
+    let stmt_slots: Vec<Option<u16>> = rest
+        .iter()
+        .map(|stmt| match stmt {
+            ResolvedStmt::Binding { .. } => binding_slot_iter.next().copied(),
+            ResolvedStmt::Expr(_) => None,
+        })
+        .collect();
+
     // Right-fold: walk earlier stmts in reverse, wrapping each
     // around the accumulating `body`.
-    for stmt in rest.iter().rev() {
+    for (stmt, stmt_slot) in rest.iter().zip(stmt_slots.iter()).rev() {
         let (binding, binding_name, value_expr) = match stmt {
             ResolvedStmt::Binding { name, value, .. } if name == "_" => {
                 // Discard binding `_ = effect()?` — the idiomatic "run an
                 // effect, drop the Ok, continue" form. The resolver
-                // assigns `_` no slot (it returns `u16::MAX` and never
-                // inserts it), so there's nothing to look up. Evaluate the
+                // records the `u16::MAX` sentinel for `_` (it claims no
+                // slot), so there's nothing to store into. Evaluate the
                 // value for its effects under a fresh synthetic slot the
                 // body never reads, exactly as a non-tail `Stmt::Expr`.
                 let fresh = LocalId(*next_synthetic_local);
@@ -720,9 +740,8 @@ fn lower_stmt_chain(
                 (fresh, String::new(), value)
             }
             ResolvedStmt::Binding { name, value, .. } => {
-                let slot = *resolution
-                    .local_slots
-                    .get(name)
+                let slot = stmt_slot
+                    .filter(|&s| s != u16::MAX)
                     .ok_or(SkipReason::BindingSlotLookupMissing)?;
                 (LocalId(u32::from(slot)), name.clone(), value)
             }

--- a/src/ir/mir/lower.rs
+++ b/src/ir/mir/lower.rs
@@ -723,6 +723,20 @@ fn lower_stmt_chain(
             ResolvedStmt::Expr(_) => None,
         })
         .collect();
+    // Contract: the resolver records exactly one entry per fn-body
+    // `Stmt::Binding` in source order, and this pass consumes them
+    // positionally — so after the forward pass the iterator must be
+    // drained EXACTLY. A shortfall already fails per-binding above
+    // (`BindingSlotLookupMissing`); a LEFTOVER means some pass added,
+    // removed, or reordered statement bindings without rebuilding the
+    // table, i.e. every zip above may have paired a binding with a
+    // NEIGHBOR's slot — silent cross-wiring, not a missing entry — so
+    // it must be caught here, not shrugged off.
+    debug_assert!(
+        binding_slot_iter.next().is_none(),
+        "stmt_binding_slots not exhausted: statement bindings and the resolver's \
+         per-statement slot table are misaligned"
+    );
 
     // Right-fold: walk earlier stmts in reverse, wrapping each
     // around the accumulating `body`.

--- a/src/ir/mir/optimize/const_fold.rs
+++ b/src/ir/mir/optimize/const_fold.rs
@@ -639,10 +639,11 @@ fn arm_matches_ctor(pattern: &MirPattern, ctor: BuiltinCtor, arity: usize) -> bo
 /// `Let` binds the first field, so args evaluate left-to-right, once each.
 ///
 /// Each `Let` carries the pattern field's source binder name
-/// (`binding_names[i]`) — this is load-bearing: the wasm-gc / Rust
-/// backends resolve a `Let`'s slot by *name* (`self_local_slot`), and an
-/// empty name routes them down the synthetic-discard path that drops the
-/// value. The VM keys off `binding` (the `LocalId`). Each `Let` also
+/// (`binding_names[i]`) — this is load-bearing: the Rust backend emits
+/// `let {binding_name} = …` by source name, and the wasm-gc emitter
+/// (which keys the slot off `binding`, the `LocalId`, since #948)
+/// routes an EMPTY name down the synthetic-discard path that drops the
+/// value. The VM keys off `binding` too. Each `Let` also
 /// carries the body's value type (`match_ty`) so wasm-gc has a stamp on
 /// every node.
 fn wrap_in_lets(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -121,11 +121,13 @@ fn resolve_fn(fd: &mut FnDef, type_info: &TypeInfo) {
     let next_slot = state.next_slot;
     let last_alloc = state.last_alloc;
     let slot_types = state.slot_types;
+    let stmt_binding_slots = state.stmt_binding_slots;
     state.scopes.pop();
 
     fd.resolution = Some(FnResolution {
         local_count: next_slot,
         local_slots: Rc::new(last_alloc),
+        stmt_binding_slots: Rc::new(stmt_binding_slots),
         local_slot_types: Rc::new(slot_types),
         aliased_slots: Rc::new(vec![false; next_slot as usize]),
     });
@@ -150,6 +152,11 @@ struct ResolverState<'a> {
     /// inside a match arm should prefer `MatchArm::binding_slots`
     /// (resolver writes the actual per-arm slot there).
     last_alloc: HashMap<String, u16>,
+    /// Slot of each fn-body statement binding in source order —
+    /// `u16::MAX` for `_`. Becomes `FnResolution.stmt_binding_slots`,
+    /// the per-statement identity the MIR lowering consumes instead
+    /// of the name-keyed (last-wins) `last_alloc` (issue #948).
+    stmt_binding_slots: Vec<u16>,
 }
 
 impl<'a> ResolverState<'a> {
@@ -160,6 +167,7 @@ impl<'a> ResolverState<'a> {
             slot_types: Vec::new(),
             scopes: Vec::new(),
             last_alloc: HashMap::new(),
+            stmt_binding_slots: Vec::new(),
         }
     }
 
@@ -236,7 +244,8 @@ impl<'a> ResolverState<'a> {
                     // local_slots` keeps params, then top-level let
                     // bindings, then pattern-introduced bindings).
                     let ty = expr.ty().cloned().unwrap_or(Type::Invalid);
-                    self.declare(name, ty);
+                    let slot = self.declare(name, ty);
+                    self.stmt_binding_slots.push(slot);
                     self.walk_expr(expr);
                 }
                 Stmt::Expr(expr) => self.walk_expr(expr),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -154,8 +154,16 @@ struct ResolverState<'a> {
     last_alloc: HashMap<String, u16>,
     /// Slot of each fn-body statement binding in source order —
     /// `u16::MAX` for `_`. Becomes `FnResolution.stmt_binding_slots`,
-    /// the per-statement identity the MIR lowering consumes instead
-    /// of the name-keyed (last-wins) `last_alloc` (issue #948).
+    /// the per-statement identity the MIR lowering and the alias pass
+    /// consume instead of the name-keyed (last-wins) `last_alloc`
+    /// (issue #948).
+    ///
+    /// CONTRACT (producer side): exactly one entry per fn-body
+    /// `Stmt::Binding`, pushed in source order. Consumers zip this
+    /// positionally against the body's statements and assert the list
+    /// drains exactly — any pass that adds, removes, or reorders
+    /// statement bindings after resolution MUST rebuild this table, or
+    /// every later binding silently pairs with a neighbor's slot.
     stmt_binding_slots: Vec<u16>,
 }
 

--- a/src/self_host/aver_generated/domain/builtins/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/mod.rs
@@ -494,7 +494,10 @@ pub fn builtinArgsGet(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
         aver_replay::invoke_effect("Args.get", vec![], || aver_replay::current_cli_args())
     };
     Ok(crate::aver_generated::domain::value::Val::ValList(
-        crate::aver_generated::domain::builtins::stringsToVals(rawArgs, aver_rt::AverList::empty()),
+        crate::aver_generated::domain::builtins::stringsToVals__collected(
+            rawArgs,
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
+        ),
     ))
 }
 
@@ -575,14 +578,16 @@ pub fn builtinMapEntries(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> 
     match v {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValList(
-                crate::aver_generated::domain::builtins::mapEntriesToTuples(
+                crate::aver_generated::domain::builtins::mapEntriesToTuples__collected(
                     {
                         let mut es: Vec<_> =
                             m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
                         es.sort_by(|a, b| a.0.cmp(&b.0));
                         aver_rt::AverList::from_vec(es)
                     },
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             ))
         }
@@ -615,13 +620,15 @@ pub fn builtinMapKeys(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
     match v {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValList(
-                crate::aver_generated::domain::builtins::stringsToVals(
+                crate::aver_generated::domain::builtins::stringsToVals__collected(
                     {
                         let mut ks: Vec<_> = m.keys().cloned().collect();
                         ks.sort();
                         aver_rt::AverList::from_vec(ks)
                     },
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             ))
         }
@@ -1447,9 +1454,11 @@ pub fn builtinDiskListDir(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr>
     } {
         Ok(entries) => Ok(crate::aver_generated::domain::value::Val::ValOk(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValList(
-                crate::aver_generated::domain::builtins::stringsToVals(
+                crate::aver_generated::domain::builtins::stringsToVals__collected(
                     entries,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )),
         )),
@@ -1967,7 +1976,7 @@ pub fn headersToValMap(
         crate::cancel_checkpoint();
         aver_list_match!(names, [] => { return acc; }, [name, rest] => { match headers.get(&name).cloned() { Some(values) => { {
             let __tco1 = rest;
-            let __tco2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(crate::aver_generated::domain::builtins::stringsToValStrs(values, aver_rt::AverList::empty())));
+            let __tco2 = acc.insert_owned(name, crate::aver_generated::domain::value::Val::ValList(crate::aver_generated::domain::builtins::stringsToValStrs__collected(values, aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)))));
             names = __tco1;
             acc = __tco2;
             continue;
@@ -2319,6 +2328,60 @@ pub fn builtinTcpClose(args: &aver_rt::AverList<Val>) -> Result<Val, AverStr> {
         Err(e) => Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(e)),
         )),
+    }
+}
+
+/// Synthesized collecting variant of `stringsToVals`. Appends to a builder where `stringsToVals` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn stringsToVals__collected(
+    mut strs: aver_rt::AverList<AverStr>,
+    mut acc: aver_rt::AverList<Val>,
+) -> aver_rt::AverList<Val> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(strs, [] => { return aver_rt::list_builder_finalize(acc); }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::value::Val::ValStr(s));
+            strs = __tco0;
+            acc = __tco1;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `mapEntriesToTuples`. Appends to a builder where `mapEntriesToTuples` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn mapEntriesToTuples__collected(
+    mut entries: aver_rt::AverList<(AverStr, Val)>,
+    mut acc: aver_rt::AverList<Val>,
+) -> aver_rt::AverList<Val> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(entries, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (k, v) = pair; {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::value::Val::ValTuple(aver_rt::AverList::from_vec(vec![crate::aver_generated::domain::value::Val::ValStr(k), v])));
+            entries = __tco0;
+            acc = __tco1;
+            continue;
+        } } })
+    }
+}
+
+/// Synthesized collecting variant of `stringsToValStrs`. Appends to a builder where `stringsToValStrs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn stringsToValStrs__collected(
+    mut values: aver_rt::AverList<AverStr>,
+    mut acc: aver_rt::AverList<Val>,
+) -> aver_rt::AverList<Val> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(values, [] => { return aver_rt::list_builder_finalize(acc); }, [v, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::value::Val::ValStr(v));
+            values = __tco0;
+            acc = __tco1;
+            continue;
+        } })
     }
 }
 

--- a/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
@@ -370,9 +370,9 @@ pub fn builtinStringJoinInner(lstV: &Val, sepV: &Val) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
     let sep = crate::aver_generated::domain::builtins::helpers::expectStr(sepV)?;
-    let strs = crate::aver_generated::domain::builtins::primitives::extractStrings(
+    let strs = crate::aver_generated::domain::builtins::primitives::extractStrings__collected(
         items,
-        aver_rt::AverList::empty(),
+        aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     )?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (aver_rt::string_join(&strs, &sep)).into_aver(),
@@ -986,9 +986,9 @@ pub fn builtinStringSplitInner(sV: &Val, sepV: &Val) -> Result<Val, AverStr> {
         (aver_rt::AverList::from_vec(s.split(&*sep).map(|s| s.to_string()).collect::<Vec<_>>()))
             .into_aver();
     Ok(crate::aver_generated::domain::value::Val::ValList(
-        crate::aver_generated::domain::builtins::primitives::strPartsToVals(
+        crate::aver_generated::domain::builtins::primitives::strPartsToVals__collected(
             parts,
-            aver_rt::AverList::empty(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
         ),
     ))
 }
@@ -1079,4 +1079,47 @@ pub fn builtinStringReplaceAllDo(sV: &Val, fromV: &Val, toV: &Val) -> Result<Val
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (s.replace(&*from, &*to)).into_aver(),
     ))
+}
+
+/// Synthesized collecting variant of `extractStrings`. Appends to a builder where `extractStrings` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn extractStrings__collected(
+    mut items: aver_rt::AverList<Val>,
+    mut acc: aver_rt::AverList<AverStr>,
+) -> Result<aver_rt::AverList<AverStr>, AverStr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(items, [] => { return Ok(aver_rt::list_builder_finalize(acc)); }, [v, rest] => { match v {
+        crate::aver_generated::domain::value::Val::ValStr(s) => {
+            {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, s);
+            items = __tco0;
+            acc = __tco1;
+            continue;
+        }
+        },
+        _ => {
+            return Err(AverStr::from("String.join requires list of strings"));
+        }
+    } })
+    }
+}
+
+/// Synthesized collecting variant of `strPartsToVals`. Appends to a builder where `strPartsToVals` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn strPartsToVals__collected(
+    mut parts: aver_rt::AverList<AverStr>,
+    mut acc: aver_rt::AverList<Val>,
+) -> aver_rt::AverList<Val> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(parts, [] => { return aver_rt::list_builder_finalize(acc); }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::value::Val::ValStr(s));
+            parts = __tco0;
+            acc = __tco1;
+            continue;
+        } })
+    }
 }

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -3221,9 +3221,9 @@ pub fn evalIndependentProduct(
     crate::cancel_checkpoint();
     let items = crate::aver_generated::domain::eval::core::evalIndependentItems(exprs, env, fns)?;
     if unwrap {
-        crate::aver_generated::domain::eval::core::unwrapProductResults(
+        crate::aver_generated::domain::eval::core::unwrapProductResults__collected(
             items,
-            aver_rt::AverList::empty(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
         )
     } else {
         Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
@@ -4164,10 +4164,10 @@ pub fn fastForwardCall(
     fns: &FnStore,
 ) -> Result<Val, AverStr> {
     crate::cancel_checkpoint();
-    let args = crate::aver_generated::domain::eval::core::collectFastForwardArgs(
+    let args = crate::aver_generated::domain::eval::core::collectFastForwardArgs__collected(
         slotArgs.clone(),
         calleeEnv.clone(),
-        aver_rt::AverList::empty(),
+        aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     )?;
     let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
     crate::aver_generated::domain::eval::core::callResolvedById(fnId, &fd, &args, fns)
@@ -5015,9 +5015,9 @@ pub fn evalIndependentProductSlot(
         exprs, env, slotMap, fns,
     )?;
     if unwrap {
-        crate::aver_generated::domain::eval::core::unwrapProductResults(
+        crate::aver_generated::domain::eval::core::unwrapProductResults__collected(
             items,
-            aver_rt::AverList::empty(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
         )
     } else {
         Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
@@ -5033,4 +5033,60 @@ pub fn evalIndependentItemsSlot(
 ) -> Result<aver_rt::AverList<Val>, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns) { Ok(va) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalExprSlot(&b, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExprSlot(&b, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = crate::aver_generated::domain::eval::core::splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })); let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(crate::aver_generated::domain::eval::core::interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
+}
+
+/// Synthesized collecting variant of `unwrapProductResults`. Appends to a builder where `unwrapProductResults` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn unwrapProductResults__collected(
+    mut items: aver_rt::AverList<Val>,
+    mut acc: aver_rt::AverList<Val>,
+) -> Result<Val, AverStr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(items, [] => { return Ok(crate::aver_generated::domain::value::Val::ValTuple(aver_rt::list_builder_finalize(acc))); }, [v, rest] => { match v {
+        crate::aver_generated::domain::value::Val::ValOk(x) => {
+            let x = (*x).clone();
+            {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, x);
+            items = __tco0;
+            acc = __tco1;
+            continue;
+        }
+        },
+        crate::aver_generated::domain::value::Val::ValErr(e) => {
+            let e = (*e).clone();
+            match e {
+        crate::aver_generated::domain::value::Val::ValStr(msg) => {
+            return Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(msg));
+        },
+        _ => {
+            return Err(crate::aver_generated::domain::eval::common::wrapPropagatedError(AverStr::from("propagated error")));
+        }
+    }
+        },
+        _ => {
+            return Err(AverStr::from("?! operator requires all elements to be Result values"));
+        }
+    } })
+    }
+}
+
+/// Synthesized collecting variant of `collectFastForwardArgs`. Appends to a builder where `collectFastForwardArgs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn collectFastForwardArgs__collected(
+    mut slotArgs: aver_rt::AverList<aver_rt::AverInt>,
+    mut calleeEnv: aver_rt::AverVector<Val>,
+    mut acc: aver_rt::AverList<Val>,
+) -> Result<aver_rt::AverList<Val>, AverStr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(slotArgs, [] => { return Ok(aver_rt::list_builder_finalize(acc)); }, [slot, rest] => { match crate::aver_generated::domain::eval::slots::lookupSlot(&calleeEnv, slot) { Ok(v) => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::list_builder_push(acc, v);
+            slotArgs = __tco0;
+            acc = __tco2;
+            continue;
+        } }, Err(e) => { return Err(e); } } })
+    }
 }

--- a/src/self_host/aver_generated/domain/eval/records/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/records/mod.rs
@@ -3,84 +3,6 @@ use crate::aver_generated::domain::value::*;
 #[allow(unused_imports)]
 use crate::*;
 
-#[allow(non_camel_case_types)]
-enum __MutualTco1 {
-    MergeRecordFieldsAcc(
-        aver_rt::AverList<(AverStr, Val)>,
-        aver_rt::AverList<(AverStr, Val)>,
-        aver_rt::AverList<(AverStr, Val)>,
-    ),
-    MergeOneField(
-        AverStr,
-        Val,
-        aver_rt::AverList<(AverStr, Val)>,
-        aver_rt::AverList<(AverStr, Val)>,
-        aver_rt::AverList<(AverStr, Val)>,
-    ),
-}
-
-fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverList<(AverStr, Val)> {
-    loop {
-        __state = match __state {
-            __MutualTco1::MergeRecordFieldsAcc(mut existing, mut overrides, mut acc) => {
-                crate::cancel_checkpoint();
-                aver_list_match!(existing, [] => { return aver_rt::AverList::concat(&acc.reverse(), &overrides) }, [pair, rest] => { { let (k, v) = pair; __MutualTco1::MergeOneField(k, v, rest, overrides, acc) } })
-            }
-            __MutualTco1::MergeOneField(mut k, mut v, mut rest, mut overrides, mut acc) => {
-                crate::cancel_checkpoint();
-                match crate::aver_generated::domain::eval::records::findOverride(
-                    k.clone(),
-                    overrides.clone(),
-                ) {
-                    Some(newV) => __MutualTco1::MergeRecordFieldsAcc(
-                        rest,
-                        crate::aver_generated::domain::eval::records::removeOverride(
-                            k.clone(),
-                            &overrides,
-                        ),
-                        aver_rt::AverList::prepend((k, newV), &acc),
-                    ),
-                    None => __MutualTco1::MergeRecordFieldsAcc(
-                        rest,
-                        overrides,
-                        aver_rt::AverList::prepend((k, v), &acc),
-                    ),
-                }
-            }
-        };
-    }
-}
-
-/// Accumulate merged fields.
-pub fn mergeRecordFieldsAcc(
-    existing: &aver_rt::AverList<(AverStr, Val)>,
-    overrides: &aver_rt::AverList<(AverStr, Val)>,
-    acc: &aver_rt::AverList<(AverStr, Val)>,
-) -> aver_rt::AverList<(AverStr, Val)> {
-    __mutual_tco_trampoline_1(__MutualTco1::MergeRecordFieldsAcc(
-        existing.clone(),
-        overrides.clone(),
-        acc.clone(),
-    ))
-}
-
-/// Check if field k has an override.
-pub fn mergeOneField(
-    k: AverStr,
-    v: &Val,
-    rest: &aver_rt::AverList<(AverStr, Val)>,
-    overrides: &aver_rt::AverList<(AverStr, Val)>,
-    acc: &aver_rt::AverList<(AverStr, Val)>,
-) -> aver_rt::AverList<(AverStr, Val)> {
-    __mutual_tco_trampoline_1(__MutualTco1::MergeOneField(
-        k,
-        v.clone(),
-        rest.clone(),
-        overrides.clone(),
-        acc.clone(),
-    ))
-}
-
 /// Check if this is a Type.update(record, _named(...)) call.
 #[inline(always)]
 pub fn isRecordUpdate(name: AverStr, args: &aver_rt::AverList<Val>) -> bool {
@@ -183,11 +105,62 @@ pub fn mergeRecordFields(
     overrides: &aver_rt::AverList<(AverStr, Val)>,
 ) -> aver_rt::AverList<(AverStr, Val)> {
     crate::cancel_checkpoint();
-    crate::aver_generated::domain::eval::records::mergeRecordFieldsAcc(
-        existing,
-        overrides,
-        &aver_rt::AverList::empty(),
+    crate::aver_generated::domain::eval::records::mergeRecordFieldsAcc__collected(
+        existing.clone(),
+        overrides.clone(),
+        aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     )
+}
+
+/// Accumulate merged fields.
+#[inline(always)]
+pub fn mergeRecordFieldsAcc(
+    mut existing: aver_rt::AverList<(AverStr, Val)>,
+    mut overrides: aver_rt::AverList<(AverStr, Val)>,
+    mut acc: aver_rt::AverList<(AverStr, Val)>,
+) -> aver_rt::AverList<(AverStr, Val)> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(existing, [] => { return aver_rt::AverList::concat(&acc.reverse(), &overrides); }, [pair, rest] => { { let (k, v) = pair; match crate::aver_generated::domain::eval::records::findOverride(k.clone(), overrides.clone()) { Some(__stp0) => { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::eval::records::removeOverride(k.clone(), &overrides);
+            let __tco2 = aver_rt::AverList::prepend((k, __stp0), &acc);
+            existing = __tco0;
+            overrides = __tco1;
+            acc = __tco2;
+            continue;
+        } }, None => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend((k, v), &acc);
+            existing = __tco0;
+            acc = __tco2;
+            continue;
+        } } } } })
+    }
+}
+
+/// Check if field k has an override.
+#[inline(always)]
+pub fn mergeOneField(
+    k: AverStr,
+    v: &Val,
+    rest: &aver_rt::AverList<(AverStr, Val)>,
+    overrides: &aver_rt::AverList<(AverStr, Val)>,
+    acc: &aver_rt::AverList<(AverStr, Val)>,
+) -> aver_rt::AverList<(AverStr, Val)> {
+    crate::cancel_checkpoint();
+    match crate::aver_generated::domain::eval::records::findOverride(k.clone(), overrides.clone()) {
+        Some(newV) => crate::aver_generated::domain::eval::records::mergeRecordFieldsAcc(
+            rest.clone(),
+            crate::aver_generated::domain::eval::records::removeOverride(k.clone(), overrides),
+            aver_rt::AverList::prepend((k, newV), &acc.clone()),
+        ),
+        None => crate::aver_generated::domain::eval::records::mergeRecordFieldsAcc(
+            rest.clone(),
+            overrides.clone(),
+            aver_rt::AverList::prepend((k, v.clone()), &acc.clone()),
+        ),
+    }
 }
 
 /// Find a field value in the overrides list.
@@ -237,5 +210,32 @@ pub fn removeOverrideAcc(
             acc = __tco2;
             continue;
         } } } })
+    }
+}
+
+/// Synthesized collecting variant of `mergeRecordFieldsAcc`. Appends to a builder where `mergeRecordFieldsAcc` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn mergeRecordFieldsAcc__collected(
+    mut existing: aver_rt::AverList<(AverStr, Val)>,
+    mut overrides: aver_rt::AverList<(AverStr, Val)>,
+    mut acc: aver_rt::AverList<(AverStr, Val)>,
+) -> aver_rt::AverList<(AverStr, Val)> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(existing, [] => { return aver_rt::AverList::concat(&aver_rt::list_builder_finalize(acc), &overrides); }, [pair, rest] => { { let (k, v) = pair; match crate::aver_generated::domain::eval::records::findOverride(k.clone(), overrides.clone()) { Some(__stp0) => { {
+            let __tco0 = rest;
+            let __tco1 = crate::aver_generated::domain::eval::records::removeOverride(k.clone(), &overrides);
+            let __tco2 = aver_rt::list_builder_push(acc, (k, __stp0));
+            existing = __tco0;
+            overrides = __tco1;
+            acc = __tco2;
+            continue;
+        } }, None => { {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::list_builder_push(acc, (k, v));
+            existing = __tco0;
+            acc = __tco2;
+            continue;
+        } } } } })
     }
 }

--- a/src/self_host/aver_generated/domain/lexer/chars/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/chars/mod.rs
@@ -8,35 +8,36 @@ use crate::*;
 pub fn isDigit(c: AverStr) -> bool {
     crate::cancel_checkpoint();
     {
-        let __dispatch_subject = c;
-        if &*__dispatch_subject == "0" {
+        let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+        if __dispatch_subject == aver_rt::AverInt::from_i64(48) {
             true
         } else {
-            if &*__dispatch_subject == "1" {
+            if __dispatch_subject == aver_rt::AverInt::from_i64(49) {
                 true
             } else {
-                if &*__dispatch_subject == "2" {
+                if __dispatch_subject == aver_rt::AverInt::from_i64(50) {
                     true
                 } else {
-                    if &*__dispatch_subject == "3" {
+                    if __dispatch_subject == aver_rt::AverInt::from_i64(51) {
                         true
                     } else {
-                        if &*__dispatch_subject == "4" {
+                        if __dispatch_subject == aver_rt::AverInt::from_i64(52) {
                             true
                         } else {
-                            if &*__dispatch_subject == "5" {
+                            if __dispatch_subject == aver_rt::AverInt::from_i64(53) {
                                 true
                             } else {
-                                if &*__dispatch_subject == "6" {
+                                if __dispatch_subject == aver_rt::AverInt::from_i64(54) {
                                     true
                                 } else {
-                                    if &*__dispatch_subject == "7" {
+                                    if __dispatch_subject == aver_rt::AverInt::from_i64(55) {
                                         true
                                     } else {
-                                        if &*__dispatch_subject == "8" {
+                                        if __dispatch_subject == aver_rt::AverInt::from_i64(56) {
                                             true
                                         } else {
-                                            if &*__dispatch_subject == "9" {
+                                            if __dispatch_subject == aver_rt::AverInt::from_i64(57)
+                                            {
                                                 true
                                             } else {
                                                 false
@@ -117,35 +118,36 @@ pub fn isAlphaNum(c: AverStr) -> bool {
 pub fn digitVal(c: AverStr) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     {
-        let __dispatch_subject = c;
-        if &*__dispatch_subject == "0" {
+        let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+        if __dispatch_subject == aver_rt::AverInt::from_i64(48) {
             aver_rt::AverInt::from_i64(0)
         } else {
-            if &*__dispatch_subject == "1" {
+            if __dispatch_subject == aver_rt::AverInt::from_i64(49) {
                 aver_rt::AverInt::from_i64(1)
             } else {
-                if &*__dispatch_subject == "2" {
+                if __dispatch_subject == aver_rt::AverInt::from_i64(50) {
                     aver_rt::AverInt::from_i64(2)
                 } else {
-                    if &*__dispatch_subject == "3" {
+                    if __dispatch_subject == aver_rt::AverInt::from_i64(51) {
                         aver_rt::AverInt::from_i64(3)
                     } else {
-                        if &*__dispatch_subject == "4" {
+                        if __dispatch_subject == aver_rt::AverInt::from_i64(52) {
                             aver_rt::AverInt::from_i64(4)
                         } else {
-                            if &*__dispatch_subject == "5" {
+                            if __dispatch_subject == aver_rt::AverInt::from_i64(53) {
                                 aver_rt::AverInt::from_i64(5)
                             } else {
-                                if &*__dispatch_subject == "6" {
+                                if __dispatch_subject == aver_rt::AverInt::from_i64(54) {
                                     aver_rt::AverInt::from_i64(6)
                                 } else {
-                                    if &*__dispatch_subject == "7" {
+                                    if __dispatch_subject == aver_rt::AverInt::from_i64(55) {
                                         aver_rt::AverInt::from_i64(7)
                                     } else {
-                                        if &*__dispatch_subject == "8" {
+                                        if __dispatch_subject == aver_rt::AverInt::from_i64(56) {
                                             aver_rt::AverInt::from_i64(8)
                                         } else {
-                                            if &*__dispatch_subject == "9" {
+                                            if __dispatch_subject == aver_rt::AverInt::from_i64(57)
+                                            {
                                                 aver_rt::AverInt::from_i64(9)
                                             } else {
                                                 aver_rt::AverInt::from_i64(0)

--- a/src/self_host/aver_generated/domain/lexer/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/mod.rs
@@ -31,15 +31,15 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> (aver_rt::AverInt, av
                 .into_aver()
                 {
                     Some(c) => {
-                        let __dispatch_subject = c;
-                        if &*__dispatch_subject == " " {
+                        let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+                        if __dispatch_subject == aver_rt::AverInt::from_i64(32) {
                             __MutualTco1::CountIndent(
                                 src,
                                 nextPos,
                                 spaces.add(&aver_rt::AverInt::from_i64(1)),
                             )
                         } else {
-                            if &*__dispatch_subject == "\n" {
+                            if __dispatch_subject == aver_rt::AverInt::from_i64(10) {
                                 __MutualTco1::CountIndent(
                                     src,
                                     nextPos,
@@ -123,21 +123,21 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                 crate::cancel_checkpoint();
                 let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
-                    let __dispatch_subject = c.clone();
-                    if &*__dispatch_subject == " " {
+                    let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+                    if __dispatch_subject == aver_rt::AverInt::from_i64(32) {
                         __MutualTco2::Tokenize(src, nextPos)
                     } else {
-                        if &*__dispatch_subject == "\n" {
+                        if __dispatch_subject == aver_rt::AverInt::from_i64(10) {
                             return crate::aver_generated::domain::lexer::tokenizeNewline(
                                 src, nextPos,
                             );
                         } else {
-                            if &*__dispatch_subject == "/" {
+                            if __dispatch_subject == aver_rt::AverInt::from_i64(47) {
                                 return crate::aver_generated::domain::lexer::tokenizeSlashOrComment(
                                     src, pos,
                                 );
                             } else {
-                                if &*__dispatch_subject == "+" {
+                                if __dispatch_subject == aver_rt::AverInt::from_i64(43) {
                                     return aver_rt::AverList::prepend(
                                         crate::aver_generated::domain::token::Token::TkPlus,
                                         &crate::aver_generated::domain::lexer::tokenize(
@@ -145,7 +145,7 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                                         ),
                                     );
                                 } else {
-                                    if &*__dispatch_subject == "*" {
+                                    if __dispatch_subject == aver_rt::AverInt::from_i64(42) {
                                         return aver_rt::AverList::prepend(
                                             crate::aver_generated::domain::token::Token::TkStar,
                                             &crate::aver_generated::domain::lexer::tokenize(
@@ -153,46 +153,43 @@ fn __mutual_tco_trampoline_2(mut __state: __MutualTco2) -> aver_rt::AverList<Tok
                                             ),
                                         );
                                     } else {
-                                        if &*__dispatch_subject == "<" {
+                                        if __dispatch_subject == aver_rt::AverInt::from_i64(60) {
                                             return crate::aver_generated::domain::lexer::tokenizeLt(
                                                 src, pos,
                                             );
                                         } else {
-                                            if &*__dispatch_subject == ">" {
+                                            if __dispatch_subject == aver_rt::AverInt::from_i64(62)
+                                            {
                                                 return crate::aver_generated::domain::lexer::tokenizeGt(src, pos);
                                             } else {
-                                                if &*__dispatch_subject == "!" {
+                                                if __dispatch_subject
+                                                    == aver_rt::AverInt::from_i64(33)
+                                                {
                                                     return crate::aver_generated::domain::lexer::tokenizeBang(src, pos);
                                                 } else {
-                                                    if &*__dispatch_subject == "?" {
+                                                    if __dispatch_subject
+                                                        == aver_rt::AverInt::from_i64(63)
+                                                    {
                                                         return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkQuestion, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                     } else {
-                                                        if &*__dispatch_subject == "\"" {
+                                                        if __dispatch_subject
+                                                            == aver_rt::AverInt::from_i64(34)
+                                                        {
                                                             return crate::aver_generated::domain::lexer::tokenizeString(src, nextPos, AverStr::from(""));
                                                         } else {
-                                                            if &*__dispatch_subject == "(" {
+                                                            if __dispatch_subject
+                                                                == aver_rt::AverInt::from_i64(40)
+                                                            {
                                                                 return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLParen, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                             } else {
-                                                                if &*__dispatch_subject == ")" {
+                                                                if __dispatch_subject
+                                                                    == aver_rt::AverInt::from_i64(
+                                                                        41,
+                                                                    )
+                                                                {
                                                                     return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRParen, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
                                                                 } else {
-                                                                    if &*__dispatch_subject == "[" {
-                                                                        return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLBracket, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
-                                                                    } else {
-                                                                        if &*__dispatch_subject
-                                                                            == "]"
-                                                                        {
-                                                                            return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRBracket, &crate::aver_generated::domain::lexer::tokenize(src, nextPos));
-                                                                        } else {
-                                                                            if &*__dispatch_subject
-                                                                                == "."
-                                                                            {
-                                                                                return crate::aver_generated::domain::lexer::tokenizeDot(src, pos);
-                                                                            } else {
-                                                                                if &*__dispatch_subject == "," { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkComma, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == ":" { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkColon, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if &*__dispatch_subject == "=" { return crate::aver_generated::domain::lexer::tokenizeEq(src, pos) } else { if &*__dispatch_subject == "-" { return crate::aver_generated::domain::lexer::tokenizeMinus(src, pos) } else { __MutualTco2::TokenizeDefault(c, src, pos) } } } }
-                                                                            }
-                                                                        }
-                                                                    }
+                                                                    if __dispatch_subject == aver_rt::AverInt::from_i64(91) { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLBracket, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if __dispatch_subject == aver_rt::AverInt::from_i64(93) { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRBracket, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if __dispatch_subject == aver_rt::AverInt::from_i64(46) { return crate::aver_generated::domain::lexer::tokenizeDot(src, pos) } else { if __dispatch_subject == aver_rt::AverInt::from_i64(44) { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkComma, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if __dispatch_subject == aver_rt::AverInt::from_i64(58) { return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkColon, &crate::aver_generated::domain::lexer::tokenize(src, nextPos)) } else { if __dispatch_subject == aver_rt::AverInt::from_i64(61) { return crate::aver_generated::domain::lexer::tokenizeEq(src, pos) } else { if __dispatch_subject == aver_rt::AverInt::from_i64(45) { return crate::aver_generated::domain::lexer::tokenizeMinus(src, pos) } else { __MutualTco2::TokenizeDefault(c, src, pos) } } } } } } }
                                                                 }
                                                             }
                                                         }
@@ -354,11 +351,11 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                 crate::cancel_checkpoint();
                 let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
-                    let __dispatch_subject = c;
-                    if &*__dispatch_subject == " " {
+                    let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+                    if __dispatch_subject == aver_rt::AverInt::from_i64(32) {
                         __MutualTco3::TokenizeInterpExpr(src, nextPos)
                     } else {
-                        if &*__dispatch_subject == "(" {
+                        if __dispatch_subject == aver_rt::AverInt::from_i64(40) {
                             return aver_rt::AverList::prepend(
                                 crate::aver_generated::domain::token::Token::TkLParen,
                                 &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
@@ -366,7 +363,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                                 ),
                             );
                         } else {
-                            if &*__dispatch_subject == ")" {
+                            if __dispatch_subject == aver_rt::AverInt::from_i64(41) {
                                 return aver_rt::AverList::prepend(
                                     crate::aver_generated::domain::token::Token::TkRParen,
                                     &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
@@ -374,7 +371,7 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                                     ),
                                 );
                             } else {
-                                if &*__dispatch_subject == "+" {
+                                if __dispatch_subject == aver_rt::AverInt::from_i64(43) {
                                     return aver_rt::AverList::prepend(
                                         crate::aver_generated::domain::token::Token::TkPlus,
                                         &crate::aver_generated::domain::lexer::tokenizeInterpExpr(
@@ -382,25 +379,34 @@ fn __mutual_tco_trampoline_3(mut __state: __MutualTco3) -> aver_rt::AverList<Tok
                                         ),
                                     );
                                 } else {
-                                    if &*__dispatch_subject == "-" {
+                                    if __dispatch_subject == aver_rt::AverInt::from_i64(45) {
                                         return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkMinus, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                     } else {
-                                        if &*__dispatch_subject == "*" {
+                                        if __dispatch_subject == aver_rt::AverInt::from_i64(42) {
                                             return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkStar, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                         } else {
-                                            if &*__dispatch_subject == "," {
+                                            if __dispatch_subject == aver_rt::AverInt::from_i64(44)
+                                            {
                                                 return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkComma, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                             } else {
-                                                if &*__dispatch_subject == "." {
+                                                if __dispatch_subject
+                                                    == aver_rt::AverInt::from_i64(46)
+                                                {
                                                     return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkDot, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                 } else {
-                                                    if &*__dispatch_subject == "[" {
+                                                    if __dispatch_subject
+                                                        == aver_rt::AverInt::from_i64(91)
+                                                    {
                                                         return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkLBracket, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                     } else {
-                                                        if &*__dispatch_subject == "]" {
+                                                        if __dispatch_subject
+                                                            == aver_rt::AverInt::from_i64(93)
+                                                        {
                                                             return aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkRBracket, &crate::aver_generated::domain::lexer::tokenizeInterpExpr(src, nextPos));
                                                         } else {
-                                                            if &*__dispatch_subject == "\"" {
+                                                            if __dispatch_subject
+                                                                == aver_rt::AverInt::from_i64(34)
+                                                            {
                                                                 return crate::aver_generated::domain::lexer::tokenizeInterpString(src, nextPos, AverStr::from(""));
                                                             } else {
                                                                 __MutualTco3::TokenizeInterpExpr(
@@ -556,46 +562,49 @@ fn __mutual_tco_trampoline_4(mut __state: __MutualTco4) -> aver_rt::AverList<Tok
                 .into_aver()
                 {
                     Some(c) => {
-                        let __dispatch_subject = c.clone();
-                        if &*__dispatch_subject == "n" {
+                        let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+                        if __dispatch_subject == aver_rt::AverInt::from_i64(110) {
                             __MutualTco4::TokenizeString(src, nextPos, (acc + &AverStr::from("\n")))
                         } else {
-                            if &*__dispatch_subject == "t" {
+                            if __dispatch_subject == aver_rt::AverInt::from_i64(116) {
                                 __MutualTco4::TokenizeString(
                                     src,
                                     nextPos,
                                     (acc + &AverStr::from("\t")),
                                 )
                             } else {
-                                if &*__dispatch_subject == "r" {
+                                if __dispatch_subject == aver_rt::AverInt::from_i64(114) {
                                     __MutualTco4::TokenizeString(
                                         src,
                                         nextPos,
                                         (acc + &AverStr::from("\r")),
                                     )
                                 } else {
-                                    if &*__dispatch_subject == "b" {
+                                    if __dispatch_subject == aver_rt::AverInt::from_i64(98) {
                                         __MutualTco4::TokenizeString(
                                             src,
                                             nextPos,
                                             (acc + &AverStr::from("\u{8}")),
                                         )
                                     } else {
-                                        if &*__dispatch_subject == "f" {
+                                        if __dispatch_subject == aver_rt::AverInt::from_i64(102) {
                                             __MutualTco4::TokenizeString(
                                                 src,
                                                 nextPos,
                                                 (acc + &AverStr::from("\u{c}")),
                                             )
                                         } else {
-                                            if &*__dispatch_subject == "\"" {
+                                            if __dispatch_subject == aver_rt::AverInt::from_i64(34)
+                                            {
                                                 __MutualTco4::TokenizeString(
                                                     src,
                                                     nextPos,
                                                     (acc + &AverStr::from("\"")),
                                                 )
                                             } else {
-                                                if &*__dispatch_subject == "\\" {
+                                                if __dispatch_subject
+                                                    == aver_rt::AverInt::from_i64(92)
+                                                {
                                                     __MutualTco4::TokenizeString(
                                                         src,
                                                         nextPos,
@@ -1408,14 +1417,14 @@ pub fn tokenizeEq(src: AverStr, pos: aver_rt::AverInt) -> aver_rt::AverList<Toke
     .into_aver()
     {
         Some(c) => {
-            let __dispatch_subject = c;
-            if &*__dispatch_subject == "=" {
+            let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
+            if __dispatch_subject == aver_rt::AverInt::from_i64(61) {
                 aver_rt::AverList::prepend(
                     crate::aver_generated::domain::token::Token::TkEqEq,
                     &crate::aver_generated::domain::lexer::tokenize(src, pos2),
                 )
             } else {
-                if &*__dispatch_subject == ">" {
+                if __dispatch_subject == aver_rt::AverInt::from_i64(62) {
                     aver_rt::AverList::prepend(
                         crate::aver_generated::domain::token::Token::TkFatArrow,
                         &crate::aver_generated::domain::lexer::tokenize(src, pos2),

--- a/src/self_host/aver_generated/domain/resolver/calls/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/calls/mod.rs
@@ -51,10 +51,10 @@ pub fn resolveCallsInFn(fd: &FnDef, fnMap: &aver_rt::AverMap<AverStr, aver_rt::A
     crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
-        body: crate::aver_generated::domain::resolver::calls::resolveCallsInStmts(
+        body: crate::aver_generated::domain::resolver::calls::resolveCallsInStmts__collected(
             fd.body.clone(),
             fnMap.clone(),
-            aver_rt::AverList::empty(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
         ),
         slotCount: fd.slotCount.clone(),
         slotMap: fd.slotMap.clone(),
@@ -143,10 +143,12 @@ pub fn resolveCallsInExpr(
         crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallDirect(
                 fnId,
-                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                     args,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -154,18 +156,22 @@ pub fn resolveCallsInExpr(
             match crate::aver_generated::domain::ast::builtinNameToId(name.clone()) {
                 Some(id) => crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
                     id,
-                    crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                         args,
                         fnMap.clone(),
-                        aver_rt::AverList::empty(),
+                        aver_rt::list_builder_new(
+                            (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                        ),
                     ),
                 ),
                 None => crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                     name,
-                    crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                    crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                         args,
                         fnMap.clone(),
-                        aver_rt::AverList::empty(),
+                        aver_rt::list_builder_new(
+                            (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                        ),
                     ),
                 ),
             }
@@ -173,10 +179,12 @@ pub fn resolveCallsInExpr(
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
                 id,
-                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                     args,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -376,10 +384,12 @@ pub fn resolveCallsInExprTail(
                         &subj, fnMap,
                     ),
                 ),
-                crate::aver_generated::domain::resolver::calls::resolveCallsInArms(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInArms__collected(
                     arms,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -391,48 +401,58 @@ pub fn resolveCallsInExprTail(
         }
         crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
             crate::aver_generated::domain::ast::Expr::ExprConcat(
-                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                     parts,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
             crate::aver_generated::domain::ast::Expr::ExprTuple(
-                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                     exprs,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
             crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
-                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                     exprs,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
                 unwrap,
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
             crate::aver_generated::domain::ast::Expr::ExprList(
-                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
                     exprs,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
             crate::aver_generated::domain::ast::Expr::ExprRecord(
                 name,
-                crate::aver_generated::domain::resolver::calls::resolveCallsInFields(
+                crate::aver_generated::domain::resolver::calls::resolveCallsInFields__collected(
                     fields,
                     fnMap.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -457,11 +477,12 @@ pub fn resolveOneCall(
     fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> Expr {
     crate::cancel_checkpoint();
-    let resolvedArgs = crate::aver_generated::domain::resolver::calls::resolveCallsInExprs(
-        args.clone(),
-        fnMap.clone(),
-        aver_rt::AverList::empty(),
-    );
+    let resolvedArgs =
+        crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
+            args.clone(),
+            fnMap.clone(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
+        );
     match fnMap.get(&name).cloned() {
         Some(fnId) => crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, resolvedArgs),
         None => {
@@ -769,6 +790,90 @@ pub fn resolveCallsInFields(
             let __tco0 = rest;
             let __tco1 = fnMap.clone();
             let __tco2 = aver_rt::AverList::prepend((name, crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, &fnMap)), &acc);
+            fields = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
+            continue;
+        } } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveCallsInStmts`. Appends to a builder where `resolveCallsInStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveCallsInStmts__collected(
+    mut stmts: aver_rt::AverList<Stmt>,
+    mut fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<Stmt>,
+) -> aver_rt::AverList<Stmt> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(stmts, [] => { return aver_rt::list_builder_finalize(acc); }, [s, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::resolver::calls::resolveCallsInStmt(&s, &fnMap));
+            stmts = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveCallsInExprs`. Appends to a builder where `resolveCallsInExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveCallsInExprs__collected(
+    mut exprs: aver_rt::AverList<Expr>,
+    mut fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<Expr>,
+) -> aver_rt::AverList<Expr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(exprs, [] => { return aver_rt::list_builder_finalize(acc); }, [e, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&e, &fnMap));
+            exprs = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveCallsInArms`. Appends to a builder where `resolveCallsInArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveCallsInArms__collected(
+    mut arms: aver_rt::AverList<MatchArm>,
+    mut fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<MatchArm>,
+) -> aver_rt::AverList<MatchArm> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(arms, [] => { return aver_rt::list_builder_finalize(acc); }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::ast::MatchArm { pattern: arm.pattern.clone(), body: crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&arm.body, &fnMap), bindingSlots: arm.bindingSlots.clone() });
+            arms = __tco0;
+            fnMap = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveCallsInFields`. Appends to a builder where `resolveCallsInFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveCallsInFields__collected(
+    mut fields: aver_rt::AverList<(AverStr, Expr)>,
+    mut fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<(AverStr, Expr)>,
+) -> aver_rt::AverList<(AverStr, Expr)> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(fields, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = fnMap.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, (name, crate::aver_generated::domain::resolver::calls::resolveCallsInExpr(&expr, &fnMap)));
             fields = __tco0;
             fnMap = __tco1;
             acc = __tco2;

--- a/src/self_host/aver_generated/domain/resolver/core/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/core/mod.rs
@@ -240,321 +240,6 @@ pub fn maxSlotInExprPair(a: &Expr, b: &Expr, acc: aver_rt::AverInt) -> aver_rt::
     __mutual_tco_trampoline_1(__MutualTco1::MaxSlotInExprPair(a.clone(), b.clone(), acc))
 }
 
-#[allow(non_camel_case_types)]
-enum __MutualTco2 {
-    ResolveArms(
-        aver_rt::AverList<MatchArm>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverList<MatchArm>,
-    ),
-    ResolveOneArm(
-        MatchArm,
-        aver_rt::AverList<MatchArm>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverList<MatchArm>,
-    ),
-}
-
-fn __mutual_tco_trampoline_2(
-    mut __state: __MutualTco2,
-) -> (
-    aver_rt::AverList<MatchArm>,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    loop {
-        __state = match __state {
-            __MutualTco2::ResolveArms(mut arms, mut slots, mut acc) => {
-                crate::cancel_checkpoint();
-                aver_list_match!(arms, [] => { return (acc.reverse(), slots) }, [arm, rest] => __MutualTco2::ResolveOneArm(arm, rest, slots, acc))
-            }
-            __MutualTco2::ResolveOneArm(mut arm, mut rest, mut slots, mut acc) => {
-                crate::cancel_checkpoint();
-                {
-                    let (resolvedArm, mergedSlots) =
-                        crate::aver_generated::domain::resolver::core::resolveArm(&arm, &slots);
-                    __MutualTco2::ResolveArms(
-                        rest,
-                        mergedSlots,
-                        aver_rt::AverList::prepend(resolvedArm, &acc),
-                    )
-                }
-            }
-        };
-    }
-}
-
-/// Resolve match arms, collecting all pattern slots.
-pub fn resolveArms(
-    arms: &aver_rt::AverList<MatchArm>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    acc: &aver_rt::AverList<MatchArm>,
-) -> (
-    aver_rt::AverList<MatchArm>,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_2(__MutualTco2::ResolveArms(
-        arms.clone(),
-        slots.clone(),
-        acc.clone(),
-    ))
-}
-
-/// Resolve one match arm and continue.
-pub fn resolveOneArm(
-    arm: &MatchArm,
-    rest: &aver_rt::AverList<MatchArm>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    acc: &aver_rt::AverList<MatchArm>,
-) -> (
-    aver_rt::AverList<MatchArm>,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_2(__MutualTco2::ResolveOneArm(
-        arm.clone(),
-        rest.clone(),
-        slots.clone(),
-        acc.clone(),
-    ))
-}
-
-#[allow(non_camel_case_types)]
-enum __MutualTco3 {
-    ResolveStmts(
-        aver_rt::AverList<Stmt>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverInt,
-        aver_rt::AverList<Stmt>,
-    ),
-    ResolveOneStmt(
-        Stmt,
-        aver_rt::AverList<Stmt>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverInt,
-        aver_rt::AverList<Stmt>,
-    ),
-    ResolveStmtExpr(
-        Expr,
-        aver_rt::AverList<Stmt>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverInt,
-        aver_rt::AverList<Stmt>,
-    ),
-    ResolveStmtBind(
-        AverStr,
-        Expr,
-        aver_rt::AverList<Stmt>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverInt,
-        aver_rt::AverList<Stmt>,
-    ),
-    ResolveStmtBindFinish(
-        AverStr,
-        Expr,
-        aver_rt::AverList<Stmt>,
-        aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-        aver_rt::AverInt,
-        aver_rt::AverList<Stmt>,
-    ),
-}
-
-fn __mutual_tco_trampoline_3(
-    mut __state: __MutualTco3,
-) -> (
-    aver_rt::AverList<Stmt>,
-    aver_rt::AverInt,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    loop {
-        __state = match __state {
-            __MutualTco3::ResolveStmts(mut stmts, mut slots, mut next, mut acc) => {
-                crate::cancel_checkpoint();
-                aver_list_match!(stmts, [] => { return (acc.reverse(), next, slots) }, [s, rest] => __MutualTco3::ResolveOneStmt(s, rest, slots, next, acc))
-            }
-            __MutualTco3::ResolveOneStmt(mut s, mut rest, mut slots, mut next, mut acc) => {
-                crate::cancel_checkpoint();
-                match s.clone() {
-                    crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr) => {
-                        __MutualTco3::ResolveStmtBind(name, expr, rest, slots, next, acc)
-                    }
-                    crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
-                        __MutualTco3::ResolveStmtExpr(expr, rest, slots, next, acc)
-                    }
-                    crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, _) => {
-                        __MutualTco3::ResolveStmts(
-                            rest,
-                            slots,
-                            next,
-                            aver_rt::AverList::prepend(s, &acc),
-                        )
-                    }
-                }
-            }
-            __MutualTco3::ResolveStmtExpr(mut expr, mut rest, mut slots, mut next, mut acc) => {
-                crate::cancel_checkpoint();
-                {
-                    let (re, newSlots) =
-                        crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots);
-                    __MutualTco3::ResolveStmts(
-                        rest,
-                        newSlots.clone(),
-                        crate::aver_generated::domain::resolver::core::maxInt(
-                            next,
-                            crate::aver_generated::domain::resolver::core::mapMaxVal(&newSlots)
-                                .add(&aver_rt::AverInt::from_i64(1)),
-                        ),
-                        aver_rt::AverList::prepend(
-                            crate::aver_generated::domain::ast::Stmt::StmtExpr(re),
-                            &acc,
-                        ),
-                    )
-                }
-            }
-            __MutualTco3::ResolveStmtBind(
-                mut name,
-                mut expr,
-                mut rest,
-                mut slots,
-                mut next,
-                mut acc,
-            ) => {
-                crate::cancel_checkpoint();
-                {
-                    let (newExpr, exprSlots) =
-                        crate::aver_generated::domain::resolver::core::resolveExpr(&expr, &slots);
-                    __MutualTco3::ResolveStmtBindFinish(name, newExpr, rest, exprSlots, next, acc)
-                }
-            }
-            __MutualTco3::ResolveStmtBindFinish(
-                mut name,
-                mut newExpr,
-                mut rest,
-                mut slots,
-                mut next,
-                mut acc,
-            ) => {
-                crate::cancel_checkpoint();
-                let newSlots = slots.insert_owned(name, next.clone());
-                __MutualTco3::ResolveStmts(
-                    rest,
-                    newSlots,
-                    next.add(&aver_rt::AverInt::from_i64(1)),
-                    aver_rt::AverList::prepend(
-                        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(next, newExpr),
-                        &acc,
-                    ),
-                )
-            }
-        };
-    }
-}
-
-/// Resolve statements, threading slot assignments.
-pub fn resolveStmts(
-    stmts: &aver_rt::AverList<Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<Stmt>,
-) -> (
-    aver_rt::AverList<Stmt>,
-    aver_rt::AverInt,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_3(__MutualTco3::ResolveStmts(
-        stmts.clone(),
-        slots.clone(),
-        next,
-        acc.clone(),
-    ))
-}
-
-/// Resolve a single statement and continue.
-pub fn resolveOneStmt(
-    s: &Stmt,
-    rest: &aver_rt::AverList<Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<Stmt>,
-) -> (
-    aver_rt::AverList<Stmt>,
-    aver_rt::AverInt,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_3(__MutualTco3::ResolveOneStmt(
-        s.clone(),
-        rest.clone(),
-        slots.clone(),
-        next,
-        acc.clone(),
-    ))
-}
-
-/// Resolve an expression statement, collecting pattern slots.
-pub fn resolveStmtExpr(
-    expr: &Expr,
-    rest: &aver_rt::AverList<Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<Stmt>,
-) -> (
-    aver_rt::AverList<Stmt>,
-    aver_rt::AverInt,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_3(__MutualTco3::ResolveStmtExpr(
-        expr.clone(),
-        rest.clone(),
-        slots.clone(),
-        next,
-        acc.clone(),
-    ))
-}
-
-/// Resolve a binding: assign a new slot, replace with StmtBindSlot.
-pub fn resolveStmtBind(
-    name: AverStr,
-    expr: &Expr,
-    rest: &aver_rt::AverList<Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<Stmt>,
-) -> (
-    aver_rt::AverList<Stmt>,
-    aver_rt::AverInt,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_3(__MutualTco3::ResolveStmtBind(
-        name,
-        expr.clone(),
-        rest.clone(),
-        slots.clone(),
-        next,
-        acc.clone(),
-    ))
-}
-
-/// Finish resolving a binding after expr is resolved.
-pub fn resolveStmtBindFinish(
-    name: AverStr,
-    newExpr: &Expr,
-    rest: &aver_rt::AverList<Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<Stmt>,
-) -> (
-    aver_rt::AverList<Stmt>,
-    aver_rt::AverInt,
-    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-) {
-    __mutual_tco_trampoline_3(__MutualTco3::ResolveStmtBindFinish(
-        name,
-        newExpr.clone(),
-        rest.clone(),
-        slots.clone(),
-        next,
-        acc.clone(),
-    ))
-}
-
 /// Resolve each function definition.
 #[inline(always)]
 pub fn resolveFns(
@@ -618,11 +303,11 @@ pub fn resolveBody(
     nextSlot: aver_rt::AverInt,
 ) -> FnDef {
     crate::cancel_checkpoint();
-    let resolved = crate::aver_generated::domain::resolver::core::resolveStmts(
-        &fd.body,
-        slots,
+    let resolved = crate::aver_generated::domain::resolver::core::resolveStmts__collected(
+        fd.body.clone(),
+        slots.clone(),
         nextSlot,
-        &aver_rt::AverList::empty(),
+        aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     );
     {
         let (newBody, finalSlot, finalSlotMap) = resolved;
@@ -754,6 +439,176 @@ pub fn maxSlotInArms(
 pub fn maxInt(a: aver_rt::AverInt, b: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     if (a > b) { a } else { b }
+}
+
+/// Resolve statements, threading slot assignments.
+#[inline(always)]
+pub fn resolveStmts(
+    mut stmts: aver_rt::AverList<Stmt>,
+    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<Stmt>,
+) -> (
+    aver_rt::AverList<Stmt>,
+    aver_rt::AverInt,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(stmts, [] => { return (acc.reverse(), next, slots); }, [s, rest] => { match s.clone() {
+        crate::aver_generated::domain::ast::Stmt::StmtBind(__stp1, __stp0) => {
+            { let (__stp3, __stp2) = crate::aver_generated::domain::resolver::core::resolveExpr(&__stp0, &slots); { let __stp4 = __stp2.insert_owned(__stp1, next.clone()); {
+            let __tco0 = rest;
+            let __tco1 = __stp4;
+            let __tco2 = next.add(&aver_rt::AverInt::from_i64(1));
+            let __tco3 = aver_rt::AverList::prepend(crate::aver_generated::domain::ast::Stmt::StmtBindSlot(next, __stp3), &acc);
+            stmts = __tco0;
+            slots = __tco1;
+            next = __tco2;
+            acc = __tco3;
+            continue;
+        } } }
+        },
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(__stp0) => {
+            { let (__stp6, __stp5) = crate::aver_generated::domain::resolver::core::resolveExpr(&__stp0, &slots); {
+            let __tco0 = rest;
+            let __tco1 = __stp5.clone();
+            let __tco2 = crate::aver_generated::domain::resolver::core::maxInt(next, crate::aver_generated::domain::resolver::core::mapMaxVal(&__stp5).add(&aver_rt::AverInt::from_i64(1)));
+            let __tco3 = aver_rt::AverList::prepend(crate::aver_generated::domain::ast::Stmt::StmtExpr(__stp6), &acc);
+            stmts = __tco0;
+            slots = __tco1;
+            next = __tco2;
+            acc = __tco3;
+            continue;
+        } }
+        },
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, _) => {
+            {
+            let __tco0 = rest;
+            let __tco3 = aver_rt::AverList::prepend(s, &acc);
+            stmts = __tco0;
+            acc = __tco3;
+            continue;
+        }
+        }
+    } })
+    }
+}
+
+/// Resolve a single statement and continue.
+pub fn resolveOneStmt(
+    s: &Stmt,
+    rest: &aver_rt::AverList<Stmt>,
+    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next: aver_rt::AverInt,
+    acc: &aver_rt::AverList<Stmt>,
+) -> (
+    aver_rt::AverList<Stmt>,
+    aver_rt::AverInt,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    crate::cancel_checkpoint();
+    match s.clone() {
+        crate::aver_generated::domain::ast::Stmt::StmtBind(name, expr) => {
+            crate::aver_generated::domain::resolver::core::resolveStmtBind(
+                name, &expr, rest, slots, next, acc,
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(expr) => {
+            crate::aver_generated::domain::resolver::core::resolveStmtExpr(
+                &expr, rest, slots, next, acc,
+            )
+        }
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, _) => {
+            crate::aver_generated::domain::resolver::core::resolveStmts(
+                rest.clone(),
+                slots.clone(),
+                next,
+                aver_rt::AverList::prepend(s.clone(), &acc.clone()),
+            )
+        }
+    }
+}
+
+/// Resolve an expression statement, collecting pattern slots.
+pub fn resolveStmtExpr(
+    expr: &Expr,
+    rest: &aver_rt::AverList<Stmt>,
+    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next: aver_rt::AverInt,
+    acc: &aver_rt::AverList<Stmt>,
+) -> (
+    aver_rt::AverList<Stmt>,
+    aver_rt::AverInt,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    crate::cancel_checkpoint();
+    {
+        let (re, newSlots) =
+            crate::aver_generated::domain::resolver::core::resolveExpr(expr, slots);
+        crate::aver_generated::domain::resolver::core::resolveStmts(
+            rest.clone(),
+            newSlots.clone(),
+            crate::aver_generated::domain::resolver::core::maxInt(
+                next,
+                crate::aver_generated::domain::resolver::core::mapMaxVal(&newSlots)
+                    .add(&aver_rt::AverInt::from_i64(1)),
+            ),
+            aver_rt::AverList::prepend(
+                crate::aver_generated::domain::ast::Stmt::StmtExpr(re),
+                &acc.clone(),
+            ),
+        )
+    }
+}
+
+/// Resolve a binding: assign a new slot, replace with StmtBindSlot.
+pub fn resolveStmtBind(
+    name: AverStr,
+    expr: &Expr,
+    rest: &aver_rt::AverList<Stmt>,
+    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next: aver_rt::AverInt,
+    acc: &aver_rt::AverList<Stmt>,
+) -> (
+    aver_rt::AverList<Stmt>,
+    aver_rt::AverInt,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    crate::cancel_checkpoint();
+    {
+        let (newExpr, exprSlots) =
+            crate::aver_generated::domain::resolver::core::resolveExpr(expr, slots);
+        crate::aver_generated::domain::resolver::core::resolveStmtBindFinish(
+            name, &newExpr, rest, &exprSlots, next, acc,
+        )
+    }
+}
+
+/// Finish resolving a binding after expr is resolved.
+pub fn resolveStmtBindFinish(
+    name: AverStr,
+    newExpr: &Expr,
+    rest: &aver_rt::AverList<Stmt>,
+    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next: aver_rt::AverInt,
+    acc: &aver_rt::AverList<Stmt>,
+) -> (
+    aver_rt::AverList<Stmt>,
+    aver_rt::AverInt,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    crate::cancel_checkpoint();
+    let newSlots = slots.clone().insert_owned(name, next.clone());
+    crate::aver_generated::domain::resolver::core::resolveStmts(
+        rest.clone(),
+        newSlots,
+        next.add(&aver_rt::AverInt::from_i64(1)),
+        aver_rt::AverList::prepend(
+            crate::aver_generated::domain::ast::Stmt::StmtBindSlot(next, newExpr.clone()),
+            &acc.clone(),
+        ),
+    )
 }
 
 /// Resolve an expression. Returns (resolved expr, slots with any new pattern bindings).
@@ -986,10 +841,12 @@ pub fn resolveExprAfterArith(
         crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => (
             crate::aver_generated::domain::ast::Expr::ExprCallDirect(
                 fnId,
-                crate::aver_generated::domain::resolver::core::resolveExprs(
+                crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                     args,
                     slots.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             ),
             slots.clone(),
@@ -997,10 +854,12 @@ pub fn resolveExprAfterArith(
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => (
             crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 name,
-                crate::aver_generated::domain::resolver::core::resolveExprs(
+                crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                     args,
                     slots.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             ),
             slots.clone(),
@@ -1008,10 +867,12 @@ pub fn resolveExprAfterArith(
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => (
             crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
                 id,
-                crate::aver_generated::domain::resolver::core::resolveExprs(
+                crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                     args,
                     slots.clone(),
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             ),
             slots.clone(),
@@ -1190,10 +1051,10 @@ pub fn resolveCallExpr(
     (
         crate::aver_generated::domain::ast::Expr::ExprCall(
             name,
-            crate::aver_generated::domain::resolver::core::resolveExprs(
+            crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                 args.clone(),
                 slots.clone(),
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ),
         ),
         slots.clone(),
@@ -1208,10 +1069,10 @@ pub fn resolveMatchExpr(
 ) -> (Expr, aver_rt::AverMap<AverStr, aver_rt::AverInt>) {
     crate::cancel_checkpoint();
     let rs = crate::aver_generated::domain::resolver::core::resolveExprSimple(subj, slots);
-    let armsResult = crate::aver_generated::domain::resolver::core::resolveArms(
-        arms,
-        slots,
-        &aver_rt::AverList::empty(),
+    let armsResult = crate::aver_generated::domain::resolver::core::resolveArms__collected(
+        arms.clone(),
+        slots.clone(),
+        aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     );
     {
         let (resolvedArms, mergedSlots) = armsResult;
@@ -1247,10 +1108,10 @@ pub fn resolveConcatExpr(
     crate::cancel_checkpoint();
     (
         crate::aver_generated::domain::ast::Expr::ExprConcat(
-            crate::aver_generated::domain::resolver::core::resolveExprs(
+            crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                 parts.clone(),
                 slots.clone(),
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ),
         ),
         slots.clone(),
@@ -1265,10 +1126,10 @@ pub fn resolveTupleExpr(
     crate::cancel_checkpoint();
     (
         crate::aver_generated::domain::ast::Expr::ExprTuple(
-            crate::aver_generated::domain::resolver::core::resolveExprs(
+            crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                 exprs.clone(),
                 slots.clone(),
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ),
         ),
         slots.clone(),
@@ -1284,10 +1145,10 @@ pub fn resolveIndependentProductExpr(
     crate::cancel_checkpoint();
     (
         crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
-            crate::aver_generated::domain::resolver::core::resolveExprs(
+            crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                 exprs.clone(),
                 slots.clone(),
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ),
             unwrap,
         ),
@@ -1303,10 +1164,10 @@ pub fn resolveListExpr(
     crate::cancel_checkpoint();
     (
         crate::aver_generated::domain::ast::Expr::ExprList(
-            crate::aver_generated::domain::resolver::core::resolveExprs(
+            crate::aver_generated::domain::resolver::core::resolveExprs__collected(
                 exprs.clone(),
                 slots.clone(),
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ),
         ),
         slots.clone(),
@@ -1323,10 +1184,10 @@ pub fn resolveRecordExpr(
     (
         crate::aver_generated::domain::ast::Expr::ExprRecord(
             name,
-            crate::aver_generated::domain::resolver::core::resolveFields(
+            crate::aver_generated::domain::resolver::core::resolveFields__collected(
                 fields.clone(),
                 slots.clone(),
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ),
         ),
         slots.clone(),
@@ -1400,6 +1261,50 @@ pub fn resolveFields(
             acc = __tco2;
             continue;
         } } })
+    }
+}
+
+/// Resolve match arms, collecting all pattern slots.
+#[inline(always)]
+pub fn resolveArms(
+    mut arms: aver_rt::AverList<MatchArm>,
+    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<MatchArm>,
+) -> (
+    aver_rt::AverList<MatchArm>,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(arms, [] => { return (acc.reverse(), slots); }, [arm, rest] => { { let (__stp0, _) = crate::aver_generated::domain::resolver::core::resolveArm(&arm, &slots); {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::AverList::prepend(__stp0, &acc);
+            arms = __tco0;
+            acc = __tco2;
+            continue;
+        } } })
+    }
+}
+
+/// Resolve one match arm; continue with the ORIGINAL slots, since an arm's pattern binders are scoped to its own body. Threading the arm-extended map onward leaked binder slots into later arms and past the match, where a wrapping binding aliased them and shadowed names resolved wrong.
+pub fn resolveOneArm(
+    arm: &MatchArm,
+    rest: &aver_rt::AverList<MatchArm>,
+    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    acc: &aver_rt::AverList<MatchArm>,
+) -> (
+    aver_rt::AverList<MatchArm>,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    crate::cancel_checkpoint();
+    {
+        let (resolvedArm, _) =
+            crate::aver_generated::domain::resolver::core::resolveArm(arm, slots);
+        crate::aver_generated::domain::resolver::core::resolveArms(
+            rest.clone(),
+            slots.clone(),
+            aver_rt::AverList::prepend(resolvedArm, &acc.clone()),
+        )
     }
 }
 
@@ -1730,6 +1635,124 @@ pub fn addTuplePatternSlots(
             pats = __tco0;
             slots = __tco1;
             next = __tco2;
+            continue;
+        } } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveStmts`. Appends to a builder where `resolveStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveStmts__collected(
+    mut stmts: aver_rt::AverList<Stmt>,
+    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<Stmt>,
+) -> (
+    aver_rt::AverList<Stmt>,
+    aver_rt::AverInt,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(stmts, [] => { return (aver_rt::list_builder_finalize(acc), next, slots); }, [s, rest] => { match s.clone() {
+        crate::aver_generated::domain::ast::Stmt::StmtBind(__stp1, __stp0) => {
+            { let (__stp3, __stp2) = crate::aver_generated::domain::resolver::core::resolveExpr(&__stp0, &slots); { let __stp4 = __stp2.insert_owned(__stp1, next.clone()); {
+            let __tco0 = rest;
+            let __tco1 = __stp4;
+            let __tco2 = next.add(&aver_rt::AverInt::from_i64(1));
+            let __tco3 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::ast::Stmt::StmtBindSlot(next, __stp3));
+            stmts = __tco0;
+            slots = __tco1;
+            next = __tco2;
+            acc = __tco3;
+            continue;
+        } } }
+        },
+        crate::aver_generated::domain::ast::Stmt::StmtExpr(__stp0) => {
+            { let (__stp6, __stp5) = crate::aver_generated::domain::resolver::core::resolveExpr(&__stp0, &slots); {
+            let __tco0 = rest;
+            let __tco1 = __stp5.clone();
+            let __tco2 = crate::aver_generated::domain::resolver::core::maxInt(next, crate::aver_generated::domain::resolver::core::mapMaxVal(&__stp5).add(&aver_rt::AverInt::from_i64(1)));
+            let __tco3 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::ast::Stmt::StmtExpr(__stp6));
+            stmts = __tco0;
+            slots = __tco1;
+            next = __tco2;
+            acc = __tco3;
+            continue;
+        } }
+        },
+        crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, _) => {
+            {
+            let __tco0 = rest;
+            let __tco3 = aver_rt::list_builder_push(acc, s);
+            stmts = __tco0;
+            acc = __tco3;
+            continue;
+        }
+        }
+    } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveExprs`. Appends to a builder where `resolveExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveExprs__collected(
+    mut exprs: aver_rt::AverList<Expr>,
+    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<Expr>,
+) -> aver_rt::AverList<Expr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(exprs, [] => { return aver_rt::list_builder_finalize(acc); }, [e, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = slots.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::resolver::core::resolveExprSimple(&e, &slots));
+            exprs = __tco0;
+            slots = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveFields`. Appends to a builder where `resolveFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveFields__collected(
+    mut fields: aver_rt::AverList<(AverStr, Expr)>,
+    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<(AverStr, Expr)>,
+) -> aver_rt::AverList<(AverStr, Expr)> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(fields, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = slots.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, (name, crate::aver_generated::domain::resolver::core::resolveExprSimple(&expr, &slots)));
+            fields = __tco0;
+            slots = __tco1;
+            acc = __tco2;
+            continue;
+        } } })
+    }
+}
+
+/// Synthesized collecting variant of `resolveArms`. Appends to a builder where `resolveArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn resolveArms__collected(
+    mut arms: aver_rt::AverList<MatchArm>,
+    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc: aver_rt::AverList<MatchArm>,
+) -> (
+    aver_rt::AverList<MatchArm>,
+    aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+) {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(arms, [] => { return (aver_rt::list_builder_finalize(acc), slots); }, [arm, rest] => { { let (__stp0, _) = crate::aver_generated::domain::resolver::core::resolveArm(&arm, &slots); {
+            let __tco0 = rest;
+            let __tco2 = aver_rt::list_builder_push(acc, __stp0);
+            arms = __tco0;
+            acc = __tco2;
             continue;
         } } })
     }

--- a/src/self_host/aver_generated/domain/resolver/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/fast/mod.rs
@@ -896,9 +896,9 @@ pub fn classifyFastForwardCall(
     args: &aver_rt::AverList<Expr>,
 ) -> FnFastPath {
     crate::cancel_checkpoint();
-    match crate::aver_generated::domain::resolver::fast::classifyFastForwardSlots(
+    match crate::aver_generated::domain::resolver::fast::classifyFastForwardSlots__collected(
         args.clone(),
-        aver_rt::AverList::empty(),
+        aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     ) {
         Some(slotArgs) => {
             crate::aver_generated::domain::ast::FnFastPath::FastForwardCall(fnId, slotArgs)
@@ -1144,5 +1144,30 @@ pub fn classifyFastLtScrutinee(
             _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
         },
         _ => crate::aver_generated::domain::ast::FnFastPath::FastSingleExpr,
+    }
+}
+
+/// Synthesized collecting variant of `classifyFastForwardSlots`. Appends to a builder where `classifyFastForwardSlots` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn classifyFastForwardSlots__collected(
+    mut args: aver_rt::AverList<Expr>,
+    mut acc: aver_rt::AverList<aver_rt::AverInt>,
+) -> Option<aver_rt::AverList<aver_rt::AverInt>> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(args, [] => { return Some(aver_rt::list_builder_finalize(acc)); }, [arg, rest] => { match arg {
+        crate::aver_generated::domain::ast::Expr::ExprSlot(slot) => {
+            {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, slot);
+            args = __tco0;
+            acc = __tco1;
+            continue;
+        }
+        },
+        _ => {
+            return None;
+        }
+    } })
     }
 }

--- a/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
@@ -27,9 +27,9 @@ pub fn rewriteInternalFn(fd: &FnDef) -> FnDef {
     crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
-        body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmts(
+        body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmts__collected(
             fd.body.clone(),
-            aver_rt::AverList::empty(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
         ),
         slotCount: fd.slotCount.clone(),
         slotMap: fd.slotMap.clone(),
@@ -254,9 +254,11 @@ pub fn rewriteInternalExprAfterArith(expr: &Expr) -> Expr {
             let scrutinee = (*scrutinee).clone();
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalMatch(
                 &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&scrutinee),
-                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalArms(
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalArms__collected(
                     arms,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -268,43 +270,53 @@ pub fn rewriteInternalExprAfterArith(expr: &Expr) -> Expr {
         }
         crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
             crate::aver_generated::domain::ast::Expr::ExprConcat(
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     parts,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
             crate::aver_generated::domain::ast::Expr::ExprTuple(
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     exprs,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
             crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     exprs,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
                 unwrap,
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
             crate::aver_generated::domain::ast::Expr::ExprList(
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     exprs,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
             crate::aver_generated::domain::ast::Expr::ExprRecord(
                 name,
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalFields(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalFields__collected(
                     fields,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -325,36 +337,44 @@ pub fn rewriteInternalExprAfterArith(expr: &Expr) -> Expr {
         crate::aver_generated::domain::ast::Expr::ExprCall(name, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCall(
                 crate::aver_generated::domain::ast::canonicalCtorName(name),
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     args,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallDirect(
                 fnId,
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     args,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => {
             crate::aver_generated::domain::resolver::rewrite::rewriteInternalBuiltin(
                 name,
-                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                &crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     args,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
                 id,
-                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs(
+                crate::aver_generated::domain::resolver::rewrite::rewriteInternalExprs__collected(
                     args,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -425,9 +445,11 @@ pub fn rewritePattern(pat: &Pattern) -> Pattern {
         }
         crate::aver_generated::domain::ast::Pattern::PatTuple(pats) => {
             crate::aver_generated::domain::ast::Pattern::PatTuple(
-                crate::aver_generated::domain::resolver::rewrite::rewritePatterns(
+                crate::aver_generated::domain::resolver::rewrite::rewritePatterns__collected(
                     pats,
-                    aver_rt::AverList::empty(),
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
                 ),
             )
         }
@@ -1098,5 +1120,95 @@ pub fn rewriteBoolMatchArmPairBools(
         (true, false) => Some((body1.clone(), body2.clone())),
         (false, true) => Some((body2.clone(), body1.clone())),
         _ => None,
+    }
+}
+
+/// Synthesized collecting variant of `rewriteInternalStmts`. Appends to a builder where `rewriteInternalStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn rewriteInternalStmts__collected(
+    mut stmts: aver_rt::AverList<Stmt>,
+    mut acc: aver_rt::AverList<Stmt>,
+) -> aver_rt::AverList<Stmt> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(stmts, [] => { return aver_rt::list_builder_finalize(acc); }, [stmt, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::resolver::rewrite::rewriteInternalStmt(&stmt));
+            stmts = __tco0;
+            acc = __tco1;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `rewriteInternalExprs`. Appends to a builder where `rewriteInternalExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn rewriteInternalExprs__collected(
+    mut exprs: aver_rt::AverList<Expr>,
+    mut acc: aver_rt::AverList<Expr>,
+) -> aver_rt::AverList<Expr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(exprs, [] => { return aver_rt::list_builder_finalize(acc); }, [expr, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr));
+            exprs = __tco0;
+            acc = __tco1;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `rewriteInternalFields`. Appends to a builder where `rewriteInternalFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn rewriteInternalFields__collected(
+    mut fields: aver_rt::AverList<(AverStr, Expr)>,
+    mut acc: aver_rt::AverList<(AverStr, Expr)>,
+) -> aver_rt::AverList<(AverStr, Expr)> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(fields, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, (name, crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&expr)));
+            fields = __tco0;
+            acc = __tco1;
+            continue;
+        } } })
+    }
+}
+
+/// Synthesized collecting variant of `rewriteInternalArms`. Appends to a builder where `rewriteInternalArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn rewriteInternalArms__collected(
+    mut arms: aver_rt::AverList<MatchArm>,
+    mut acc: aver_rt::AverList<MatchArm>,
+) -> aver_rt::AverList<MatchArm> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(arms, [] => { return aver_rt::list_builder_finalize(acc); }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::ast::MatchArm { pattern: crate::aver_generated::domain::resolver::rewrite::rewritePattern(&arm.pattern), body: crate::aver_generated::domain::resolver::rewrite::rewriteInternalExpr(&arm.body), bindingSlots: arm.bindingSlots.clone() });
+            arms = __tco0;
+            acc = __tco1;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `rewritePatterns`. Appends to a builder where `rewritePatterns` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn rewritePatterns__collected(
+    mut pats: aver_rt::AverList<Pattern>,
+    mut acc: aver_rt::AverList<Pattern>,
+) -> aver_rt::AverList<Pattern> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(pats, [] => { return aver_rt::list_builder_finalize(acc); }, [p, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::resolver::rewrite::rewritePattern(&p));
+            pats = __tco0;
+            acc = __tco1;
+            continue;
+        } })
     }
 }

--- a/src/self_host/aver_generated/entry/mod.rs
+++ b/src/self_host/aver_generated/entry/mod.rs
@@ -69,10 +69,12 @@ fn __mutual_tco_trampoline_1(
                         moduleRoot,
                         aver_rt::AverList::concat(
                             &accWithInner.clone(),
-                            &shiftFnIdsInFns(
+                            &shiftFnIdsInFns__collected(
                                 moduleFns,
                                 aver_rt::AverInt::from_i64(accWithInner.len() as i64),
-                                aver_rt::AverList::empty(),
+                                aver_rt::list_builder_new(
+                                    (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                                ),
                             ),
                         ),
                         loaded3,
@@ -390,8 +392,16 @@ pub fn shiftFnIdsInProgram(prog: &Program, offset: aver_rt::AverInt) -> Program 
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::Program {
         deps: prog.deps.clone(),
-        fns: shiftFnIdsInFns(prog.fns.clone(), offset.clone(), aver_rt::AverList::empty()),
-        stmts: shiftFnIdsInStmts(prog.stmts.clone(), offset, aver_rt::AverList::empty()),
+        fns: shiftFnIdsInFns__collected(
+            prog.fns.clone(),
+            offset.clone(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
+        ),
+        stmts: shiftFnIdsInStmts__collected(
+            prog.stmts.clone(),
+            offset,
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
+        ),
     }
 }
 
@@ -401,7 +411,11 @@ pub fn shiftFnIdsInFn(fd: &FnDef, offset: aver_rt::AverInt) -> FnDef {
     crate::aver_generated::domain::ast::FnDef {
         name: fd.name.clone(),
         params: fd.params.clone(),
-        body: shiftFnIdsInStmts(fd.body.clone(), offset.clone(), aver_rt::AverList::empty()),
+        body: shiftFnIdsInStmts__collected(
+            fd.body.clone(),
+            offset.clone(),
+            aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
+        ),
         slotCount: fd.slotCount.clone(),
         slotMap: fd.slotMap.clone(),
         fastPath: shiftFnIdsInFastPath(&fd.fastPath, offset),
@@ -591,30 +605,36 @@ pub fn shiftFnIdsInExprTail(expr: &Expr, offset: aver_rt::AverInt) -> Expr {
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprConcat(parts) => {
-            crate::aver_generated::domain::ast::Expr::ExprConcat(shiftFnIdsInExprs(
+            crate::aver_generated::domain::ast::Expr::ExprConcat(shiftFnIdsInExprs__collected(
                 parts,
                 offset,
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ))
         }
         crate::aver_generated::domain::ast::Expr::ExprTuple(exprs) => {
-            crate::aver_generated::domain::ast::Expr::ExprTuple(shiftFnIdsInExprs(
+            crate::aver_generated::domain::ast::Expr::ExprTuple(shiftFnIdsInExprs__collected(
                 exprs,
                 offset,
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ))
         }
         crate::aver_generated::domain::ast::Expr::ExprList(exprs) => {
-            crate::aver_generated::domain::ast::Expr::ExprList(shiftFnIdsInExprs(
+            crate::aver_generated::domain::ast::Expr::ExprList(shiftFnIdsInExprs__collected(
                 exprs,
                 offset,
-                aver_rt::AverList::empty(),
+                aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
             ))
         }
         crate::aver_generated::domain::ast::Expr::ExprRecord(name, fields) => {
             crate::aver_generated::domain::ast::Expr::ExprRecord(
                 name,
-                shiftFnIdsInFields(fields, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInFields__collected(
+                    fields,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
             )
         }
         _ => shiftFnIdsInExprCalls(expr, offset),
@@ -635,32 +655,62 @@ pub fn shiftFnIdsInExprCalls(expr: &Expr, offset: aver_rt::AverInt) -> Expr {
         crate::aver_generated::domain::ast::Expr::ExprCall(name, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCall(
                 name,
-                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInExprs__collected(
+                    args,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallDirect(
                 fnId.add(&offset),
-                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInExprs__collected(
+                    args,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(name, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallBuiltin(
                 name,
-                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInExprs__collected(
+                    args,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(id, args) => {
             crate::aver_generated::domain::ast::Expr::ExprCallBuiltinId(
                 id,
-                shiftFnIdsInExprs(args, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInExprs__collected(
+                    args,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprMatch(scrutinee, arms) => {
             let scrutinee = (*scrutinee).clone();
             crate::aver_generated::domain::ast::Expr::ExprMatch(
                 std::sync::Arc::new(shiftFnIdsInExpr(&scrutinee, offset.clone())),
-                shiftFnIdsInArms(arms, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInArms__collected(
+                    arms,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
             )
         }
         crate::aver_generated::domain::ast::Expr::ExprPropagate(inner) => {
@@ -671,7 +721,13 @@ pub fn shiftFnIdsInExprCalls(expr: &Expr, offset: aver_rt::AverInt) -> Expr {
         }
         crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(exprs, unwrap) => {
             crate::aver_generated::domain::ast::Expr::ExprIndependentProduct(
-                shiftFnIdsInExprs(exprs, offset, aver_rt::AverList::empty()),
+                shiftFnIdsInExprs__collected(
+                    exprs,
+                    offset,
+                    aver_rt::list_builder_new(
+                        (aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0),
+                    ),
+                ),
                 unwrap,
             )
         }
@@ -1006,6 +1062,111 @@ pub fn runDemo() -> Result<(), AverStr> {
         )
     };
     Ok(())
+}
+
+/// Synthesized collecting variant of `shiftFnIdsInFns`. Appends to a builder where `shiftFnIdsInFns` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn shiftFnIdsInFns__collected(
+    mut fns: aver_rt::AverList<FnDef>,
+    mut offset: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<FnDef>,
+) -> aver_rt::AverList<FnDef> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(fns, [] => { return aver_rt::list_builder_finalize(acc); }, [fd, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = offset.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, shiftFnIdsInFn(&fd, offset));
+            fns = __tco0;
+            offset = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `shiftFnIdsInStmts`. Appends to a builder where `shiftFnIdsInStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn shiftFnIdsInStmts__collected(
+    mut stmts: aver_rt::AverList<Stmt>,
+    mut offset: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<Stmt>,
+) -> aver_rt::AverList<Stmt> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(stmts, [] => { return aver_rt::list_builder_finalize(acc); }, [stmt, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = offset.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, shiftFnIdsInStmt(&stmt, offset));
+            stmts = __tco0;
+            offset = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `shiftFnIdsInExprs`. Appends to a builder where `shiftFnIdsInExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn shiftFnIdsInExprs__collected(
+    mut exprs: aver_rt::AverList<Expr>,
+    mut offset: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<Expr>,
+) -> aver_rt::AverList<Expr> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(exprs, [] => { return aver_rt::list_builder_finalize(acc); }, [expr, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = offset.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, shiftFnIdsInExpr(&expr, offset));
+            exprs = __tco0;
+            offset = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
+}
+
+/// Synthesized collecting variant of `shiftFnIdsInFields`. Appends to a builder where `shiftFnIdsInFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn shiftFnIdsInFields__collected(
+    mut fields: aver_rt::AverList<(AverStr, Expr)>,
+    mut offset: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<(AverStr, Expr)>,
+) -> aver_rt::AverList<(AverStr, Expr)> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(fields, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (name, expr) = pair; {
+            let __tco0 = rest;
+            let __tco1 = offset.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, (name, shiftFnIdsInExpr(&expr, offset)));
+            fields = __tco0;
+            offset = __tco1;
+            acc = __tco2;
+            continue;
+        } } })
+    }
+}
+
+/// Synthesized collecting variant of `shiftFnIdsInArms`. Appends to a builder where `shiftFnIdsInArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
+#[inline(always)]
+pub fn shiftFnIdsInArms__collected(
+    mut arms: aver_rt::AverList<MatchArm>,
+    mut offset: aver_rt::AverInt,
+    mut acc: aver_rt::AverList<MatchArm>,
+) -> aver_rt::AverList<MatchArm> {
+    loop {
+        crate::cancel_checkpoint();
+        aver_list_match!(arms, [] => { return aver_rt::list_builder_finalize(acc); }, [arm, rest] => { {
+            let __tco0 = rest;
+            let __tco1 = offset.clone();
+            let __tco2 = aver_rt::list_builder_push(acc, crate::aver_generated::domain::ast::MatchArm { pattern: arm.pattern.clone(), body: shiftFnIdsInExpr(&arm.body, offset), bindingSlots: arm.bindingSlots.clone() });
+            arms = __tco0;
+            offset = __tco1;
+            acc = __tco2;
+            continue;
+        } })
+    }
 }
 
 pub fn main() -> Result<(), AverStr> {

--- a/src/self_host/main.rs
+++ b/src/self_host/main.rs
@@ -16,6 +16,7 @@ extern crate aver_rt;
 pub use ::aver_rt::AverMap as HashMap;
 pub use ::aver_rt::AverStr;
 pub use ::aver_rt::Buffer;
+pub use ::aver_rt::ByteBuilder;
 
 mod runtime_support;
 pub use runtime_support::*;

--- a/src/vm/compiler/expr.rs
+++ b/src/vm/compiler/expr.rs
@@ -45,6 +45,13 @@ impl<'a> FnCompiler<'a> {
         Ok(())
     }
 
+    /// Resolve a fn-referenced-as-a-value name (`MirExpr::FnValue`, its
+    /// only caller). `self.local_slots` is EMPTY for resolved fns (see
+    /// the field doc): a `FnValue` name survived the resolver, so no
+    /// local with that spelling was in scope at the use site and the
+    /// honest answers are module fns / globals / builtin symbols. The
+    /// local branch fires only on the no-resolution fallback map
+    /// (params only), where a bare param read can reach `FnValue`.
     pub(super) fn compile_ident(&mut self, name: &str) -> Result<(), CompileError> {
         if let Some(&slot) = self.local_slots.get(name) {
             self.emit_op(LOAD_LOCAL);

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -338,13 +338,14 @@ pub(super) fn compile_mir_expr(
 
         // ── Phase 6: fn referenced as a value ───────────────────
         // `callWith(dbl)` passes `dbl` — a top-level fn / builtin in
-        // value position. Reuse the HIR walker's `compile_ident`
-        // verbatim: it tries local slot → global → module-scope fn
-        // (symbol_ref of the qualified name) → interned symbol with a
-        // kind. Sharing the path guarantees byte-identical emit with
-        // the HIR walker, and an unresolved name surfaces as the same
-        // `CompileError` (folded to `InnerError`, so a malformed input
-        // still drops to the HIR fallback rather than miscompiling).
+        // value position. `compile_ident` tries global → module-scope
+        // fn (symbol_ref of the qualified name) → interned symbol with
+        // a kind; its local-slot branch is inert for resolved fns
+        // (their `local_slots` table is deliberately empty — a
+        // `FnValue` name was left bare by the resolver, so a name-keyed
+        // local hit could only be an out-of-scope pattern binder
+        // sharing the spelling, issue #948). An unresolved name
+        // surfaces as a `CompileError` (folded to `InnerError`).
         MirExpr::FnValue(name) => {
             fc.compile_ident(name)?;
             Ok(())

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -835,15 +835,29 @@ impl ProgramCompiler {
             .local_count
             .max(resolution.map_or(rfd.params.len() as u32, |r| u32::from(r.local_count)))
             as u16;
-        let local_slots: HashMap<String, u16> = resolution
-            .map(|r| r.local_slots.as_ref().clone())
-            .unwrap_or_else(|| {
-                rfd.params
-                    .iter()
-                    .enumerate()
-                    .map(|(i, (name, _))| (name.clone(), i as u16))
-                    .collect()
-            });
+        // `FnCompiler.local_slots` feeds exactly one consumer: the
+        // `MirExpr::FnValue` path (`compile_ident`). A `FnValue` name is
+        // an ident the resolver left bare — so when a resolution exists,
+        // NO local with that spelling was in scope at the use site, and
+        // any name-keyed hit would be an out-of-scope pattern binder
+        // that shares the spelling (`FnResolution.local_slots` is
+        // last-allocation-wins, issue #948). Loading that slot reads an
+        // unrelated — typically uninitialized — local ("cannot call
+        // non-function (got Unit)") and hijacks a module-fn reference.
+        // Hand the compiler an EMPTY local table so `FnValue` resolves
+        // through module fns / globals / builtin symbols only. The
+        // params-only fallback stays for bodies compiled WITHOUT a
+        // resolution, where idents were never rewritten and a bare
+        // param read can legitimately reach `FnValue`.
+        let local_slots: HashMap<String, u16> = match resolution {
+            Some(_) => HashMap::new(),
+            None => rfd
+                .params
+                .iter()
+                .enumerate()
+                .map(|(i, (name, _))| (name.clone(), i as u16))
+                .collect(),
+        };
 
         let mut fc = FnCompiler::new(
             &rfd.name,
@@ -1053,6 +1067,14 @@ pub(super) struct FnCompiler<'a> {
     arity: u8,
     local_count: u16,
     effects: Vec<u32>,
+    /// Name → slot table consulted ONLY by the `MirExpr::FnValue` path
+    /// (`compile_ident`). Deliberately EMPTY when the fn carries a
+    /// resolution: every in-scope local was already rewritten to
+    /// `Resolved` by the resolver, so a bare `FnValue` name can never
+    /// legitimately be a local, and a name-keyed hit would be an
+    /// out-of-scope pattern binder sharing the spelling (issue #948).
+    /// Holds the params-only fallback map when the fn has no
+    /// resolution (idents never rewritten).
     pub(super) local_slots: HashMap<String, u16>,
     global_names: &'a HashMap<String, u16>,
     /// Module-local function scope: simple_name → fn_id.

--- a/tests/vm_pattern_shadow_matrix.rs
+++ b/tests/vm_pattern_shadow_matrix.rs
@@ -44,11 +44,14 @@
 //! protection against all backends agreeing on a wrong value.
 //!
 //! The suite also carries the SAME-DISEASE witnesses the #948 review
-//! flushed out — three more consumers that resolved a specific
-//! binding's slot by name through the last-wins `local_slots` map:
-//! the alias pass (`ALIAS_VEC_SRC` / `ALIAS_MAP_SRC`), the escape
-//! pass's arm binders (`ESCAPE_SIBLING_ARMS_SRC`), and the VM's
-//! fn-as-value path (`FN_VALUE_SRC`). Each witness sits next to a
+//! flushed out — more consumers that matched a specific binding by
+//! bare name: three resolved a binding's slot through the last-wins
+//! `local_slots` map — the alias pass (`ALIAS_VEC_SRC` /
+//! `ALIAS_MAP_SRC`), the escape pass's arm binders
+//! (`ESCAPE_SIBLING_ARMS_SRC`), and the VM's fn-as-value path
+//! (`FN_VALUE_SRC`) — and one matched a call site against a
+//! name-keyed CANDIDATE map even when the callee was a resolved
+//! local (`ESCAPE_SHADOWED_CALLEE_SRC`). Each witness sits next to a
 //! renamed control that must answer identically. Recorded pre-fix
 //! reds live on each source constant.
 
@@ -542,6 +545,65 @@ fn main()
 
 const FN_VALUE_EXPECTED: &str = "26\n6\n26\n6";
 
+/// Same-disease witness at the CANDIDATE-MAP door of the escape pass
+/// (`src/ir/escape.rs`, `rewrite_in_expr`): the inline-candidate map is
+/// keyed by fn NAME, and the call-site matcher accepted a callee that
+/// was `Expr::Resolved` — but a resolved callee is a LOCAL by
+/// construction of the resolver (only locals get slots). Here the
+/// param `area: Fn(Shape) -> Int` shadows the one-argument inlinable
+/// module fn `area`, so `area(Shape.Circle(5))` inside `apply` was
+/// spliced with the MODULE fn's arm body no matter which fn the caller
+/// actually passed.
+///
+/// Hand-computed truth: `apply(big)` = 100 (`big` ignores its arg),
+/// `apply(area)` = 10 (`area(Circle(5))` = 5 * 2), and the renamed
+/// control `applyRenamed` answers the same 100/10.
+///
+/// Recorded pre-fix red:
+///   VM: `10 / 10 / 100 / 10` — `apply(big)` answered with the spliced
+///       `area` body (10) instead of 100; the renamed control was
+///       correct, pinning the shadowing spelling as the trigger.
+/// No compiled-Rust column: the emitted Rust for this higher-order
+/// shape does not compile — pre-existing E0308, fn item
+/// `for<'a> fn(&'a Shape) -> AverInt {big}` vs expected fn pointer
+/// `fn(Shape) -> AverInt` (issue #952) — so the VM is pinned against
+/// the hand-computed truth above. No self-host column either: the
+/// self-host parser does not accept `Fn(..)`-typed parameters yet
+/// (same gap as `FN_VALUE_SRC`).
+/// On main (before this branch's per-arm `binding_slots` fix) the same
+/// program PANICKED the VM with a dangling-slot splice; the arm fix
+/// made the wrong splice SUCCEED, so this witness keeps the silent
+/// version red.
+const ESCAPE_SHADOWED_CALLEE_SRC: &str = r#"module Tmp
+
+type Shape
+    Circle(Int)
+    Square(Int)
+
+fn area(s: Shape) -> Int
+    match s
+        Shape.Circle(n) -> n * 2
+        Shape.Square(n) -> n * 3
+
+fn big(s: Shape) -> Int
+    100
+
+fn apply(area: Fn(Shape) -> Int) -> Int
+    area(Shape.Circle(5))
+
+fn applyRenamed(f: Fn(Shape) -> Int) -> Int
+    f(Shape.Circle(5))
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(apply(big)))
+    Console.print(String.fromInt(apply(area)))
+    Console.print(String.fromInt(applyRenamed(big)))
+    Console.print(String.fromInt(applyRenamed(area)))
+"#;
+
+const ESCAPE_SHADOWED_CALLEE_EXPECTED: &str = "100\n10\n100\n10";
+
 #[test]
 fn alias_shadowed_vector_in_map_vm() {
     assert_eq!(
@@ -642,6 +704,16 @@ fn fn_value_shadowed_by_out_of_scope_binder_compiled_rust() {
         run_compiled_rust("fnv", FN_VALUE_SRC),
         FN_VALUE_EXPECTED,
         "compiled Rust diverged on the fn-value witness"
+    );
+}
+
+#[test]
+fn escape_shadowed_callee_param_vm() {
+    assert_eq!(
+        run_vm("esc-callee-vm", ESCAPE_SHADOWED_CALLEE_SRC),
+        ESCAPE_SHADOWED_CALLEE_EXPECTED,
+        "a Fn-typed param shadowing an inlinable module fn must call the \
+         PASSED fn, not the spliced module-fn body (pre-fix: 10/10)"
     );
 }
 

--- a/tests/vm_pattern_shadow_matrix.rs
+++ b/tests/vm_pattern_shadow_matrix.rs
@@ -1,0 +1,368 @@
+//! Regression net for issue #948 — a match-pattern binder that
+//! shadows an earlier binding must read its own slot, and the
+//! shadowed binding must keep its own slot, on every backend.
+//!
+//! The witness (issue #948): the VM printed a constant `3/3` for
+//! `once(5)/once(1)` while compiled Rust answered `11/3`. Root
+//! cause: the MIR statement-chain lowering looked the statement
+//! binding's slot up by NAME in `FnResolution.local_slots` — a
+//! last-allocation-wins map — so a later pattern binder spelled
+//! the same steals the statement's slot. The `let` then writes
+//! the pattern binder's slot and every read of the statement
+//! binding hits an uninitialized one.
+//!
+//! The matrix below is order-controlled: every cell's value
+//! depends on the argument, each cell is evaluated for two
+//! arguments, and each cell pins one combination of
+//!   - shadowing binder position: constructor-pattern binder,
+//!     cons-pattern head, cons-pattern tail, tuple-pattern
+//!     binder, nested match two deep, second arm after a
+//!     binder arm;
+//!   - shadowed thing: statement binding, fn parameter,
+//!     earlier pattern binder;
+//!   - read position: arm body, nested arm, after the match
+//!     via a wrapping binding (both the wrapper and the
+//!     original shadowed binding are read).
+//!
+//! Recorded pre-fix reds (truth = the compiled-Rust column,
+//! which matched every hand-computed value):
+//!   VM:        cell1 3/3 (want 11/3), cell3 32/32 (want
+//!              120/32), cell4 301/301 (want 701/301), cell6
+//!              304/304 (want 1112/304), cell10 2006/2006
+//!              (want 7021/3009), cell11 runtime error
+//!              "String.fromInt: argument must be an Int"
+//!              (want 105/7).
+//!   self-host: cell3 220/60 (want 120/32), cell9 1616/404
+//!              (want 1605/401), cell10 21021/9009 (want
+//!              7021/3009), cell11 runtime error "expected int
+//!              argument" (want 105/7) — its resolver leaked
+//!              arm-binder slots past the match, aliasing the
+//!              wrapper binding's slot.
+//!
+//! Every backend must print `EXPECTED` exactly; asserting each
+//! against the same literal is the three-way differential plus
+//! protection against all backends agreeing on a wrong value.
+
+#![cfg(feature = "runtime")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static UNIQUE: AtomicU64 = AtomicU64::new(0);
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn aver_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aver")
+}
+
+fn temp_module(prefix: &str, source: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let n = UNIQUE.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("aver-shadow-matrix-{prefix}-{nanos}-{n}"));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join("main.av");
+    fs::write(&path, source).expect("write temp module source");
+    path
+}
+
+fn cleanup(path: &Path) {
+    let _ = fs::remove_dir_all(path.parent().expect("temp module has parent"));
+}
+
+fn format_output(out: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    )
+}
+
+fn run_vm(prefix: &str, source: &str) -> String {
+    let path = temp_module(prefix, source);
+    let out = Command::new(aver_bin())
+        .current_dir(repo_root())
+        .arg("run")
+        .arg(&path)
+        .output()
+        .expect("expected `aver run` (VM) to execute");
+    cleanup(&path);
+    assert!(
+        out.status.success(),
+        "{prefix} VM run failed:\n{}",
+        format_output(&out)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn run_self_host(prefix: &str, source: &str) -> String {
+    let path = temp_module(prefix, source);
+    let module_root = path.parent().expect("temp module has parent").to_path_buf();
+    let out = Command::new(aver_bin())
+        .current_dir(repo_root())
+        .arg("run")
+        .arg(&path)
+        .arg("--module-root")
+        .arg(&module_root)
+        .arg("--self-host")
+        .output()
+        .expect("expected `aver run --self-host` to execute");
+    cleanup(&path);
+    assert!(
+        out.status.success(),
+        "{prefix} self-host run failed:\n{}",
+        format_output(&out)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Compile to Rust, `cargo build --offline` against a shared target
+/// dir (same amortisation pattern as `rust_codegen_differential`),
+/// run the produced binary, return trimmed stdout.
+fn run_compiled_rust(prefix: &str, source: &str) -> String {
+    let path = temp_module(prefix, source);
+    let module_root = path.parent().expect("temp module has parent").to_path_buf();
+    let project = module_root.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let name = format!("shadow_{prefix}");
+
+    let compile = Command::new(aver_bin())
+        .current_dir(repo_root())
+        .arg("compile")
+        .arg(&path)
+        .arg("--target")
+        .arg("rust")
+        .arg("--name")
+        .arg(&name)
+        .arg("-o")
+        .arg(&project)
+        .arg("--module-root")
+        .arg(&module_root)
+        .output()
+        .expect("expected `aver compile --target rust` to spawn");
+    assert!(
+        compile.status.success(),
+        "{prefix}: aver compile --target rust failed:\n{}",
+        format_output(&compile)
+    );
+
+    let target = repo_root().join("target").join("shadow-matrix-shared");
+    fs::create_dir_all(&target).expect("create cargo target dir");
+    let build = Command::new("cargo")
+        .arg("build")
+        .arg("-q")
+        .arg("--offline")
+        .arg("--manifest-path")
+        .arg(project.join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", &target)
+        .output()
+        .expect("expected `cargo build` to spawn");
+    assert!(
+        build.status.success(),
+        "{prefix}: cargo build failed on emitted project:\n{}",
+        format_output(&build)
+    );
+
+    let bin = target
+        .join("debug")
+        .join(format!("{name}{}", std::env::consts::EXE_SUFFIX));
+    let out = Command::new(&bin)
+        .output()
+        .expect("expected compiled binary to run");
+    cleanup(&path);
+    assert!(
+        out.status.success(),
+        "{prefix}: compiled binary exited non-zero:\n{}",
+        format_output(&out)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// The issue-#948 witness, verbatim shape.
+const WITNESS_SRC: &str = r#"module Tmp
+
+fn once(sh: Int) -> Int
+    v = sh * 2
+    match Option.Some(v + 1)
+        Option.Some(v) -> v
+        Option.None -> 0
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(once(5)))
+    Console.print(String.fromInt(once(1)))
+"#;
+
+const WITNESS_OUT: &str = "11\n3";
+
+/// The order-controlled shadow matrix. Cell shapes:
+///   cell1  ctor binder shadows statement binding, read in arm body
+///   cell2  ctor binder shadows fn parameter, read in arm body
+///   cell3  ctor binder shadows statement binding, wrapper + original
+///          read after the match
+///   cell4  cons-head binder shadows statement binding, read in arm body
+///   cell5  cons-tail binder shadows statement binding (different type),
+///          read in arm body
+///   cell6  tuple binder shadows statement binding, read in arm body
+///   cell7  nested match two deep — inner ctor binder shadows the outer
+///          arm's binder, read in the inner arm body
+///   cell8  inner ctor binder shadows a statement binding, inner arm
+///          reads both the inner and the outer binder
+///   cell9  ctor binder shadows fn parameter, wrapper + original
+///          parameter read after the match
+///   cell10 cons-head binder shadows statement binding, wrapper +
+///          original read after the match
+///   cell11 first arm binds the shadowing name, second arm reads the
+///          original statement binding
+const MATRIX_SRC: &str = r#"module Tmp
+
+fn cell1(x: Int) -> Int
+    v = x * 2
+    match Option.Some(v + 1)
+        Option.Some(v) -> v
+        Option.None -> 0
+
+fn cell2(v: Int) -> Int
+    match Option.Some(v + 1)
+        Option.Some(v) -> v * 10
+        Option.None -> 0
+
+fn cell3(x: Int) -> Int
+    v = x * 2
+    r = match Option.Some(v + 1)
+        Option.Some(v) -> v * 10
+        Option.None -> 0
+    r + v
+
+fn cell4(x: Int) -> Int
+    v = x + 1
+    match [v + 1, v + 2]
+        [] -> 0
+        [v, ..rest] -> v * 100 + List.len(rest)
+
+fn cell5(x: Int) -> Int
+    v = x + 3
+    match [x, x * 2]
+        [] -> 0
+        [h, ..v] -> h * 10 + List.len(v)
+
+fn cell6(x: Int) -> Int
+    v = x * 2
+    match (v + 1, v + 2)
+        (v, w) -> v * 100 + w
+
+fn cell7(x: Int) -> Int
+    match Option.Some(x + 1)
+        Option.Some(v) -> match Option.Some(v * 2)
+            Option.Some(v) -> v + 1
+            Option.None -> 0
+        Option.None -> 0
+
+fn cell8(x: Int) -> Int
+    v = x * 5
+    match Option.Some(x + 1)
+        Option.Some(w) -> match Option.Some(w + 1)
+            Option.Some(v) -> v * 10 + w
+            Option.None -> 0
+        Option.None -> 0
+
+fn cell9(v: Int) -> Int
+    r = match Option.Some(v * 3)
+        Option.Some(v) -> v + 1
+        Option.None -> 0
+    r * 100 + v
+
+fn cell10(x: Int) -> Int
+    v = x + 2
+    r = match [v]
+        [] -> 0
+        [v, ..rest] -> v * 3
+    r + v * 1000
+
+fn intToOpt(x: Int) -> Option<Int>
+    match x > 3
+        true -> Option.Some(x + 100)
+        false -> Option.None
+
+fn cell11(x: Int) -> Int
+    v = x * 7
+    match intToOpt(x)
+        Option.Some(v) -> v
+        Option.None -> v
+
+fn printCells(x: Int)
+    ! [Console.print]
+    Console.print(String.fromInt(cell1(x)))
+    Console.print(String.fromInt(cell2(x)))
+    Console.print(String.fromInt(cell3(x)))
+    Console.print(String.fromInt(cell4(x)))
+    Console.print(String.fromInt(cell5(x)))
+    Console.print(String.fromInt(cell6(x)))
+    Console.print(String.fromInt(cell7(x)))
+    Console.print(String.fromInt(cell8(x)))
+    Console.print(String.fromInt(cell9(x)))
+    Console.print(String.fromInt(cell10(x)))
+    Console.print(String.fromInt(cell11(x)))
+
+fn main()
+    ! [Console.print]
+    printCells(5)
+    printCells(1)
+"#;
+
+/// Hand-computed truth, confirmed cell by cell against the compiled
+/// Rust backend before the fix (Rust emits pattern syntax by source
+/// name, so its scoping never depended on the resolver slots).
+///
+/// x = 5: cell1 = 11, cell2 = 60, cell3 = 120, cell4 = 701,
+///        cell5 = 51, cell6 = 1112, cell7 = 13, cell8 = 76,
+///        cell9 = 1605, cell10 = 7021, cell11 = 105.
+/// x = 1: cell1 = 3, cell2 = 20, cell3 = 32, cell4 = 301,
+///        cell5 = 11, cell6 = 304, cell7 = 5, cell8 = 32,
+///        cell9 = 401, cell10 = 3009, cell11 = 7.
+const EXPECTED: &str = "11\n60\n120\n701\n51\n1112\n13\n76\n1605\n7021\n105\n3\n20\n32\n301\n11\n304\n5\n32\n401\n3009\n7";
+
+#[test]
+fn witness_shadowed_pattern_binder_on_the_vm() {
+    assert_eq!(
+        run_vm("witness", WITNESS_SRC),
+        WITNESS_OUT,
+        "issue #948 witness: the VM must answer 11/3, not a constant"
+    );
+}
+
+#[test]
+fn shadow_matrix_vm() {
+    assert_eq!(
+        run_vm("matrix-vm", MATRIX_SRC),
+        EXPECTED,
+        "VM diverged from the shadow-matrix truth"
+    );
+}
+
+#[test]
+fn shadow_matrix_compiled_rust() {
+    assert_eq!(
+        run_compiled_rust("matrix", MATRIX_SRC),
+        EXPECTED,
+        "compiled Rust diverged from the shadow-matrix truth"
+    );
+}
+
+#[test]
+fn shadow_matrix_self_host() {
+    assert_eq!(
+        run_self_host("matrix-sh", MATRIX_SRC),
+        EXPECTED,
+        "self-host diverged from the shadow-matrix truth"
+    );
+}

--- a/tests/vm_pattern_shadow_matrix.rs
+++ b/tests/vm_pattern_shadow_matrix.rs
@@ -42,6 +42,15 @@
 //! Every backend must print `EXPECTED` exactly; asserting each
 //! against the same literal is the three-way differential plus
 //! protection against all backends agreeing on a wrong value.
+//!
+//! The suite also carries the SAME-DISEASE witnesses the #948 review
+//! flushed out — three more consumers that resolved a specific
+//! binding's slot by name through the last-wins `local_slots` map:
+//! the alias pass (`ALIAS_VEC_SRC` / `ALIAS_MAP_SRC`), the escape
+//! pass's arm binders (`ESCAPE_SIBLING_ARMS_SRC`), and the VM's
+//! fn-as-value path (`FN_VALUE_SRC`). Each witness sits next to a
+//! renamed control that must answer identically. Recorded pre-fix
+//! reds live on each source constant.
 
 #![cfg(feature = "runtime")]
 
@@ -330,6 +339,311 @@ fn main()
 ///        cell5 = 11, cell6 = 304, cell7 = 5, cell8 = 32,
 ///        cell9 = 401, cell10 = 3009, cell11 = 7.
 const EXPECTED: &str = "11\n60\n120\n701\n51\n1112\n13\n76\n1605\n7021\n105\n3\n20\n32\n301\n11\n304\n5\n32\n401\n3009\n7";
+
+/// Same-disease witness in the ALIAS pass (`src/ir/alias.rs`): the
+/// statement binding `v = pick(outer)` extracts a Vector out of a Map,
+/// and a later Int pattern binder reuses the spelling `v`. The pass
+/// used to fetch the statement binding's slot BY NAME from the
+/// last-wins `local_slots` map, judged the binder's Int slot (never a
+/// collection → no flag), and left the extracted vector owned-eligible
+/// — the VM's in-place fast path then mutated the arena entry the map
+/// still holds.
+///
+/// Recorded pre-fix reds:
+///   VM: `-989 / -997` for corrupt(5)/corrupt(1) — `Vector.set`
+///       consumed (`mem::take`) the map's stored vector, so the
+///       re-read `at0(pick(outer))` saw a gutted entry (-1), while
+///       self-host and compiled Rust answered `7011 / 7003`.
+///   The `control` twin (binder renamed `y`) answered 7011/7003
+///   everywhere pre-fix — pinning the shadowing spelling as the
+///   trigger.
+const ALIAS_VEC_SRC: &str = r#"module Tmp
+
+fn build() -> Map<Int, Vector<Int>>
+    Map.set({}, 1, Vector.fromList([7, 7, 7]))
+
+fn pick(m: Map<Int, Vector<Int>>) -> Vector<Int>
+    match Map.get(m, 1)
+        Option.Some(inner) -> inner
+        Option.None -> Vector.new(1, 0)
+
+fn unwrapVec(o: Option<Vector<Int>>) -> Vector<Int>
+    match o
+        Option.Some(inner) -> inner
+        Option.None -> Vector.new(1, 0)
+
+fn at0(vec: Vector<Int>) -> Int
+    match Vector.get(vec, 0)
+        Option.Some(e) -> e
+        Option.None -> 0 - 1
+
+fn corrupt(x: Int) -> Int
+    outer = build()
+    v = pick(outer)
+    s = unwrapVec(Vector.set(v, 0, x))
+    r = match Option.Some(x)
+        Option.Some(v) -> v + 1
+        Option.None -> 0
+    at0(pick(outer)) * 1000 + at0(s) + r
+
+fn control(x: Int) -> Int
+    outer = build()
+    v = pick(outer)
+    s = unwrapVec(Vector.set(v, 0, x))
+    r = match Option.Some(x)
+        Option.Some(y) -> y + 1
+        Option.None -> 0
+    at0(pick(outer)) * 1000 + at0(s) + r
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(corrupt(5)))
+    Console.print(String.fromInt(corrupt(1)))
+    Console.print(String.fromInt(control(5)))
+    Console.print(String.fromInt(control(1)))
+"#;
+
+/// The Map-in-Map variant of the same alias-pass witness. Pre-fix the
+/// VM did not corrupt silently — it PANICKED at
+/// `src/vm/execute/slots.rs:482`: "Map.set was granted ownership of
+/// slot 4 statically, and something off the operand stack … still
+/// holds it" — the issue-#926 runtime fence falsifying the static
+/// grant the alias pass mis-stamped. Self-host and compiled Rust:
+/// `7011 / 7003 / 7011 / 7003`.
+const ALIAS_MAP_SRC: &str = r#"module Tmp
+
+fn build() -> Map<Int, Map<Int, Int>>
+    Map.set({}, 1, Map.set({}, 10, 7))
+
+fn pick(m: Map<Int, Map<Int, Int>>) -> Map<Int, Int>
+    match Map.get(m, 1)
+        Option.Some(inner) -> inner
+        Option.None -> {}
+
+fn at10(mm: Map<Int, Int>) -> Int
+    match Map.get(mm, 10)
+        Option.Some(e) -> e
+        Option.None -> 0 - 1
+
+fn corrupt(x: Int) -> Int
+    outer = build()
+    v = pick(outer)
+    s = Map.set(v, 10, x)
+    r = match Option.Some(x)
+        Option.Some(v) -> v + 1
+        Option.None -> 0
+    at10(pick(outer)) * 1000 + at10(s) + r
+
+fn control(x: Int) -> Int
+    outer = build()
+    v = pick(outer)
+    s = Map.set(v, 10, x)
+    r = match Option.Some(x)
+        Option.Some(y) -> y + 1
+        Option.None -> 0
+    at10(pick(outer)) * 1000 + at10(s) + r
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(corrupt(5)))
+    Console.print(String.fromInt(corrupt(1)))
+    Console.print(String.fromInt(control(5)))
+    Console.print(String.fromInt(control(1)))
+"#;
+
+/// corrupt(5), corrupt(1), control(5), control(1) — identical by
+/// design: the shadowing spelling must not change the answer.
+const ALIAS_EXPECTED: &str = "7011\n7003\n7011\n7003";
+
+/// Same-disease witness in the ESCAPE pass (`src/ir/escape.rs`): two
+/// SIBLING arms of an inline-eligible fn bind the same name. The pass
+/// used to resolve arm-binder slots by name through the fn-level
+/// last-wins map, handing BOTH arms the second arm's slot — the first
+/// arm's body then spliced into the caller with its binder
+/// unsubstituted, a dangling slot reference.
+///
+/// Recorded pre-fix reds:
+///   VM: panicked at `src/vm/execute/dispatch.rs:216` — "index out of
+///       bounds: the len is 1 but the index is 1".
+///   emitted Rust: rustc E0425 "cannot find value `n` in this scope".
+///   wasm-gc: validation error (pinned in
+///       `tests/wasm_gc_codegen_regression.rs`).
+///   self-host: `6 / 30` — correct (it does not run this pass).
+/// `evalRenamed` is the renamed control: distinct binder spellings,
+/// green everywhere pre-fix.
+const ESCAPE_SIBLING_ARMS_SRC: &str = r#"module Tmp
+
+type Shape
+    Circle(Int)
+    Square(Int)
+
+fn eval(p: Shape) -> Int
+    match p
+        Shape.Circle(n) -> n + 1
+        Shape.Square(n) -> n * 10
+
+fn evalRenamed(p: Shape) -> Int
+    match p
+        Shape.Circle(a) -> a + 1
+        Shape.Square(b) -> b * 10
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(eval(Shape.Circle(5))))
+    Console.print(String.fromInt(eval(Shape.Square(3))))
+    Console.print(String.fromInt(evalRenamed(Shape.Circle(5))))
+    Console.print(String.fromInt(evalRenamed(Shape.Square(3))))
+"#;
+
+const ESCAPE_EXPECTED: &str = "6\n30\n6\n30";
+
+/// Same-class witness on the VM's `MirExpr::FnValue` path
+/// (`src/vm/compiler/expr.rs`): a top-level fn referenced as a VALUE
+/// was hijacked by a same-spelled pattern binder in the enclosing fn —
+/// even though the binder is out of scope at the use site (the
+/// resolver left `dbl` bare precisely because no local was in scope
+/// there). The compiler's name-keyed local-slot check fired first and
+/// loaded the binder's (uninitialized) slot.
+///
+/// Recorded pre-fix reds:
+///   VM: "Type error [line 7]: cannot call non-function (got Unit =
+///       \"Unit\") in callWith at ip=6" (exit 1).
+///   compiled Rust: `26 / 6` — correct.
+/// `control` renames the binder to `y`, green everywhere pre-fix.
+/// No self-host executor here: the self-host parser does not accept
+/// `Fn(..)`-typed parameters yet.
+const FN_VALUE_SRC: &str = r#"module Tmp
+
+fn dbl(n: Int) -> Int
+    n * 2
+
+fn callWith(f: Fn(Int) -> Int, x: Int) -> Int
+    f(x)
+
+fn hijack(x: Int) -> Int
+    r = match Option.Some(x * 3)
+        Option.Some(dbl) -> dbl + 1
+        Option.None -> 0
+    callWith(dbl, x) + r
+
+fn control(x: Int) -> Int
+    r = match Option.Some(x * 3)
+        Option.Some(y) -> y + 1
+        Option.None -> 0
+    callWith(dbl, x) + r
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(hijack(5)))
+    Console.print(String.fromInt(hijack(1)))
+    Console.print(String.fromInt(control(5)))
+    Console.print(String.fromInt(control(1)))
+"#;
+
+const FN_VALUE_EXPECTED: &str = "26\n6\n26\n6";
+
+#[test]
+fn alias_shadowed_vector_in_map_vm() {
+    assert_eq!(
+        run_vm("alias-vec-vm", ALIAS_VEC_SRC),
+        ALIAS_EXPECTED,
+        "the VM mutated a map-held vector through a shadowed statement binding"
+    );
+}
+
+#[test]
+fn alias_shadowed_vector_in_map_compiled_rust() {
+    assert_eq!(
+        run_compiled_rust("aliasvec", ALIAS_VEC_SRC),
+        ALIAS_EXPECTED,
+        "compiled Rust diverged on the alias-vector witness"
+    );
+}
+
+#[test]
+fn alias_shadowed_vector_in_map_self_host() {
+    assert_eq!(
+        run_self_host("alias-vec-sh", ALIAS_VEC_SRC),
+        ALIAS_EXPECTED,
+        "self-host diverged on the alias-vector witness"
+    );
+}
+
+#[test]
+fn alias_shadowed_map_in_map_vm() {
+    assert_eq!(
+        run_vm("alias-map-vm", ALIAS_MAP_SRC),
+        ALIAS_EXPECTED,
+        "the VM must not trip the issue-#926 ownership fence on a shadowed \
+         statement binding (pre-fix: panic at slots.rs:482)"
+    );
+}
+
+#[test]
+fn alias_shadowed_map_in_map_compiled_rust() {
+    assert_eq!(
+        run_compiled_rust("aliasmap", ALIAS_MAP_SRC),
+        ALIAS_EXPECTED,
+        "compiled Rust diverged on the alias-map witness"
+    );
+}
+
+#[test]
+fn alias_shadowed_map_in_map_self_host() {
+    assert_eq!(
+        run_self_host("alias-map-sh", ALIAS_MAP_SRC),
+        ALIAS_EXPECTED,
+        "self-host diverged on the alias-map witness"
+    );
+}
+
+#[test]
+fn escape_sibling_arm_binders_vm() {
+    assert_eq!(
+        run_vm("esc-vm", ESCAPE_SIBLING_ARMS_SRC),
+        ESCAPE_EXPECTED,
+        "the escape pass spliced a sibling arm with the wrong binder slot \
+         (pre-fix: VM slot-index panic)"
+    );
+}
+
+#[test]
+fn escape_sibling_arm_binders_compiled_rust() {
+    assert_eq!(
+        run_compiled_rust("escarms", ESCAPE_SIBLING_ARMS_SRC),
+        ESCAPE_EXPECTED,
+        "emitted Rust must compile and answer (pre-fix: rustc E0425 on the \
+         unsubstituted binder)"
+    );
+}
+
+#[test]
+fn escape_sibling_arm_binders_self_host() {
+    assert_eq!(
+        run_self_host("esc-sh", ESCAPE_SIBLING_ARMS_SRC),
+        ESCAPE_EXPECTED,
+        "self-host diverged on the escape sibling-arms witness"
+    );
+}
+
+#[test]
+fn fn_value_shadowed_by_out_of_scope_binder_vm() {
+    assert_eq!(
+        run_vm("fnv-vm", FN_VALUE_SRC),
+        FN_VALUE_EXPECTED,
+        "a fn referenced as a value was hijacked by an out-of-scope pattern \
+         binder (pre-fix: 'cannot call non-function (got Unit)')"
+    );
+}
+
+#[test]
+fn fn_value_shadowed_by_out_of_scope_binder_compiled_rust() {
+    assert_eq!(
+        run_compiled_rust("fnv", FN_VALUE_SRC),
+        FN_VALUE_EXPECTED,
+        "compiled Rust diverged on the fn-value witness"
+    );
+}
 
 #[test]
 fn witness_shadowed_pattern_binder_on_the_vm() {

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -680,3 +680,35 @@ fn countMap(o: Option<Map<String, Int>>) -> Int
 "#,
     );
 }
+
+/// Two SIBLING match arms binding the same name in an inline-eligible
+/// fn (issue #948's disease, in the escape pass). `classify_fn` used
+/// to resolve arm-binder slots by name through the fn-level last-wins
+/// `local_slots` map, handing BOTH arms the second arm's slot — the
+/// first arm's body then spliced into `main` with its binder
+/// unsubstituted, a dangling local index the wasmparser validator
+/// rejected (recorded pre-fix red: this exact source failed
+/// validation). Slots now come from `MatchArm::binding_slots`. The
+/// behavioural half (all backends answering 6/30) lives in
+/// `tests/vm_pattern_shadow_matrix.rs`.
+#[test]
+fn sibling_arms_reusing_a_binder_name_compile_and_validate() {
+    assert_compiles_and_validates(
+        r#"module Tmp
+
+type Shape
+    Circle(Int)
+    Square(Int)
+
+fn eval(p: Shape) -> Int
+    match p
+        Shape.Circle(n) -> n + 1
+        Shape.Square(n) -> n * 10
+
+fn main()
+    ! [Console.print]
+    Console.print(String.fromInt(eval(Shape.Circle(5))))
+    Console.print(String.fromInt(eval(Shape.Square(3))))
+"#,
+    );
+}


### PR DESCRIPTION
Fixes #948 — a backend divergence on a plain program: the VM printed a constant `3/3` for `once(5)/once(1)` where compiled Rust answered `11/3`.

## Root cause — which layer lied

The resolver was innocent: it assigns fresh slots per scope correctly (`sh=0`, statement `v=1`, pattern binder `v=2`), stamps arm binders into `MatchArm::binding_slots`, and rewrites every read to the right slot. The lie was in the **MIR statement-chain lowering** (`src/ir/mir/lower.rs::lower_stmt_chain`): it fetched the statement binding's slot **by name** from `FnResolution.local_slots` — a *last-allocation-wins* map — so the later pattern binder spelled `v` owned the entry. The lowering emitted `let %2 = sh * 2` while the match subject read `%1`, which nothing ever wrote:

```
fn once(%0 sh: Int) -> Int {
  let %2 = (%0 Mul Int(2))          <-- wrote the PATTERN binder's slot
  in match Option.Some((%1 Add 1))  <-- read the statement's slot: uninitialized
```

The constant `3` was frame garbage (`uninit + 1`), bound and returned. The same name-keyed lookup existed a second time in the **wasm-gc emitter's `MirExpr::Let` arm** (`self_local_slot(&l.binding_name)`), where the witness program trapped with `null reference`.

**Why compiled Rust was immune:** the Rust backend emits `let {binding_name} = …` and match patterns by *source name* and never consults the slot table — Rust's own lexical scoping recovers exactly Aver's semantics. (This is also why the driver-step fusion path answered correctly: its rename eliminates the shadowed spelling.)

## Fix (at the layer that lied)

- The resolver records each fn-body statement binding's slot in source order: `FnResolution.stmt_binding_slots` (`u16::MAX` for `_`). No name-keyed map can answer "this statement's slot" — a later statement may legally reuse an earlier arm binder's name, so first-wins is as wrong as last-wins; identity has to be per statement.
- `lower_stmt_chain` consumes those positionally; `MirLet.binding` now carries the true slot.
- The wasm-gc `Let` arm reads `l.binding` instead of repeating the name lookup.

## The matrix (before → after)

Order-controlled over shadowing binder position × shadowed thing × read position, two inputs per cell so every value depends on the argument. Truth = hand-computed, confirmed cell-by-cell on compiled Rust pre-fix. Red receipts, verbatim:

- Witness on the VM: `3\n3` (want `11\n3`).
- `shadow_matrix_vm`: cells 1/3/4/6/10 wrong (`3, 32, 301, 304, 2006` for x=5 against `11, 120, 701, 1112, 7021`), cell 11 aborted the run: `Runtime error [line ..]: String.fromInt: argument must be an Int`.
- `shadow_matrix_self_host`: cells 3/9/10 wrong (`220, 1616, 21021` for x=5 against `120, 1605, 7021`), cell 11: `Runtime error: expected int argument`.
- `shadow_matrix_compiled_rust`: green pre-fix (the clean vote).

| cell | shape | pre-fix VM | pre-fix self-host |
|---|---|---|---|
| 1 | ctor binder shadows statement, read in arm body | red | green |
| 2 | ctor binder shadows parameter, read in arm body | green | green |
| 3 | ctor binder shadows statement, wrapper + original read after | red | red |
| 4 | cons head shadows statement, read in arm body | red | green |
| 5 | cons tail shadows statement (List vs Int), read in arm body | green | green |
| 6 | tuple binder shadows statement, read in arm body | red | green |
| 7 | nested two deep, inner shadows outer binder | green | green |
| 8 | inner binder shadows statement, nested arm reads both | red* | green |
| 9 | ctor binder shadows parameter, wrapper + original read after | green | red |
| 10 | cons head shadows statement, wrapper + original read after | red | red |
| 11 | later arm reads the statement the first arm's binder shadowed | red (aborts) | red (aborts) |

\* cell 8's wrong write was clobbered before any read, so its printed value was coincidentally right; the cell pins the clobber order.

After the fix all 22 outputs match the expected literal on **VM, compiled Rust, self-host and wasm-gc**; the three-backend differential is pinned as `tests/vm_pattern_shadow_matrix.rs` (each backend asserted against the same hand-computed literal, so three backends agreeing on a wrong value still fails).

## Sibling defects the matrix flushed out

1. **Self-host resolver leak** (cells 3/9/10/11 on self-host): its match-arm resolution threaded the arm-extended slot map into later arms *and out of the match*, so a wrapping binding aliased the binder's slot — reads of the shadowed name after the match returned the match result. One-line scope fix in `self_hosted/domain/resolver/core.av` (`resolveOneArm` continues with the match's incoming scope); `src/self_host` regenerated exactly the `tools/release.py` way. Its 156 verify cases pass; the `AVER_SELF_HOST_REGEN=1` canary passes (compiles, corpus parity 3/3).
2. **Driver-step fusion renamed pattern discards** (#947, exposed by the regen): `_` entered the hygiene-rename map as if it were a name, so both `_`s of one pattern became the *same* fresh identifier — the VM shrugged, but rustc rejects it (E0416) and the self-host regen no longer built. `_` now never enters the rename map; regression test beside the pass.

## Verification

- `vm_pattern_shadow_matrix` (new, 4 tests: recorded red first, now green)
- vm_spec, eval_spec, vm_slot_uniqueness, vm_map_runtime_ownership, stdlib_spec, alias_soundness, driver_step_pairs, hir_mir_differential, mir_vm_codegen, mir phase suites, chars/list-build declines, own_param_soundness + graduation, const_fold_drop_soundness, interval_analysis_spec, identity_guardrails, frame_boundary_inplace_write, map_iteration_order, typechecker/parser suites, replay_proptest — all green
- rust_codegen_differential (41), rust_codegen_regression — green
- wasm lane: wasm_gc_spec, wasm_gc_differential_mir, wasm_gc_codegen_regression, wasm_gc_verify_option_case_regression, cross_backend_stress, cross_backend_proptest — green
- self-host regen canary (`AVER_SELF_HOST_REGEN=1`) — green
- both CI clippy lanes, `cargo fmt --all -- --check` — clean

---

## Review follow-up (second commit): the same disease in three more places

The review found the same one-line class — "resolve a *specific* binding's slot by NAME through the last-wins `FnResolution.local_slots` map" — in three more consumers. All three are fixed in this PR because they are the class this PR's own doc comment now forbids.

### In scope of the original fix (this PR had made a loud failure silent)

**`src/ir/alias.rs` judged a statement binding by the shadowing binder's slot.** Witness: `v = pick(outer)` extracts a `Vector` out of a `Map`, a later `Int` pattern binder is also spelled `v`. The pass fetched "`v`'s slot" by name → got the binder's Int slot → never flagged the extracted vector as aliased → the VM's owned in-place fast path mutated the arena entry the map still holds. Recorded reds on this branch:

- Vector-in-Map: VM printed `-989 / -997` (the re-read of the map saw a gutted entry) where compiled Rust and the self-host answer `7011 / 7003` — *silent corruption*.
- Map-in-Map: the VM **panicked** at `src/vm/execute/slots.rs:482` — the issue-#926 runtime ownership fence falsifying the static grant this pass mis-stamped ("Map.set was granted ownership of slot 4 statically, and something off the operand stack … still holds it"). Before the fence work this would have been the same silent corruption.

Fix: the pass consumes the resolver's per-statement `stmt_binding_slots` positionally — the same identity `lower_stmt_chain` now uses. Discarded `_ = …` bindings keep their pre-existing skip (a dropped value retains nothing; the slot-uniqueness suite pins the owned grant after `_ = f(m)`). Both witnesses + renamed controls are in `tests/vm_pattern_shadow_matrix.rs` on all three executors, plus a positional unit test in the pass itself.

### Same disease, pre-existing (not introduced by this PR, fixed here)

**`src/ir/escape.rs` resolved arm-binder and param slots by name.** Two SIBLING arms binding the same name both got the LAST arm's slot, so the first arm's body spliced into the caller with its binder unsubstituted — a dangling slot. Recorded reds (witness: `match p { Shape.Circle(n) -> n + 1; Shape.Square(n) -> n * 10 }` inlined at `eval(Shape.Circle(5))`):

- VM: panic at `src/vm/execute/dispatch.rs:216` — "index out of bounds: the len is 1 but the index is 1".
- emitted Rust: rustc `E0425: cannot find value `n` in this scope`.
- wasm-gc: emit-time validation failure — "type mismatch: expected (ref null $type), found i32".
- self-host: `6 / 30` — correct (it does not run this pass).

Fix: arm binders are read from `MatchArm::binding_slots` (per-arm, pattern order — where the doc says they live), and the candidate's single param is the positional slot 0 (params own slots 0..N-1 by resolver construction), not a name lookup a param-shadowing binder can steal. Witness + renamed control in the matrix suite (VM / compiled Rust / self-host) and pinned in `tests/wasm_gc_codegen_regression.rs`; unit tests for both lookups beside the pass.

**`src/vm/compiler/expr.rs` — a fn referenced as a VALUE was hijacked by an out-of-scope binder.** `MirExpr::FnValue` carries a *bare name* (the resolver leaves an ident bare exactly when no local with that spelling is in scope at the use site — in-scope locals are rewritten to `Resolved`), but `compile_ident` checked the flat per-fn `local_slots` table FIRST, so any same-spelled pattern binder anywhere in the fn stole the reference. Recorded red: `callWith(dbl, x)` after a match arm binding `dbl` → VM abort "Type error [line 7]: cannot call non-function (got Unit)" where compiled Rust answers `26 / 6`.

Fix at the honest layer: since a bare `FnValue` name can only be a module fn / global / builtin when a resolution exists, a resolved fn now hands the compiler an **empty** local table — module-fn lookup wins, and a name that matches nothing fails closed as "undefined variable" instead of loading frame garbage. The params-only fallback table remains for bodies compiled without a resolution (their idents were never rewritten, so a bare param read can legitimately reach `FnValue`). This is the narrow correct fix; `FnValue` still carries a bare name rather than a resolved symbol id — routing a resolved identity through MIR is a bigger change than this PR should carry. Witness + renamed control in the matrix suite (VM / compiled Rust; the self-host parser does not accept `Fn(..)`-typed parameters yet, so it has no executor for this shape).

### Robustness

`lower_stmt_chain` and the alias pass now `debug_assert` that the per-statement slot iterator is **exhausted** after their forward pass — misalignment (a pass reordering or rewriting statement bindings without rebuilding the table), not just shortfall, is caught. The producer/consumer contract is documented on `ResolverState::stmt_binding_slots` and `FnResolution::stmt_binding_slots`. No dedicated test: no pass reorders bindings today, the assert *is* the guard.

### Sweep: every remaining by-name binding lookup, classified

The class is wider than name-keyed **slot** maps. The re-review found the same disease in a name-keyed **candidate** map: a lookup that answers "which fn/binding does this name mean HERE?" is wrong whenever the name at the site can be a local's spelling — whether the map's value is a slot or an inline candidate. Grep for both kinds.

| site | what it reads | verdict |
|---|---|---|
| `src/ir/escape.rs` (`rewrite_in_expr`, callee match) | inline-candidate map (fn name → candidate) | **fixed in the third commit** — a candidate may only match a BARE `Ident` callee. An `Expr::Resolved` callee is a local by construction of the resolver (only locals get slots), so matching it by name spliced the module fn's body over whichever fn the caller actually passed |
| `src/ir/mir/lower.rs` (`lower_stmt_chain`) | statement binding slots | **fixed in the first commit** (positional), exhaustion assert added |
| `src/codegen/wasm_gc/body/from_mir/mod.rs` (`Let` arm) | let slot | **fixed in the first commit** (reads `MirLet.binding`) |
| `src/ir/alias.rs` (`annotate_fn`) | statement binding slots | **fixed here** (positional `stmt_binding_slots`) |
| `src/ir/escape.rs:145` (`classify_fn`, param) | param slot | **fixed here** (positional slot 0) |
| `src/ir/escape.rs:180` (`classify_fn`, arm binders) | binder slots | **fixed here** (`MatchArm::binding_slots`) |
| `src/vm/compiler/expr.rs` (`compile_ident` ← `MirExpr::FnValue`) | any name | **fixed here** (empty local table for resolved fns; params-only fallback otherwise) |
| `src/codegen/lean/law_auto/homomorphism.rs:353` | param slot | **fixed here** (positional slot 0). Was fail-closed either way — a misrecognized shape yields a lemma the Lean kernel rejects, never a false theorem — but the check now asks about the right slot |
| `src/codegen/wasm_gc/body.rs` `self_local_slot` → `from_mir/mod.rs:773` | existence only | **safe** — the slot VALUE is never consumed; a hit merely selects between two failure modes for a fn id with no wasm index (`unreachable` trap-stub vs hard compile error). No wrong code can be selected; both outcomes are failures |
| `src/ir/alias.rs` test helper `local_is_flagged` | test-only | **safe** — fixture locals are uniquely named; the shadowed case is asserted through the new positional helper `stmt_binding_is_flagged` |
| `src/ir/escape.rs` test builders | test-only | **safe** — the tests construct the map themselves (producer side) |
| `src/resolver.rs` unit tests | map contents | **safe** — producer-side pins of the documented last-wins layout |
| `src/vm/compiler/mod.rs:838` | (construction site) | producer of the `FnValue` table; its semantics are the fix above |

No other name-keyed slot or candidate map exists: `hash_helpers.rs` / `eq_helpers.rs` `slots` maps are type-name → helper-function registries consulted with checker-resolved type identities, not expression-position names, and `MatchArm::binding_slots` / `stmt_binding_slots` are positional by design. A stale comment in `const_fold.rs` still claiming the wasm-gc emitter resolves `Let` slots by name was corrected.

### Verification (second commit)

- All new witnesses recorded red on this branch first (VM corruption / #926-fence panic / dispatch panic / E0425 / wasm-gc validation failure / VM abort), green after, on every executor listed above.
- Full net re-run: lib unit tests (1170), vm/eval/uniqueness/ownership/matrix/differential suites, MIR phase suites, rust_codegen_differential + regression, wasm lane (wasm_gc_spec, wasm_gc_differential_mir, wasm_gc_codegen_regression, wasm_gc_verify_option_case_regression, cross_backend_stress, cross_backend_proptest), self-host regen canary — all green.
- Both CI clippy lanes clean, `cargo fmt --all -- --check` clean.

---

## Re-review follow-up (third commit): the candidate map matched a shadowed callee

The re-review found one more site, in the escape pass itself but at a different door: `rewrite_in_expr` matched the CALLEE of a call site against the name-keyed inline-candidate map even when the callee was `Expr::Resolved` — and a resolved callee is a local by construction of the resolver (only locals get slots). A `Fn`-typed param spelled like a one-argument inlinable module fn was therefore spliced away: `fn apply(area: Fn(Shape) -> Int) = area(Shape.Circle(5))` always answered with the module fn `area`'s body, no matter which fn the caller passed.

Recorded red (witness + renamed control in `tests/vm_pattern_shadow_matrix.rs`): the VM printed `10 / 10 / 100 / 10` for `apply(big) / apply(area) / applyRenamed(big) / applyRenamed(area)` against the hand-computed `100 / 10 / 100 / 10`. On main the same program PANICKED the VM (the pre-fix arm splice left a dangling slot); this branch's per-arm `binding_slots` fix made the wrong splice SUCCEED silently, which is why the re-review caught it here. No compiled-Rust column for this witness: the emitted Rust for the higher-order shape does not compile (pre-existing E0308, fn item `for<'a> fn(&'a Shape) -> AverInt` vs expected fn pointer `fn(Shape) -> AverInt`, issue #952); the self-host parser does not accept `Fn(..)`-typed parameters, so the VM is pinned against the hand-computed truth. Fix: the candidate map may only match a bare `Ident` callee; unit test beside the pass, and a fault-injection run (re-allowing `Resolved`) flipped the witness back to `10 / 10` before the fix was restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

