### PR TITLE
Copy a container-read collection before mutating it on wasm-gc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
             wasm_gc_capture_output \
             wasm_gc_carrier_i64_differential \
             wasm_gc_codegen_regression \
+            wasm_gc_container_read_ownership \
             wasm_gc_differential_mir \
             wasm_gc_plan_mir_equivalence \
             wasm_gc_effect_arg_overflow_regression \

--- a/aver-memory/src/arena.rs
+++ b/aver-memory/src/arena.rs
@@ -19,6 +19,7 @@ impl<T: ArenaTypes> Arena<T> {
             map_entries_scanned: 0,
             rewrite_out_of_region_roots: false,
             holds_any_map: false,
+            holds_any_vector: false,
             inplace_visit_stamps: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             inplace_visit_epoch: 0,
             type_keys: Vec::new(),
@@ -65,6 +66,7 @@ impl<T: ArenaTypes> Arena<T> {
             // The stable entries come across whole, and a map among them is
             // still a map here.
             holds_any_map: self.holds_any_map,
+            holds_any_vector: self.holds_any_vector,
             inplace_visit_stamps: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             inplace_visit_epoch: 0,
             type_keys: self.type_keys.clone(),
@@ -151,10 +153,12 @@ impl<T: ArenaTypes> Arena<T> {
                 let idx = self.push_map(new_map);
                 NanValue::new_map(idx)
             }
-            ArenaEntry::Vector(items) => {
+            ArenaEntry::Vector { items, .. } => {
                 let imported: Vec<NanValue> =
                     items.iter().map(|v| self.deep_import(*v, source)).collect();
-                let idx = self.push(ArenaEntry::Vector(imported));
+                // Through `push_vector`, so imported children that are
+                // themselves collections get their held-elsewhere mark.
+                let idx = self.push_vector(imported);
                 NanValue::new_vector(idx)
             }
             ArenaEntry::Record { type_id, fields } => {
@@ -197,15 +201,17 @@ impl<T: ArenaTypes> Arena<T> {
     /// Record that something other than the caller's own handle now holds
     /// `value`'s slot.
     ///
-    /// A no-op for anything but a heap-backed map, which is the only entry that
-    /// carries the flag, and the only one anything ever empties in place. The
-    /// consumer calls this for the roots the arena cannot see for itself — a
-    /// global it stores into, a constant table it hands the program, a value it
-    /// writes into an entry that already exists. `ArenaEntry::Map`'s
-    /// `held_elsewhere` carries the full list of marking sites.
+    /// A no-op for anything but a heap-backed map or vector — the two entries
+    /// that carry the flag, because they are the two anything ever empties in
+    /// place (`take_map_value` / `take_vector_value`). The consumer calls this
+    /// for the roots the arena cannot see for itself — a global it stores
+    /// into, a constant table it hands the program, a value it writes into an
+    /// entry that already exists. `ArenaEntry::Map`'s `held_elsewhere` carries
+    /// the full list of marking sites; the vector flag rides the same choke
+    /// points.
     #[inline(always)]
     pub fn note_held_elsewhere(&mut self, value: NanValue) {
-        if value.is_heap_map() {
+        if value.is_heap_map() || (value.is_vector() && !value.is_empty_vector_immediate()) {
             self.mark_held_elsewhere(value.arena_index());
         }
     }
@@ -218,31 +224,34 @@ impl<T: ArenaTypes> Arena<T> {
     /// enough to reach through a call.
     #[inline(never)]
     fn mark_held_elsewhere(&mut self, index: u32) {
-        if let ArenaEntry::Map { held_elsewhere, .. } = self.get_mut(index) {
-            *held_elsewhere = true;
+        match self.get_mut(index) {
+            ArenaEntry::Map { held_elsewhere, .. } | ArenaEntry::Vector { held_elsewhere, .. } => {
+                *held_elsewhere = true
+            }
+            _ => {}
         }
     }
 
-    /// Mark every map `entry` holds DIRECTLY, so the entry counts as a holder
-    /// of those slots from here on.
+    /// Mark every map or vector `entry` holds DIRECTLY, so the entry counts as
+    /// a holder of those slots from here on.
     ///
-    /// Direct is enough: a map reachable from the arena at all is a direct
-    /// child of SOME entry, and that entry came through here. What it does not
-    /// do is walk a map's own table — that would put an `O(size)` pass in front
-    /// of the one insert that is `O(1)`. The two builders of a map entry mark
-    /// its keys and values themselves: [`Arena::push_map`] in the pass it
-    /// already makes over the table, and the owned insert for the one pair it
-    /// adds.
+    /// Direct is enough: a map or vector reachable from the arena at all is a
+    /// direct child of SOME entry, and that entry came through here. What it
+    /// does not do is walk a map's own table or a vector entry's own elements —
+    /// that would put an `O(size)` pass in front of the one insert that is
+    /// `O(1)`. The builders mark their own children instead: [`Arena::push_map`]
+    /// and the owned map insert for tables, [`Arena::push_vector`] and the
+    /// owned `Vector.set` (which marks the one element it stores) for vectors.
     ///
-    /// Reached only when the arena has stored a map at all — [`Arena::push`]
-    /// reads that flag off the same discriminant it was already reading — and
-    /// deliberately not inlined into it, so a program that never builds a map
-    /// carries none of this in its allocation path.
+    /// Reached only when the arena has stored a map or vector at all —
+    /// [`Arena::push`] reads that off the same discriminant it was already
+    /// reading — and deliberately not inlined into it, so a program that never
+    /// builds a collection carries none of this in its allocation path.
     #[inline(never)]
-    fn note_entry_holds_maps(&mut self, entry: &ArenaEntry<T>) {
+    fn note_entry_holds_collections(&mut self, entry: &ArenaEntry<T>) {
         match entry {
             ArenaEntry::Boxed(value) => self.note_held_elsewhere(*value),
-            ArenaEntry::Tuple(items) | ArenaEntry::Vector(items) => {
+            ArenaEntry::Tuple(items) => {
                 for value in items {
                     self.note_held_elsewhere(*value);
                 }
@@ -254,7 +263,7 @@ impl<T: ArenaTypes> Arena<T> {
             }
             ArenaEntry::List(list) => match list {
                 ArenaList::Flat { items, start } => {
-                    if items.holds_map() {
+                    if items.holds_collection() {
                         for value in &items[(*start).min(items.len())..] {
                             self.note_held_elsewhere(*value);
                         }
@@ -275,16 +284,18 @@ impl<T: ArenaTypes> Arena<T> {
                     ..
                 } => {
                     self.note_held_elsewhere(*current);
-                    if rest.holds_map() {
+                    if rest.holds_collection() {
                         for value in &rest[(*start).min(rest.len())..] {
                             self.note_held_elsewhere(*value);
                         }
                     }
                 }
             },
-            // A map's own table is marked by whoever built it; see the doc
-            // above. Everything else holds no `NanValue` at all.
+            // A map's own table and a vector entry's own elements are marked
+            // by whoever built them; see the doc above. Everything else holds
+            // no `NanValue` at all.
             ArenaEntry::Map { .. }
+            | ArenaEntry::Vector { .. }
             | ArenaEntry::Int(_)
             | ArenaEntry::BigInt(_)
             | ArenaEntry::String(_)
@@ -300,14 +311,14 @@ impl<T: ArenaTypes> Arena<T> {
 
     #[inline]
     pub fn push(&mut self, entry: ArenaEntry<T>) -> u32 {
-        // The map bookkeeping rides on the discriminant read this match was
-        // already doing, so an allocation that has nothing to do with maps pays
-        // one bool for it.
+        // The collection bookkeeping rides on the discriminant read this match
+        // was already doing, so an allocation that has nothing to do with maps
+        // or vectors pays one bool for it.
         //
-        // A map entry is where the flag comes from: nothing else in this arena
-        // can carry a map's index until one exists, and the only way one comes
-        // to exist is this arm. Everything else asks the flag first and walks
-        // its children only if the answer could be yes.
+        // A map or vector entry is where its flag comes from: nothing else in
+        // this arena can carry such an index until one exists, and the only
+        // way one comes to exist is its arm. Everything else asks the flags
+        // first and walks its children only if the answer could be yes.
         match &entry {
             ArenaEntry::Fn(_) | ArenaEntry::Builtin(_) | ArenaEntry::Namespace { .. } => {}
             ArenaEntry::Map { .. } => {
@@ -320,6 +331,16 @@ impl<T: ArenaTypes> Arena<T> {
                 }
                 return self.push_heap(entry);
             }
+            // Like the map arm: the entry's OWN elements are the builder's
+            // to mark ([`Arena::push_vector`] walks them; the owned
+            // `Vector.set` marks the one element it stores), so this arm
+            // only records that vector indices exist now.
+            ArenaEntry::Vector { .. } => {
+                if !self.holds_any_vector {
+                    self.holds_any_vector = true;
+                }
+                return self.push_heap(entry);
+            }
             // Nothing here holds a `NanValue`, so there is nothing to mark and
             // no reason to leave the match to find that out. A map fold
             // allocates one of these per step for its keys.
@@ -327,8 +348,8 @@ impl<T: ArenaTypes> Arena<T> {
                 return self.push_heap(entry);
             }
             _ => {
-                if self.holds_any_map {
-                    self.note_entry_holds_maps(&entry);
+                if self.holds_any_map || self.holds_any_vector {
+                    self.note_entry_holds_collections(&entry);
                 }
                 return self.push_heap(entry);
             }
@@ -761,7 +782,8 @@ impl<T: ArenaTypes> Arena<T> {
         for (key, value) in map.values() {
             all_immediate &= key.is_immediate() && value.is_immediate();
             for child in [*key, *value] {
-                if child.is_heap_map() {
+                if child.is_heap_map() || (child.is_vector() && !child.is_empty_vector_immediate())
+                {
                     held.get_or_insert_default().push(child);
                 }
             }
@@ -778,8 +800,29 @@ impl<T: ArenaTypes> Arena<T> {
     pub fn push_tuple(&mut self, items: Vec<NanValue>) -> u32 {
         self.push(ArenaEntry::Tuple(items))
     }
+    /// Store a vector, marking every map or vector it holds as held by this
+    /// entry — the vector spelling of [`Arena::push_map`]'s marking pass, made
+    /// in the walk this builder can afford because its callers already paid
+    /// `O(n)` to build `items`. The one builder that must NOT come through
+    /// here is the owned `Vector.set`, which is `O(1)` per write and marks the
+    /// single element it stores itself (see `vec_set_nv_owned`).
     pub fn push_vector(&mut self, items: Vec<NanValue>) -> u32 {
-        self.push(ArenaEntry::Vector(items))
+        if self.holds_any_map || self.holds_any_vector {
+            let mut held: Option<Vec<NanValue>> = None;
+            for child in &items {
+                if child.is_heap_map() || (child.is_vector() && !child.is_empty_vector_immediate())
+                {
+                    held.get_or_insert_default().push(*child);
+                }
+            }
+            for child in held.into_iter().flatten() {
+                self.note_held_elsewhere(child);
+            }
+        }
+        self.push(ArenaEntry::Vector {
+            items,
+            held_elsewhere: false,
+        })
     }
     pub fn push_fn(&mut self, f: Rc<T::Fn>) -> u32 {
         self.push_symbol(ArenaSymbol::Fn(f))
@@ -868,14 +911,34 @@ impl<T: ArenaTypes> Arena<T> {
     }
     pub fn get_vector(&self, index: u32) -> &[NanValue] {
         match self.get(index) {
-            ArenaEntry::Vector(items) => items,
+            ArenaEntry::Vector { items, .. } => items,
             _ => panic!("Arena: expected Vector at {}", index),
         }
     }
     pub fn get_vector_mut(&mut self, index: u32) -> &mut Vec<NanValue> {
         match self.get_mut(index) {
-            ArenaEntry::Vector(items) => items,
+            ArenaEntry::Vector { items, .. } => items,
             _ => panic!("Arena: expected Vector at {}", index),
+        }
+    }
+    /// Everything a caller deciding whether to empty this vector's slot needs
+    /// from the arena, out of one lookup — the vector spelling of
+    /// [`Arena::map_slot`]. `None` for anything that is not a heap-backed
+    /// vector, the empty-vector immediate among them.
+    #[inline]
+    pub fn vector_slot(&self, value: NanValue) -> Option<VectorSlot> {
+        if !value.is_vector() || value.is_empty_vector_immediate() {
+            return None;
+        }
+        match self.get(value.arena_index()) {
+            ArenaEntry::Vector {
+                items,
+                held_elsewhere,
+            } => Some(VectorSlot {
+                held_elsewhere: *held_elsewhere,
+                len: items.len(),
+            }),
+            _ => panic!("Arena: expected Vector at {}", value.arena_index()),
         }
     }
     pub fn vector_ref_value(&self, value: NanValue) -> &[NanValue] {
@@ -892,6 +955,11 @@ impl<T: ArenaTypes> Arena<T> {
         }
     }
     /// Take ownership of a vector, replacing the arena slot with an empty vec.
+    ///
+    /// `held_elsewhere` is deliberately left alone, for the same reason
+    /// [`Arena::take_map_value`] leaves the map's: emptying the slot does not
+    /// discharge a holder, and a second take over the same slot must be
+    /// refused for the same reason the first one should have been.
     pub fn take_vector_value(&mut self, value: NanValue) -> Vec<NanValue> {
         if value.is_empty_vector_immediate() {
             Vec::new()

--- a/aver-memory/src/lib.rs
+++ b/aver-memory/src/lib.rs
@@ -125,6 +125,19 @@ pub struct MapSlot {
     pub entries: usize,
 }
 
+/// What a caller deciding whether to mutate a vector's arena slot in place
+/// needs to know about it — the vector spelling of [`MapSlot`], for the
+/// vector spelling of the same decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VectorSlot {
+    /// Whether anything but the handle in the caller's hand holds this slot —
+    /// another arena entry, or a root the consumer registered through
+    /// [`Arena::note_held_elsewhere`].
+    pub held_elsewhere: bool,
+    /// How many elements a copy would move.
+    pub len: usize,
+}
+
 /// Whether `entry` holds `index` directly, read out of the entry itself.
 ///
 /// The searched answer behind [`Arena::any_entry_holds_slot`], and deliberately
@@ -140,7 +153,7 @@ pub fn entry_holds_slot<T: ArenaTypes>(entry: &ArenaEntry<T>, index: u32) -> boo
     let holds = |value: &NanValue| value.heap_index() == Some(index);
     match entry {
         ArenaEntry::Boxed(value) => holds(value),
-        ArenaEntry::Tuple(items) | ArenaEntry::Vector(items) => items.iter().any(holds),
+        ArenaEntry::Tuple(items) | ArenaEntry::Vector { items, .. } => items.iter().any(holds),
         ArenaEntry::Record { fields, .. } | ArenaEntry::Variant { fields, .. } => {
             fields.iter().any(holds)
         }
@@ -1394,6 +1407,11 @@ pub struct Arena<T: ArenaTypes> {
     /// because an index that stopped being reachable does not make the question
     /// cheaper to answer, and a stale `true` only costs the pass.
     holds_any_map: bool,
+    /// Whether this arena has ever stored a heap-backed vector — the vector
+    /// spelling of `holds_any_map`, with the same monotonicity and the same
+    /// job: no vector entry means no value here can carry a vector's index,
+    /// so the per-push marking pass has nothing to find.
+    holds_any_vector: bool,
     /// Which out-of-region slots the descent above has already rewritten, one
     /// stamp array per heap space, indexed by raw arena index.
     ///
@@ -1516,7 +1534,17 @@ pub enum ArenaEntry<T: ArenaTypes> {
         /// arena has just built and not yet handed to anybody.
         held_elsewhere: bool,
     },
-    Vector(Vec<NanValue>),
+    Vector {
+        items: Vec<NanValue>,
+        /// The vector spelling of [`ArenaEntry::Map::held_elsewhere`] — see
+        /// that field for the full contract; the marking choke points
+        /// ([`Arena::note_held_elsewhere`] and everything that funnels into
+        /// it) cover heap vectors and heap maps alike. It exists for the
+        /// interpreter's runtime fence on the owned `Vector.set`, which
+        /// empties the slot it takes from (`Arena::take_vector_value`) and
+        /// may only do so when no off-stack holder is left to read it.
+        held_elsewhere: bool,
+    },
     Record {
         type_id: u32,
         fields: Vec<NanValue>,
@@ -1569,21 +1597,21 @@ pub enum ArenaSymbol<T: ArenaTypes> {
 pub struct ListBody {
     items: Vec<NanValue>,
     all_immediate: bool,
-    holds_map: bool,
+    holds_collection: bool,
 }
 
 impl ListBody {
     pub fn new(items: Vec<NanValue>) -> Self {
         let mut all_immediate = true;
-        let mut holds_map = false;
+        let mut holds_collection = false;
         for value in &items {
             all_immediate &= value.is_immediate();
-            holds_map |= value.is_map() && !value.is_immediate();
+            holds_collection |= (value.is_map() || value.is_vector()) && !value.is_immediate();
         }
         Self {
             items,
             all_immediate,
-            holds_map,
+            holds_collection,
         }
     }
 
@@ -1594,17 +1622,19 @@ impl ListBody {
         self.all_immediate
     }
 
-    /// Whether any element is a heap-backed map, so pushing an entry over this
-    /// body puts a second holder on a map slot.
+    /// Whether any element is a heap-backed map or vector, so pushing an entry
+    /// over this body puts a second holder on a slot the owned in-place write
+    /// path could otherwise empty.
     ///
     /// Decided in the same pass as `all_immediate` and for the same reason: a
     /// body is immutable once built, and a body a collection views at an
     /// advanced offset is the SAME body — `List.drop` re-pushes the `Rc` rather
     /// than copying it. Reading the flag is what keeps that push `O(1)` instead
-    /// of a walk over elements that are never maps.
+    /// of a walk over elements that are never collections. Was `holds_map`
+    /// until the vector fence needed the same record for vector slots.
     #[inline]
-    pub fn holds_map(&self) -> bool {
-        self.holds_map
+    pub fn holds_collection(&self) -> bool {
+        self.holds_collection
     }
 }
 

--- a/aver-memory/src/memory.rs
+++ b/aver-memory/src/memory.rs
@@ -333,11 +333,20 @@ impl<T: ArenaTypes> Arena<T> {
                 }
                 ArenaEntry::Tuple(items)
             }
-            ArenaEntry::Vector(mut items) => {
+            ArenaEntry::Vector {
+                mut items,
+                held_elsewhere,
+            } => {
+                // `held_elsewhere` travels with the entry untouched — same
+                // argument as the map arm: a rewrite renames indices, it
+                // neither creates a reference nor discharges one.
                 for value in &mut items {
                     *value = rewrite(self, *value);
                 }
-                ArenaEntry::Vector(items)
+                ArenaEntry::Vector {
+                    items,
+                    held_elsewhere,
+                }
             }
             ArenaEntry::Map {
                 map,
@@ -1884,7 +1893,7 @@ impl<T: ArenaTypes> Arena<T> {
         // to young >= mark, skip the rewrite — move the entry as-is.
         // Only check types where the scan is cheap relative to the rewrite cost.
         match &entry {
-            ArenaEntry::Vector(items) | ArenaEntry::Tuple(items)
+            ArenaEntry::Vector { items, .. } | ArenaEntry::Tuple(items)
                 if !items.is_empty()
                     && !items
                         .iter()

--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -265,8 +265,8 @@ pub(super) struct EmitCtx<'a> {
     /// on the MIR path it is sourced from `MirFn::aliased_slots`, so the
     /// owned-mutate fast path reads its gate off MIR rather than reaching
     /// back into the AST `FnResolution` side-channel. `is_aliased_slot`
-    /// reads this; an out-of-range slot is `false` (not aliased → fast
-    /// path sound).
+    /// reads this; an out-of-range slot is `true` (no verdict → treated
+    /// as aliased, so the mutation copies — see its doc, #950).
     pub(super) aliased_slots: &'a [bool],
     /// Per-slot / per-param Int representation for the current fn (ETAP-2
     /// SLICE 2a). Sourced from `MirFn::repr` (mirror of `aliased_slots`).
@@ -573,21 +573,23 @@ impl<'a> EmitCtx<'a> {
     }
 
     /// Whether `slot` is flagged as alias-prone by `ir::alias`. Backends
-    /// that want to skip clone-on-write must check this first; default
-    /// `false` for slots outside the table (empty table, scratch
-    /// slots) is the safe-but-fast answer (no aliasing suspicion →
-    /// in-place is sound). The alias pass always runs in real builds,
-    /// so an empty table only happens in test paths that pre-resolve
-    /// manually. Reads the `aliased_slots` field, which is
-    /// resolution-sourced on the HIR path and `MirFn`-sourced on the
-    /// MIR path — identical bits, different home. Read by the MIR
+    /// that want to skip clone-on-write must check this first. A slot
+    /// OUTSIDE the table (empty table, synthetic MIR temps past the
+    /// resolver's count) reads as ALIASED: no verdict is not the same
+    /// thing as "proven unshared", and treating it as clean is exactly
+    /// how #950 mutated a map-held vector in place — the post-flatten
+    /// re-resolve had re-stamped `aliased_slots` with a default table,
+    /// and every container-read local sailed through. Missing evidence
+    /// now costs the fast path, never soundness. Reads the
+    /// `aliased_slots` field, which is `MirFn`-sourced on the MIR path
+    /// (the resolver bits, cloned at lowering). Read by the MIR
     /// emitter's `mir_arg_uniquely_owned` (from_mir/builtins.rs), which
     /// is the only caller now that the `ResolvedExpr` walker is gone.
     pub(super) fn is_aliased_slot(&self, slot: u16) -> bool {
         self.aliased_slots
             .get(slot as usize)
             .copied()
-            .unwrap_or(false)
+            .unwrap_or(true)
     }
 
     /// `fn_sig_key` for the `Fn(..)` param named `name`, used to look up

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -1791,19 +1791,82 @@ pub(crate) fn emit_mir_list_builtin(
     Ok(MirBuiltinEmit::Produced(true))
 }
 
-/// MIR analogue of `EmitCtx::arg_uniquely_owned` (body.rs). The
-/// ownership fast-path key — `last_use` on a non-alias-prone local — is
-/// carried verbatim on `MirLocal` (the lowerer copies it from
-/// `ResolvedExpr::Resolved { last_use }`, see `crate::ir::mir::lower`), and
-/// `is_aliased_slot` reads the same resolver `aliased_slots` table, so
-/// this returns the identical verdict to the HIR oracle for the same
-/// source expression. Anonymous / transient args are uniquely owned.
+/// May the emitter mutate this receiver in place instead of copying it
+/// first? The ownership fast-path key for a LOCAL — `last_use` on a
+/// non-alias-prone slot — is carried verbatim on `MirLocal` (the lowerer
+/// copies it from `ResolvedExpr::Resolved { last_use }`, see
+/// `crate::ir::mir::lower`), and `is_aliased_slot` reads the resolver's
+/// `aliased_slots` table. A NON-local receiver earns the fast path only
+/// by being a provably-fresh collection ([`mir_expr_is_fresh_collection`]);
+/// anything else — a container read, a user-fn result — copies (#950).
 pub(crate) fn mir_arg_uniquely_owned(arg: &Spanned<MirExpr>, ctx: &EmitCtx<'_>) -> bool {
     match &arg.node {
         MirExpr::Local(local) => {
             local.node.last_use && !ctx.is_aliased_slot(local.node.slot.0 as u16)
         }
-        _ => true,
+        other => mir_expr_is_fresh_collection(other, ctx),
+    }
+}
+
+/// Does this non-local receiver expression yield a PROVABLY-FRESH
+/// collection — one no other binding (a map entry, a list element, a
+/// caller's local) can still reach?
+///
+/// MIR mirror of `ir::alias::rhs_is_fresh_collection`, and the same
+/// burden of proof: in-place mutation is an optimizer privilege that
+/// has to be earned, so everything unrecognized is NOT fresh and the
+/// mutation copies first. Before this predicate the wildcard arm of
+/// [`mir_arg_uniquely_owned`] answered `true` for every anonymous
+/// receiver — which made `Vector.set(Option.withDefault(Map.get(m, k),
+/// d), i, x)` mutate the map-held array in place (#950). A container
+/// read is exactly the shape that must fail this test.
+fn mir_expr_is_fresh_collection(expr: &MirExpr, ctx: &EmitCtx<'_>) -> bool {
+    match expr {
+        MirExpr::MapLiteral(_) => true,
+        // Fresh only if EVERY arm is fresh — one aliasing arm taints the
+        // value (same rule as the AST-side pass).
+        MirExpr::Match(m) => m
+            .node
+            .arms
+            .iter()
+            .all(|a| mir_expr_is_fresh_collection(&a.body.node, ctx)),
+        MirExpr::IfThenElse(ite) => {
+            mir_expr_is_fresh_collection(&ite.node.then_branch.node, ctx)
+                && mir_expr_is_fresh_collection(&ite.node.else_branch.node, ctx)
+        }
+        MirExpr::Call(call) => {
+            let MirCallee::Builtin(id) = &call.node.callee else {
+                // A user fn may return a handle it read out of a
+                // container (or one of its own arguments), so its result
+                // is not provably fresh.
+                return false;
+            };
+            let Some(dotted) = ctx.mir_builtins.and_then(|names| names.get(id.0 as usize)) else {
+                return false;
+            };
+            match dotted.as_str() {
+                // Allocating builtins — each returns a collection it just
+                // built, so nothing else holds the handle. Same list as
+                // `ir::alias::is_fresh_collection_builtin`.
+                "Vector.set" | "Vector.fromList" | "Map.set" | "Map.remove" | "Map.fromList" => {
+                    true
+                }
+                // `Vector.new` is fresh only for a non-compound fill —
+                // mirror of the AST-side rule.
+                "Vector.new" if call.node.args.len() == 2 => {
+                    !crate::ir::alias::type_is_compound(&aver_type_str_of(&call.node.args[1]))
+                }
+                // `Option.withDefault(a, b)` is fresh when both branches
+                // are. (`Vector.get` / `Map.get` inside makes it a
+                // container read, which correctly fails the branch test.)
+                "Option.withDefault" if call.node.args.len() == 2 => {
+                    mir_expr_is_fresh_collection(&call.node.args[0].node, ctx)
+                        && mir_expr_is_fresh_collection(&call.node.args[1].node, ctx)
+                }
+                _ => false,
+            }
+        }
+        _ => false,
     }
 }
 

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -731,6 +731,13 @@ fn emit_mir_vector_set_or_default(
 
     // Fast path: dead, non-aliased binding → mutate the engine array in
     // place and return the same handle. No scratch, no allocation.
+    //
+    // Re-emitting `vector` three times is free HERE and nowhere else: the
+    // call-site guard above only reaches this emitter when the receiver and
+    // the `withDefault` default are the same `MirExpr::Local`, so every
+    // emission is one `local.get` of one cell. (The boxed spelling,
+    // `emit_mir_vector_set_boxed`, has no such guard — its receiver can be a
+    // provably-fresh non-local, and re-emitting THAT builds another array.)
     if mir_arg_uniquely_owned(vector, ctx) {
         idx_nonneg!();
         idx_i32!();
@@ -761,12 +768,38 @@ fn emit_mir_vector_set_or_default(
                  (slot-pre-pass missed this site)"
             ))
         })?;
+    let vec_ref = wasm_encoder::ValType::Ref(wasm_encoder::RefType {
+        nullable: true,
+        heap_type: wasm_encoder::HeapType::Concrete(vec_idx),
+    });
+
+    // The bounds test runs BEFORE the copy, and the whole clone lives inside
+    // the taken branch. Out of bounds this fusion's answer is the default,
+    // which the call-site guard proved is the receiver itself, so the else
+    // branch hands back the original instead of an identical copy of it —
+    // the same value, and no allocation at all on the miss.
+    //
+    // Scratch discipline, the same one `emit_mir_vector_set_boxed` states in
+    // full: there is ONE scratch local per `Vector<T>` per fn and this
+    // emitter is re-entrant, so every read of `scratch` happens before any
+    // operand that could contain another `Vector.set` of the same type is
+    // re-emitted. Both reads — the result and the `array.set` target — are
+    // therefore pushed before the index is re-emitted and before `value` is.
+    // The index used to be emitted between the store and the reads, so an
+    // index like `Vector.len(Option.withDefault(Vector.set(…), …))` handed
+    // back the array the NESTED set had left in the local.
+    idx_nonneg!();
+    idx_i32!();
+    e!(vector);
+    func.instruction(&Instruction::ArrayLen);
+    func.instruction(&Instruction::I32LtU);
+    func.instruction(&Instruction::I32And);
+    func.instruction(&Instruction::If(wasm_encoder::BlockType::Result(vec_ref)));
 
     e!(vector);
     func.instruction(&Instruction::ArrayLen);
     func.instruction(&Instruction::ArrayNewDefault(vec_idx));
     func.instruction(&Instruction::LocalSet(scratch));
-
     func.instruction(&Instruction::LocalGet(scratch));
     func.instruction(&Instruction::I32Const(0));
     e!(vector);
@@ -777,21 +810,15 @@ fn emit_mir_vector_set_or_default(
         array_type_index_dst: vec_idx,
         array_type_index_src: vec_idx,
     });
-
-    idx_nonneg!();
-    idx_i32!();
     func.instruction(&Instruction::LocalGet(scratch));
-    func.instruction(&Instruction::ArrayLen);
-    func.instruction(&Instruction::I32LtU);
-    func.instruction(&Instruction::I32And);
-    func.instruction(&Instruction::If(wasm_encoder::BlockType::Empty));
     func.instruction(&Instruction::LocalGet(scratch));
     idx_i32!();
     e!(value);
     func.instruction(&Instruction::ArraySet(vec_idx));
-    func.instruction(&Instruction::End);
 
-    func.instruction(&Instruction::LocalGet(scratch));
+    func.instruction(&Instruction::Else);
+    e!(vector);
+    func.instruction(&Instruction::End);
     Ok(MirBuiltinEmit::Produced(true))
 }
 
@@ -2078,31 +2105,6 @@ pub(crate) fn emit_mir_vector_set_boxed(
             }
         };
     }
-    if mir_arg_uniquely_owned(vector, ctx) {
-        idx_nonneg!();
-        idx_i32!();
-        e!(vector);
-        func.instruction(&Instruction::ArrayLen);
-        func.instruction(&Instruction::I32LtU);
-        func.instruction(&Instruction::I32And);
-        func.instruction(&Instruction::If(block_ty));
-        e!(vector);
-        idx_i32!();
-        e!(value);
-        func.instruction(&Instruction::ArraySet(vec_idx));
-        func.instruction(&Instruction::I32Const(1));
-        e!(vector);
-        func.instruction(&Instruction::StructNew(opt_idx));
-        func.instruction(&Instruction::Else);
-        func.instruction(&Instruction::I32Const(0));
-        func.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(
-            vec_idx,
-        )));
-        func.instruction(&Instruction::StructNew(opt_idx));
-        func.instruction(&Instruction::End);
-        return Ok(MirBuiltinEmit::Produced(true));
-    }
-
     let scratch = slots
         .vector_set_scratch
         .get(&canonical)
@@ -2113,6 +2115,61 @@ pub(crate) fn emit_mir_vector_set_boxed(
                  (slot-pre-pass missed this site)"
             ))
         })?;
+    if mir_arg_uniquely_owned(vector, ctx) {
+        // The receiver is emitted ONCE, into the scratch local, and read back
+        // from there at all three sites. Re-emitting it is only free for a
+        // LOCAL; a non-local receiver is owned-eligible when it is a provably
+        // FRESH collection, and re-emitting a fresh collection BUILDS ANOTHER
+        // ONE. Three emissions then meant three different arrays: the bounds
+        // check measured the first, `array.set` wrote the second, and the
+        // `Some` wrapped the third — so
+        // `Vector.set(Vector.fromList([x, 9]), 0, x + 5000)` answered `x`
+        // where every other backend answered `x + 5000` (#953 round 3, probe
+        // h). Freshness earns the write, it does not make the value free.
+        //
+        // ## Scratch discipline: every read of it before any re-emission
+        //
+        // There is ONE scratch local per `Vector<T>` per fn, and the emitter
+        // is re-entrant: an operand re-emitted here can be another
+        // `Vector.set` of the same `Vector<T>`, which stores into that same
+        // local. So the whole body obeys one rule — emit everything that can
+        // re-enter, THEN store, THEN read, and let the tail re-emissions
+        // clobber a local nothing will read again:
+        //
+        // - the index goes first, before the store. It is emitted up to three
+        //   times (non-negative test, bounds test, `array.set` operand), and
+        //   a nested set inside it would otherwise overwrite the receiver
+        //   between the store and the first read;
+        // - the `Some` is built BEFORE the write, so both remaining reads of
+        //   `scratch` — the payload and the `array.set` target — happen
+        //   before the index is re-emitted and before `value` is. It still
+        //   observes the mutation: the struct holds the array by reference.
+        idx_nonneg!();
+        idx_i32!();
+        e!(vector);
+        func.instruction(&Instruction::LocalSet(scratch));
+        func.instruction(&Instruction::LocalGet(scratch));
+        func.instruction(&Instruction::ArrayLen);
+        func.instruction(&Instruction::I32LtU);
+        func.instruction(&Instruction::I32And);
+        func.instruction(&Instruction::If(block_ty));
+        func.instruction(&Instruction::I32Const(1));
+        func.instruction(&Instruction::LocalGet(scratch));
+        func.instruction(&Instruction::StructNew(opt_idx));
+        func.instruction(&Instruction::LocalGet(scratch));
+        idx_i32!();
+        e!(value);
+        func.instruction(&Instruction::ArraySet(vec_idx));
+        func.instruction(&Instruction::Else);
+        func.instruction(&Instruction::I32Const(0));
+        func.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(
+            vec_idx,
+        )));
+        func.instruction(&Instruction::StructNew(opt_idx));
+        func.instruction(&Instruction::End);
+        return Ok(MirBuiltinEmit::Produced(true));
+    }
+
     idx_nonneg!();
     idx_i32!();
     e!(vector);
@@ -2134,13 +2191,20 @@ pub(crate) fn emit_mir_vector_set_boxed(
         array_type_index_dst: vec_idx,
         array_type_index_src: vec_idx,
     });
+    // Same scratch discipline as the owned path above: the `Some` wraps the
+    // copy BEFORE the copy is written, so both reads of `scratch` are done
+    // before the index is re-emitted and before `value` is. Without it a
+    // nested `Vector.set` of the same `Vector<T>` in either operand — an
+    // index like `Vector.len(Option.withDefault(Vector.set(…), …))` is enough
+    // — left the payload pointing at the nested set's array while the write
+    // landed correctly on this one.
+    func.instruction(&Instruction::I32Const(1));
+    func.instruction(&Instruction::LocalGet(scratch));
+    func.instruction(&Instruction::StructNew(opt_idx));
     func.instruction(&Instruction::LocalGet(scratch));
     idx_i32!();
     e!(value);
     func.instruction(&Instruction::ArraySet(vec_idx));
-    func.instruction(&Instruction::I32Const(1));
-    func.instruction(&Instruction::LocalGet(scratch));
-    func.instruction(&Instruction::StructNew(opt_idx));
     func.instruction(&Instruction::Else);
     func.instruction(&Instruction::I32Const(0));
     func.instruction(&Instruction::RefNull(wasm_encoder::HeapType::Concrete(

--- a/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
+++ b/src/codegen/wasm_gc/body/from_mir/pattern_match.rs
@@ -260,8 +260,38 @@ pub(crate) fn emit_mir_match(
                 Ok(None)
             }
         }
-        // Non-primitive subjects (sum/record/etc.) fall back.
-        _ => Ok(None),
+        // Non-primitive subjects. The irrefutable single-arm binder
+        // `match subj { v -> body }` is a rename: store the subject into
+        // the binder's slot and emit the body — no tag to test, no branch
+        // block, so the body inherits `result_raw` directly, like
+        // `emit_mir_tuple_match`. This shape used to fall through to the
+        // trap stub, which made a bare-ident binder over a `Vector` a
+        // trapping program (#953 follow-up). Scoped to non-primitive
+        // subjects: their locals are always refs, so the `LocalSet` type
+        // matches; a primitive binder would have to reckon with per-slot
+        // int unboxing and keeps its (loud) trap-stub fallback.
+        _ => {
+            if m.arms.len() == 1
+                && let MirPattern::Bind(slot, _) = &m.arms[0].pattern
+            {
+                if emit_mir_expr(func, &m.subject, slots, ctx)?.is_none() {
+                    return Ok(None);
+                }
+                if slot.0 == u32::from(u16::MAX) {
+                    // A wildcard-position binder binds nothing; the
+                    // subject was emitted for its effects only.
+                    func.instruction(&Instruction::Drop);
+                } else {
+                    func.instruction(&Instruction::LocalSet(slot.0));
+                }
+                ctx.int_result_raw.set(result_raw);
+                let Some(body_produces) = emit_mir_expr(func, &m.arms[0].body, slots, ctx)? else {
+                    return Ok(None);
+                };
+                return Ok(Some(body_produces));
+            }
+            Ok(None)
+        }
     }
 }
 

--- a/src/diagnostics/wasm_gc_verify.rs
+++ b/src/diagnostics/wasm_gc_verify.rs
@@ -175,7 +175,10 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
     let mut type_aliases = std::collections::HashMap::new();
     if !dep_modules.is_empty() {
         type_aliases = crate::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
-        crate::ir::pipeline::resolve(&mut items);
+        // `_and_reannotate`: a bare post-flatten re-resolve wipes
+        // `aliased_slots` and the wasm-gc in-place fast path goes
+        // wrong (#950).
+        crate::ir::pipeline::resolve_and_reannotate(&mut items);
     }
 
     let bytes = crate::codegen::wasm_gc::compile_to_wasm_gc_flattened(

--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -113,6 +113,21 @@ fn annotate_fn(fd: &mut FnDef) {
         }
     }
 
+    // Match-pattern binders. A binder slot is a container read spelled as a
+    // pattern: `Option.Some(v)`, `[h, ..t]`, `(a, b)`, or the bare-ident
+    // rename `v ->` all hand the arm body a handle INTO the subject's value.
+    // The two statement passes above never see those slots — they iterate
+    // `Stmt::Binding` only — so a binder used to read as "never shared" and
+    // the in-place fast path wrote through the stored entry (issue #953
+    // follow-up). Symmetric with the statement rule: a binder is judged by
+    // its subject's freshness, exactly as a binding is judged by its RHS.
+    for stmt in stmts {
+        let expr = match stmt {
+            Stmt::Binding(_, _, expr) | Stmt::Expr(expr) => expr,
+        };
+        flag_match_binder_slots(expr, &res.local_slot_types, &mut aliased);
+    }
+
     // Re-stamp the resolution. `Arc` swap keeps the rest of the
     // resolution shape unchanged.
     let new_res = crate::ast::FnResolution {
@@ -325,6 +340,107 @@ fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &m
             }
         }
         Expr::Literal(_) | Expr::Ident(_) | Expr::TailCall(_) => {}
+    }
+}
+
+/// Flag every binder slot a match pattern introduces, wherever the match
+/// sits in `expr`, unless the SUBJECT's value is provably fresh.
+///
+/// A pattern binder is an extraction: `Option.Some(v)` hands the arm body the
+/// payload, `[h, ..t]` the head, `(a, b)` the components, and the bare-ident
+/// arm `v ->` the whole subject — every one of them a handle that may share an
+/// arena entry with whatever the subject was read out of. The same freshness
+/// judgment the statement pass applies to a binding RHS
+/// ([`rhs_is_fresh_collection`]) applies to the subject here; when it cannot
+/// prove the subject fresh, every binder slot in every arm is flagged. The
+/// slots come from `MatchArm::binding_slots` — the resolver's positional
+/// stamp (#949) — never from a name lookup; wildcard positions (`u16::MAX`)
+/// bind nothing and are skipped.
+///
+/// Every binder slot is flagged, not only the collection-typed ones: the
+/// consumers gate on collection receivers anyway, so a flag on an `Int`
+/// binder is inert, while skipping a slot whose type stamp is missing would
+/// be unsound. When the subject binds anything, the subject's own bare
+/// collection locals are flagged too, through the same escape half the
+/// statement pass uses — a bare-ident arm IS a rename (`b = a` spelled as a
+/// match), and an in-place write to the subject local inside the arm would be
+/// observed through the binder.
+fn flag_match_binder_slots(expr: &Spanned<Expr>, slot_types: &[Type], aliased: &mut [bool]) {
+    match &expr.node {
+        Expr::Match { subject, arms } => {
+            flag_match_binder_slots(subject, slot_types, aliased);
+            let subject_fresh = rhs_is_fresh_collection(subject);
+            for arm in arms {
+                if !subject_fresh && let Some(slots) = arm.binding_slots.get() {
+                    let mut binds_anything = false;
+                    for &slot in slots {
+                        if slot != u16::MAX {
+                            binds_anything = true;
+                            if let Some(s) = aliased.get_mut(slot as usize) {
+                                *s = true;
+                            }
+                        }
+                    }
+                    if binds_anything {
+                        flag_escaping_collection_locals(&subject.node, slot_types, aliased);
+                    }
+                }
+                flag_match_binder_slots(&arm.body, slot_types, aliased);
+            }
+        }
+        Expr::FnCall(callee, args) => {
+            flag_match_binder_slots(callee, slot_types, aliased);
+            for a in args {
+                flag_match_binder_slots(a, slot_types, aliased);
+            }
+        }
+        Expr::TailCall(tc) => {
+            for a in &tc.args {
+                flag_match_binder_slots(a, slot_types, aliased);
+            }
+        }
+        Expr::Attr(inner, _) | Expr::Neg(inner) | Expr::ErrorProp(inner) => {
+            flag_match_binder_slots(inner, slot_types, aliased);
+        }
+        Expr::BinOp(_, lhs, rhs) => {
+            flag_match_binder_slots(lhs, slot_types, aliased);
+            flag_match_binder_slots(rhs, slot_types, aliased);
+        }
+        Expr::Constructor(_, payload) => {
+            if let Some(p) = payload {
+                flag_match_binder_slots(p, slot_types, aliased);
+            }
+        }
+        Expr::Tuple(items) | Expr::List(items) | Expr::IndependentProduct(items, _) => {
+            for i in items {
+                flag_match_binder_slots(i, slot_types, aliased);
+            }
+        }
+        Expr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                flag_match_binder_slots(k, slot_types, aliased);
+                flag_match_binder_slots(v, slot_types, aliased);
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, e) in fields {
+                flag_match_binder_slots(e, slot_types, aliased);
+            }
+        }
+        Expr::RecordUpdate { base, updates, .. } => {
+            flag_match_binder_slots(base, slot_types, aliased);
+            for (_, e) in updates {
+                flag_match_binder_slots(e, slot_types, aliased);
+            }
+        }
+        Expr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let StrPart::Parsed(e) = p {
+                    flag_match_binder_slots(e, slot_types, aliased);
+                }
+            }
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } => {}
     }
 }
 

--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -328,7 +328,10 @@ fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &m
     }
 }
 
-fn type_is_compound(ty: &str) -> bool {
+/// Shared with the wasm-gc MIR emitter's `mir_expr_is_fresh_collection`,
+/// which mirrors [`rhs_is_fresh_collection`]'s `Vector.new` rule for
+/// receiver positions — keep the two freshness tests deciding alike.
+pub(crate) fn type_is_compound(ty: &str) -> bool {
     let trimmed = ty.trim();
     trimmed.starts_with("Vector<")
         || trimmed.starts_with("Map<")

--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -26,9 +26,15 @@
 //! - **No escape (source half, `flag_escaping_collection_locals`).** Its
 //!   handle is not RETAINED by any other binding — not stored into an
 //!   aggregate (record / tuple / list / map value), not passed as a builtin
-//!   value-arg, not passed to a user fn that might return it, not renamed. The
+//!   value-arg, not passed to a user fn that might return it, not renamed, and
+//!   not put inside the subject of a match one of whose arms BINDS. The
 //!   receiver (arg 0) of a `Vector` / `Map` builtin and the self-keep fallback
 //!   are consuming moves, not escapes.
+//!
+//! Freshness is a claim about an AGGREGATE, never about its contents, so the
+//! two halves are asymmetric on purpose: the escape half runs over every
+//! value-producing position whether or not the value is fresh, and only the
+//! DESTINATION half is gated on freshness.
 //!
 //! Vector / Map PARAMS are always flagged here (a caller may hold the same
 //! entry); the MIR `own_param` pass later clears that bit interprocedurally
@@ -120,7 +126,8 @@ fn annotate_fn(fd: &mut FnDef) {
     // `Stmt::Binding` only — so a binder used to read as "never shared" and
     // the in-place fast path wrote through the stored entry (issue #953
     // follow-up). Symmetric with the statement rule: a binder is judged by
-    // its subject's freshness, exactly as a binding is judged by its RHS.
+    // its subject, exactly as a binding is judged by its RHS — and by BOTH
+    // halves of it, the subject's freshness and what the subject retains.
     for stmt in stmts {
         let expr = match stmt {
             Stmt::Binding(_, _, expr) | Stmt::Expr(expr) => expr,
@@ -299,7 +306,15 @@ fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &m
             flag_escaping_collection_locals(&lhs.node, slot_types, aliased);
             flag_escaping_collection_locals(&rhs.node, slot_types, aliased);
         }
-        // The scrutinee is read/consumed; each arm tail becomes the value.
+        // The scrutinee is read/consumed and each arm tail becomes the value,
+        // so nothing of the subject escapes through the match's own VALUE —
+        // which is all this half is asked about here. What the subject
+        // RETAINS is the separate question a BINDER asks, because a binder is
+        // the only thing that hands the arm body a handle into the subject;
+        // [`flag_match_binder_slots`] runs this same walk over the subject
+        // exactly when an arm binds. Skipping the subject here and asking
+        // there is what keeps `keeper = match Map.get(m, k) { … }` from
+        // costing `m` anything the read never took.
         Expr::Match { subject: _, arms } => {
             for a in arms {
                 flag_escaping_collection_locals(&a.body.node, slot_types, aliased);
@@ -343,8 +358,8 @@ fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &m
     }
 }
 
-/// Flag every binder slot a match pattern introduces, wherever the match
-/// sits in `expr`, unless the SUBJECT's value is provably fresh.
+/// Flag every binder slot a match pattern introduces, wherever the match sits
+/// in `expr`, unless the SUBJECT is provably fresh AND retains nothing.
 ///
 /// A pattern binder is an extraction: `Option.Some(v)` hands the arm body the
 /// payload, `[h, ..t]` the head, `(a, b)` the components, and the bare-ident
@@ -360,31 +375,81 @@ fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &m
 /// Every binder slot is flagged, not only the collection-typed ones: the
 /// consumers gate on collection receivers anyway, so a flag on an `Int`
 /// binder is inert, while skipping a slot whose type stamp is missing would
-/// be unsound. When the subject binds anything, the subject's own bare
-/// collection locals are flagged too, through the same escape half the
-/// statement pass uses — a bare-ident arm IS a rename (`b = a` spelled as a
-/// match), and an in-place write to the subject local inside the arm would be
-/// observed through the binder.
+/// be unsound.
+///
+/// ## The subject's RETENTION, and why it is two separate obligations
+///
+/// A binder is the only construct that hands the arm body a handle INTO the
+/// subject, so whenever an arm binds anything, the subject's retention has to
+/// be settled. It is settled once, by running the escape half
+/// ([`flag_escaping_collection_locals`]) over the subject into a scratch
+/// buffer, and the answer discharges two different duties:
+///
+/// - **What the subject retains is shared.** Every local in the buffer is
+///   merged into the table. A fresh aggregate still RETAINS what was put in
+///   it — `match {"k" => held} { mm -> mm }` hands `mm` a map that holds
+///   `held`, so an owned `Vector.set(held, …)` later in the fn would rewrite
+///   what `mm` reads back. The escape half used to run only when the subject
+///   was NOT provably fresh, which is exactly backwards: freshness is a claim
+///   about the aggregate, never about its contents (#953 round 3, probes
+///   b/c/d/e). This is the same asymmetry the statement pass already has —
+///   for `x = <rhs>` the escape half runs ALWAYS and only the DESTINATION
+///   half is gated on freshness.
+/// - **The binder itself is exempt only if there is nothing to share.** The
+///   exemption's argument is that a fresh subject cannot be reached from
+///   anywhere else — which covers the AGGREGATE and says nothing about what is
+///   inside it, so it only carries a binder that IS the whole aggregate. Today
+///   every binder over a fresh subject is exactly that: a fresh subject is a
+///   `Vector` or a `Map`, and neither has a destructuring pattern, so the
+///   condition below has no runtime witness and is a fence rather than a bug
+///   fix. It is here because the exemption is new in this change and the
+///   module's rule is that a slot clears only on positive proof of
+///   fresh-AND-non-escaping; a binder resting on freshness alone is the one
+///   place that rule was not being applied, and the day a pattern reaches
+///   inside a collection the exemption would be wrong rather than merely
+///   unproven.
+///
+/// `match Map.get(m, k) { … }` still costs `m` nothing: the escape half skips
+/// arg 0 of a `Vector` / `Map` builtin (a receiver is read, not retained), so
+/// the buffer is empty and only the binder — a genuine container read — is
+/// flagged, by the not-fresh half of the rule.
 fn flag_match_binder_slots(expr: &Spanned<Expr>, slot_types: &[Type], aliased: &mut [bool]) {
     match &expr.node {
         Expr::Match { subject, arms } => {
             flag_match_binder_slots(subject, slot_types, aliased);
-            let subject_fresh = rhs_is_fresh_collection(subject);
-            for arm in arms {
-                if !subject_fresh && let Some(slots) = arm.binding_slots.get() {
-                    let mut binds_anything = false;
-                    for &slot in slots {
-                        if slot != u16::MAX {
-                            binds_anything = true;
-                            if let Some(s) = aliased.get_mut(slot as usize) {
-                                *s = true;
-                            }
-                        }
-                    }
-                    if binds_anything {
-                        flag_escaping_collection_locals(&subject.node, slot_types, aliased);
+            // Only a BINDER makes the subject's retention anyone's business,
+            // so a match that binds nothing pays for none of this.
+            let binds_anywhere = arms.iter().any(|a| {
+                a.binding_slots
+                    .get()
+                    .is_some_and(|slots| slots.iter().any(|&s| s != u16::MAX))
+            });
+            if binds_anywhere {
+                // What the subject's value still holds onto, computed into a
+                // scratch buffer so the same walk answers both duties above.
+                let mut retained = vec![false; aliased.len()];
+                flag_escaping_collection_locals(&subject.node, slot_types, &mut retained);
+                let retains_nothing = !retained.iter().any(|&r| r);
+                for (i, _) in retained.iter().enumerate().filter(|&(_, &r)| r) {
+                    if let Some(s) = aliased.get_mut(i) {
+                        *s = true;
                     }
                 }
+                if !(retains_nothing && rhs_is_fresh_collection(subject)) {
+                    for slot in arms
+                        .iter()
+                        .filter_map(|a| a.binding_slots.get())
+                        .flatten()
+                        .copied()
+                        .filter(|&s| s != u16::MAX)
+                    {
+                        if let Some(s) = aliased.get_mut(slot as usize) {
+                            *s = true;
+                        }
+                    }
+                }
+            }
+            for arm in arms {
                 flag_match_binder_slots(&arm.body, slot_types, aliased);
             }
         }
@@ -572,6 +637,112 @@ fn main() -> Int
             local_is_flagged(src, "main", "held"),
             "a fresh map whose handle was stored into a live tuple must stay \
              flagged — freshness does not survive an escape"
+        );
+    }
+
+    /// A fresh AGGREGATE spelled as a match subject still RETAINS what was put
+    /// in it.
+    ///
+    /// The escape half is deliberately not run on a match subject from the
+    /// statement pass — the arm tails become the value, so nothing of the
+    /// subject escapes through it — and the binder pass used to run it only
+    /// when the subject was NOT provably fresh. Between the two, `held` was
+    /// never asked about at all, and the `Vector.set` after it took the owned
+    /// in-place path straight through the map the binder is holding.
+    ///
+    /// Freshness answers for the map literal, never for `held` inside it, so
+    /// the retention walk runs whenever an arm BINDS, whatever the subject's
+    /// freshness says.
+    #[test]
+    fn a_fresh_match_subject_still_retains_the_local_it_holds() {
+        let src = r#"
+fn main() -> Int
+    held = Vector.fromList([1, 2])
+    keeper = match {"k" => held}
+        mm -> mm
+    Vector.len(Option.withDefault(Vector.set(held, 0, 5), Vector.fromList([]))) + Map.len(keeper)
+"#;
+        assert!(
+            local_is_flagged(src, "main", "held"),
+            "a local retained by a fresh match subject must be flagged — the \
+             binder hands the arm body a container that still holds it"
+        );
+    }
+
+    /// The binder's own exemption, which is the other half of the same
+    /// question.
+    ///
+    /// A binder over a provably-fresh subject is owned-eligible — nothing else
+    /// can reach a value nothing else has seen. But that argument only covers
+    /// the aggregate: a fresh subject that RETAINS a non-fresh local can hand a
+    /// binder that local itself, and then the arm writes through it. So the
+    /// exemption is `fresh AND retains nothing`.
+    ///
+    /// `mm` is read only in receiver position here (`Map.len`), which the
+    /// escape half treats as a consuming read — so the flag under test comes
+    /// from the binder rule alone and from nowhere else.
+    #[test]
+    fn a_binder_over_a_retaining_fresh_subject_is_not_exempt() {
+        let src = r#"
+fn main() -> Int
+    held = Vector.fromList([1, 2])
+    n = match {"k" => held}
+        mm -> Map.len(mm)
+    n + Vector.len(held)
+"#;
+        assert!(
+            local_is_flagged(src, "main", "mm"),
+            "a binder over a fresh subject that retains a local must stay \
+             flagged — the subject can hand the binder the retained local"
+        );
+    }
+
+    /// The same rule's other direction: a fresh subject that retains NOTHING
+    /// keeps its binders owned-eligible. This is what stops the retention walk
+    /// from being a blanket "every binder is aliased" and taking the in-place
+    /// path away from the shapes it was built for.
+    #[test]
+    fn a_binder_over_a_fresh_subject_that_retains_nothing_stays_owned() {
+        let src = r#"
+fn main() -> Int
+    n = match Vector.new(4, 0)
+        vv -> Vector.len(vv)
+    n
+"#;
+        assert!(
+            !local_is_flagged(src, "main", "vv"),
+            "a binder over a fresh subject holding nothing was flagged, so the \
+             owned fast path is gone from every match on a freshly built \
+             collection"
+        );
+    }
+
+    /// A container READ as a subject costs the container nothing.
+    ///
+    /// `Map.get(m, k)` reads `m` in receiver position, which is a consuming
+    /// read and not a retention, so the walk over the subject leaves `m`
+    /// owned-eligible. The BINDER is a different matter — it is a handle into
+    /// what the map holds — and it is flagged by the not-fresh half of the
+    /// rule, as it was before.
+    #[test]
+    fn a_match_on_a_container_read_costs_the_receiver_nothing() {
+        let src = r#"
+fn main() -> Int
+    m = Map.set({}, "k", 1)
+    n = match Map.get(m, "k")
+        Option.Some(v) -> v
+        Option.None -> 0
+    Map.len(Map.set(m, "z", 9)) + n
+"#;
+        assert!(
+            !local_is_flagged(src, "main", "m"),
+            "matching on `Map.get(m, k)` flagged `m`, so every read-then-write \
+             on a map now copies the whole map first"
+        );
+        assert!(
+            local_is_flagged(src, "main", "v"),
+            "the binder of a container read must stay flagged — it is a handle \
+             into what the map holds"
         );
     }
 }

--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -398,11 +398,16 @@ fn flag_escaping_collection_locals(expr: &Expr, slot_types: &[Type], aliased: &m
 /// - **The binder itself is exempt only if there is nothing to share.** The
 ///   exemption's argument is that a fresh subject cannot be reached from
 ///   anywhere else — which covers the AGGREGATE and says nothing about what is
-///   inside it, so it only carries a binder that IS the whole aggregate. Today
-///   every binder over a fresh subject is exactly that: a fresh subject is a
-///   `Vector` or a `Map`, and neither has a destructuring pattern, so the
-///   condition below has no runtime witness and is a fence rather than a bug
-///   fix. It is here because the exemption is new in this change and the
+///   inside it, so it is safe only for a binder that IS the whole aggregate.
+///   A destructuring binder over a fresh subject DOES occur — `Vector.set`
+///   counts as fresh and returns `Option<Vector<T>>`, which `Option.Some(w)`
+///   takes apart — and there the payload is the freshly built collection
+///   itself, so the exemption still holds for the shapes that exist today.
+///   It holds by what the whitelisted builders happen to return, though, not
+///   by the argument above: a future fresh builder whose payload is a handle
+///   into something older would break it. The condition below therefore has
+///   no runtime witness today and is a fence rather than a bug fix; it is
+///   here because the exemption is new in this change and the
 ///   module's rule is that a slot clears only on positive proof of
 ///   fresh-AND-non-escaping; a binder resting on freshness alone is the one
 ///   place that rule was not being applied, and the day a pattern reaches

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -721,8 +721,33 @@ pub fn buffer_build(items: &mut Vec<TopLevel>) -> BufferBuildPassReport {
 
 /// Resolve local bindings — maps `Expr::Ident(name)` → `Expr::Resolved { slot, .. }`
 /// per fn. Does not annotate last-use; that's a separate stage.
+///
+/// CAUTION: re-resolving stamps every fn with a FRESH `FnResolution`
+/// whose `aliased_slots` is the all-`false` default (see
+/// `crate::resolver::resolve_fn`) — it silently withdraws every verdict
+/// `ir::alias` had recorded, while the `last_use` marks on the body
+/// survive. A consumer that reads `last_use` + `aliased_slots` as
+/// mutation-ownership evidence (the wasm-gc in-place fast path) then
+/// sees "dead and never shared" for a container-read local and mutates
+/// a stored value in place (#950). Any re-resolve whose output feeds
+/// such a consumer must go through [`resolve_and_reannotate`] instead.
 pub fn resolve(items: &mut [TopLevel]) {
     crate::resolver::resolve_program(items);
+}
+
+/// [`resolve`] followed by the ownership stages the canonical pipeline
+/// pairs it with: `last_use` re-marking and the `ir::alias` per-slot
+/// table. This is the entry point for every post-flatten / post-rewrite
+/// re-resolve that feeds a backend reading `aliased_slots` as mutation
+/// evidence — bare `resolve` leaves the fresh stamp's all-`false`
+/// default in place (#950, see [`resolve`]'s caution). It also gives
+/// the freshly appended dep-module fns real ownership facts (their
+/// Vector / Map params get flagged, their dead fresh locals keep the
+/// in-place fast path) instead of whatever their pristine load carried.
+pub fn resolve_and_reannotate(items: &mut [TopLevel]) {
+    resolve(items);
+    last_use(items);
+    crate::ir::alias::annotate_program_alias_slots(items);
 }
 
 /// Last-use ownership annotation. Walks each fn body backwards, sets

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -1444,6 +1444,16 @@ pub(super) fn cmd_run_vm(
             "  refused, something off the stack holds it:{} not examined, walk dearer than the copy:{}",
             owned.refused_off_stack_holder, owned.unexamined_walk_too_costly
         );
+        let fence = &report.vector_ownership;
+        eprintln!("\nVector writes the compiler granted, confirmed at run time:");
+        eprintln!(
+            "  kept in place:{} revoked, a stack cell holds it:{}",
+            fence.grants, fence.refused_stack_holder
+        );
+        eprintln!(
+            "  revoked, something off the stack holds it:{} revoked unexamined, walk dearer than the copy:{}",
+            fence.refused_off_stack_holder, fence.unexamined_walk_too_costly
+        );
         // The mirror that re-derives every grant from scratch is budgeted, and a
         // spent budget is a smaller claim, not a clean one — so it says so. Only
         // a build with debug assertions runs the mirror at all, which is why a

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -5262,8 +5262,11 @@ fn cmd_compile_wasm_gc(
     let type_aliases = flatten_multimodule(&mut items, &dep_modules);
     // Re-run resolver after flatten so dep fns get a FnResolution
     // (slot_types). Entry items already had one from `pipeline::run`
-    // above; this picks up the newly appended dep FnDefs.
-    aver::ir::pipeline::resolve(&mut items);
+    // above; this picks up the newly appended dep FnDefs. The
+    // `_and_reannotate` half is load-bearing: a bare re-resolve wipes
+    // `aliased_slots` and the wasm-gc in-place fast path then mutates
+    // container-held collections through extracted locals (#950).
+    aver::ir::pipeline::resolve_and_reannotate(&mut items);
 
     let wasm_gc_output = match wasm_gc::compile_to_wasm_gc_flattened(
         &items,
@@ -5512,7 +5515,9 @@ fn cmd_compile_wasip2(
         // directly — `wasip2` enables `wasm-compile` (which exposes
         // it) but does not pull `wasm`.
         let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
-        aver::ir::pipeline::resolve(&mut items);
+        // `_and_reannotate`: same #950 wipe-guard as the wasm-gc
+        // compile path — a bare re-resolve wipes `aliased_slots`.
+        aver::ir::pipeline::resolve_and_reannotate(&mut items);
 
         // Phase 1.6 — static effect-set check. Catches every Aver
         // effect that `--target wasip2` cannot lower today, BEFORE

--- a/src/main/run_wasip2.rs
+++ b/src/main/run_wasip2.rs
@@ -122,7 +122,10 @@ fn build_component_bytes(
         super::commands::DepLowering::PRISTINE,
     );
     let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
-    aver::ir::pipeline::resolve(&mut items);
+    // `_and_reannotate`: a bare post-flatten re-resolve wipes
+    // `aliased_slots`, and the wasm-gc in-place fast path then mutates
+    // container-held collections through extracted locals (#950).
+    aver::ir::pipeline::resolve_and_reannotate(&mut items);
 
     if let Err(unsupported) = wasip2_codegen::check_supported_effects(&items) {
         let mut out = format!(

--- a/src/main/run_wasm_gc.rs
+++ b/src/main/run_wasm_gc.rs
@@ -166,8 +166,11 @@ pub(super) fn try_run_wasm_gc(
     // The first `pipeline::run` only saw entry items; without this
     // pass, dep fn bodies fall back to the `slots::build_for_fn`
     // params-only path and any local beyond a param trips the wasm
-    // validator with a slot-type mismatch.
-    aver::ir::pipeline::resolve(&mut items);
+    // validator with a slot-type mismatch. The `_and_reannotate` half
+    // is load-bearing: a bare re-resolve wipes `aliased_slots` back to
+    // all-`false`, and the wasm-gc in-place fast path then mutated
+    // map-held vectors through extracted locals (#950).
+    aver::ir::pipeline::resolve_and_reannotate(&mut items);
 
     let outcome = rt::run_in_process(
         &items,

--- a/src/nan_value/tests.rs
+++ b/src/nan_value/tests.rs
@@ -199,9 +199,10 @@ fn the_cheap_heap_reference_filter_turns_nothing_heap_backed_away() {
     cases.push(NanValue::new_tuple(
         arena.push_tuple(vec![NanValue::UNIT, NanValue::TRUE]),
     ));
-    cases.push(NanValue::new_vector(
-        arena.push(ArenaEntry::Vector(vec![NanValue::UNIT])),
-    ));
+    cases.push(NanValue::new_vector(arena.push(ArenaEntry::Vector {
+        items: vec![NanValue::UNIT],
+        held_elsewhere: false,
+    })));
     cases.push(NanValue::new_list(arena.push(ArenaEntry::List(
         ArenaList::Flat {
             items: std::sync::Arc::new(crate::nan_value::ListBody::new(vec![NanValue::TRUE])),

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -94,7 +94,9 @@ pub fn compile_project_to_wasm(
         .collect();
 
     let type_aliases = codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
-    crate::ir::pipeline::resolve(&mut entry_items);
+    // `_and_reannotate`: a bare post-flatten re-resolve wipes
+    // `aliased_slots` and the wasm-gc in-place fast path goes wrong (#950).
+    crate::ir::pipeline::resolve_and_reannotate(&mut entry_items);
     codegen::wasm_gc::compile_to_wasm_gc_flattened(
         &entry_items,
         pipeline_result.analysis.as_ref(),
@@ -158,7 +160,8 @@ pub fn compile_project_to_wasm_with_entry(
         .map(|m| loaded_to_module_info(m, false))
         .collect();
     let type_aliases = codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
-    crate::ir::pipeline::resolve(&mut entry_items);
+    // `_and_reannotate`: same #950 wipe-guard as the compile path above.
+    crate::ir::pipeline::resolve_and_reannotate(&mut entry_items);
     let bytes = codegen::wasm_gc::compile_to_wasm_gc_flattened(
         &entry_items,
         pipeline_result.analysis.as_ref(),

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -279,8 +279,19 @@ pub fn vec_set_nv_owned(args: &[NanValue], arena: &mut Arena) -> Result<NanValue
         return Ok(NanValue::NONE);
     }
     items[uidx] = args[2];
-    let new_vec_idx =
-        arena.push_inheriting_source_space(aver_memory::ArenaEntry::Vector(items), source);
+    // The one element this write stores is the one child the O(1) path owes a
+    // held-elsewhere mark — every other element was marked when the source
+    // vector was built, and the flags live on the pointed-to entries, so they
+    // survive the take-and-repush. Mirror of the owned `Map.set`'s single-pair
+    // marking.
+    arena.note_held_elsewhere(args[2]);
+    let new_vec_idx = arena.push_inheriting_source_space(
+        aver_memory::ArenaEntry::Vector {
+            items,
+            held_elsewhere: false,
+        },
+        source,
+    );
     Ok(NanValue::new_some_value(
         NanValue::new_vector(new_vec_idx),
         arena,

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -1523,12 +1523,21 @@ fn try_emit_vector_compound(
             // owned-param refinement (`own_param.rs`) is what proves a
             // threaded `Vector`/`Map` param non-aliased, and only then
             // does the in-place set fire — keeping the guard load-bearing.
+            //
+            // Like the `CALL_BUILTIN_OWNED` spelling, the bit is a PROPOSAL
+            // the running program confirms or revokes
+            // (`VM::runtime_confirms_fused_vector_grant`), so the target's
+            // slot travels with it: the fusion deletes the textually-last
+            // read, the target therefore arrives through `LOAD_LOCAL`, and
+            // the fence has to know which cell is the target's own before it
+            // can tell that cell from a real alias.
             let owned = (vec_last_use || def_last_use) && !fc.is_aliased_slot(vec_slot as u16);
             compile_mir_expr(fc, &inner_args[0])?;
             compile_mir_expr(fc, &inner_args[1])?;
             compile_mir_expr(fc, &inner_args[2])?;
             fc.emit_op(VECTOR_SET_OR_KEEP);
             fc.emit_u8(u8::from(owned));
+            fc.emit_u8(vec_slot as u8);
             Ok(true)
         }
         Some(VmBuiltin::VectorGet) if inner_args.len() == 2 => {

--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -1888,7 +1888,8 @@ impl VM {
                 }
 
                 VECTOR_SET_OR_KEEP => {
-                    let vec_owned = read_u8!(code, ip) != 0;
+                    let static_grant = read_u8!(code, ip) != 0;
+                    let target_slot = read_u8!(code, ip) as usize;
                     let value = self.stack.pop().ok_or(VmError::StackUnderflow)?;
                     let index = self.stack.pop().ok_or(VmError::StackUnderflow)?;
                     let vec = self.stack.pop().ok_or(VmError::StackUnderflow)?;
@@ -1899,6 +1900,20 @@ impl VM {
                         self.stack.push(vec);
                         continue;
                     };
+                    // The static bit is a PROPOSAL, exactly as it is on the
+                    // `CALL_BUILTIN_OWNED` spelling of the same write: the
+                    // owned branch below is the VM's only true in-place arena
+                    // write, and a container that still held this slot would
+                    // read the mutation back with nothing failing loudly. Ask
+                    // once the three operands are off the stack, so "no cell
+                    // holds this" and "the operand cell was the only holder"
+                    // are the same statement — the target's own local cell is
+                    // the single exception, and it is named rather than
+                    // guessed (`bp + target_slot`, the slot the opcode
+                    // carries). A revoked grant costs exactly the copy the
+                    // program made before the fusion existed.
+                    let vec_owned = static_grant
+                        && self.runtime_confirms_fused_vector_grant(vec, bp + target_slot);
                     if vec_owned && !vec.is_empty_vector_immediate() {
                         // Owned path: modify vector in-place at the same arena slot.
                         // No new allocation, no promotion needed.

--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -819,6 +819,22 @@ impl VM {
                         owned_mask |= 1;
                     }
 
+                    // The reverse direction, for vectors: a static grant on
+                    // `Vector.set` is a proposal the running program confirms
+                    // or revokes. The owned path would `mem::take` the
+                    // target's arena entry, and a container that still holds
+                    // that slot would read back an empty vector with nothing
+                    // failing loudly — so the fence declines in place and the
+                    // write copies whenever anything else holds the slot or
+                    // the walk is dearer than the copy.
+                    if owned_mask & 1 != 0
+                        && builtin == VmBuiltin::VectorSet
+                        && let Some(target) = args.first().copied()
+                        && !self.runtime_confirms_vector_grant(target)
+                    {
+                        owned_mask &= !1;
+                    }
+
                     if builtin.is_http_server() {
                         self.runtime.ensure_builtin_effects_allowed(
                             &self.code.symbols,

--- a/src/vm/execute/mod.rs
+++ b/src/vm/execute/mod.rs
@@ -89,6 +89,11 @@ pub struct VM {
     /// Maintained everywhere, release included: it is the receipt for a decision
     /// this VM took, not an observation somebody asked for.
     runtime_ownership: VmRuntimeOwnershipStats,
+    /// What the runtime decided about the vector writes the compiler GRANTED —
+    /// the same buckets read in the revocation direction (see
+    /// [`VM::vector_ownership_stats`]). Maintained everywhere, release
+    /// included, for the same reason as `runtime_ownership`.
+    vector_ownership: VmRuntimeOwnershipStats,
 }
 
 /// One pooled byte builder: the octets collected so far, and the first
@@ -147,6 +152,7 @@ impl VM {
             step_limit: None,
             slot_uniqueness: VmSlotUniquenessStats::default(),
             runtime_ownership: VmRuntimeOwnershipStats::default(),
+            vector_ownership: VmRuntimeOwnershipStats::default(),
         }
     }
 
@@ -170,9 +176,15 @@ impl VM {
     pub fn profile_report(&self) -> Option<VmProfileReport> {
         let slot_uniqueness = self.slot_uniqueness;
         let runtime_ownership = self.runtime_ownership;
-        self.profile
-            .as_ref()
-            .map(|profile| profile.report(&self.code, slot_uniqueness, runtime_ownership))
+        let vector_ownership = self.vector_ownership;
+        self.profile.as_ref().map(|profile| {
+            profile.report(
+                &self.code,
+                slot_uniqueness,
+                runtime_ownership,
+                vector_ownership,
+            )
+        })
     }
 
     pub fn profile_top_bigrams(&self, n: usize) -> Vec<((u8, u8), u64)> {

--- a/src/vm/execute/slots.rs
+++ b/src/vm/execute/slots.rs
@@ -147,12 +147,16 @@
 //!   `CALL_VALUE` pops its arguments in the same place, so it is a call site to
 //!   add, not a predicate to design.
 //! - A DECLINED `Vector.set` never reaches this code at all. `mir` lowers it to
-//!   the dedicated `VECTOR_SET` opcode and only routes the owned spelling
-//!   through `CALL_BUILTIN_OWNED`. So this decision is a MAP decision, and the
-//!   vector half of the same payoff is untouched. P3 owes this the opcode's own
-//!   dispatch point, and owes it the `held_elsewhere` equivalent for vectors
-//!   first: nothing marks a vector today, because nothing takes one in place
-//!   through this route.
+//!   the dedicated `VECTOR_SET` opcode (which always copies) and only routes
+//!   the owned spelling through `CALL_BUILTIN_OWNED`. So the upgrade decision
+//!   is a MAP decision, and the vector half of that payoff is still owed to
+//!   P3. What the vector route DOES have now is the reverse direction:
+//!   [`VM::runtime_confirms_vector_grant`] verifies every STATIC vector grant
+//!   against the same two holder sets before `vec_set_nv_owned` is allowed to
+//!   `mem::take` the slot, because the match-binder hole showed a static grant
+//!   reaching a container-held vector and draining it silently. Vectors carry
+//!   the `held_elsewhere` record now (`ArenaEntry::Vector`), marked through
+//!   the same choke points as maps.
 //! - `VECTOR_SET_OR_KEEP`'s owned branch is not audited here, and the predicate
 //!   does not extend to it — which is why P2 does not touch it. That branch is
 //!   the VM's only true in-place arena write, and its grant is `vec_last_use ||
@@ -501,6 +505,18 @@ impl VM {
         self.runtime_ownership
     }
 
+    /// What the runtime decided about the vector writes the compiler GRANTED.
+    ///
+    /// The same four buckets as [`VM::runtime_ownership_stats`], read in the
+    /// opposite direction: `grants` is a static grant the fence confirmed, the
+    /// two `refused_*` buckets are static grants it revoked (the write copied
+    /// instead), and `unexamined_walk_too_costly` is a grant revoked without
+    /// looking because the walk would have cost more than the copy. Maintained
+    /// on every path, release included.
+    pub fn vector_ownership_stats(&self) -> VmRuntimeOwnershipStats {
+        self.vector_ownership
+    }
+
     /// Whether the owned path may have `target`, at a `Map.set` / `Map.remove`
     /// the compiler declined and whose arguments have just been popped.
     ///
@@ -552,6 +568,82 @@ impl VM {
             "Map builtin took its target in place on the runtime's word, but \
              slot {} is reachable from somewhere the decision did not look — \
              {} operand stack cell(s) hold it, and the search over globals, \
+             chunk constants and arena entries found another holder",
+            target.arena_index(),
+            self.live_refs_to_slot(target.arena_index()),
+        );
+        true
+    }
+
+    /// Whether the owned path may KEEP `target`, at a `Vector.set` the
+    /// compiler granted statically and whose arguments have just been popped.
+    ///
+    /// The map decision above runs in the trusting direction: a static map
+    /// grant is a claim the compiler must get right, and the runtime only ever
+    /// ADDS grants to the declines. The vector route runs the other way. The
+    /// owned `Vector.set` (`vec_set_nv_owned`) empties the target's arena slot
+    /// with `mem::take`, and the match-binder hole showed a static grant
+    /// reaching a vector a container still held — the container read back an
+    /// empty vector and nothing failed loudly. So a static vector grant is a
+    /// PROPOSAL: it is confirmed against the same two holder sets the map
+    /// decision asks, in the same cost order — `held_elsewhere` first (one
+    /// arena read, answering for every holder the stack walk cannot see), then
+    /// the walk, bounded by [`WALK_SLACK`] over the vector's own length — and
+    /// revoked when either answers "held" or the walk would cost more than the
+    /// copy it was avoiding. A revoked grant costs exactly the copy the program
+    /// made before the grant existed; a wrong confirmation would be the silent
+    /// corruption this exists to stop, which is why the confirmed case is
+    /// re-derived from scratch under debug assertions, same as the map grant.
+    ///
+    /// Deliberately NOT behind the `AVER_NO_RUNTIME_MAP_OWNERSHIP` switch: that
+    /// switch turns an optimization off (declines stay declines, everything
+    /// copies — always safe). Turning THIS off would mean trusting the static
+    /// grant again, which is the unsound direction, and a safety switch must
+    /// not have an unsafe setting.
+    ///
+    /// ## The wrapper toll on non-fused chains — a decision, not an accident
+    ///
+    /// `Vector.set` returns `Option<Vector>`, and a `Some` over a heap value
+    /// allocates an `ArenaEntry::Boxed` holding it — so the owned set's OWN
+    /// return wrapper marks the fresh result `held_elsewhere` the moment it is
+    /// built. The box usually dies at the very next `UNWRAP_OR`, but the flag
+    /// is monotone and neither instrument can see that the box is dead, so
+    /// from the SECOND write of a chain spelled through the plain builtin the
+    /// fence revokes and the write copies. This is the conservative side of
+    /// the bargain and it is measured: the fused self-keep spelling
+    /// (`VECTOR_SET_OR_KEEP`) never comes through here and keeps its in-place
+    /// grant — that is the accumulator shape every measured workload uses —
+    /// and `a_second_owned_set_in_a_non_fused_chain_pays_the_wrapper_toll`
+    /// pins the revocation so a change in either direction is a recorded
+    /// decision. Buying the non-fused chain back needs a way to say "this
+    /// box's payload has exactly one live reader", which is the same
+    /// still-owed predicate the module doc records for the fused opcode.
+    #[inline]
+    pub(super) fn runtime_confirms_vector_grant(&mut self, target: NanValue) -> bool {
+        // An immediate (the empty vector) owns no slot: nothing to empty,
+        // nothing to corrupt, and the copying path is O(1) on it. Decline —
+        // the copying `Vector.set` answers identically.
+        let Some(slot) = self.arena.vector_slot(target) else {
+            return false;
+        };
+        if slot.held_elsewhere {
+            self.vector_ownership.refused_off_stack_holder += 1;
+            return false;
+        }
+        if self.stack.len() > slot.len + WALK_SLACK {
+            self.vector_ownership.unexamined_walk_too_costly += 1;
+            return false;
+        }
+        if !self.slot_is_unheld(target) {
+            self.vector_ownership.refused_stack_holder += 1;
+            return false;
+        }
+        self.vector_ownership.grants += 1;
+        debug_assert!(
+            self.nothing_else_holds_slot(target.arena_index()) != Some(false),
+            "Vector.set kept its static in-place grant on the runtime's word, \
+             but slot {} is reachable from somewhere the decision did not look \
+             — {} operand stack cell(s) hold it, and the search over globals, \
              chunk constants and arena entries found another holder",
             target.arena_index(),
             self.live_refs_to_slot(target.arena_index()),

--- a/src/vm/execute/slots.rs
+++ b/src/vm/execute/slots.rs
@@ -129,9 +129,9 @@
 //!
 //! ## What the decision never sees
 //!
-//! Four blind spots, all of them shared with the cross-check, and every one
+//! Three blind spots, all of them shared with the cross-check, and every one
 //! still UNDERCOUNTS — a write the decision cannot see is a write that copies,
-//! which is what the program did before any of this existed. None of the four
+//! which is what the program did before any of this existed. None of the three
 //! can produce a wrong grant, and the one that could is the section above.
 //! What each one owes a later phase:
 //!
@@ -157,23 +157,27 @@
 //!   reaching a container-held vector and draining it silently. Vectors carry
 //!   the `held_elsewhere` record now (`ArenaEntry::Vector`), marked through
 //!   the same choke points as maps.
-//! - `VECTOR_SET_OR_KEEP`'s owned branch is not audited here, and the predicate
-//!   does not extend to it — which is why P2 does not touch it. That branch is
-//!   the VM's only true in-place arena write, and its grant is `vec_last_use ||
-//!   def_last_use`. In the fused shape the inner vector read compiles to
-//!   `LOAD_LOCAL` rather than `MOVE_LOCAL`, because `last_use` annotates the
-//!   textually-last read, which the fusion deletes. So the target's own local
-//!   cell is STILL LIVE at the write, and [`VM::slot_is_unheld`] would answer
-//!   HELD at the strongest grant in the VM. The trick that makes the builtin
-//!   check work — ask once the argument list has been popped — has no analogue
-//!   at a fused opcode that never builds one. P3 owes this a predicate of its
-//!   own that excludes the target's own cell, not another call site.
 //!
-//! The two vector items are pinned rather than asserted in prose:
+//! `VECTOR_SET_OR_KEEP`'s owned branch — the VM's only true in-place arena
+//! write — used to be the fourth item on that list, and it is not a blind spot
+//! any more. Its grant is `vec_last_use || def_last_use`, and the fusion
+//! deletes the textually-last read, so the target arrives through `LOAD_LOCAL`
+//! and its own local cell is still live at the write: [`VM::slot_is_unheld`]
+//! would answer HELD at the strongest grant in the VM, and the trick that makes
+//! the builtin check work — ask once the argument list has been popped — needs
+//! a correction rather than a call site. The correction is the target's slot,
+//! which the opcode now carries as a second operand, so
+//! [`VM::runtime_confirms_fused_vector_grant`] can exempt that one cell and
+//! nothing else. It shares the whole rest of the fence with the plain
+//! spelling: `held_elsewhere` first, then the [`WALK_SLACK`]-bounded walk, the
+//! same four counters, the same from-scratch re-derivation under debug
+//! assertions.
+//!
 //! `a_vector_fold_writes_nothing_the_cross_check_can_see` in
-//! `tests/vm_slot_uniqueness.rs` runs both vector spellings and expects all four
-//! tallies to stay at zero, so the day either one starts being observed, that
-//! test is what says the list above needs rewriting.
+//! `tests/vm_slot_uniqueness.rs` runs both vector spellings and reads the
+//! tallies back: the CROSS-CHECK still sees neither (it is a builtin-call
+//! instrument, and a declined `Vector.set` lowers to `VECTOR_SET`), while the
+//! vector ownership tallies now record the fused fold's grants.
 //!
 //! ## The way out
 //!
@@ -347,9 +351,20 @@ impl VM {
     /// built argument list — which is the point: an argument of an enclosing
     /// call is exactly the holder a per-frame view would miss.
     pub fn live_refs_to_slot(&self, index: u32) -> u32 {
+        self.stack_holders_excluding(index, None)
+    }
+
+    /// [`VM::live_refs_to_slot`] with at most one cell not counted — the
+    /// target's own local cell at a fused in-place write, see
+    /// [`VM::runtime_confirms_fused_vector_grant`]. `None` counts every cell,
+    /// which is what every other caller wants.
+    pub(super) fn stack_holders_excluding(&self, index: u32, exempt: Option<usize>) -> u32 {
         self.stack
             .iter()
-            .filter(|cell| cell.may_hold_heap_index() && cell.heap_index() == Some(index))
+            .enumerate()
+            .filter(|&(i, cell)| {
+                Some(i) != exempt && cell.may_hold_heap_index() && cell.heap_index() == Some(index)
+            })
             .count() as u32
     }
 
@@ -365,14 +380,19 @@ impl VM {
     /// An immediate answers `false`: it names no slot, so there is nothing to
     /// hold uniquely and nothing to mutate in place.
     pub fn slot_is_unheld(&self, value: NanValue) -> bool {
+        self.slot_is_unheld_excluding(value, None)
+    }
+
+    /// [`VM::slot_is_unheld`] with at most one cell not counted — see
+    /// [`VM::stack_holders_excluding`]. Still walks from the top down and
+    /// stops at the first holder that is not the exempt one.
+    pub(super) fn slot_is_unheld_excluding(&self, value: NanValue, exempt: Option<usize>) -> bool {
         let Some(index) = value.heap_index() else {
             return false;
         };
-        !self
-            .stack
-            .iter()
-            .rev()
-            .any(|cell| cell.may_hold_heap_index() && cell.heap_index() == Some(index))
+        !self.stack.iter().enumerate().rev().any(|(i, cell)| {
+            Some(i) != exempt && cell.may_hold_heap_index() && cell.heap_index() == Some(index)
+        })
     }
 
     /// Total live references the operand stack holds across every arena slot.
@@ -564,7 +584,7 @@ impl VM {
             // `None` is the budget being spent, not an answer: the assert is
             // skipped explicitly and counted, rather than reading an audit
             // nobody performed as a clean bill.
-            self.nothing_else_holds_slot(target.arena_index()) != Some(false),
+            self.nothing_else_holds_slot(target.arena_index(), None) != Some(false),
             "Map builtin took its target in place on the runtime's word, but \
              slot {} is reachable from somewhere the decision did not look — \
              {} operand stack cell(s) hold it, and the search over globals, \
@@ -620,6 +640,44 @@ impl VM {
     /// still-owed predicate the module doc records for the fused opcode.
     #[inline]
     pub(super) fn runtime_confirms_vector_grant(&mut self, target: NanValue) -> bool {
+        self.confirm_vector_grant(target, None)
+    }
+
+    /// The same fence for the FUSED spelling (`VECTOR_SET_OR_KEEP`'s owned
+    /// branch), which is the VM's only true in-place arena write.
+    ///
+    /// One difference, and it is the reason this needed a predicate of its own
+    /// rather than another call site. The fusion deletes the textually-last
+    /// read of the target — the `withDefault` default — so `last_use` lands on
+    /// an occurrence that is never compiled, the surviving read comes in
+    /// through `LOAD_LOCAL`, and the target's OWN local cell is therefore
+    /// still live when the write happens. Asking [`VM::slot_is_unheld`] here
+    /// would answer HELD at the strongest grant in the VM and revoke every
+    /// accumulator fold. `own_cell` — the operand-stack index `bp + slot` of
+    /// that cell, from the slot the opcode now carries — is excluded from both
+    /// the walk and the debug re-derivation, and NOTHING else is: a second
+    /// binding, a half-built argument, a container, a global and a chunk
+    /// constant all still revoke.
+    ///
+    /// What the exclusion costs the claim, stated plainly: the fence adds the
+    /// holder check the static grant never had, and it does NOT re-derive
+    /// `last_use`. Excluding the target's own cell is sound exactly because
+    /// the grant already says the slot is dead after the op — with the
+    /// destination being that same slot in the shape this exists for, so the
+    /// cell is overwritten by the op's own result. A wrong `last_use` is a
+    /// different bug in a different pass, and this fence does not claim it.
+    #[inline]
+    pub(super) fn runtime_confirms_fused_vector_grant(
+        &mut self,
+        target: NanValue,
+        own_cell: usize,
+    ) -> bool {
+        self.confirm_vector_grant(target, Some(own_cell))
+    }
+
+    /// Shared body of the two vector fences. `exempt` is the one operand-stack
+    /// cell that does not count as a holder, or `None` when every cell does.
+    fn confirm_vector_grant(&mut self, target: NanValue, exempt: Option<usize>) -> bool {
         // An immediate (the empty vector) owns no slot: nothing to empty,
         // nothing to corrupt, and the copying path is O(1) on it. Decline —
         // the copying `Vector.set` answers identically.
@@ -634,19 +692,19 @@ impl VM {
             self.vector_ownership.unexamined_walk_too_costly += 1;
             return false;
         }
-        if !self.slot_is_unheld(target) {
+        if !self.slot_is_unheld_excluding(target, exempt) {
             self.vector_ownership.refused_stack_holder += 1;
             return false;
         }
         self.vector_ownership.grants += 1;
         debug_assert!(
-            self.nothing_else_holds_slot(target.arena_index()) != Some(false),
+            self.nothing_else_holds_slot(target.arena_index(), exempt) != Some(false),
             "Vector.set kept its static in-place grant on the runtime's word, \
              but slot {} is reachable from somewhere the decision did not look \
              — {} operand stack cell(s) hold it, and the search over globals, \
              chunk constants and arena entries found another holder",
             target.arena_index(),
-            self.live_refs_to_slot(target.arena_index()),
+            self.stack_holders_excluding(target.arena_index(), exempt),
         );
         true
     }
@@ -700,8 +758,8 @@ impl VM {
     /// `tests/vm_map_runtime_ownership.rs` is what says the corpus is on the
     /// covered side of that line.
     #[cfg(debug_assertions)]
-    fn nothing_else_holds_slot(&self, index: u32) -> Option<bool> {
-        if self.live_refs_to_slot(index) > 0 {
+    fn nothing_else_holds_slot(&self, index: u32, exempt: Option<usize>) -> Option<bool> {
+        if self.stack_holders_excluding(index, exempt) > 0 {
             return Some(false);
         }
         if self.globals.iter().any(|v| v.heap_index() == Some(index)) {
@@ -730,7 +788,7 @@ impl VM {
     }
 
     #[cfg(not(debug_assertions))]
-    fn nothing_else_holds_slot(&self, _index: u32) -> Option<bool> {
+    fn nothing_else_holds_slot(&self, _index: u32, _exempt: Option<usize>) -> Option<bool> {
         None
     }
 }

--- a/src/vm/execute/tests.rs
+++ b/src/vm/execute/tests.rs
@@ -1193,6 +1193,9 @@ fn a_stable_vector_written_in_place_survives_the_depth_zero_return() {
             CONCAT,
             VECTOR_SET_OR_KEEP,
             1,
+            // Target slot: the fence exempts the target's own local cell and
+            // nothing else, so it has to be told which cell that is.
+            0,
             RETURN,
         ],
         constants: Vec::new(),

--- a/src/vm/execute/tests.rs
+++ b/src/vm/execute/tests.rs
@@ -50,7 +50,7 @@ fn assert_no_young_refs(value: NanValue, arena: &Arena, context: &str) {
                     }
                 }
             },
-            ArenaEntry::Tuple(items) | ArenaEntry::Vector(items) => {
+            ArenaEntry::Tuple(items) | ArenaEntry::Vector { items, .. } => {
                 for item in items.iter().copied() {
                     assert_no_young_refs(item, arena, context);
                 }
@@ -1262,5 +1262,152 @@ fn a_stable_vector_written_in_place_survives_the_depth_zero_return() {
         vm.arena.get_string_value(element).to_string(),
         "PAYLOAD-MARKER",
         "the depth-0 return dropped the element written into a stable vector",
+    );
+}
+
+// ── The vector fence: a static `Vector.set` grant is confirmed or
+//    revoked at run time ─────────────────────────────────────────────
+//
+// The owned `Vector.set` empties its target's arena slot with
+// `mem::take`, and the match-binder hole showed a static grant reaching
+// a container-held vector — the container read back an empty vector,
+// silently. `runtime_confirms_vector_grant` is the fence in front of
+// that take; these pin its four answers, one bucket each, away from any
+// program so the states are exact.
+
+#[test]
+fn a_vector_grant_is_confirmed_when_nothing_else_holds_the_slot() {
+    let mut arena = Arena::new();
+    let idx = arena.push_vector(vec![NanValue::new_int_inline(1)]);
+    let mut vm = VM::new(CodeStore::new(), Vec::new(), arena);
+
+    assert!(vm.runtime_confirms_vector_grant(NanValue::new_vector(idx)));
+    let stats = vm.vector_ownership_stats();
+    assert_eq!(
+        (stats.grants, stats.refused_stack_holder),
+        (1, 0),
+        "an unheld fresh vector is exactly what the static grant claimed"
+    );
+}
+
+#[test]
+fn a_vector_grant_is_revoked_when_a_container_holds_the_slot() {
+    let mut arena = Arena::new();
+    let idx = arena.push_vector(vec![NanValue::new_int_inline(1)]);
+    let handle = NanValue::new_vector(idx);
+    // A tuple pushed over the handle is an off-stack holder; `Arena::push`
+    // marks the vector `held_elsewhere` on the way in.
+    let _tuple = arena.push_tuple(vec![handle, NanValue::new_int_inline(2)]);
+    let mut vm = VM::new(CodeStore::new(), Vec::new(), arena);
+
+    assert!(
+        !vm.runtime_confirms_vector_grant(handle),
+        "an arena entry still holds the slot the owned path would empty"
+    );
+    assert_eq!(vm.vector_ownership_stats().refused_off_stack_holder, 1);
+}
+
+#[test]
+fn a_vector_grant_is_revoked_while_a_stack_cell_still_holds_the_slot() {
+    let mut arena = Arena::new();
+    let idx = arena.push_vector(vec![NanValue::new_int_inline(1)]);
+    let handle = NanValue::new_vector(idx);
+    let mut vm = VM::new(CodeStore::new(), Vec::new(), arena);
+
+    vm.stack.push(handle);
+    assert!(
+        !vm.runtime_confirms_vector_grant(handle),
+        "a live cell would observe the in-place mutation"
+    );
+    assert_eq!(vm.vector_ownership_stats().refused_stack_holder, 1);
+
+    vm.stack.pop();
+    assert!(
+        vm.runtime_confirms_vector_grant(handle),
+        "the same slot with the cell gone is uniquely held again"
+    );
+    assert_eq!(vm.vector_ownership_stats().grants, 1);
+}
+
+#[test]
+fn a_vector_grant_is_revoked_unexamined_when_the_walk_outcosts_the_copy() {
+    let mut arena = Arena::new();
+    let idx = arena.push_vector(vec![NanValue::new_int_inline(1)]);
+    let mut vm = VM::new(CodeStore::new(), Vec::new(), arena);
+
+    // A one-element vector under a stack far past `len + WALK_SLACK`:
+    // the copy is cheaper than the walk, so the fence revokes without
+    // looking — and counts that it did not look, rather than reading an
+    // unasked question as a clean answer.
+    for _ in 0..512 {
+        vm.stack.push(NanValue::new_int_inline(0));
+    }
+    assert!(!vm.runtime_confirms_vector_grant(NanValue::new_vector(idx)));
+    assert_eq!(vm.vector_ownership_stats().unexamined_walk_too_costly, 1);
+}
+
+#[test]
+fn the_empty_vector_immediate_owns_no_slot_to_grant() {
+    let mut vm = VM::new(CodeStore::new(), Vec::new(), Arena::new());
+    assert!(
+        !vm.runtime_confirms_vector_grant(NanValue::EMPTY_VECTOR),
+        "nothing to empty and nothing to keep: the copying path answers it"
+    );
+    let stats = vm.vector_ownership_stats();
+    assert_eq!(
+        (
+            stats.grants,
+            stats.refused_stack_holder
+                + stats.refused_off_stack_holder
+                + stats.unexamined_walk_too_costly
+        ),
+        (0, 0),
+        "an immediate is not a decision, so it lands in no bucket"
+    );
+}
+
+/// The dispatch wiring, end to end: a fresh last-use receiver earns the
+/// static grant, the fence confirms it, and the tally says the owned
+/// path really was reached — if the `CALL_BUILTIN_OWNED` route ever
+/// stops consulting the fence, `grants` stays zero and this fails.
+#[test]
+fn a_granted_vector_set_is_confirmed_through_the_dispatch_point() {
+    let mut vm = compile_vm_with_ownership(
+        "fn main() -> Int\n    v = Vector.fromList([1, 2])\n    w = Option.withDefault(Vector.set(v, 0, 9), Vector.fromList([0]))\n    Option.withDefault(Vector.get(w, 0), 0 - 1)\n",
+    );
+    let result = vm.run().expect("vector set program should run");
+    assert_eq!(result.as_int(&vm.arena), 9);
+    let stats = vm.vector_ownership_stats();
+    assert_eq!(
+        (
+            stats.grants,
+            stats.refused_stack_holder + stats.refused_off_stack_holder
+        ),
+        (1, 0),
+        "the static grant should reach the fence and be confirmed"
+    );
+}
+
+/// The wrapper toll, pinned: `Vector.set` wraps its result in `Some`,
+/// which boxes a heap vector, and the box marks its payload
+/// held-elsewhere on the way in — so in a chain spelled through the
+/// plain builtin only the FIRST granted write keeps its grant; the
+/// second is revoked by the first one's own dead wrapper and copies.
+/// The answer stays right either way. If this ever changes — the fence
+/// learning to see through dead boxes, or the marking getting wider —
+/// this test is the recorded decision that must be revisited.
+#[test]
+fn a_second_owned_set_in_a_non_fused_chain_pays_the_wrapper_toll() {
+    let mut vm = compile_vm_with_ownership(
+        "fn main() -> Int\n    v = Vector.fromList([1, 2])\n    w = Option.withDefault(Vector.set(v, 0, 9), Vector.fromList([0]))\n    u = Option.withDefault(Vector.set(w, 1, 7), Vector.fromList([0]))\n    a = Option.withDefault(Vector.get(u, 0), 0 - 1)\n    b = Option.withDefault(Vector.get(u, 1), 0 - 1)\n    a + b\n",
+    );
+    let result = vm.run().expect("chained vector set program should run");
+    assert_eq!(result.as_int(&vm.arena), 16);
+    let stats = vm.vector_ownership_stats();
+    assert_eq!(
+        (stats.grants, stats.refused_off_stack_holder),
+        (1, 1),
+        "expected the first grant confirmed and the second revoked by \
+         the first result's own Some-wrapper box"
     );
 }

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -737,11 +737,18 @@ pub fn opcode_operand_width(op: u8, code: &[u8], ip: usize) -> usize {
         // 1-byte
         LOAD_LOCAL | MOVE_LOCAL | STORE_LOCAL | CALL_VALUE | RECORD_GET | EXTRACT_FIELD
         | EXTRACT_TUPLE_ITEM | LIST_NEW | WRAP | TUPLE_NEW | TAIL_CALL_SELF
-        | TAIL_CALL_SELF_THIN | VECTOR_SET_OR_KEEP => 1,
+        | TAIL_CALL_SELF_THIN => 1,
 
         // 2-byte (u16 or u8+u8)
         LOAD_CONST | LOAD_GLOBAL | STORE_GLOBAL | JUMP | JUMP_IF_FALSE | MATCH_FAIL | MATCH_NIL
         | MATCH_CONS | LOAD_LOCAL_2 | VECTOR_GET_OR => 2,
+
+        // owned:u8 + target_slot:u8. The slot is the target's own local cell,
+        // which the runtime fence must exempt: the fusion deletes the
+        // textually-last read, so the target comes in through `LOAD_LOCAL` and
+        // its own cell is still live at the write. See
+        // `VM::runtime_confirms_fused_vector_grant`.
+        VECTOR_SET_OR_KEEP => 2,
 
         // 3-byte
         CALL_KNOWN | CALL_LEAF | MATCH_TAG | MATCH_UNWRAP | MATCH_TUPLE | RECORD_NEW

--- a/src/vm/profile.rs
+++ b/src/vm/profile.rs
@@ -61,6 +61,11 @@ pub struct VmProfileReport {
     /// Unlike the tallies above, these are maintained by every build and every
     /// run — the profile is where they are READ, not where they are kept.
     pub runtime_ownership: super::VmRuntimeOwnershipStats,
+    /// What the runtime decided about the vector writes the compiler granted —
+    /// the same buckets, read in the revocation direction (a `refused_*` here
+    /// is a static grant the fence took back). Maintained by every build and
+    /// every run, like `runtime_ownership`.
+    pub vector_ownership: super::VmRuntimeOwnershipStats,
 }
 
 impl VmProfileReport {
@@ -109,6 +114,7 @@ impl VmProfileReport {
         self.returns.regular_slow_returns += other.returns.regular_slow_returns;
         self.slot_uniqueness.merge(&other.slot_uniqueness);
         self.runtime_ownership.merge(&other.runtime_ownership);
+        self.vector_ownership.merge(&other.vector_ownership);
     }
 }
 
@@ -213,6 +219,7 @@ impl VmProfileState {
         code: &CodeStore,
         slot_uniqueness: super::VmSlotUniquenessStats,
         runtime_ownership: super::VmRuntimeOwnershipStats,
+        vector_ownership: super::VmRuntimeOwnershipStats,
     ) -> VmProfileReport {
         let total_opcodes = self.opcode_counts.iter().sum();
         let mut opcodes = self
@@ -273,6 +280,7 @@ impl VmProfileState {
             returns: self.return_stats.clone(),
             slot_uniqueness,
             runtime_ownership,
+            vector_ownership,
         }
     }
 }

--- a/tests/vm_slot_uniqueness.rs
+++ b/tests/vm_slot_uniqueness.rs
@@ -404,19 +404,22 @@ fn every_tail_call_window_hands_back_the_previous_iterations_cell() {
 
 #[test]
 fn a_vector_fold_writes_nothing_the_cross_check_can_see() {
-    // The module lists four blind spots; this pins the two on the vector side,
-    // because they are the ones that decide how the numbers should be READ. A
-    // declined `Vector.set` is lowered to its own `VECTOR_SET` opcode and never
-    // becomes a `CALL_BUILTIN` at all, and the fused `Vector.set(v, i, x)`
-    // kept-by-default spelling becomes `VECTOR_SET_OR_KEEP` — the VM's only true
-    // in-place arena write, and the one grant this predicate could not answer
-    // even if it were asked, since the fused shape reads the vector with
-    // `LOAD_LOCAL` and leaves the target's own cell live across the write.
+    // Why the vector side is invisible HERE, and where it is visible instead.
+    // The cross-check is a builtin-call instrument: a declined `Vector.set` is
+    // lowered to its own `VECTOR_SET` opcode and never becomes a
+    // `CALL_BUILTIN` at all, and the fused kept-by-default spelling becomes
+    // `VECTOR_SET_OR_KEEP` — the VM's only true in-place arena write, and not
+    // a call either. So `unique_slot_without_owned_grant` is a MAP number, and
+    // anyone sizing a P2 decision from it is reading a Map-shaped floor.
     //
-    // So `unique_slot_without_owned_grant` is a MAP number, and anyone sizing a
-    // P2 decision from it is reading a Map-shaped floor. The day the vector side
-    // is brought in, this test is what will say so.
-    let stats = tallies(
+    // The fused write is no longer unwatched, though: its static grant is a
+    // proposal the runtime confirms, and the confirmations land in the VECTOR
+    // ownership tallies, which the second half of this test reads back. The
+    // fence had to be given the target's slot to do it — the fusion deletes
+    // the textually-last read, so the vector arrives through `LOAD_LOCAL` and
+    // its own cell is still live across the write — and the day that exemption
+    // stops being enough, the fold below is what stops granting.
+    let mut machine = compiled_vm(
         r#"module SlotVectorFold
     intent = "a vector threaded through a fold, and a set that keeps a default"
     depends []
@@ -439,12 +442,21 @@ fn main() -> Int
     Option.withDefault(Vector.get(kept, 1), 0)
 "#,
     );
+    machine.run().expect("program should run");
     assert_eq!(
-        stats,
+        machine.slot_uniqueness_stats(),
         sorted_writes(0, 0, 0, 0),
         "a vector fold reached the cross-check, so the blind spots the module \
          enumerates are no longer the ones it has — re-read that list before \
          trusting either tally as a whole-VM number",
+    );
+    let vectors = machine.vector_ownership_stats();
+    assert!(
+        vectors.grants > 0,
+        "the fused self-keep fold took no in-place grant at all ({vectors:?}) \
+         — either the fence stopped exempting the target's own local cell, or \
+         the accumulator lost its static grant, and both cost every fold in \
+         the language its in-place write",
     );
 }
 

--- a/tests/wasm_gc_container_read_ownership.rs
+++ b/tests/wasm_gc_container_read_ownership.rs
@@ -524,6 +524,326 @@ fn main() -> Unit
     );
 }
 
+// ── A FRESH subject still RETAINS what was put in it ──────────────
+//
+// The row above reads a value OUT of a container. This one puts a
+// value IN, spells the aggregate as a match subject, and pokes the
+// local afterwards. The escape half used to skip a match's subject
+// entirely — the arm tails become the value, so nothing of the subject
+// escapes through it — and the binder pass ran that half over the
+// subject only when the subject was NOT provably fresh. Both halves of
+// that were the same mistake: freshness is a claim about the
+// AGGREGATE, never about its contents, so `held` stayed owned-eligible
+// and the poke wrote into the map the binder was still holding. Every
+// cell here answered 10000 on wasm-gc (write-through: 5000 read back
+// where `x` was stored, plus the 5000 poked in), and the nested-map
+// cell tripped the VM's own debug audit.
+
+#[test]
+fn map_literal_match_subject_retains_the_local_it_holds() {
+    assert_cell(
+        "own-c17",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Fresh map-literal subject retains held; the binder keeps a handle, then held is poked."
+    held = Vector.fromList([x, x + 2])
+    keeper = match {"k" => held}
+        mm -> mm
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([0, 0]))
+    back = Option.withDefault(Map.get(keeper, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn from_list_match_subject_retains_its_element() {
+    assert_cell(
+        "own-c18",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Fresh Vector.fromList subject retains held through its element; held is then poked."
+    held = Vector.fromList([x, x + 2])
+    carrier = match Vector.fromList([held])
+        c -> c
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([0, 0]))
+    inner = Option.withDefault(Vector.get(carrier, 0), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(inner, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn map_set_match_subject_retains_its_value() {
+    assert_cell(
+        "own-c19",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Fresh Map.set subject retains held as its value; held is then poked."
+    held = Vector.fromList([x, x + 2])
+    keeper = match Map.set({}, "k", held)
+        mm -> mm
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([0, 0]))
+    back = Option.withDefault(Map.get(keeper, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn nested_map_literal_match_subject_retains_the_inner_map() {
+    assert_cell(
+        "own-c20",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Map spelling: fresh map-literal subject retains inner; inner is then Map.set."
+    inner = Map.set({}, "a", x)
+    keeper = match {"in" => inner}
+        mm -> mm
+    poked = Map.set(inner, "a", 5000)
+    back = Option.withDefault(Map.get(keeper, "in"), {})
+    stored = Option.withDefault(Map.get(back, "a"), 0 - 1)
+    fresh = Option.withDefault(Map.get(poked, "a"), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+/// The same retention, poked through the FUSED self-keep set — the
+/// `VECTOR_SET_OR_KEEP` opcode, which is the VM's only true in-place
+/// arena write. Its static grant used to reach the arena with neither
+/// the runtime fence nor the debug audit in front of it, so the VM
+/// printed 10000 here while wasm-gc printed the right answer: the one
+/// cell in this file whose original failure was the VM's alone.
+#[test]
+fn map_literal_match_subject_retention_survives_the_fused_self_keep_set() {
+    assert_cell(
+        "own-c21",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Fresh map-literal subject retains held; held is poked through the fused self-keep set."
+    held = Vector.fromList([x, x + 2])
+    keeper = match {"k" => held}
+        mm -> mm
+    poked = Option.withDefault(Vector.set(held, 0, 5000), held)
+    back = Option.withDefault(Map.get(keeper, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+// ── A fresh receiver is EARNED, not free ──────────────────────────
+//
+// The owned wasm-gc `Vector.set` emitted its receiver three times —
+// once for the bounds check, once as the `array.set` target, once as
+// the `Some` payload. Free for a local; for the other owned-eligible
+// receiver, a provably-fresh non-local, each emission BUILT ANOTHER
+// ARRAY, so the write landed on build #2 and the answer came back out
+// of the untouched build #3.
+
+/// `x + 5000` written into a fresh receiver, read straight back:
+/// 7011/7003 everywhere, and 2011/2003 on wasm-gc when the write goes
+/// to an array nobody reads.
+#[test]
+fn inline_fresh_receiver_set_is_read_back_from_the_array_it_wrote() {
+    assert_cell(
+        "own-c22",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Vector.set straight on an inline fresh Vector.fromList receiver."
+    poked = Option.withDefault(Vector.set(Vector.fromList([x, 9]), 0, x + 5000), Vector.fromList([]))
+    Option.withDefault(Vector.get(poked, 0), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+/// Chained: the receiver is itself an owned `Vector.set` result. Both
+/// writes have to land in the one array the result names — cell 1 keeps
+/// the 7 the inner set wrote, cell 0 the `x + 5000` the outer one did,
+/// so the sum moves if either build is duplicated.
+#[test]
+fn chained_fresh_receiver_sets_land_in_one_array() {
+    assert_cell(
+        "own-c23",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Chained fresh receiver: Vector.set of a Vector.set result, one build only."
+    poked = Option.withDefault(Vector.set(Option.withDefault(Vector.set(Vector.fromList([x, 9]), 1, 7), Vector.fromList([0, 0])), 0, x + 5000), Vector.fromList([0, 0]))
+    a = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    b = Option.withDefault(Vector.get(poked, 1), 0 - 1)
+    a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "7018\n7010",
+    );
+}
+
+// ── One scratch local per Vector<T>, and a re-entrant emitter ─────
+//
+// Holding the receiver in the per-type scratch local is what stops the
+// rebuild above, and it puts the owned path on a local the emitter can
+// re-enter: every operand it re-emits may itself be a `Vector.set` of
+// the SAME `Vector<T>`, which stores into that same local. The three
+// emitters therefore share one rule — emit everything that can
+// re-enter, then store, then read — and these cells are the ones that
+// notice when a read drifts back behind a re-emission. Each index below
+// is written as `Vector.len(<a nested set of the same type>) - 2`, so
+// the nested set is emitted at every point the outer one re-emits its
+// index.
+
+/// Owned receiver, nested owned set in the index. Cell 0 carries the
+/// write and cell 1 the untouched 9; reading the nested set's array
+/// instead answers 2 for cell 1.
+#[test]
+fn owned_receiver_survives_a_nested_set_in_its_index() {
+    assert_cell(
+        "own-c24",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Owned fresh receiver whose index rebuilds a nested same-type set."
+    poked = Option.withDefault(Vector.set(Vector.fromList([x, 9]), Vector.len(Option.withDefault(Vector.set(Vector.fromList([1, 2]), 0, 7), Vector.fromList([]))) - 2, x + 5000), Vector.fromList([]))
+    a = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    b = Option.withDefault(Vector.get(poked, 1), 0 - 1)
+    a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "7020\n7012",
+    );
+}
+
+/// The clone-on-write half of the same question: a shared receiver, so
+/// the set copies, and the nested set in the index lands in the local
+/// between the copy and the `Some` that has to wrap it.
+#[test]
+fn cloned_receiver_survives_a_nested_set_in_its_index() {
+    assert_cell(
+        "own-c25",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Clone-on-write set whose index rebuilds a nested same-type set."
+    stash = {"k" => Vector.fromList([x, 9])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    poked = Option.withDefault(Vector.set(held, Vector.len(Option.withDefault(Vector.set(Vector.fromList([1, 2]), 0, 7), Vector.fromList([]))) - 2, x + 5000), Vector.fromList([]))
+    a = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    b = Option.withDefault(Vector.get(poked, 1), 0 - 1)
+    a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "7020\n7012",
+    );
+}
+
+/// And the FUSED self-keep spelling, which reaches the third emitter:
+/// its clone-on-write branch read the local back twice after the index
+/// had been re-emitted, once for the write target and once for the
+/// result.
+#[test]
+fn fused_self_keep_set_survives_a_nested_set_in_its_index() {
+    assert_cell(
+        "own-c26",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Fused self-keep set on a shared receiver whose index rebuilds a nested same-type set."
+    stash = {"k" => Vector.fromList([x, 9])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    poked = Option.withDefault(Vector.set(held, Vector.len(Option.withDefault(Vector.set(Vector.fromList([1, 2]), 0, 7), Vector.fromList([]))) - 2, x + 5000), held)
+    a = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    b = Option.withDefault(Vector.get(poked, 1), 0 - 1)
+    a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "7020\n7012",
+    );
+}
+
+/// The fused self-keep set with the index OUT of bounds, which is the
+/// branch the restructure changed: it now hands back the receiver
+/// itself rather than an identical copy of it, and allocates nothing.
+/// The answer must not move — `poked` is `held`, unchanged.
+#[test]
+fn fused_self_keep_set_out_of_bounds_keeps_the_receiver() {
+    assert_cell(
+        "own-c27",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Fused self-keep set past the end keeps the receiver unchanged."
+    stash = {"k" => Vector.fromList([x, 9])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    poked = Option.withDefault(Vector.set(held, 7, 5000), held)
+    a = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    b = Option.withDefault(Vector.get(poked, 1), 0 - 1)
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    a + b + Option.withDefault(Vector.get(back, 0), 0 - 1)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "4031\n4015",
+    );
+}
+
 // ── Emitted-code pin: the conservative default did not swallow the
 //    fresh-local fast path ─────────────────────────────────────────
 

--- a/tests/wasm_gc_container_read_ownership.rs
+++ b/tests/wasm_gc_container_read_ownership.rs
@@ -1,0 +1,463 @@
+//! A value read out of a container is not yours to mutate (#950).
+//!
+//! On the wasm-gc backend the in-place `Vector.set` / `Map.set` fast
+//! path is granted statically, from `last_use` + `aliased_slots`. Two
+//! holes let a container-read value take that fast path and write
+//! straight through to the stored entry:
+//!
+//! - every `aver run --wasm-gc` / `--wasip2` / `compile` path re-ran
+//!   the slot resolver after `flatten_multimodule`, and a fresh
+//!   `FnResolution` carries the all-`false` default `aliased_slots` —
+//!   the re-resolve silently withdrew every verdict `ir::alias` had
+//!   stamped, while the stale `last_use` marks survived. A local
+//!   extracted from a Map entry then read as "dead and never shared";
+//! - `mir_arg_uniquely_owned` answered `true` for every NON-local
+//!   receiver, so an inline `Vector.set(Option.withDefault(
+//!   Map.get(m, k), d), i, x)` mutated the map-held array with no
+//!   local involved at all.
+//!
+//! The probe answered 5011/1003-style write-through values where
+//! compiled Rust and the self-host interpreter answered 7011/7003.
+//!
+//! This file pins the full provenance × operation matrix, every cell
+//! run on VM, wasm-gc, and self-host through the real CLI, each backend
+//! asserted against the same hand-computed literal — three backends
+//! agreeing on a wrong value still fails. The two green-by-design cells
+//! (fresh local, fresh chain) pin that the conservative fix did not
+//! swallow the owned fast path, and `fresh_local_set_stays_in_place`
+//! additionally pins the *emitted code*: the clone (`array.new_default`)
+//! exists only in the container-read variant.
+
+#![cfg(feature = "wasm")]
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_module(prefix: &str, source: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("{}-{}", prefix, nanos));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join("main.av");
+    fs::write(&path, source).expect("write temp module source");
+    path
+}
+
+fn cleanup(path: &std::path::Path) {
+    let _ = fs::remove_dir_all(path.parent().expect("temp module has parent"));
+}
+
+fn format_output(out: &std::process::Output) -> String {
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    )
+}
+
+/// Run one cell program through the real CLI on the given backend
+/// flags, returning trimmed stdout.
+fn run_cli(prefix: &str, source: &str, extra_args: &[&str]) -> String {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let path = temp_module(prefix, source);
+    let mut cmd = Command::new(aver_bin);
+    cmd.current_dir(&repo_root).arg("run").arg(&path);
+    for a in extra_args {
+        if *a == "--module-root" {
+            cmd.arg(a)
+                .arg(path.parent().expect("temp module has parent"));
+        } else {
+            cmd.arg(a);
+        }
+    }
+    let out = cmd.output().expect("expected `aver run` to execute");
+    cleanup(&path);
+    assert!(
+        out.status.success(),
+        "{} run {:?} failed:\n{}",
+        prefix,
+        extra_args,
+        format_output(&out)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Assert one matrix cell: VM, wasm-gc and self-host each print exactly
+/// the hand-computed literal.
+fn assert_cell(name: &str, source: &str, expected: &str) {
+    let vm = run_cli(name, source, &[]);
+    assert_eq!(
+        vm, expected,
+        "{name}: VM diverged from the hand-computed answer"
+    );
+    let wasm = run_cli(name, source, &["--wasm-gc"]);
+    assert_eq!(
+        wasm, expected,
+        "{name}: wasm-gc diverged from the hand-computed answer — an \
+         in-place mutation reached a container-held value"
+    );
+    let self_host = run_cli(name, source, &["--module-root", "--self-host"]);
+    assert_eq!(
+        self_host, expected,
+        "{name}: self-host diverged from the hand-computed answer"
+    );
+}
+
+/// Every write-through cell prints `x + 5000` for x ∈ {2011, 2003}: the
+/// stored entry must still hold `x` after the local was poked to 5000.
+/// A backend that writes through prints 10000 (5000 + 5000) instead.
+const POKED: &str = "7011\n7003";
+
+#[test]
+fn map_entry_local_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c01",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Map entry read into a local, Vector.set on the local, entry re-read."
+    stash = {"k" => Vector.fromList([x, x + 2])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn map_entry_local_fused_self_keep_set_does_not_write_through() {
+    assert_cell(
+        "own-c02",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Map entry read into a local, fused self-keep Vector.set, entry re-read."
+    stash = {"k" => Vector.fromList([x, x + 2])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    poked = Option.withDefault(Vector.set(held, 0, 5000), held)
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn nested_map_entry_local_map_set_does_not_write_through() {
+    assert_cell(
+        "own-c03",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Inner map read out of a Map-in-Map, Map.set on the local, outer re-read."
+    outer = {"in" => {"a" => x}}
+    inner = Option.withDefault(Map.get(outer, "in"), {})
+    poked = Map.set(inner, "a", 5000)
+    back = Option.withDefault(Map.get(outer, "in"), {})
+    stored = Option.withDefault(Map.get(back, "a"), 0 - 1)
+    fresh = Option.withDefault(Map.get(poked, "a"), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn list_element_local_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c04",
+        r#"
+fn probe(x: Int) -> Int
+    ? "List element read into a local by pattern match, Vector.set, element re-read."
+    lst = [Vector.fromList([x, 9])]
+    held = match lst
+        [] -> Vector.fromList([0, 0])
+        [h, ..t] -> h
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([0, 0]))
+    again = match lst
+        [] -> Vector.fromList([0, 0])
+        [h2, ..t2] -> h2
+    stored = Option.withDefault(Vector.get(again, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn helper_returned_container_read_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c05",
+        r#"
+fn fetch(m: Map<String, Vector<Int>>) -> Vector<Int>
+    ? "Read the k entry out of the map."
+    Option.withDefault(Map.get(m, "k"), Vector.fromList([]))
+
+fn probe(x: Int) -> Int
+    ? "Helper returns a map-held vector, Vector.set on it, entry re-read."
+    stash = {"k" => Vector.fromList([x, 9])}
+    held = fetch(stash)
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn vector_param_set_does_not_clobber_the_callers_local() {
+    assert_cell(
+        "own-c06",
+        r#"
+fn stamp(v: Vector<Int>) -> Vector<Int>
+    ? "Vector.set on a parameter the caller still holds."
+    Option.withDefault(Vector.set(v, 0, 5000), Vector.fromList([]))
+
+fn probe(x: Int) -> Int
+    ? "Pass a local to a setter, then read the local again."
+    mine = Vector.fromList([x, 9])
+    poked = stamp(mine)
+    kept = Option.withDefault(Vector.get(mine, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    kept + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn map_param_set_does_not_clobber_the_callers_local() {
+    assert_cell(
+        "own-c07",
+        r#"
+fn put(m: Map<String, Int>) -> Map<String, Int>
+    ? "Map.set on a parameter the caller still holds."
+    Map.set(m, "a", 5000)
+
+fn probe(x: Int) -> Int
+    ? "Pass a local map to a setter, then read the local again."
+    mine = {"a" => x}
+    poked = put(mine)
+    kept = Option.withDefault(Map.get(mine, "a"), 0 - 1)
+    fresh = Option.withDefault(Map.get(poked, "a"), 0 - 1)
+    kept + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn fresh_local_set_still_answers_right() {
+    assert_cell(
+        "own-c08",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Freshly built vector, dead after the set: the in-place fast path is fine."
+    fresh = Vector.fromList([x, 9])
+    poked = Option.withDefault(Vector.set(fresh, 0, x + 5000), Vector.fromList([]))
+    a = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    b = Option.withDefault(Vector.get(poked, 1), 0 - 1)
+    a + b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "7020\n7012",
+    );
+}
+
+#[test]
+fn inline_container_read_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c09",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Vector.set straight on an inline Map.get read, no local in between."
+    stash = {"k" => Vector.fromList([x, 9])}
+    poked = Option.withDefault(Vector.set(Option.withDefault(Map.get(stash, "k"), Vector.fromList([])), 0, 5000), Vector.fromList([]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn inline_container_read_map_set_does_not_write_through() {
+    assert_cell(
+        "own-c10",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Map.set straight on an inline Map.get read of a nested map."
+    outer = {"in" => {"a" => x}}
+    poked = Map.set(Option.withDefault(Map.get(outer, "in"), {}), "a", 5000)
+    back = Option.withDefault(Map.get(outer, "in"), {})
+    stored = Option.withDefault(Map.get(back, "a"), 0 - 1)
+    fresh = Option.withDefault(Map.get(poked, "a"), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn fresh_chained_map_set_still_answers_right() {
+    assert_cell(
+        "own-c11",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Chained Map.set over a fresh map: the owned fast path must survive."
+    base = Map.set({}, "a", x)
+    two = Map.set(Map.set(base, "b", 2), "c", 3)
+    got = Option.withDefault(Map.get(two, "a"), 0 - 1)
+    got + Map.len(two)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        "2014\n2006",
+    );
+}
+
+// ── Emitted-code pin: the conservative default did not swallow the
+//    fresh-local fast path ─────────────────────────────────────────
+
+/// Compile one program to wasm-gc bytes through the same pipeline shape
+/// as `aver compile --target wasm-gc` and return its printed WAT.
+fn wat_of(source: &str) -> String {
+    let mut items = aver::source::parse_source(source).expect("parse");
+    let neutral_policy = aver::ir::NeutralAllocPolicy;
+    let result = aver::ir::pipeline::run(
+        &mut items,
+        aver::ir::PipelineConfig {
+            typecheck: Some(aver::ir::TypecheckMode::Full { base_dir: None }),
+            alloc_policy: Some(&neutral_policy),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            run_chars_fusion: false,
+            run_list_build: false,
+            ..Default::default()
+        },
+    );
+    let tc = result.typecheck.as_ref().expect("typecheck requested");
+    assert!(tc.errors.is_empty(), "typecheck failed: {:?}", tc.errors);
+    let bytes = aver::codegen::wasm_gc::compile_to_wasm_gc(&items, result.analysis.as_ref())
+        .expect("wasm-gc compile");
+    wasmprinter::print_bytes(&bytes).expect("print wat")
+}
+
+/// The two programs are identical except for `held`'s provenance —
+/// fresh `Vector.fromList` vs a read out of the map — so their type /
+/// helper sets match and the WAT `array.new_default` count isolates the
+/// ownership decision at the `Vector.set` site. The container-read
+/// variant must carry exactly one more (its clone-before-mutate); if
+/// the fresh variant ever gains one, the fast path was silently
+/// pessimized, and if the read variant loses its extra one, the copy
+/// guard regressed.
+#[test]
+fn fresh_local_set_stays_in_place_while_container_read_copies() {
+    let fresh = r#"
+fn probe(x: Int) -> Int
+    ? "Fresh receiver: the set may mutate in place."
+    stash = {"k" => Vector.fromList([x, 9])}
+    held = Vector.fromList([x, 9])
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([0, 0]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+"#;
+    let read = r#"
+fn probe(x: Int) -> Int
+    ? "Container-read receiver: the set must copy first."
+    stash = {"k" => Vector.fromList([x, 9])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([0, 0]))
+    poked = Option.withDefault(Vector.set(held, 0, 5000), Vector.fromList([0, 0]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+"#;
+    let fresh_clones = wat_of(fresh).matches("array.new_default").count();
+    let read_clones = wat_of(read).matches("array.new_default").count();
+    assert_eq!(
+        read_clones,
+        fresh_clones + 1,
+        "expected the container-read variant to carry exactly one more \
+         array.new_default (the clone-before-mutate) than the fresh \
+         variant ({read_clones} vs {fresh_clones}) — either the fresh \
+         fast path was pessimized or the copy guard regressed"
+    );
+}

--- a/tests/wasm_gc_container_read_ownership.rs
+++ b/tests/wasm_gc_container_read_ownership.rs
@@ -383,6 +383,147 @@ fn main() -> Unit
     );
 }
 
+// ── Match-binder provenance (#953 follow-up) ──────────────────────
+//
+// A match arm's pattern binders are container reads too: the binder
+// aliases (part of) the subject, and the subject may be a stored
+// entry. The alias pass used to flag only `Stmt::Binding` slots, so
+// every binder slot read as "never shared" — wasm-gc mutated the
+// stored entry in place (10000/10000), and the VM's static owned
+// mask took the arena entry with `mem::take` while the container
+// still held it (4999/4999, silent). Each cell below is one binder
+// shape; all three backends must answer the hand-computed literal.
+
+#[test]
+fn bare_ident_binder_vector_set_does_not_write_through() {
+    // This shape used to TRAP on wasm-gc (`unreachable`): the MIR
+    // emitter had no arm for a single-Bind match over a collection
+    // subject, so `probe` compiled to a trap stub.
+    assert_cell(
+        "own-c12",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Launder a flagged container-read local through a bare Ident match binder, mutate the binder."
+    stash = {"k" => Vector.fromList([x, x + 2])}
+    held = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    poked = match held
+        v -> Option.withDefault(Vector.set(v, 0, 5000), Vector.fromList([0, 0]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn some_binder_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c13",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Mutate the Some-binder of a map read inside the arm body."
+    stash = {"k" => Vector.fromList([x, x + 2])}
+    poked = match Map.get(stash, "k")
+        Option.None -> Vector.fromList([0, 0])
+        Option.Some(v) -> Option.withDefault(Vector.set(v, 0, 5000), Vector.fromList([0, 0]))
+    back = Option.withDefault(Map.get(stash, "k"), Vector.fromList([]))
+    stored = Option.withDefault(Vector.get(back, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn cons_head_binder_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c14",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Mutate the head binder of a list pattern inside the arm body."
+    lst = [Vector.fromList([x, 9])]
+    poked = match lst
+        [] -> Vector.fromList([0, 0])
+        [h, ..t] -> Option.withDefault(Vector.set(h, 0, 5000), Vector.fromList([0, 0]))
+    again = match lst
+        [] -> Vector.fromList([0, 0])
+        [h2, ..t2] -> h2
+    stored = Option.withDefault(Vector.get(again, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn tuple_binder_vector_set_does_not_write_through() {
+    assert_cell(
+        "own-c15",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Mutate a tuple-pattern binder that aliases the tuple's element."
+    pair = (Vector.fromList([x, 9]), 1)
+    poked = match pair
+        (v, n) -> Option.withDefault(Vector.set(v, 0, 5000), Vector.fromList([0, 0]))
+    kept = match pair
+        (v2, n2) -> v2
+    stored = Option.withDefault(Vector.get(kept, 0), 0 - 1)
+    fresh = Option.withDefault(Vector.get(poked, 0), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
+#[test]
+fn some_binder_map_set_does_not_write_through() {
+    assert_cell(
+        "own-c16",
+        r#"
+fn probe(x: Int) -> Int
+    ? "Map.set on the Some-binder of a nested-map read inside the arm."
+    outer = {"in" => {"a" => x}}
+    poked = match Map.get(outer, "in")
+        Option.None -> {"a" => 0 - 1}
+        Option.Some(m) -> Map.set(m, "a", 5000)
+    back = Option.withDefault(Map.get(outer, "in"), {"a" => 0 - 1})
+    stored = Option.withDefault(Map.get(back, "a"), 0 - 1)
+    fresh = Option.withDefault(Map.get(poked, "a"), 0 - 1)
+    stored + fresh
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print(String.fromInt(probe(2011)))
+    Console.print(String.fromInt(probe(2003)))
+"#,
+        POKED,
+    );
+}
+
 // ── Emitted-code pin: the conservative default did not swallow the
 //    fresh-local fast path ─────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #950 — on the wasm-gc backend, a vector (or map) read out of a container and then updated in place wrote through to the stored entry. The VM, compiled Rust, and the self-host interpreter all preserve the stored value; wasm-gc alone mutated it. **Review round 2 falsified half of that sentence: the VM corrupted too, on the match-binder shapes, silently. Review round 3 found the same class one question further out — what a match subject KEEPS, not what it was read out of — plus an unfenced fused write in the VM and a wasm-gc receiver that was built three times.**

## The decision site and what evidence it reads

The in-place/copy choice for `Vector.set` (plain and the fused `Option.withDefault(Vector.set(v, ..), v)`) and `Map.set` (`set_in_place` vs the cloning `set` helper) is made in `src/codegen/wasm_gc/body/from_mir/builtins.rs::mir_arg_uniquely_owned`. Its evidence is:

- for a **local** receiver: `last_use` on the `MirLocal` occurrence AND the per-slot `aliased_slots` table stamped by the `ir::alias` pass (default FLAGGED; a slot clears only on positive proof of fresh-and-non-escaping — container reads are explicitly *not* fresh);
- for a **non-local** receiver: nothing — the wildcard arm answered "uniquely owned" for every anonymous expression.

Two independent holes let container reads through:

1. **The alias verdicts were being wiped after they were computed.** Every wasm-gc-shaped CLI path (`aver run --wasm-gc`, `--wasip2`, `aver compile --target wasm-gc|wasip2`, the playground, the verify wasm lane) re-runs the slot resolver after `flatten_multimodule` so freshly appended dep fns get a `FnResolution`. But a fresh `FnResolution` carries the default all-`false` `aliased_slots` (`src/resolver.rs`), so the re-resolve silently withdrew every verdict the alias pass had stamped on the entry fns — while the `last_use` marks on the body expressions survived. The combination read as "dead and never shared" for a local whose value came straight out of `Map.get`.
2. **The non-local arm assumed transient = owned.** `Vector.set(Option.withDefault(Map.get(m, k), d), i, x)` — no local anywhere — mutated the map-held array through the wildcard arm.

## The fix (conservative, no new analysis)

- `ir::pipeline::resolve_and_reannotate` — `resolve` + `last_use` + the alias pass, in the canonical pipeline order — and every post-flatten re-resolve that feeds wasm-gc codegen now uses it (7 call sites). Bare `resolve` carries a caution note pointing at it. This also gives dep-module fns real ownership facts instead of a default table.
- The wildcard arm of `mir_arg_uniquely_owned` is gone: a non-local receiver earns the fast path only by being a **provably fresh collection** — a MIR mirror of the alias pass's existing freshness whitelist (map literal, `Vector.set`/`fromList`, `Map.set`/`remove`/`fromList`, `Vector.new` of a non-compound fill, `Option.withDefault` with both branches fresh, match/if with all arms fresh). Anything else — a container read, a user-fn result — copies first. The burden of proof is on the mutation.
- A slot outside the alias table now reads as **aliased** (`EmitCtx::is_aliased_slot` out-of-range default flipped `false` → `true`): missing evidence costs the fast path, never soundness.

Known gap left as follow-up: a *user-fn result* receiver always copies now, even when the callee provably returns a fresh collection — interprocedural return-freshness would recover that grant if a real workload ever pays for it (none of the measured ones do).

## Review round 2: the class was open on two more axes

The review attacked the same write-through class from two directions the first round never exercised, and both landed.

### Finding 1 (critical, wasm-gc): match-pattern binders never entered `aliased_slots`

`ir::alias::annotate_fn` iterated `Stmt::Binding` only. A match arm's pattern binder — `Option.Some(v)`, `[h, ..t]`, a tuple component `(v, n)`, or the bare-ident arm `v ->` — hands the arm body a handle INTO the subject's value, and none of those slots were ever examined, so a binder read as `last_use=true` + `aliased=false` and `Vector.set`/`Map.set` on it mutated the stored entry in place.

**Fix at the alias layer:** when the match SUBJECT's value is not provably fresh (the pass's existing `rhs_is_fresh_collection` judgment, the same one a binding RHS gets), every binder slot the arm's pattern introduces is flagged — read positionally from `MatchArm::binding_slots`, the resolver's per-arm stamp (#949), never by name. When anything binds, bare collection locals in the subject are additionally run through the escape half: a bare-ident arm is a rename, and an in-place write to the subject local inside the arm would be observed through the binder.

**The bare-ident trap was a second, separate bug.** `match held { v -> ... }` over a `Vector` did not write through on wasm-gc — it TRAPPED (`unreachable` on a valid program), because the MIR emitter had no arm for a single-`Bind` match over a non-primitive subject and the whole fn fell back to the trap stub. The binder-flag fix alone could not have fixed that; the emitter now compiles the shape as what it is — a rename: emit the subject, store it into the binder's slot, emit the body. Scoped to non-primitive subjects (their locals are always refs); a primitive-subject binder keeps its loud trap-stub fallback rather than guessing at per-slot int unboxing.

### Finding 2 (high, VM): "the VM's paths need no change" — falsified

The original body claimed the VM's runtime ownership walk was the guard there. It guards `Map.set`/`Map.remove` ONLY (#929, and only in the decline-upgrade direction). On the binder shapes the compiler's owned mask — fed by the same missing binder flags — routed `Vector.set` through `CALL_BUILTIN_OWNED`, and `vec_set_nv_owned` empties the target's arena entry with `mem::take` while the container still holds it. The container reads back an empty vector: **4999/4999 where the answer is 7011/7003, no panic.** (`Map.set` through a binder hit the same static hole; a debug build dies on the #929 off-stack-holder audit assert — `slots.rs:482` — a release build corrupts silently there too. The alias fix closes it for both.)

**Fix in the VM, independent of the static fix:** a static in-place grant on `Vector.set` is now a proposal the running program confirms, not a verdict it trusts.

- `ArenaEntry::Vector` carries the `held_elsewhere` record `ArenaEntry::Map` has, marked through the same choke points (`Arena::push`'s child walk, `push_map`'s table pass, `push_vector`'s own element pass, the owned inserts marking the one child they add, globals, chunk constants, the in-place `VECTOR_SET_OR_KEEP` store). The `ListBody::holds_map` fast-path flag widened to `holds_collection` for the same reason.
- `VM::runtime_confirms_vector_grant` (`src/vm/execute/slots.rs`) checks a granted `Vector.set` target in the map decision's cost order — `held_elsewhere` first, then the operand-stack walk under the same `WALK_SLACK` budget — and REVOKES the grant when either finds a holder or the walk is dearer than the copy: the write copies, which is what the program did before the grant existed. A confirmed grant is re-derived from scratch under debug assertions, same as the map grant.
- Deliberately not behind `AVER_NO_RUNTIME_MAP_OWNERSHIP`: that switch turns an optimization off (safe direction); turning the fence off would mean trusting the static grant again, and a safety switch must not have an unsafe setting.
- The counters mirror the map decision's four buckets (`VM::vector_ownership_stats`, printed in the `--profile` report next to the map block), read in the revocation direction, so the cross-check accounting stays honest.

Still owed to a later phase, unchanged: the decline-upgrade direction for vectors, `CALL_VALUE`, and `VECTOR_SET_OR_KEEP`'s own fused grant (its `!is_aliased_slot` gate is repaired by the binder fix; a predicate of its own remains the documented P3 debt).

### The binder matrix (verbatim, before → after)

Five reviewer attack shapes, each printing `probe(2011)` / `probe(2003)`, expected `7011 / 7003` (`x + 5000`; write-through prints 10000; the VM's drained-entry corruption prints 4999 = 5000 + (-1)).

| cell | binder shape × op | VM BEFORE | wasm-gc BEFORE | self-host | compiled Rust | VM AFTER | wasm-gc AFTER |
|---|---|---|---|---|---|---|---|
| c12 | bare ident binder × `Vector.set` | **4999/4999** | **trap: `unreachable`** | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 |
| c13 | `Option.Some(v)` binder × `Vector.set` | **4999/4999** | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 |
| c14 | `[h, ..t]` head binder × `Vector.set` | **4999/4999** | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 |
| c15 | tuple binder × `Vector.set` | **4999/4999** | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 |
| c16 | `Option.Some(m)` binder × `Map.set` | **debug: audit assert panic (release: silent)** | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 |

All five are pinned as cells c12–c16 in `tests/wasm_gc_container_read_ownership.rs`, run on VM, wasm-gc and self-host through the real CLI against the same hand-computed literal.

### Fault injection: each fix carries its own witnesses

- **Binder flagging disabled** (alias pass): wasm-gc flips red on all five (c12 becomes 10000/10000 through the new match arm — the arm is only safe because the binder is flagged); the VM stays at 7011/7003 on c12–c15 **solely because the vector fence revokes the now-lying static grant** (c16, the map cell, dies on the debug audit assert — the map side has no release-path fence, unchanged from #929's design, so the alias pass is its guard).
- **Binder flagging AND the vector fence disabled**: the VM flips to 4999/4999 on c12–c15.
- Both restored; all cells green again on all three backends.

## Review round 3: the same class, read from the other side

Round 2 asked what a match subject was READ out of. Round 3 asked what it KEEPS, and the corrected rule is one sentence: **the escape half runs over a match subject whenever an arm binds, whatever the subject's freshness says, because freshness is a claim about the aggregate and never about its contents.** That is the asymmetry the statement rule already had — for `x = <rhs>` the escape half runs always and only the destination is gated on freshness — and the binder rule was the one place it was not being applied.

### Finding 1 (critical, wasm-gc and VM): a fresh subject still retains what was put in it

`flag_escaping_collection_locals` skips a match's subject on purpose: the arm tails become the value, so nothing of the subject escapes through the match's own value. That is true, and it is the wrong question once an arm BINDS — a binder is the only construct that hands the arm body a handle into the subject. The binder pass did run the escape half over the subject, but only inside its `!subject_fresh` branch. Between the two, `keeper = match {"k" => held} { mm -> mm }` never asked about `held` at all, `held` stayed owned-eligible, and the next `Vector.set(held, ..)` wrote straight through the map the binder is holding.

The walk now runs whenever an arm binds, into a scratch buffer that is merged into the table. `match Map.get(m, k) { … }` still costs `m` nothing: the escape half treats arg 0 of a `Vector` / `Map` builtin as a consuming read, so the buffer comes back empty and only the binder is flagged.

A binder over a provably-fresh subject stays owned-eligible only when the buffer came back EMPTY as well. **That second condition is a fence, not a bug fix, and the difference is stated rather than blurred:** the exemption's argument covers the aggregate and says nothing about what is inside it, so it only carries a binder that IS the whole aggregate — which today every such binder is, because a fresh subject is a `Vector` or a `Map` and neither has a destructuring pattern. I could not build a program that refutes the exemption, and the fault injection below says so out loud: removing the condition flips no runtime witness, only the unit test. It is here because the exemption is new in this branch and this module's rule is that a slot clears only on positive proof of fresh-AND-non-escaping.

### Finding 2 (high, VM): the fused write reached the arena with nothing in front of it

`VECTOR_SET_OR_KEEP`'s owned branch is the VM's only true in-place arena write, and round 2 left it as documented debt: it had neither the runtime fence the plain `CALL_BUILTIN_OWNED` spelling grew nor the debug audit, so the retention shape corrupted there silently — the one cell in this round whose original failure was the VM's alone.

Its static grant is now a proposal the running program confirms, sharing the whole fence with the plain spelling: `held_elsewhere` first, then the same budgeted stack walk, revoke costs exactly the copy the program made before the fusion existed, the same four counters, the same from-scratch re-derivation under debug assertions. One difference, and it is why this needed a predicate rather than another call site: the fusion deletes the textually-last read of the target, so the target arrives through `LOAD_LOCAL` and its own local cell is still live across the write. The opcode carries the target's slot as a second operand so the fence can exempt `bp + slot` and nothing else — a second binding, a half-built argument, a container, a global and a chunk constant all still revoke.

### Finding 3 (medium, wasm-gc): a fresh receiver is earned, not free

The owned `Vector.set` emitted its receiver three times — bounds test, `array.set` target, `Some` payload. Free for a local; for the other owned-eligible receiver, a provably fresh non-local, each emission BUILDS ANOTHER ARRAY, so the bounds check measured the first, the write landed on the second and the answer came out of the untouched third. `Vector.set(Vector.fromList([x, 9]), 0, x + 5000)` answered `x` where every other backend answered `x + 5000`.

The receiver is emitted once into the per-type scratch local now — and that is where the interesting half is. There is ONE scratch local per `Vector<T>` per fn and this emitter is re-entrant: any operand it re-emits can be another `Vector.set` of the same type, which stores into that same local. Putting the owned path on that local made a dormant hazard live, so all three vector emitters now obey one rule: **emit everything that can re-enter, then store, then read**, and let the tail re-emissions clobber a local nothing will read again. Concretely — the index goes before the store (it is emitted up to three times), and the `Some` is built before the write so both remaining reads happen before the index is re-emitted and before `value` is; it still observes the mutation, since the struct holds the array by reference. The fused self-keep spelling's clone-on-write branch was restructured the same way, and its out-of-bounds branch now hands back the receiver itself rather than an identical copy of it — the same value, and no allocation at all on the miss.

The sweep the finding asked for, with its answers: `Map.set` emits each argument exactly once into a per-`Map<K,V>` helper call and has no such site; `emit_mir_vector_set_or_default`'s receiver is a `MirExpr::Local` **by construction** (the call-site guard only fuses when the receiver and the `withDefault` default are the same local), so re-emitting it is one `local.get` and the multi-eval bug cannot reach it. Both are now stated at the code, so the sweep does not have to be redone from scratch.

### The round-3 matrix (verbatim, before → after)

Each cell prints `probe(2011)` / `probe(2003)`. BEFORE is `af03125`, the reviewed head. c17–c22 expect `7011 / 7003` (`x + 5000`; a write-through prints 10000, a lost build prints `x`); c24–c26 expect `7020 / 7012`; c27 expects `4031 / 4015`.

| cell | shape | VM BEFORE | wasm-gc BEFORE | self-host | AFTER (all three) |
|---|---|---|---|---|---|
| c17 | fresh map-literal subject retains `held` × `Vector.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 |
| c18 | `Vector.fromList([held])` subject × `Vector.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 |
| c19 | `Map.set({}, "k", held)` subject × `Vector.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 |
| c20 | nested map-literal subject × `Map.set` | **debug: audit assert panic (release: silent)** | **10000/10000** | 7011/7003 | 7011/7003 |
| c21 | same retention × the FUSED self-keep set | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c22 | inline fresh receiver `Vector.set(Vector.fromList([x, 9]), 0, x + 5000)` | 7011/7003 | **2011/2003** | 7011/7003 | 7011/7003 |
| c24 | owned receiver, nested same-type set in the INDEX | 7020/7012 | **2020/2012** | 7020/7012 | 7020/7012 |

c25 and c26 are the two cells that were GREEN at `af03125` and that the Finding 3 fix would have BROKEN, so they are recorded against the intermediate state rather than against the reviewed head: with the receiver held in the scratch local but before the ordering rule, the clone-on-write `Vector.set` (c25) and the fused self-keep set (c26) each answered `9 / 9` on wasm-gc, handing back the array a nested set had left in the shared local. c27 pins the restructured out-of-bounds branch, which allocates nothing and keeps the receiver.

All seven are cells c17–c27 in `tests/wasm_gc_container_read_ownership.rs`, run on VM, wasm-gc and self-host through the real CLI against the same hand-computed literal.

### Fault injection: each fix carries its own witnesses

- **Retention walk removed** (Finding 1a): wasm-gc flips to 10000/10000 on c17–c19, the VM dies on the debug audit assert on c20 — and c21 stays green on the VM **solely because the fused fence revokes the now-lying static grant**, which is the same independence round 2 recorded for the plain spelling.
- **Binder-retention condition removed** (Finding 1b): **no runtime witness flips.** Only `a_binder_over_a_retaining_fresh_subject_is_not_exempt` fails. A companion probe says why: `[h, ..t]` over a `Vector` is not a destructure — wasm-gc refuses to compile it ("subject type `Vector<Vector<Int>>` is not a registered List<T>") and the VM and self-host take the catch-all arm — so a binder over a fresh subject is always the whole fresh aggregate. This is the honest reading of that condition and the reason it is described above as a fence.
- **Retention walk AND the fused fence disabled**: the VM flips to 10000/10000 on c21. With the fence alone disabled, `a_vector_fold_writes_nothing_the_cross_check_can_see` fails on `grants: 0` — the fence's wiring is pinned, not assumed.
- **Receiver re-emitted three times** (Finding 3): wasm-gc flips to 2011/2003 on c22 and 2020/2012 on c24.
- **Receiver stored before the index is emitted**: c22 stays green, c24 flips to 7013/7005 — the ordering rule alone.
- **The `Some` built after the write again** (clone-on-write path): c25 flips to 9/9. **The fused spelling's pre-restructure order**: c26 flips to 9/9.
- Everything restored; all cells green on all three backends.

### Measured cost (release, this machine, p50 of 9 interleaved runs)

BEFORE = `af03125`, AFTER = this head. `aver run` wall clock, compile included on the wasm-gc rows.

| workload | before p50 | after p50 |
|---|---|---|
| VM `bench/scenarios/vector_ops` | 8.6 ms | 8.2 ms |
| VM `bench/scenarios/map_build` | 5.6 ms | 5.5 ms |
| VM 1 MiB `Bytes.fromHex` decode | 191.8 ms | 191.9 ms |
| wasm-gc `bench/scenarios/vector_ops` | 88.1 ms | 88.3 ms |
| wasm-gc `bench/scenarios/map_build` | 28.3 ms | 28.3 ms |
| wasm-gc `bench/scenarios/map_lookup` | 30.0 ms | 29.9 ms |
| wasm-gc 1 MiB `Bytes.fromHex` decode | 346.7 ms | 346.5 ms |

The fused accumulator confirms cheaply, and the counters say so rather than the clock: `--profile` on `vector_ops` reports 5000 fused writes granted and **5000 kept in place, 0 revoked** — the target's own local cell is the exemption, and nothing else in that fold holds the array.

### The matrix was not running in CI

`tests/wasm_gc_container_read_ownership.rs` is feature-gated on `wasm`, so the `Check & Test` job compiles it to zero tests, and it was never added to the WASM job's explicit suite list when it was created earlier in this branch. This PR's central evidence has therefore never run in CI. It is listed now.

## The original matrix (round 1, verbatim, before → after)

Receiver provenance × operation, each cell one program printing `probe(2011)` / `probe(2003)`, run on all four implementations. Expected values are hand-computed (`x + 5000`; a write-through prints `10000`).

| cell | provenance × op | VM | wasm-gc BEFORE | self-host | compiled Rust | wasm-gc AFTER |
|---|---|---|---|---|---|---|
| c01 | Map entry local × `Vector.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c02 | Map entry local × fused self-keep `Vector.set` | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 | 7011/7003 |
| c03 | nested Map-in-Map local × `Map.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c04 | List element local × `Vector.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c05 | helper-returned container read × `Vector.set` | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c06 | fn parameter × `Vector.set` (caller retains) | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c07 | fn parameter × `Map.set` (caller retains) | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c08 | fresh local × `Vector.set` | 7020/7012 | 7020/7012 | 7020/7012 | 7020/7012 | 7020/7012 |
| c09 | inline container read × `Vector.set` (no local) | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c10 | inline container read × `Map.set` (no local) | 7011/7003 | **10000/10000** | 7011/7003 | 7011/7003 | 7011/7003 |
| c11 | fresh chained `Map.set` | 2014/2006 | 2014/2006 | 2014/2006 | 2014/2006 | 2014/2006 |

`--wasip2` smoke-checked on c01: 7011/7003 after.

## The fresh fast path is proven kept, not assumed

`fresh_local_set_stays_in_place_while_container_read_copies` compiles two programs identical except for the receiver's provenance and asserts the WAT of the container-read variant carries **exactly one more** `array.new_default` (the clone-before-mutate) than the fresh variant — if the fresh path is ever silently pessimized, or the copy guard ever regresses, the equality breaks. Cells c08/c11 pin the same paths behaviorally.

## Measured cost (release, this machine, p50 of 9 interleaved runs)

BEFORE = the reviewed head of this branch (round 1 fix only), AFTER = with both round-2 fixes. `aver run` wall clock, compile included on the wasm-gc rows, same harness both sides.

| workload | before p50 | after p50 |
|---|---|---|
| wasm-gc `bench/scenarios/vector_ops` | 91.1 ms | 90.7 ms |
| wasm-gc `bench/scenarios/map_build` | 29.3 ms | 29.3 ms |
| wasm-gc `bench/scenarios/map_lookup` | 31.0 ms | 30.8 ms |
| wasm-gc 1 MiB `Bytes.fromHex` decode | 363.9 ms | 363.1 ms |
| VM 1 MiB `Bytes.fromHex` decode | 197.3 ms | 197.5 ms |
| VM `bench/scenarios/vector_ops` | 5.1 ms | 5.1 ms |
| VM `bench/scenarios/map_build` | 5.5 ms | 5.4 ms |

All rows within run-to-run noise: the fused self-keep accumulator (`vector_ops`, the shape the optimizer worked hardest on) never crosses the fence, and the map paths are untouched.

One shape pays, and it is documented and pinned rather than hidden. The plain `Vector.set` returns `Option<Vector>`, and a `Some` over a heap vector allocates a `Boxed` wrapper that marks its payload held-elsewhere on the way in — so in a chain spelled through the plain builtin (a non-self-keep fold: `Option.withDefault(Vector.set(v, i, x), <other fallback>)`) only the FIRST granted write keeps its grant; from the second on the fence revokes on the dead wrapper's mark and the write copies. Measured at the worst case I could build — a 50,000-cell fill spelled exactly that way, release, p50 of 9 interleaved — the reviewed head runs 5793.9 ms (owned path all the way) and this head 3420.7 ms (one grant, 49,999 revocations, copy path): on this machine the copy path is actually FASTER at that size, because the owned take's emptied husks pile up in young space and the boundary scans pay for them, but I make no general claim from that — the honest statement is that the non-fused chain loses its in-place grant from write 2, the counters say so (`revoked, something off the stack holds it: 49999` in the `--profile` report), and `a_second_owned_set_in_a_non_fused_chain_pays_the_wrapper_toll` pins the behavior as a recorded decision. Buying it back needs a dead-box-aware predicate, the same still-owed work the module doc records for the fused opcode.

## Verification

- `wasm_gc_container_read_ownership` (now 27 cells — the round-1 matrix, the five binder cells, and the round-3 retention / single-emission / scratch-discipline cells; every red cell recorded above before its fix, all green after), and the file is listed in the WASM job so CI runs it
- vector-fence unit tests in `vm::execute::tests` — one per fence answer (confirmed, revoked off-stack, revoked stack-holder, revoked unexamined, immediate), plus a dispatch-wiring pin that fails if `CALL_BUILTIN_OWNED` ever stops consulting the fence
- `wasm_gc_spec`, `wasm_gc_differential_mir`, `wasm_gc_games_differential_mir`, `wasm_gc_codegen_regression`, `wasm_gc_capture_output`, `wasm_gc_record_replay_spec`, `wasm_gc_perslot_int_unboxing_differential`, `wasm_gc_packed_sequence`, `wasm_gc_carrier_i64_differential` — green
- `cross_backend_stress`, `cross_backend_proptest` — green
- `alias_soundness`, `own_param_soundness`, `own_param_graduation`, `vm_map_runtime_ownership`, `vm_slot_uniqueness`, `frame_boundary_inplace_write`, `mir_call_known_owned_regression`, `wasip2_codegen_regression` — green
- full library unit suite — green
- `stdlib_spec::embedded_crypto_sha256_matches_fips_vectors_on_wasm_gc` fails locally under `--features wasm`, on this branch and on its base alike: it asserts `13/13 cases passed` while `tests/fixtures/stdlib_bytes_app.av` now carries 18. Neither file is touched here, no CI job runs that test (it is `wasm`-gated and `stdlib_spec` is not in the WASM job's list), and the stale count is left for its own change rather than folded in
- both CI clippy lanes, `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

