### PR TITLE
Fix ambiguous Rust match binders from dependency imports

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -20,6 +20,17 @@ use std::collections::HashSet;
 pub use super::syntax::aver_name_to_rust;
 pub(super) use super::syntax::{has_list_patterns, has_string_literal_patterns};
 
+/// Render an identifier in a Rust pattern as an explicit binding.
+///
+/// A bare identifier in a pattern is also eligible for item resolution. When
+/// two dependency glob imports expose the same function name, rustc reports
+/// `Ok(name)` as ambiguous instead of treating `name` as the local binder that
+/// Aver declares. `name @ _` is semantically identical and syntactically
+/// unambiguous, while keeping all body references under the original name.
+fn explicit_binding_pattern(name: &str) -> String {
+    format!("{} @ _", aver_name_to_rust(name))
+}
+
 /// Predicate adapter shared by every resolved-shape classifier — the
 /// shared classifiers don't know about [`CodegenContext`] (it lives in
 /// the codegen crate, classifiers live in the IR), so they take a
@@ -420,7 +431,7 @@ where
                 SemanticDispatchPattern::WrapperTag(kind),
                 DispatchBindingPlan::WrapperPayload(name),
             ) => {
-                let binding = aver_name_to_rust(name);
+                let binding = explicit_binding_pattern(name);
                 let extractor = match kind {
                     WrapperKind::ResultOk => "Ok",
                     WrapperKind::ResultErr => "Err",
@@ -448,7 +459,7 @@ where
         let arm = &arms[default_arm.arm_index];
         let body = body_for_arm(arm);
         if let Some(name) = &default_arm.binding_name {
-            let binding = aver_name_to_rust(name);
+            let binding = explicit_binding_pattern(name);
             match_arms.push(format!("{binding} => {{ {body} }}"));
         } else {
             match_arms.push(format!("_ => {{ {body} }}"));
@@ -507,13 +518,14 @@ fn emit_dispatch_arm_body(
             DispatchBindingPlan::WrapperPayload(binding_name),
         ) => {
             let binding = aver_name_to_rust(binding_name);
+            let binding_pattern = explicit_binding_pattern(binding_name);
             let extractor = match kind {
                 WrapperKind::ResultOk => "Ok",
                 WrapperKind::ResultErr => "Err",
                 WrapperKind::OptionSome => "Some",
             };
             format!(
-                "{{ let {binding} = if let {extractor}({binding}) = &{subject_name} {{ {binding}.clone() }} else {{ unreachable!(\"Aver Rust codegen: dispatch tag mismatch\") }}; {body} }}"
+                "{{ let {binding_pattern} = if let {extractor}({binding_pattern}) = &{subject_name} {{ {binding}.clone() }} else {{ unreachable!(\"Aver Rust codegen: dispatch tag mismatch\") }}; {body} }}"
             )
         }
         _ => body,
@@ -531,7 +543,10 @@ fn emit_default_dispatch_arm(
         None => body,
         Some(name) => {
             let name = aver_name_to_rust(name);
-            format!("{{ let {} = {}.clone(); {} }}", name, subject_name, body)
+            format!(
+                "{{ let {} @ _ = {}.clone(); {} }}",
+                name, subject_name, body
+            )
         }
     }
 }

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -2402,7 +2402,7 @@ fn loop(r: Result<Int, String>) -> Int
         // via the full pipeline, matching the CLI) lets it move into the
         // match without a `.clone()`.
         assert!(entry.contains("match r {"));
-        assert!(entry.contains("Ok(n)"));
+        assert!(entry.contains("Ok(n @ _)"));
         assert!(!entry.contains("__dispatch_subject"));
     }
 
@@ -2433,7 +2433,7 @@ fn right(r: Result<Int, String>) -> Int
         // via the full pipeline, matching the CLI) lets it move into the
         // match without a `.clone()`.
         assert!(entry.contains("match r {"));
-        assert!(entry.contains("Ok(n)"));
+        assert!(entry.contains("Ok(n @ _)"));
         assert!(!entry.contains("__dispatch_subject"));
     }
 

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -4533,6 +4533,96 @@ fn main() -> Unit
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Regression for #1042: dependency glob imports must not turn an Aver match
+/// binder into an ambiguous Rust name. Both dependencies expose `message`, but
+/// the entry calls only `Legacy.message`; `Result.Ok(message)` is purely local.
+#[test]
+fn colliding_dependency_function_names_do_not_conflict_with_match_binders() {
+    let ws = temp_dir("dependency_function_binder_collision");
+    fs::write(
+        ws.join("Legacy.av"),
+        r#"module Legacy
+    exposes [message]
+    intent = "Expose the legacy message calculation."
+    effects []
+
+fn message(value: Int) -> Result<Int, String>
+    ? "Return the legacy message."
+    Result.Ok(value)
+"#,
+    )
+    .expect("write Legacy module");
+    fs::write(
+        ws.join("Modern.av"),
+        r#"module Modern
+    exposes [message]
+    intent = "Expose the modern message calculation."
+    effects []
+
+fn message(value: Int) -> Result<Int, String>
+    ? "Return the modern message."
+    Result.Ok(value + 1)
+"#,
+    )
+    .expect("write Modern module");
+
+    let entry = ws.join("main.av");
+    fs::write(
+        &entry,
+        r#"module Main
+    depends [Legacy, Modern]
+    intent = "Select one qualified message without importing either short name."
+    effects [Console]
+
+fn select() -> Option<Int>
+    ? "Bind the result under the same short name exposed by both dependencies."
+    match Legacy.message(7)
+        Result.Err(why) -> Option.None
+        Result.Ok(message) -> Option.Some(message)
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("picked={Option.withDefault(select(), 0)}")
+"#,
+    )
+    .expect("write entry module");
+
+    let vm_stdout = run_vm(&entry, Some(&ws)).expect("VM run");
+    assert_eq!(vm_stdout, "picked=7", "VM contract changed");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(
+            &entry,
+            &project,
+            "dependency_function_binder_collision",
+            Some(&ws),
+            &[],
+        )?;
+        let bin = cargo_build(&project, "dependency_function_binder_collision")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "dependency-function-binder generated binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "dependency-function-binder stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 // ─── Mode (h): Int.fromString / Float.fromString Err-message bytes ────────
 //
 // `Int.fromString` / `Float.fromString` return a `Result<_, String>`.


### PR DESCRIPTION
## Summary
- emit wrapper-match binders as explicit `name @ _` Rust patterns
- cover direct wrapper matches and fallback dispatch extraction
- add a multi-module build-and-run regression with two dependencies exposing `message`

## Testing
- `cargo test` — 3191 passed, 25 ignored
- `cargo clippy -p aver-lang --lib --bin aver -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Fixes #1042