### PR TITLE
test: format tests/stdlib_spec.rs

### DIFF
--- a/tests/stdlib_spec.rs
+++ b/tests/stdlib_spec.rs
@@ -629,7 +629,10 @@ fn embedded_crypto_sha256_matches_fips_vectors_on_wasm_gc() {
         })
         .unwrap_or_else(|| panic!("no `N/M cases passed` summary in:\n{rendered}"));
     assert_eq!(passed, total, "{rendered}");
-    assert!(total >= 13, "fewer cases than the original FIPS vectors: {rendered}");
+    assert!(
+        total >= 13,
+        "fewer cases than the original FIPS vectors: {rendered}"
+    );
 }
 
 #[cfg(feature = "wasip2")]


### PR DESCRIPTION
rustfmt-only change to the assertion added in #1045; that PR was merged with the Format step red, so main currently fails Check & Test at the first step. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)