### PR TITLE
fix: respect match branches in CSE diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Changed
 
+- **CSE diagnostics now respect mutually exclusive `match` arms.** Repeating the same pure builtin call or arithmetic expression in sibling arms no longer produces an impossible “extract to a binding” repair. Counts still add across sequential work and within one arm, while alternative arms contribute their maximum reachable count, so genuine duplicates remain visible.
+
 - **Capability-backed modules no longer fall out of Lean proof export.** A plain `verify` case on a branch that never dispatches its declared capability effect is exported against the Oracle-lifted function and quantified over the unused oracle, so the generated theorem states that the concrete result is provider-independent. A case with an explicit `given` keeps using that concrete stub. Qualified dependency operations such as `Infra.Kv.get` are now lifted through the same path instead of surviving as unknown host identifiers in an otherwise empty capability namespace.
 
 - **Verify stubs now reach capabilities below module namespaces by their canonical operation path.** `given probe: Sub.Probe.answer = [stub]` parses, type-checks, and installs the same `Sub.Probe.answer` identity used by calls, diagnostics, and provider dispatch. Dotted type annotations remain distinct and may also contain multiple capitalized namespace segments. A shortened or misspelled operation-shaped binding such as `Probe.answer` is rejected statically; when it uniquely matches a loaded canonical suffix, the diagnostic suggests `Sub.Probe.answer` instead of silently installing nothing and failing later with `capability-provider-missing`.

--- a/src/checker/cse.rs
+++ b/src/checker/cse.rs
@@ -4,6 +4,10 @@ use crate::ast::{BinOp, Expr, FnDef, MatchArm, Spanned, Stmt, TailCallData, TopL
 
 use super::CheckFinding;
 
+mod body_duplicates;
+
+use body_duplicates::check_fn_body_duplicates;
+
 const PURE_NAMESPACE_PREFIXES: &[&str] = &[
     "List.", "Vector.", "Map.", "String.", "Int.", "Float.", "Bool.", "Char.",
 ];
@@ -125,59 +129,6 @@ fn check_match_cse(subject: &Spanned<Expr>, arms: &[MatchArm], warnings: &mut Ve
                     extra_spans: vec![],
                 });
                 break;
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Body-wide duplicate detection
-// ---------------------------------------------------------------------------
-
-fn check_fn_body_duplicates(
-    fd: &FnDef,
-    match_warned_messages: &std::collections::HashSet<String>,
-    warnings: &mut Vec<CheckFinding>,
-) {
-    let mut all_subtrees: Vec<&Spanned<Expr>> = Vec::new();
-    for stmt in fd.body.stmts() {
-        let spanned = match stmt {
-            Stmt::Expr(e) => e,
-            Stmt::Binding(_, _, e) => e,
-        };
-        collect_all_nontrivial_from_spanned(spanned, &mut all_subtrees);
-    }
-
-    // Count occurrences via structural equality (Expr::PartialEq ignores line).
-    // Track first spanned for each unique subtree.
-    let mut counts: Vec<(&Spanned<Expr>, usize)> = Vec::new();
-    for subtree in &all_subtrees {
-        if let Some(entry) = counts.iter_mut().find(|(e, _)| e.node == subtree.node) {
-            entry.1 += 1;
-        } else {
-            counts.push((subtree, 1));
-        }
-    }
-
-    for (subtree, count) in &counts {
-        if *count >= 2 {
-            let subtree_str = expr_to_short_str(&subtree.node);
-            let msg = format!(
-                "`{}` is computed {} times in this function — consider extracting to a binding",
-                subtree_str, count
-            );
-            let already_warned = match_warned_messages
-                .iter()
-                .any(|m| m.contains(&subtree_str));
-            if !already_warned {
-                warnings.push(CheckFinding {
-                    line: subtree.line,
-                    module: None,
-                    file: None,
-                    fn_name: None,
-                    message: msg,
-                    extra_spans: vec![],
-                });
             }
         }
     }
@@ -418,66 +369,6 @@ fn collect_nontrivial_subtrees<'a>(spanned: &'a Spanned<Expr>, out: &mut Vec<&'a
     }
 }
 
