### PR TITLE
fix(codegen): align equality borrows

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1147,7 +1147,19 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 {
                     return Some(format!("({:?} {} &*{})", s, op_str, r));
                 }
-                Some(format!("({} {} {})", l, op_str, r))
+                // Borrow-by-default makes collection / wrapper / named-type
+                // parameters `&T`, while calls and constructors still produce
+                // an owned `T`. Rust does not provide `PartialEq<&T> for T`, so
+                // compare two references whenever exactly one side is a
+                // borrowed parameter. Borrowing the owned expression is
+                // temporary, allocation-free, and preserves evaluation order.
+                let lhs_borrowed = mir_expr_is_borrowed_param_read(&bop.lhs.node, emit_ctx);
+                let rhs_borrowed = mir_expr_is_borrowed_param_read(&bop.rhs.node, emit_ctx);
+                match (lhs_borrowed, rhs_borrowed) {
+                    (false, true) => Some(format!("(&({}) {} {})", l, op_str, r)),
+                    (true, false) => Some(format!("({} {} &({}))", l, op_str, r)),
+                    _ => Some(format!("({} {} {})", l, op_str, r)),
+                }
             } else {
                 Some(format!("({} {} {})", l, op_str, r))
             }
@@ -2624,7 +2636,7 @@ fn emit_mir_match_with(
         .all(|arm| crate::ir::vars::resolved_pattern_bindings(&arm.pattern).is_empty());
     let match_on_ref = no_bindings
         && !any_int_literal_pattern
-        && mir_subject_is_borrowed_param(&m.subject.node, emit_ctx);
+        && mir_expr_is_borrowed_param_read(&m.subject.node, emit_ctx);
 
     // Int unboxing: a bare-`i64` subject (a proven-bare counter) is `Copy`,
     // so it is read by value WITHOUT `.clone()` and the Int-literal guards
@@ -3013,11 +3025,13 @@ fn lower_int_literal_subpatterns(
     }
 }
 
