### PR TITLE
Expect the arm binder to carry the alias flag as well

### DIFF
--- a/src/ir/alias.rs
+++ b/src/ir/alias.rs
@@ -656,14 +656,22 @@ mod tests {
             "the positional and name-keyed identities must disagree here, or \
              this test discriminates nothing"
         );
+        // This is the assertion that discriminates: a pass reading the name map
+        // would flag the arm binder's slot and leave this one clear, which is
+        // the #948 misread verbatim.
         assert!(
             res.aliased_slots[stmt_slot as usize],
             "the statement binding's OWN slot must carry the alias flag"
         );
+        // The arm binder is flagged too, for its own reason: the subject is a
+        // Map parameter, which is not provably fresh, so the binder is a handle
+        // into it (#953). Its state therefore says nothing about which identity
+        // the statement half read — the assertion above is what holds that
+        // contract.
         assert!(
-            !res.aliased_slots[name_slot as usize],
-            "the arm binder's slot is a scalar the name map merely happens to \
-             own — flagging it instead is the #948 misread"
+            res.aliased_slots[name_slot as usize],
+            "a binder over a subject that is not provably fresh is a handle \
+             into it and must carry the flag"
         );
     }
 


### PR DESCRIPTION
Main is red from the union of two green pull requests: #956 added a guard pinning that the alias pass reads a statement binding's positional slot, and #953 made a binder over a subject that is not provably fresh carry the alias flag. Both are correct; the guard's second assertion was written against the behaviour before #953 landed and now contradicts it.

The first assertion is the discriminating one — a pass reading the name map would flag the arm binder and leave the statement's slot clear — so it keeps the contract, and the second now states the reason the binder is flagged too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)