### PR TITLE
Fix verify granularity for unbound capabilities

### DIFF
--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -711,7 +711,8 @@ pub fn run_verify_for_items_vm_with_mode(
     // "assume allocates" branch (no per-fn `no_alloc` promotion).
     // Build the resolved-identity table + lift the items to resolved
     // HIR ourselves so the VM compiler stays on the Phase E contract.
-    let symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
+    let mut symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
+    symbol_table.merge_capability_registry(&tc_result.capabilities);
     let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
     let (code, globals) = vm::compile_program_with_modules(
         &resolved_items,
@@ -724,6 +725,7 @@ pub fn run_verify_for_items_vm_with_mode(
     .map_err(|e| format!("VM compile error: {}", e))?;
     let mut machine = vm::VM::new(code, globals, arena);
     machine.set_step_limit(Some(VERIFY_VM_STEP_LIMIT));
+    configure_verify_capabilities(&mut machine, &tc_result.capabilities)?;
     if let Some(cfg) = config {
         machine.set_runtime_policy(cfg);
     }
@@ -748,6 +750,16 @@ pub fn run_verify_for_items_vm_with_mode(
 /// surface as proper `VmError::StepLimit` instead of AFL hangs. The
 /// cap resets per `run_named_function`, so cases don't share budget.
 const VERIFY_VM_STEP_LIMIT: u64 = 1_000_000;
+
+fn configure_verify_capabilities(
+    machine: &mut vm::VM,
+    capabilities: &crate::capability::CapabilityRegistry,
+) -> Result<(), String> {
+    let providers = crate::provider::ProviderRegistry::for_program(capabilities.clone())?;
+    machine.set_provider_registry(std::sync::Arc::new(providers));
+    machine.defer_missing_capability_providers_to_dispatch(true);
+    Ok(())
+}
 
 /// Variant for audit / LSP: accept pre-loaded dependency modules
 /// (virtual filesystems) instead of resolving from disk.
@@ -817,7 +829,8 @@ pub fn run_verify_for_items_vm_with_loaded_and_mode(
     // "missing VM symbol for exposed function" path that the disk path
     // hit before the fix.
     let dep_modules = crate::source::loaded_to_module_info(&loaded);
-    let symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
+    let mut symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
+    symbol_table.merge_capability_registry(&tc_result.capabilities);
     let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
     let (code, globals) = vm::compile_program_with_loaded_modules(
         &resolved_items,
@@ -830,6 +843,7 @@ pub fn run_verify_for_items_vm_with_loaded_and_mode(
     .map_err(|e| format!("VM compile error: {}", e))?;
     let mut machine = vm::VM::new(code, globals, arena);
     machine.set_step_limit(Some(VERIFY_VM_STEP_LIMIT));
+    configure_verify_capabilities(&mut machine, &tc_result.capabilities)?;
     if let Some(cfg) = config {
         machine.set_runtime_policy(cfg);
     }

--- a/src/vm/execute/mod.rs
+++ b/src/vm/execute/mod.rs
@@ -43,6 +43,11 @@ pub struct VM {
     /// no stack growth). Counter resets at the top of each
     /// `run_named_function` so consecutive cases don't share budget.
     step_limit: Option<u64>,
+    /// Verify compiles the whole module but executes one concrete case at a
+    /// time. It still validates checked contract/model identities up front,
+    /// while an absent custom binding is allowed to fail only if that case
+    /// actually dispatches the capability operation.
+    defer_missing_capability_providers_to_dispatch: bool,
     /// Mutable scratch buffers for the deforestation lowering's `__buf_*`
     /// intrinsics (0.15 Traversal). Slots are `Option<String>` so finalize
     /// can take ownership and leave a tombstone; `BUFFER_NEW` reuses freed
@@ -159,6 +164,7 @@ impl VM {
             byte_builder_pool: Vec::new(),
             byte_builder_free: Vec::new(),
             step_limit: None,
+            defer_missing_capability_providers_to_dispatch: false,
             slot_uniqueness: VmSlotUniquenessStats::default(),
             runtime_ownership: VmRuntimeOwnershipStats::default(),
             vector_ownership: VmRuntimeOwnershipStats::default(),
@@ -172,6 +178,13 @@ impl VM {
     /// pinning the host. `None` removes the cap.
     pub fn set_step_limit(&mut self, limit: Option<u64>) {
         self.step_limit = limit;
+    }
+
+    /// Keep contract/hash preflight, but let an absent provider fail at the
+    /// operation boundary. Used by concrete verify cases so an unrelated case
+    /// is not rejected merely because another function needs a custom host.
+    pub fn defer_missing_capability_providers_to_dispatch(&mut self, defer: bool) {
+        self.defer_missing_capability_providers_to_dispatch = defer;
     }
 
     pub fn start_profiling(&mut self) {
@@ -456,7 +469,11 @@ impl VM {
             }
             required.push(name.as_str());
         }
-        contracts.preflight(required).map_err(VmError::runtime)
+        if self.defer_missing_capability_providers_to_dispatch {
+            Ok(())
+        } else {
+            contracts.preflight(required).map_err(VmError::runtime)
+        }
     }
 
     pub fn run(&mut self) -> Result<NanValue, VmError> {

--- a/tests/verify_capability_granularity_spec.rs
+++ b/tests/verify_capability_granularity_spec.rs
@@ -1,0 +1,139 @@
+//! Missing custom providers fail only concrete verify cases that dispatch them.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+const HASH160_SOURCE: &str = "module Hash160
+    kind = capability
+    semantics = pure
+    exposes [digest]
+
+operation digest(input: List<Int>) -> List<Int>
+    ? \"Hash bytes through a custom provider.\"
+";
+
+const MAIN_SOURCE: &str = "module Main
+    depends [Hash160]
+    exposes [hashed, unrelated]
+
+fn hashed(input: List<Int>) -> List<Int>
+    ? \"Reach the unbound capability.\"
+    Hash160.digest(input)
+
+verify hashed
+    hashed([0]) => [1]
+
+fn unrelated(n: Int) -> Int
+    ? \"Touch no capability.\"
+    n + 1
+
+verify unrelated
+    unrelated(1) => 2
+    unrelated(0) => 1
+
+fn main() -> Int
+    unrelated(1)
+";
+
+fn aver_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aver")
+}
+
+fn command_report(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_fixture(root: &Path) {
+    fs::write(root.join("Hash160.av"), HASH160_SOURCE).expect("write capability module");
+    fs::write(root.join("main.av"), MAIN_SOURCE).expect("write entry module");
+}
+
+#[test]
+fn unrelated_cases_survive_an_unbound_capability_in_the_same_program() {
+    let temp = tempfile::tempdir().expect("temporary module root");
+    write_fixture(temp.path());
+    let output = Command::new(aver_bin())
+        .arg("verify")
+        .arg(temp.path().join("main.av"))
+        .arg("--module-root")
+        .arg(temp.path())
+        .output()
+        .expect("run aver verify");
+    assert!(
+        !output.status.success(),
+        "the reached capability case must still fail:\n{}",
+        command_report(&output)
+    );
+    let report = command_report(&output);
+    assert!(
+        report.contains("hashed") && report.contains("capability provider missing"),
+        "the reached case must fail at provider dispatch:\n{report}"
+    );
+    assert!(
+        report.contains("unrelated") && report.contains("2/2"),
+        "unrelated cases must keep running:\n{report}"
+    );
+    assert!(
+        !report.contains("capability contract missing at runtime"),
+        "verify must install the checked contract registry:\n{report}"
+    );
+}
+
+#[test]
+fn normal_run_keeps_strict_whole_program_provider_preflight() {
+    let temp = tempfile::tempdir().expect("temporary module root");
+    write_fixture(temp.path());
+    let output = Command::new(aver_bin())
+        .arg("run")
+        .arg(temp.path().join("main.av"))
+        .arg("--module-root")
+        .arg(temp.path())
+        .output()
+        .expect("run aver program");
+    assert!(
+        !output.status.success(),
+        "normal execution must keep strict provider preflight:\n{}",
+        command_report(&output)
+    );
+    let report = command_report(&output);
+    assert!(
+        report.contains("capability provider missing for 'Hash160.digest'"),
+        "normal execution must reject the unbound program before main runs:\n{report}"
+    );
+}
+
+#[test]
+fn loaded_verify_path_has_the_same_case_granularity() {
+    let items = aver::source::parse_source(MAIN_SOURCE).expect("parse entry module");
+    let loaded = vec![aver::source::LoadedModule {
+        dep_name: "Hash160".to_string(),
+        items: aver::source::parse_source(HASH160_SOURCE).expect("parse capability module"),
+        path: "Hash160.av".into(),
+    }];
+    let results = aver::diagnostics::vm_verify::run_verify_for_items_vm_with_loaded(
+        items, loaded, None, "main.av",
+    )
+    .expect("loaded verify path must compile the checked capability contract");
+
+    let hashed = results
+        .iter()
+        .find(|result| result.fn_name == "hashed")
+        .expect("hashed verify result");
+    assert_eq!((hashed.passed, hashed.failed), (0, 1));
+    assert!(matches!(
+        &hashed.case_results[0].outcome,
+        aver::checker::VerifyCaseOutcome::RuntimeError { error }
+            if error.contains("capability provider missing for 'Hash160.digest'")
+    ));
+
+    let unrelated = results
+        .iter()
+        .find(|result| result.fn_name == "unrelated")
+        .expect("unrelated verify result");
+    assert_eq!((unrelated.passed, unrelated.failed), (2, 0));
+}


### PR DESCRIPTION
## Summary

- install the typechecked capability registry in both disk-backed and loaded/LSP VM verify paths
- carry checked contract/model hashes into verify bytecode through the existing symbol-table registry seam
- keep contract/model identity preflight, but defer only missing custom provider bindings to the concrete operation dispatch during verify
- preserve strict whole-program provider preflight for normal `aver run`

## Regression coverage

- a reached `Hash160.digest` verify case fails with `capability-provider-missing`
- unrelated cases in the same program still run and pass
- the preloaded/LSP verify path has identical case granularity
- normal execution still rejects the unbound program before `main`

## Validation

- `cargo fmt --all -- --check`
- `cargo test --quiet --test verify_capability_granularity_spec` (3 passed)
- related verify/provider suites (47 passed)
- `cargo test --workspace --quiet` (3249 passed, 27 ignored)
- `cargo clippy --workspace --all-targets` (0 errors; existing warnings only)

Fixes #966