-/// Collect all nontrivial subtrees from a spanned expression, recursing into
-/// all AST nodes (not just BinOp/FnCall).
-fn collect_all_nontrivial_from_spanned<'a>(
-    spanned: &'a Spanned<Expr>,
-    out: &mut Vec<&'a Spanned<Expr>>,
-) {
-    collect_nontrivial_subtrees(spanned, out);
-    match &spanned.node {
-        Expr::Match { subject, arms } => {
-            collect_all_nontrivial_from_spanned(subject, out);
-            for arm in arms {
-                collect_all_nontrivial_from_spanned(&arm.body, out);
-            }
-        }
-        Expr::Constructor(_, Some(inner)) => {
-            collect_all_nontrivial_from_spanned(inner, out);
-        }
-        Expr::ErrorProp(inner) => {
-            collect_all_nontrivial_from_spanned(inner, out);
-        }
-        Expr::List(elements) => {
-            for e in elements {
-                collect_all_nontrivial_from_spanned(e, out);
-            }
-        }
-        Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            for e in items {
-                collect_all_nontrivial_from_spanned(e, out);
-            }
-        }
-        Expr::InterpolatedStr(parts) => {
-            for p in parts {
-                if let crate::ast::StrPart::Parsed(e) = p {
-                    collect_all_nontrivial_from_spanned(e, out);
-                }
-            }
-        }
-        Expr::RecordCreate { fields, .. } => {
-            for (_, e) in fields {
-                collect_all_nontrivial_from_spanned(e, out);
-            }
-        }
-        Expr::RecordUpdate { base, updates, .. } => {
-            collect_all_nontrivial_from_spanned(base, out);
-            for (_, e) in updates {
-                collect_all_nontrivial_from_spanned(e, out);
-            }
-        }
-        Expr::TailCall(boxed) => {
-            let TailCallData {
-                target: _, args, ..
-            } = boxed.as_ref();
-            for a in args {
-                collect_all_nontrivial_from_spanned(a, out);
-            }
-        }
-        _ => {}
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -659,6 +550,7 @@ fn expr_to_short_str(expr: &Expr) -> String {
 mod tests {
     use super::*;
     use crate::ast::{Literal, SourceLine, Spanned};
+    use crate::source::parse_source;
 
     fn spanned(node: Expr) -> Spanned<Expr> {
         Spanned::new(node, 1 as SourceLine)
@@ -678,6 +570,16 @@ mod tests {
 
     fn binop(op: BinOp, left: Expr, right: Expr) -> Expr {
         Expr::BinOp(op, Box::new(spanned(left)), Box::new(spanned(right)))
+    }
+
+    fn namespace_call(namespace: &str, method: &str, arg: Expr) -> Expr {
+        Expr::FnCall(
+            Box::new(spanned(Expr::Attr(
+                Box::new(spanned(ident(namespace))),
+                method.to_string(),
+            ))),
+            vec![spanned(arg)],
+        )
     }
 
     #[test]
@@ -845,6 +747,57 @@ mod tests {
             "expected warning for repeated String.len(s)"
         );
         assert!(warnings.iter().any(|w| w.message.contains("String.len")));
+    }
+
+    #[test]
+    fn no_warning_for_builtin_call_in_mutually_exclusive_match_arms() {
+        let source = r#"type Bag
+    Memory(Map<String, Int>)
+    Logged(String, Map<String, Int>)
+
+fn size(bag: Bag) -> Int
+    match bag
+        Bag.Memory(entries) -> Map.len(entries)
+        Bag.Logged(path, entries) -> Map.len(entries)
+"#;
+        let items = parse_source(source).expect("parse #991 regression");
+
+        let warnings = collect_cse_warnings(&items);
+
+        assert!(
+            warnings.is_empty(),
+            "mutually exclusive match arms do not duplicate work: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn warns_for_builtin_call_repeated_within_one_match_arm() {
+        let len_call = namespace_call("Map", "len", ident("entries"));
+        let match_expr = Expr::Match {
+            subject: Box::new(spanned(ident("bag"))),
+            arms: vec![
+                MatchArm {
+                    pattern: crate::ast::Pattern::Ident("memory".to_string()),
+                    body: Box::new(spanned(binop(BinOp::Add, len_call.clone(), len_call))),
+                    binding_slots: std::sync::OnceLock::new(),
+                },
+                MatchArm {
+                    pattern: crate::ast::Pattern::Wildcard,
+                    body: Box::new(spanned(int(0))),
+                    binding_slots: std::sync::OnceLock::new(),
+                },
+            ],
+        };
+        let fd = caller_fn("size", vec![], match_expr);
+
+        let warnings = collect_cse_warnings(&[TopLevel::FnDef(fd)]);
+
+        assert!(
+            warnings.iter().any(|warning| warning
+                .message
+                .contains("`Map.len(entries)` is computed 2 times")),
+            "a duplicate inside one reachable arm must still warn: {warnings:?}"
+        );
     }
 
     #[test]

--- a/src/checker/cse/body_duplicates.rs
+++ b/src/checker/cse/body_duplicates.rs
@@ -1,0 +1,180 @@
+use std::collections::HashSet;
+
+use crate::{
+    ast::{Expr, FnDef, Spanned, Stmt, StrPart, TailCallData},
+    checker::CheckFinding,
+};
+
+use super::{expr_to_short_str, is_nontrivial_arithmetic, is_nontrivial_pure_fncall};
+
+/// Maximum reachable count for each structural expression.
+///
+/// Aver expressions are eager, so sibling children compose by addition. Match
+/// arms are mutually exclusive, so their counts compose by maximum. Keeping
+/// that distinction prevents a suggestion to hoist two arm-local expressions
+/// that can never execute together. Different entries may reach their maxima
+/// on different paths; each diagnostic is decided independently.
+#[derive(Default)]
+struct PathCounts<'a> {
+    entries: Vec<(&'a Spanned<Expr>, usize)>,
+}
+
+impl<'a> PathCounts<'a> {
+    fn add_occurrence(&mut self, expression: &'a Spanned<Expr>) {
+        if let Some((_, count)) = self
+            .entries
+            .iter_mut()
+            .find(|(seen, _)| seen.node == expression.node)
+        {
+            *count += 1;
+        } else {
+            self.entries.push((expression, 1));
+        }
+    }
+
+    fn add_sequential(&mut self, other: Self) {
+        for (expression, count) in other.entries {
+            if let Some((first, seen_count)) = self
+                .entries
+                .iter_mut()
+                .find(|(seen, _)| seen.node == expression.node)
+            {
+                *seen_count += count;
+                if expression.line < first.line {
+                    *first = expression;
+                }
+            } else {
+                self.entries.push((expression, count));
+            }
+        }
+    }
+
+    fn merge_alternative(&mut self, other: Self) {
+        for (expression, count) in other.entries {
+            if let Some((representative, max_count)) = self
+                .entries
+                .iter_mut()
+                .find(|(seen, _)| seen.node == expression.node)
+            {
+                if count > *max_count {
+                    *representative = expression;
+                    *max_count = count;
+                } else if count == *max_count && expression.line < representative.line {
+                    *representative = expression;
+                }
+            } else {
+                self.entries.push((expression, count));
+            }
+        }
+    }
+}
+
+pub(super) fn check_fn_body_duplicates(
+    fd: &FnDef,
+    match_warned_messages: &HashSet<String>,
+    warnings: &mut Vec<CheckFinding>,
+) {
+    let mut counts = PathCounts::default();
+    for statement in fd.body.stmts() {
+        let expression = match statement {
+            Stmt::Expr(expression) | Stmt::Binding(_, _, expression) => expression,
+        };
+        counts.add_sequential(count_expression_paths(expression));
+    }
+
+    for (expression, count) in counts.entries {
+        if count < 2 {
+            continue;
+        }
+
+        let expression_string = expr_to_short_str(&expression.node);
+        let already_warned = match_warned_messages
+            .iter()
+            .any(|message| message.contains(&expression_string));
+        if already_warned {
+            continue;
+        }
+
+        warnings.push(CheckFinding {
+            line: expression.line,
+            module: None,
+            file: None,
+            fn_name: None,
+            message: format!(
+                "`{expression_string}` is computed {count} times in this function — consider extracting to a binding"
+            ),
+            extra_spans: vec![],
+        });
+    }
+}
+
+fn count_expression_paths(expression: &Spanned<Expr>) -> PathCounts<'_> {
+    let mut counts = PathCounts::default();
+    if is_nontrivial_arithmetic(&expression.node) || is_nontrivial_pure_fncall(&expression.node) {
+        counts.add_occurrence(expression);
+    }
+
+    match &expression.node {
+        Expr::Match { subject, arms } => {
+            counts.add_sequential(count_expression_paths(subject));
+
+            let mut alternatives = PathCounts::default();
+            for arm in arms {
+                alternatives.merge_alternative(count_expression_paths(&arm.body));
+            }
+            counts.add_sequential(alternatives);
+        }
+        Expr::BinOp(_, left, right) => {
+            counts.add_sequential(count_expression_paths(left));
+            counts.add_sequential(count_expression_paths(right));
+        }
+        Expr::Neg(inner)
+        | Expr::Attr(inner, _)
+        | Expr::Constructor(_, Some(inner))
+        | Expr::ErrorProp(inner) => counts.add_sequential(count_expression_paths(inner)),
+        Expr::FnCall(callee, arguments) => {
+            counts.add_sequential(count_expression_paths(callee));
+            add_all_sequential(&mut counts, arguments);
+        }
+        Expr::List(elements) | Expr::Tuple(elements) | Expr::IndependentProduct(elements, _) => {
+            add_all_sequential(&mut counts, elements)
+        }
+        Expr::MapLiteral(entries) => {
+            for (key, value) in entries {
+                counts.add_sequential(count_expression_paths(key));
+                counts.add_sequential(count_expression_paths(value));
+            }
+        }
+        Expr::InterpolatedStr(parts) => {
+            for part in parts {
+                if let StrPart::Parsed(parsed) = part {
+                    counts.add_sequential(count_expression_paths(parsed));
+                }
+            }
+        }
+        Expr::RecordCreate { fields, .. } => {
+            for (_, value) in fields {
+                counts.add_sequential(count_expression_paths(value));
+            }
+        }
+        Expr::RecordUpdate { base, updates, .. } => {
+            counts.add_sequential(count_expression_paths(base));
+            for (_, value) in updates {
+                counts.add_sequential(count_expression_paths(value));
+            }
+        }
+        Expr::TailCall(call) => {
+            let TailCallData { args, .. } = call.as_ref();
+            add_all_sequential(&mut counts, args);
+        }
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } | Expr::Constructor(_, None) => {}
+    }
+
+    counts
+}
+
+fn add_all_sequential<'a>(counts: &mut PathCounts<'a>, expressions: &'a [Spanned<Expr>]) {
+    for expression in expressions {
+        counts.add_sequential(count_expression_paths(expression));
+    }
+}


### PR DESCRIPTION
## Summary

- count CSE candidates additively across eager sequential expressions
- combine mutually exclusive match arms by their maximum reachable count
- preserve warnings for genuine duplicates within one arm and add the exact Bag regression
- split body-wide duplicate analysis out of the oversized CSE module

## Testing

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings
- cargo clippy -p aver-lang --lib --bin aver -- -D warnings
- cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings
- cargo test --workspace (3275 passed, 27 ignored)
- cargo test -p aver-lang checker::cse::tests::
- python3 tools/tests/test_release.py
- cargo run --bin aver -- check examples/core
- cargo run --bin aver -- check examples/data

Fixes #991