### PR TITLE
Fix dependency type re-exports

### DIFF
--- a/src/types/checker/check.rs
+++ b/src/types/checker/check.rs
@@ -31,7 +31,9 @@ impl TypeChecker {
 
         self.configure_capabilities(items, &loaded_modules, base_dir);
         if !loaded_modules.is_empty() {
-            self.integrate_loaded_modules(&loaded_modules);
+            self.prepare_loaded_modules(&loaded_modules);
+            let visible_roots = Self::visible_module_roots(items);
+            self.integrate_loaded_modules(&loaded_modules, &visible_roots);
         }
 
         self.build_signatures(items);
@@ -61,7 +63,9 @@ impl TypeChecker {
         let mut loaded = loaded.to_vec();
         crate::stdlib::append_required_standard_capability_modules(items, &mut loaded);
         self.configure_capabilities(items, &loaded, None);
-        self.integrate_loaded_modules(&loaded);
+        self.prepare_loaded_modules(&loaded);
+        let visible_roots = Self::visible_module_roots(items);
+        self.integrate_loaded_modules(&loaded, &visible_roots);
         self.build_signatures(items);
         self.check_loaded_module_bodies(&loaded);
         self.check_body(items);
@@ -124,7 +128,11 @@ impl TypeChecker {
         self.capabilities = registry;
     }
 
-    fn integrate_loaded_modules(&mut self, modules: &[crate::source::LoadedModule]) {
+    /// Record the complete dependency graph and resolve each module's public
+    /// type surface before any single importer is checked. This is resolver
+    /// context, not visibility: a facade may re-export a type declared several
+    /// files below it without making every module in between globally visible.
+    fn prepare_loaded_modules(&mut self, modules: &[crate::source::LoadedModule]) {
         // Phase B (peer review round 6): track each dep module's own
         // `depends` list so the per-owner type resolver
         // (`canonicalize_named_in_module`) can walk it instead of
@@ -140,7 +148,43 @@ impl TypeChecker {
             .iter()
             .map(|m| (m.dep_name.clone(), m.items.clone()))
             .collect();
-        let registry = crate::visibility::SymbolRegistry::from_modules(&pairs);
+        self.module_type_exports = crate::visibility::collect_module_type_exports(&pairs);
+    }
+
+    /// Names visible at an importer boundary: explicit dependencies plus
+    /// source-typed standard modules pulled in by a builtin used in that
+    /// module. The latter are ordinary nominal type owners even though users
+    /// do not have to spell them in `depends [...]`.
+    fn visible_module_roots(items: &[TopLevel]) -> Vec<String> {
+        let mut roots = Self::module_decl(items)
+            .map(|module| module.depends.clone())
+            .unwrap_or_default();
+        roots.extend(crate::stdlib::implicit_stdlib_deps(items));
+        roots.sort();
+        roots.dedup();
+        roots
+    }
+
+    /// Integrate only the named dependency surfaces into this checker's
+    /// ordinary lookup maps. The complete module list remains available so a
+    /// type re-export can bring in the original declaration's fields and
+    /// constructors while unrelated transitive modules stay hidden.
+    fn integrate_loaded_modules(
+        &mut self,
+        modules: &[crate::source::LoadedModule],
+        visible_modules: &[String],
+    ) {
+        self.visible_module_names
+            .extend(visible_modules.iter().cloned());
+        let pairs: Vec<_> = modules
+            .iter()
+            .map(|m| (m.dep_name.clone(), m.items.clone()))
+            .collect();
+        let registry = crate::visibility::SymbolRegistry::from_visible_modules(
+            &pairs,
+            visible_modules,
+            &self.module_type_exports,
+        );
         if let Err(e) = self.integrate_registry(&registry) {
             self.error(e);
         }
@@ -197,6 +241,8 @@ impl TypeChecker {
             let mut sub = TypeChecker::new_with_symbols(self.symbol_table.clone());
             sub.self_host_mode = self.self_host_mode;
             sub.capabilities = self.capabilities.clone();
+            sub.module_depends = self.module_depends.clone();
+            sub.module_type_exports = self.module_type_exports.clone();
             // Phase B: the dep module's prefix in the symbol table is
             // its `dep_name` (the path the entry's `depends` clause
             // wrote, e.g. `Pricing.Discount`), not the interior
@@ -215,16 +261,8 @@ impl TypeChecker {
             // in `B`'s own `depends [...]` declaration so the only
             // bare-name aliases the sub-checker sees come from
             // modules `B` itself imported.
-            let own_depends: Vec<String> = TypeChecker::module_decl(&module.items)
-                .map(|m| m.depends.clone())
-                .unwrap_or_default();
-            let visible_to_sub: Vec<_> = modules
-                .iter()
-                .filter(|m| own_depends.iter().any(|d| d == &m.dep_name))
-                .cloned()
-                .collect();
-            sub.integrate_loaded_modules(&visible_to_sub);
-            sub.register_capability_sigs();
+            let own_depends = Self::visible_module_roots(&module.items);
+            sub.integrate_loaded_modules(modules, &own_depends);
             sub.build_signatures(&module.items);
             sub.check_top_level_stmts(&module.items);
             sub.check_verify_blocks(&module.items);

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -555,8 +555,18 @@ struct TypeChecker {
     /// flagged on `fn takes(s: C.Shape)` references against a `C`
     /// whose `exposes` list didn't include `Shape`.
     visible_type_ids: HashSet<TypeId>,
+    /// Direct dependency modules visible to this checker. Kept separately
+    /// from `visible_type_ids` because an explicit type re-export such as
+    /// `High.Item` resolves to the original `Low.Item` identity and therefore
+    /// has no `TypeKey::in_module("High", "Item")` of its own.
+    visible_module_names: HashSet<String>,
+    /// Public type surface for every loaded module, including explicit
+    /// re-exports resolved to their original declaration identity. The full
+    /// map is resolver context; only entries whose module is in
+    /// `visible_module_names` are visible to ordinary importer lookups.
+    module_type_exports: crate::visibility::ModuleTypeExports,
     /// Per-module `depends` list, keyed by the dep module's
-    /// `dep_name`. Populated by `integrate_loaded_modules` so the
+    /// `dep_name`. Populated by `prepare_loaded_modules` so the
     /// per-owner type resolver (`canonicalize_named_in_module`) can
     /// walk an owner module's *own* depends when canonicalising its
     /// exported signatures — not the entry module's or arbitrary
@@ -658,6 +668,8 @@ impl TypeChecker {
             bare_type_aliases: HashMap::new(),
             visible_fn_ids: HashSet::new(),
             visible_type_ids: HashSet::new(),
+            visible_module_names: HashSet::new(),
+            module_type_exports: crate::visibility::ModuleTypeExports::new(),
             module_depends: HashMap::new(),
             value_members: HashMap::new(),
             record_field_types: HashMap::new(),
@@ -1141,16 +1153,27 @@ impl TypeChecker {
     /// table holds every dep type unconditionally.
     pub(crate) fn resolve_type_id(&self, name: &str) -> Option<TypeId> {
         if let Some((prefix, n)) = name.rsplit_once('.') {
-            if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n))
-                && self.visible_type_ids.contains(&id)
-            {
-                return Some(id);
+            if self.current_module_prefix.as_deref() == Some(prefix) {
+                if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n))
+                    && self.visible_type_ids.contains(&id)
+                {
+                    return Some(id);
+                }
+                if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(n))
+                    && self.visible_type_ids.contains(&id)
+                {
+                    return Some(id);
+                }
             }
-            if self.current_module_prefix.as_deref() == Some(prefix)
-                && let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(n))
-                && self.visible_type_ids.contains(&id)
-            {
-                return Some(id);
+            if self.visible_module_names.contains(prefix) {
+                if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n))
+                    && self.visible_type_ids.contains(&id)
+                {
+                    return Some(id);
+                }
+                if let Some(id) = self.type_export_id(prefix, n) {
+                    return Some(id);
+                }
             }
         }
         if let Some(prefix) = self.current_module_prefix.as_deref()
@@ -1171,6 +1194,15 @@ impl TypeChecker {
             .and_then(Resolution::unambiguous)
     }
 
+    /// Resolve `module.alias` through that module's public type surface. The
+    /// returned ID belongs to the original declaration, not necessarily to
+    /// `module` itself (explicit re-exports deliberately preserve identity).
+    pub(super) fn type_export_id(&self, module: &str, alias: &str) -> Option<TypeId> {
+        let target = self.module_type_exports.get(module)?.get(alias)?;
+        self.symbol_table
+            .type_id_of(&TypeKey::in_module(&target.module, &target.name))
+    }
+
     /// `true` when `name` (qualified `Module.Type` form) resolves to
     /// an existing `TypeId` in the symbol table but the typechecker
     /// hasn't registered that ID as visible to the current scope.
@@ -1188,10 +1220,20 @@ impl TypeChecker {
             // failure.
             return false;
         }
-        let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n)) else {
-            return false;
-        };
-        !self.visible_type_ids.contains(&id)
+        if self.visible_module_names.contains(prefix) {
+            return self.type_export_id(prefix, n).is_none()
+                && self
+                    .symbol_table
+                    .type_id_of(&TypeKey::in_module(prefix, n))
+                    .is_some();
+        }
+        self.symbol_table
+            .type_id_of(&TypeKey::in_module(prefix, n))
+            .is_some()
+            || self
+                .module_type_exports
+                .get(prefix)
+                .is_some_and(|exports| exports.contains_key(n))
     }
 
     /// Canonical name (`"Module.Type"` or bare entry name) for a

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -321,13 +321,20 @@ impl TypeChecker {
     /// `canonicalize_named_in_module` for the three-case ordering.
     fn resolve_in_owner_context(&self, name: &str, owner_module: &str) -> Option<TypeId> {
         if let Some((prefix, n)) = name.rsplit_once('.') {
-            // Qualified form: trust the prefix, but enforce
-            // visibility unless the owner is the named module.
-            let id = self
-                .symbol_table
-                .type_id_of(&TypeKey::in_module(prefix, n))?;
-            if prefix == owner_module || self.is_type_exposed_by(prefix, n) {
-                return Some(id);
+            // Qualified self-reference resolves against the declaration table.
+            if prefix == owner_module {
+                return self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n));
+            }
+            // A dependency-qualified reference may name either a type declared
+            // by that dependency or one it explicitly re-exports. Do not let a
+            // module elsewhere in the loaded closure become visible merely
+            // because its symbols exist in the shared table.
+            if self
+                .module_depends
+                .get(owner_module)
+                .is_some_and(|deps| deps.iter().any(|dep| dep == prefix))
+            {
+                return self.type_export_id(prefix, n);
             }
             return None;
         }
@@ -343,33 +350,19 @@ impl TypeChecker {
         // can't be satisfied by its own scope or its own depends
         // stay unresolved.
         if let Some(deps) = self.module_depends.get(owner_module) {
+            let mut resolved = None;
             for dep in deps {
-                if let Some(id) = self
-                    .symbol_table
-                    .type_id_of(&TypeKey::in_module(dep.as_str(), name))
-                    && self.is_type_exposed_by(dep, name)
-                {
-                    return Some(id);
+                let Some(id) = self.type_export_id(dep, name) else {
+                    continue;
+                };
+                if resolved.is_some_and(|existing| existing != id) {
+                    return None;
                 }
+                resolved = Some(id);
             }
+            return resolved;
         }
         None
-    }
-
-    /// `true` when `module` exposes a type named `type_name` to its
-    /// importers — i.e. the type is in `module`'s `exposes [...]`
-    /// list (or admitted by the underscore default rule).
-    /// The exposure source of truth is `visible_type_ids`, populated
-    /// from `visibility::SymbolRegistry::from_modules` entries. If
-    /// the type's `TypeId` is in that set, it was visibility-exposed.
-    fn is_type_exposed_by(&self, module: &str, type_name: &str) -> bool {
-        let Some(id) = self
-            .symbol_table
-            .type_id_of(&TypeKey::in_module(module, type_name))
-        else {
-            return false;
-        };
-        self.visible_type_ids.contains(&id)
     }
 
     pub(super) fn canonicalize_named(&self, ty: Type) -> Type {

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -1,4 +1,10 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::ast::{FnDef, Module, TopLevel, TypeDef, TypeVariant};
+
+mod type_exports;
+
+pub use type_exports::{ExportedTypeTarget, ModuleTypeExports, collect_module_type_exports};
 
 /// Type definition collected from a module — backend-agnostic metadata.
 #[derive(Debug, Clone)]
@@ -256,6 +262,79 @@ impl SymbolRegistry {
             let exports = collect_module_exports(items);
             Self::collect_from_exports(module_name, &exports, &mut entries);
         }
+        SymbolRegistry { entries }
+    }
+
+    /// Build the symbols visible through a module's direct dependency list.
+    ///
+    /// Functions come only from the named dependency modules themselves.
+    /// Types come from each dependency's resolved export surface, so an
+    /// explicit re-export carries the original declaration (including record
+    /// fields / sum constructors and opacity) without exposing unrelated
+    /// transitive modules.
+    pub fn from_visible_modules(
+        modules: &[(String, Vec<TopLevel>)],
+        visible_modules: &[String],
+        type_exports: &ModuleTypeExports,
+    ) -> Self {
+        let visible: HashSet<&str> = visible_modules.iter().map(String::as_str).collect();
+        let mut entries = Vec::new();
+
+        // Public functions are never pulled transitively. Type re-exports are
+        // handled separately below because their declaring module differs from
+        // the module whose `exposes` list made them visible.
+        for (module_name, items) in modules {
+            if !visible.contains(module_name.as_str()) {
+                continue;
+            }
+            let exports = collect_module_exports(items);
+            let functions_only = ModuleExports {
+                functions: exports.functions,
+                types: Vec::new(),
+            };
+            Self::collect_from_exports(module_name, &functions_only, &mut entries);
+        }
+
+        // The same declaration may be reachable through two facades. Emit its
+        // metadata once; if any visible path exposes the representation, the
+        // importer may use that public path and the aggregate is non-opaque.
+        let mut targets: HashMap<(String, String), bool> = HashMap::new();
+        for visible_module in visible_modules {
+            let Some(exports) = type_exports.get(visible_module) else {
+                continue;
+            };
+            for target in exports.values() {
+                targets
+                    .entry((target.module.clone(), target.name.clone()))
+                    .and_modify(|is_opaque| *is_opaque &= target.is_opaque)
+                    .or_insert(target.is_opaque);
+            }
+        }
+
+        // Walk in loader/source order so registry construction stays stable.
+        for (module_name, items) in modules {
+            for item in items {
+                let TopLevel::TypeDef(type_def) = item else {
+                    continue;
+                };
+                let type_name = match type_def {
+                    TypeDef::Sum { name, .. } | TypeDef::Product { name, .. } => name,
+                };
+                let key = (module_name.clone(), type_name.clone());
+                let Some(is_opaque) = targets.remove(&key) else {
+                    continue;
+                };
+                let one_type = ModuleExports {
+                    functions: Vec::new(),
+                    types: vec![ExportedTypeDef {
+                        def: type_def,
+                        is_opaque,
+                    }],
+                };
+                Self::collect_from_exports(module_name, &one_type, &mut entries);
+            }
+        }
+
         SymbolRegistry { entries }
     }
 

--- a/src/visibility/type_exports.rs
+++ b/src/visibility/type_exports.rs
@@ -1,0 +1,147 @@
+//! Explicit type re-export resolution.
+//!
+//! This module computes names at module boundaries while preserving the
+//! declaration owner's nominal identity. Symbol metadata materialisation stays
+//! in the parent `visibility` module.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::ast::{TopLevel, TypeDef};
+
+use super::{effective_exposes, is_exposed, module_decl};
+
+/// The declaration behind a type name exported by a module.
+///
+/// For an ordinary local export, `module` is the exporter itself. For an
+/// explicit re-export, it remains the module that owns the declaration, so
+/// every facade preserves the original nominal identity instead of inventing
+/// a fresh `Facade.Type`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportedTypeTarget {
+    pub module: String,
+    pub name: String,
+    pub is_opaque: bool,
+}
+
+/// Per-module public type names after resolving explicit re-exports.
+pub type ModuleTypeExports = HashMap<String, HashMap<String, ExportedTypeTarget>>;
+
+/// Resolve the type surface exported by every module in a loaded tree.
+///
+/// Default visibility exports only local non-underscore declarations. A type
+/// from a dependency crosses another module boundary only when that module
+/// names it in an explicit `exposes [...]` (or `exposes opaque [...]`) list.
+/// Re-export chains retain the `module + name` of the original declaration.
+pub fn collect_module_type_exports(modules: &[(String, Vec<TopLevel>)]) -> ModuleTypeExports {
+    let mut surfaces = ModuleTypeExports::new();
+
+    // Seed each surface with its locally declared public types.
+    for (module_name, items) in modules {
+        let mut exported = HashMap::new();
+        let exposes = effective_exposes(items);
+        let opaque_names: HashSet<&str> = module_decl(items)
+            .map(|module| module.exposes_opaque.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+        for item in items {
+            let TopLevel::TypeDef(type_def) = item else {
+                continue;
+            };
+            let name = match type_def {
+                TypeDef::Sum { name, .. } | TypeDef::Product { name, .. } => name,
+            };
+            let is_opaque = opaque_names.contains(name.as_str());
+            if is_exposed(name, exposes) || is_opaque {
+                exported.insert(
+                    name.clone(),
+                    ExportedTypeTarget {
+                        module: module_name.clone(),
+                        name: name.clone(),
+                        is_opaque,
+                    },
+                );
+            }
+        }
+        surfaces.insert(module_name.clone(), exported);
+    }
+
+    // The loader returns dependencies before importers, so one pass normally
+    // suffices. Iterate to a fixed point as a cheap guard for virtual/preloaded
+    // callers that provide an equivalent acyclic tree in another order.
+    loop {
+        let mut additions = Vec::new();
+        for (module_name, items) in modules {
+            let Some(decl) = module_decl(items) else {
+                continue;
+            };
+            let current = surfaces.get(module_name);
+
+            // `true` means this boundary explicitly narrows the re-export to
+            // opaque. If both public and opaque lists mention the same name,
+            // the restrictive form wins.
+            let mut requested = BTreeMap::new();
+            for name in &decl.exposes {
+                requested.entry(name.clone()).or_insert(false);
+            }
+            for name in &decl.exposes_opaque {
+                requested.insert(name.clone(), true);
+            }
+
+            for (name, force_opaque) in requested {
+                if current.is_some_and(|exports| exports.contains_key(&name)) {
+                    continue;
+                }
+
+                let mut identity: Option<(String, String)> = None;
+                let mut ambiguous = false;
+                let mut opaque_on_every_path = true;
+                for dependency in &decl.depends {
+                    let Some(target) = surfaces
+                        .get(dependency)
+                        .and_then(|exports| exports.get(&name))
+                    else {
+                        continue;
+                    };
+                    let next_identity = (target.module.clone(), target.name.clone());
+                    match &identity {
+                        None => identity = Some(next_identity),
+                        Some(existing) if existing == &next_identity => {}
+                        Some(_) => {
+                            ambiguous = true;
+                            break;
+                        }
+                    }
+                    opaque_on_every_path &= target.is_opaque;
+                }
+
+                if !ambiguous && let Some((target_module, target_name)) = identity {
+                    additions.push((
+                        module_name.clone(),
+                        name,
+                        ExportedTypeTarget {
+                            module: target_module,
+                            name: target_name,
+                            is_opaque: force_opaque || opaque_on_every_path,
+                        },
+                    ));
+                }
+            }
+        }
+
+        if additions.is_empty() {
+            break;
+        }
+        let mut changed = false;
+        for (module, alias, target) in additions {
+            changed |= surfaces
+                .entry(module)
+                .or_default()
+                .insert(alias, target)
+                .is_none();
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    surfaces
+}

--- a/tests/cross_module_type_keys.rs
+++ b/tests/cross_module_type_keys.rs
@@ -12,8 +12,12 @@ use aver::ast::TypeDef;
 use aver::codegen::common::{backend_named_type_key, backend_type_def_key};
 use aver::codegen::{ModuleInfo, build_context};
 use aver::ir::pipeline::{self, PipelineConfig, TypecheckMode};
+use aver::nan_value::{Arena, NanValueConvert};
 use aver::source::{LoadedModule, parse_source};
 use aver::types::Type;
+use aver::value::Value;
+use aver::vm;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 const ENTRY_SRC: &str = r#"module Entry
@@ -42,6 +46,74 @@ const SHARP_SRC: &str = r#"module Sharp
 type Shape
     Triangle
     Square(Int)
+"#;
+
+const REEXPORT_LOW_SRC: &str = r#"module Low
+    intent = "Own the type handed through an API module."
+    exposes [Item, sized]
+
+record Item
+    key: String
+
+fn sized(item: Item) -> Int
+    ? "Return the key length."
+    String.len(item.key)
+
+verify sized
+    sized(Item(key = "ab")) => 2
+"#;
+
+const REEXPORT_HIGH_SRC: &str = r#"module High
+    intent = "Explicitly re-export the dependency type."
+    exposes [Item, doubled]
+    depends [Low.Low]
+
+fn doubled(item: Item) -> Int
+    ? "Double the key length."
+    Low.Low.sized(item) * 2
+
+verify doubled
+    doubled(Item(key = "ab")) => 4
+"#;
+
+const REEXPORT_MID_SRC: &str = r#"module Mid
+    intent = "Consume the explicit type re-export."
+    exposes [tripled]
+    depends [High.High]
+
+fn tripled(item: Item) -> Int
+    ? "Add one to the doubled length."
+    High.High.doubled(item) + 1
+
+verify tripled
+    tripled(Item(key = "ab")) => 5
+"#;
+
+const REEXPORT_MAIN_SRC: &str = r#"module Main
+    intent = "Reach the re-export consumer as a dependency."
+    depends [Mid.Mid, Low.Low]
+
+fn main() -> Int
+    Mid.Mid.tripled(Low.Low.Item(key = "ab"))
+"#;
+
+const QUALIFIED_REEXPORT_MAIN_SRC: &str = r#"module Main
+    intent = "Name the facade's re-export explicitly."
+    depends [High.High, Low.Low]
+
+fn accepts(item: High.High.Item) -> Int
+    Low.Low.sized(item)
+
+fn main() -> Int
+    accepts(Low.Low.Item(key = "ab"))
+"#;
+
+const CHAIN_REEXPORT_MAIN_SRC: &str = r#"module Main
+    intent = "Consume a type handed through two explicit facades."
+    depends [Mid.Mid]
+
+fn main() -> Int
+    Mid.Mid.tripled(Item(key = "ab"))
 "#;
 
 fn build_three_module_ctx() -> aver::codegen::CodegenContext {
@@ -83,6 +155,175 @@ fn build_three_module_ctx() -> aver::codegen::CodegenContext {
         result.symbol_table,
         result.resolved_items,
     )
+}
+
+fn reexport_fixture_files(high_source: &str) -> HashMap<String, String> {
+    HashMap::from([
+        ("low/low.av".to_string(), REEXPORT_LOW_SRC.to_string()),
+        ("high/high.av".to_string(), high_source.to_string()),
+        ("mid/mid.av".to_string(), REEXPORT_MID_SRC.to_string()),
+    ])
+}
+
+fn typecheck_virtual_entry(entry_source: &str, files: &HashMap<String, String>) -> Vec<String> {
+    let mut entry_items = parse_source(entry_source).expect("entry parse");
+    let root_deps = entry_items
+        .iter()
+        .find_map(|item| match item {
+            aver::ast::TopLevel::Module(module) => Some(module.depends.clone()),
+            _ => None,
+        })
+        .expect("entry module declaration");
+    let loaded = aver::source::load_module_tree_from_map(&root_deps, files)
+        .expect("load virtual dependency tree");
+    let modules: Vec<ModuleInfo> = loaded.iter().map(ModuleInfo::from_loaded).collect();
+    let result = pipeline::run(
+        &mut entry_items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
+            run_build_symbols: true,
+            dep_modules: &modules,
+            ..Default::default()
+        },
+    );
+    result
+        .typecheck
+        .expect("typecheck result")
+        .errors
+        .into_iter()
+        .map(|error| error.message)
+        .collect()
+}
+
+fn run_virtual_main(entry_source: &str, files: &HashMap<String, String>) -> Value {
+    let mut entry_items = parse_source(entry_source).expect("entry parse");
+    let root_deps = entry_items
+        .iter()
+        .find_map(|item| match item {
+            aver::ast::TopLevel::Module(module) => Some(module.depends.clone()),
+            _ => None,
+        })
+        .expect("entry module declaration");
+    let loaded = aver::source::load_module_tree_from_map(&root_deps, files)
+        .expect("load virtual dependency tree");
+    let modules: Vec<ModuleInfo> = loaded.iter().map(ModuleInfo::from_loaded).collect();
+    let result = pipeline::run(
+        &mut entry_items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::WithLoaded(&loaded)),
+            run_build_symbols: true,
+            dep_modules: &modules,
+            ..Default::default()
+        },
+    );
+    let typecheck = result.typecheck.as_ref().expect("typecheck result");
+    assert!(
+        typecheck.errors.is_empty(),
+        "runtime fixture should typecheck: {:?}",
+        typecheck.errors
+    );
+
+    let mut arena = Arena::new();
+    vm::register_service_types(&mut arena);
+    let (code, globals) = vm::compile_program_with_loaded_modules(
+        &result.resolved_items,
+        &result.symbol_table,
+        &mut arena,
+        loaded,
+        "<test>",
+        result.analysis.as_ref(),
+    )
+    .expect("compile runtime fixture");
+    let mut machine = vm::VM::new(code, globals, arena);
+    machine.run_top_level().expect("run top level");
+    machine
+        .run_named_function("main", &[])
+        .expect("run main")
+        .to_value(&machine.arena)
+}
+
+#[test]
+fn explicit_type_reexport_survives_when_reexporter_is_a_dependency() {
+    let files = reexport_fixture_files(REEXPORT_HIGH_SRC);
+
+    let direct_errors = typecheck_virtual_entry(REEXPORT_MID_SRC, &files);
+    assert!(
+        direct_errors.is_empty(),
+        "Mid checks directly against High's explicit re-export: {direct_errors:?}"
+    );
+
+    let nested_errors = typecheck_virtual_entry(REEXPORT_MAIN_SRC, &files);
+    assert!(
+        nested_errors.is_empty(),
+        "the same Mid source must keep the re-export when loaded as a dependency: {nested_errors:?}"
+    );
+}
+
+#[test]
+fn explicit_type_reexport_program_compiles_and_runs_on_the_vm() {
+    let files = reexport_fixture_files(REEXPORT_HIGH_SRC);
+    assert_eq!(run_virtual_main(REEXPORT_MAIN_SRC, &files), Value::int(5));
+}
+
+#[test]
+fn dependency_type_stays_hidden_without_an_explicit_reexport() {
+    let hidden_high = REEXPORT_HIGH_SRC.replace("exposes [Item, doubled]", "exposes [doubled]");
+    let files = reexport_fixture_files(&hidden_high);
+    let errors = typecheck_virtual_entry(REEXPORT_MID_SRC, &files);
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.contains("Unknown type 'Item'")),
+        "a dependency must not gain transitive visibility without `exposes [Item]`: {errors:?}"
+    );
+}
+
+#[test]
+fn qualified_reexport_name_resolves_to_the_original_type_identity() {
+    let files = reexport_fixture_files(REEXPORT_HIGH_SRC);
+    let errors = typecheck_virtual_entry(QUALIFIED_REEXPORT_MAIN_SRC, &files);
+    assert!(
+        errors.is_empty(),
+        "High.High.Item should name the same nominal type as Low.Low.Item: {errors:?}"
+    );
+}
+
+#[test]
+fn reexport_chain_preserves_the_public_record_shape() {
+    let mut files = reexport_fixture_files(REEXPORT_HIGH_SRC);
+    files.insert(
+        "mid/mid.av".to_string(),
+        REEXPORT_MID_SRC.replace("exposes [tripled]", "exposes [Item, tripled]"),
+    );
+    let errors = typecheck_virtual_entry(CHAIN_REEXPORT_MAIN_SRC, &files);
+    assert!(
+        errors.is_empty(),
+        "a second explicit facade should preserve Low.Item's identity and fields: {errors:?}"
+    );
+}
+
+#[test]
+fn reexport_does_not_make_the_declaring_module_a_qualified_dependency() {
+    let files = reexport_fixture_files(REEXPORT_HIGH_SRC);
+    let errors = typecheck_virtual_entry(
+        r#"module Main
+    intent = "The facade is imported, its implementation dependency is not."
+    depends [High.High]
+
+fn illegal(item: Low.Low.Item) -> Int
+    High.High.doubled(item)
+"#,
+        &files,
+    );
+    assert!(
+        errors.iter().any(|error| {
+            error.contains("Low.Low.Item")
+                && (error.contains("not exposed")
+                    || error.contains("not visible")
+                    || error.contains("Unknown type"))
+        }),
+        "re-exporting Item must not silently import the Low.Low qualifier: {errors:?}"
+    );
 }
 
 #[test]

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -3690,7 +3690,7 @@ fn caller() -> Float
 /// to also pull in.
 ///
 /// Repro: B depends on A and re-uses `A.Shape` as bare `Shape` in
-/// its own signature. Main depends on B and C (C exposes an
+/// its own signature. Main directly depends on A, B, and C (C exposes an
 /// unrelated `Shape`). Pre-fix, when Main's checker canonicalised
 /// B's exported sig, the bare `Shape` resolved against the
 /// importer's bare alias map — which was ambiguous between
@@ -3740,7 +3740,7 @@ type Shape
     .expect("write C.av failed");
 
     let src = r#"module Main
-    depends [B, C]
+    depends [A, B, C]
     intent = "Plumbs A.make through B.pass; C is just an unrelated sibling."
 
 fn takeA(s: A.Shape) -> Float


### PR DESCRIPTION
## Summary

- resolve explicit type re-exports to the original declaration identity across dependency boundaries
- separate the complete symbol tree from each importer’s direct visibility surface
- preserve record fields, sum constructors, opacity, qualified aliases, and chained facades without leaking transitive modules
- cover the exact #992 root-vs-dependency repro and compile/run it on the VM

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings`
- `cargo clippy -p aver-lang --lib --bin aver -- -D warnings`
- `cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings`
- `cargo test --workspace`
- `cargo test -p aver-lang --lib --features wasm,wasip2`

Fixes #992