-/// Is the match subject a read of a borrowed-param local? Mirror of
-/// `emit_match`'s `match_on_ref` subject check
-/// (`ResolvedExpr::Ident | Resolved` whose name `is_borrowed_param`).
-fn mir_subject_is_borrowed_param(subject: &MirExpr, emit_ctx: &MirEmitCtx<'_>) -> bool {
-    local_of(subject).is_some_and(|local| emit_ctx.is_borrowed_param(&local.name))
+/// Is this expression a direct read of a borrowed-param local?
+///
+/// A direct read emits as `name`, whose Rust type is `&T`. Projections and
+/// compound expressions have their own ownership rules and deliberately do
+/// not count as borrowed-param reads here.
+fn mir_expr_is_borrowed_param_read(expr: &MirExpr, emit_ctx: &MirEmitCtx<'_>) -> bool {
+    local_of(expr).is_some_and(|local| emit_ctx.is_borrowed_param(&local.name))
 }
 
 /// Emit the FULL function body the MIR walker produces, in the
@@ -6413,6 +6427,73 @@ mod tests {
             bare: &policy.bare,
             try_err_to_string: false,
         }
+    }
+
+    fn list_literal_one() -> Spanned<MirExpr> {
+        span_ty(
+            MirExpr::List(vec![int_lit(1)]),
+            Type::List(Box::new(Type::Int)),
+        )
+    }
+
+    fn borrowed_list_read(name: &str, slot: u32) -> Spanned<MirExpr> {
+        span_ty(
+            MirExpr::Local(span(MirLocal {
+                slot: LocalId(slot),
+                last_use: false,
+                name: name.to_string(),
+            })),
+            Type::List(Box::new(Type::Int)),
+        )
+    }
+
+    #[test]
+    fn equality_borrows_owned_lhs_when_rhs_is_a_borrowed_param() {
+        let policy = borrowed_param_policy("other");
+        let ctx = ctx_over(&policy);
+        let expr = span(MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Eq,
+            lhs: Box::new(list_literal_one()),
+            rhs: Box::new(borrowed_list_read("other", 0)),
+        })));
+
+        assert_eq!(
+            emit_mir_expr(&expr, &ctx).expect("equality emits"),
+            "(&(aver_rt::AverList::from_vec(vec![aver_rt::AverInt::from_i64(1)])) == other)"
+        );
+    }
+
+    #[test]
+    fn inequality_borrows_owned_rhs_when_lhs_is_a_borrowed_param() {
+        let policy = borrowed_param_policy("other");
+        let ctx = ctx_over(&policy);
+        let expr = span(MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Neq,
+            lhs: Box::new(borrowed_list_read("other", 0)),
+            rhs: Box::new(list_literal_one()),
+        })));
+
+        assert_eq!(
+            emit_mir_expr(&expr, &ctx).expect("inequality emits"),
+            "(other != &(aver_rt::AverList::from_vec(vec![aver_rt::AverInt::from_i64(1)])))"
+        );
+    }
+
+    #[test]
+    fn equality_between_two_borrowed_params_stays_direct() {
+        let mut policy = borrowed_param_policy("left");
+        policy.borrowed_params.insert("right".to_string());
+        let ctx = ctx_over(&policy);
+        let expr = span(MirExpr::BinOp(span(MirBinOp {
+            op: BinOp::Eq,
+            lhs: Box::new(borrowed_list_read("left", 0)),
+            rhs: Box::new(borrowed_list_read("right", 1)),
+        })));
+
+        assert_eq!(
+            emit_mir_expr(&expr, &ctx).expect("equality emits"),
+            "(left == right)"
+        );
     }
 
     #[test]

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -4359,6 +4359,90 @@ fn mir_first_class_fn_value_builds_and_matches_vm() {
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Regression for #1037: a direct function borrows collection parameters,
+/// while another call still returns an owned collection. Equality must compare
+/// matching Rust shapes (`&T` with `&T`) in either operand order; VM execution
+/// alone cannot expose this because VM values have no Rust borrow distinction.
+#[test]
+fn call_result_equality_with_borrowed_param_builds_and_matches_vm() {
+    let ws = temp_dir("borrowed_equality");
+    let source = ws.join("main.av");
+    fs::write(
+        &source,
+        r#"module Main
+    intent = "Compare an owned call result with a borrowed collection parameter."
+    effects [Console]
+
+fn made() -> List<Int>
+    ? "Return a freshly built list by value."
+    [1, 2]
+
+fn sameRight(other: List<Int>) -> Bool
+    ? "Compare an owned call result on the left with a borrowed parameter."
+    made() == other
+
+fn sameLeft(other: List<Int>) -> Bool
+    ? "Compare a borrowed parameter on the left with an owned call result."
+    other == made()
+
+fn differs(other: List<Int>) -> Bool
+    ? "Exercise the same ownership boundary through inequality."
+    made() != other
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("right={sameRight([1, 2])} left={sameLeft([1, 2])} neq={differs([3])}")
+"#,
+    )
+    .expect("write borrowed-equality probe source");
+
+    let vm_stdout = run_vm(&source, None).expect("VM run");
+    assert_eq!(vm_stdout, "right=true left=true neq=true");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(&source, &project, "borrowed_equality", None, &[])?;
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("&(made()) == other")
+            || !emitted.contains("other == &(made())")
+            || !emitted.contains("&(made()) != other")
+        {
+            return Err(format!(
+                "owned call results were not borrowed against collection params:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, "borrowed_equality")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "borrowed-equality generated binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "borrowed-equality stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 /// A qualified project type inside `Fn` is a module-owned Rust path, not a
 /// compiler-owned dotted record alias. Before #1033 the context-free type
 /// renderer flattened `Worker.Shape` to the nonexistent `Worker_Shape`, so


### PR DESCRIPTION
Fixes #1037

Borrow the owned operand when equality or inequality compares it with a borrow-by-default parameter. This keeps both Rust operands at &T without cloning and applies uniformly to List, Map, Vector, Result, Option, tuples, and named types.

Regression coverage includes both operand orders, inequality, the unchanged borrowed/borrowed path, and a real generated-Rust cargo build with VM output parity.

Local verification:
- cargo fmt --all -- --check
- cargo clippy -p aver-lang --lib --bin aver -- -D warnings
- cargo test -p aver-lang --lib borrowed_param
- cargo test -p aver-lang --test rust_codegen_differential call_result_equality_with_borrowed_param_builds_and_matches_vm