### PR TITLE
Reject imported capability boundary types before hashing

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -378,7 +378,9 @@ impl CapabilityRegistry {
                 _ => None,
             })
             .collect();
-        validate_boundary_type_ownership(scope, &operations, &mut errors);
+        let mut locally_declared: BTreeSet<String> = type_defs.keys().cloned().collect();
+        locally_declared.extend(opaque.iter().cloned());
+        validate_boundary_type_ownership(scope, &operations, &locally_declared, &mut errors);
         let reachable_types = reachable_type_defs(&operations, &type_defs);
         let resource_tainted = resource_tainted_type_names(&opaque, &type_defs);
         validate_operation_boundaries(

--- a/src/capability/tests.rs
+++ b/src/capability/tests.rs
@@ -273,6 +273,19 @@ fn semantic_classes_reject_unsound_attribute_combinations() {
     assert!(external_boundary.iter().any(|error| {
         error.contains("cross-module boundary type") && error.contains("contract_hash")
     }));
+
+    let bare_external_boundary = error_messages(
+        "module Invalid\n    kind = capability\n    semantics = pure\n    depends [Bytes]\n\noperation f(value: Bytes) -> Bytes\n",
+    );
+    assert!(bare_external_boundary.iter().any(|error| {
+        error.contains("cross-module boundary type 'Bytes'") && error.contains("contract_hash")
+    }));
+    assert!(
+        bare_external_boundary
+            .iter()
+            .all(|error| !error.contains("Invalid.Bytes")),
+        "a bare imported type must not be misqualified as capability-owned: {bare_external_boundary:?}"
+    );
 }
 
 #[test]

--- a/src/capability/validation.rs
+++ b/src/capability/validation.rs
@@ -366,26 +366,32 @@ pub(super) fn validate_resource_map_keys(
 }
 
 /// The v1 descriptor builder owns only the capability module's declarations.
-/// Admitting a qualified type from another module would print its name in an
-/// operation row without hashing that type's layout, so a dependency could
-/// mutate the provider ABI while contract_hash stayed fixed. Fail closed until
-/// descriptors can bind cross-module type-contract identities transitively.
+/// Admitting a type from another module would print its name in an operation
+/// row without hashing that type's layout, so a dependency could mutate the
+/// provider ABI while contract_hash stayed fixed. Bare names are local only
+/// when a represented or opaque declaration proves ownership; an imported bare
+/// alias must not be silently qualified into the capability's own scope. Fail
+/// closed until descriptors can bind cross-module identities transitively.
 pub(super) fn validate_boundary_type_ownership(
     scope: &str,
     operations: &[CapabilityOperation],
+    locally_declared: &BTreeSet<String>,
     errors: &mut Vec<CapabilityError>,
 ) {
     fn visit(
         scope: &str,
         operation: &CapabilityOperation,
         ty: &Type,
+        locally_declared: &BTreeSet<String>,
         errors: &mut Vec<CapabilityError>,
     ) {
         match ty {
             Type::Named { name, .. } => {
-                if let Some((owner, _)) = name.rsplit_once('.')
-                    && owner != scope
-                {
+                let belongs_to_capability = match name.rsplit_once('.') {
+                    Some((owner, _)) => owner == scope,
+                    None => locally_declared.contains(name),
+                };
+                if !belongs_to_capability {
                     errors.push(CapabilityError::at(
                         operation.line,
                         format!(
@@ -396,18 +402,18 @@ pub(super) fn validate_boundary_type_ownership(
                 }
             }
             Type::Result(left, right) | Type::Map(left, right) => {
-                visit(scope, operation, left, errors);
-                visit(scope, operation, right, errors);
+                visit(scope, operation, left, locally_declared, errors);
+                visit(scope, operation, right, locally_declared, errors);
             }
             Type::Option(inner) | Type::List(inner) | Type::Vector(inner) => {
-                visit(scope, operation, inner, errors)
+                visit(scope, operation, inner, locally_declared, errors)
             }
             Type::Tuple(items) | Type::Fn(items, _, _) => {
                 for item in items {
-                    visit(scope, operation, item, errors);
+                    visit(scope, operation, item, locally_declared, errors);
                 }
                 if let Type::Fn(_, ret, _) = ty {
-                    visit(scope, operation, ret, errors);
+                    visit(scope, operation, ret, locally_declared, errors);
                 }
             }
             Type::Int
@@ -422,8 +428,14 @@ pub(super) fn validate_boundary_type_ownership(
 
     for operation in operations {
         for (_, ty) in &operation.params {
-            visit(scope, operation, ty, errors);
+            visit(scope, operation, ty, locally_declared, errors);
         }
-        visit(scope, operation, &operation.return_type, errors);
+        visit(
+            scope,
+            operation,
+            &operation.return_type,
+            locally_declared,
+            errors,
+        );
     }
 }

--- a/tests/capability_boundary_ownership_spec.rs
+++ b/tests/capability_boundary_ownership_spec.rs
@@ -1,0 +1,78 @@
+//! Contract-v1 must reject imported named boundary types before publishing a
+//! descriptor or attempting to bind a provider.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn aver_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aver")
+}
+
+fn command_report(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_fixture(root: &Path) {
+    fs::write(
+        root.join("Bytes.av"),
+        "module Bytes\n    exposes [Bytes]\n\nrecord Bytes\n    values: List<Int>\n",
+    )
+    .expect("write Bytes module");
+    fs::write(
+        root.join("Ripemd.av"),
+        "module Ripemd\n    kind = capability\n    semantics = pure\n    exposes [hash160]\n    depends [Bytes]\n\noperation hash160(input: Bytes) -> Bytes\n    ? \"Hash bytes.\"\n",
+    )
+    .expect("write capability module");
+    fs::write(
+        root.join("main.av"),
+        "module Main\n    depends [Bytes, Ripemd]\n    exposes [main]\n\nfn main() -> Int\n    0\n",
+    )
+    .expect("write entry module");
+}
+
+fn run(root: &Path, command: &str) -> Output {
+    Command::new(aver_bin())
+        .arg(command)
+        .arg(root.join("main.av"))
+        .arg("--module-root")
+        .arg(root)
+        .output()
+        .expect("run aver command")
+}
+
+#[test]
+fn imported_bare_boundary_type_is_rejected_before_contract_hash_publication() {
+    let temp = tempfile::tempdir().expect("temporary module root");
+    write_fixture(temp.path());
+
+    for command in ["check", "capabilities"] {
+        let output = run(temp.path(), command);
+        assert!(
+            !output.status.success(),
+            "{command} unexpectedly passed:\n{}",
+            command_report(&output)
+        );
+        let report = command_report(&output);
+        assert!(
+            report.contains("cross-module boundary type 'Bytes'")
+                && report.contains("contract_hash"),
+            "{command} missed the static contract diagnostic:\n{report}"
+        );
+        assert!(
+            !output
+                .stdout
+                .windows("contract_hash: sha256:".len())
+                .any(|window| window == b"contract_hash: sha256:"),
+            "{command} published a hash for an invalid contract:\n{report}"
+        );
+        assert!(
+            !report.contains("Ripemd.Bytes"),
+            "{command} invented a capability-owned type name:\n{report}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- treat a bare named capability boundary type as local only when the capability declares the represented or opaque type
- reject imported bare aliases before an invalid contract can be printed by `check` or `capabilities`
- preserve the source-faithful type name in the diagnostic instead of inventing a capability-owned name
- add a CLI regression covering both commands and hash non-publication

## Why

Contract v1 hashes only layouts declared by the capability module. Previously `Other.Type` was rejected, but a bare imported `Type` slipped through because ownership validation only inspected dotted names. Runtime conversion later guessed the capability scope and failed at the first provider call.

The validator now receives the exact local represented + opaque name set. Qualified names must still be owned by the capability scope; bare names must occur in that local set. Cross-module layouts therefore fail at contract validation without needing to guess an owner from the import graph.

## Verification

- `cargo test --workspace --quiet` — 3246 passed, 27 ignored
- `cargo clippy --workspace --all-targets` — 0 errors; existing warnings only
- `cargo fmt --all -- --check`
- `git diff --cached --check`
- dedicated regression proves `aver check` and `aver capabilities` both fail, print the contract-v1 diagnostic, publish no `contract_hash: sha256:...`, and never invent `Ripemd.Bytes`

Fixes #972
