### PR TITLE
Walk every sub-expression when collecting the calls a proof must unfold

### DIFF
--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -5,7 +5,7 @@
 //! (`codegen::dafny::lemmas`) and the Lean renderer
 //! (`codegen::lean::law_auto::induction`) both consume these, so a single
 //! recognizer drives a proof on either backend.
-use crate::ast::{Expr, FnBody, FnDef, Pattern, Spanned, Stmt, TailCallData, TypeDef, VerifyLaw};
+use crate::ast::{Expr, FnBody, FnDef, Pattern, Spanned, Stmt, TypeDef, VerifyLaw};
 use crate::codegen::CodegenContext;
 
 /// A canonical Peano ADT: EXACTLY one nullary constructor and exactly one unary
@@ -98,64 +98,29 @@ pub(crate) fn peano_ctor_role(
     }
 }
 
-/// Collect all function names called in an expression (top-level only).
+/// Collect the user functions called anywhere in `expr` — including inside
+/// interpolated strings, map literals and record updates. The descent is
+/// `expr_walk::walk`, so a new `Expr` variant cannot be skipped silently; a
+/// hand-rolled walk here once ended in `_ => {}` and a wrapper whose only call
+/// sat inside `"{f(x)}"` never entered the Dafny opaque closure.
 pub(crate) fn collect_called_fns(
     expr: &Spanned<Expr>,
     out: &mut std::collections::BTreeSet<String>,
 ) {
-    match &expr.node {
-        Expr::FnCall(f, args) => {
+    crate::codegen::expr_walk::walk(expr, &mut |node| match &node.node {
+        Expr::FnCall(f, _) => {
             if let Some(name) = crate::codegen::common::expr_to_dotted_name(&f.node) {
                 // Skip builtins — only user functions need fuel
                 if !name.contains('.') {
                     out.insert(name);
                 }
             }
-            collect_called_fns(f, out);
-            for a in args {
-                collect_called_fns(a, out);
-            }
         }
-        Expr::BinOp(_, l, r) => {
-            collect_called_fns(l, out);
-            collect_called_fns(r, out);
+        Expr::TailCall(tc) if !tc.target.contains('.') => {
+            out.insert(tc.target.clone());
         }
-        Expr::Match { subject, arms, .. } => {
-            collect_called_fns(subject, out);
-            for arm in arms {
-                collect_called_fns(&arm.body, out);
-            }
-        }
-        Expr::ErrorProp(inner) => collect_called_fns(inner, out),
-        Expr::Constructor(_, Some(arg)) => collect_called_fns(arg, out),
-        Expr::RecordCreate { fields, .. } => {
-            for (_, e) in fields {
-                collect_called_fns(e, out);
-            }
-        }
-        Expr::List(elems) => {
-            for e in elems {
-                collect_called_fns(e, out);
-            }
-        }
-        Expr::TailCall(tc) => {
-            let TailCallData { target, args, .. } = tc.as_ref();
-            if !target.contains('.') {
-                out.insert(target.clone());
-            }
-            for a in args {
-                collect_called_fns(a, out);
-            }
-        }
-        Expr::Tuple(elems) | Expr::IndependentProduct(elems, _) => {
-            for e in elems {
-                collect_called_fns(e, out);
-            }
-        }
-        Expr::Attr(obj, _) => collect_called_fns(obj, out),
-        Expr::Neg(inner) => collect_called_fns(inner, out),
         _ => {}
-    }
+    });
 }
 
 pub(crate) fn collect_called_fns_in_body(

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -24,6 +24,8 @@ mod lean_kernel;
 mod lemmas;
 #[path = "proof_spec/literalization.rs"]
 mod literalization;
+#[path = "proof_spec/opaque_closure.rs"]
+mod opaque_closure;
 #[path = "proof_spec/oracle_verify.rs"]
 mod oracle_verify;
 #[path = "proof_spec/panics.rs"]

--- a/tests/proof_spec/opaque_closure.rs
+++ b/tests/proof_spec/opaque_closure.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+/// Export `source` to Dafny (no `dafny` binary needed) and return every
+/// emitted `.dfy` file concatenated.
+fn export_dafny_inline(source: &str, prefix: &str) -> String {
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir(&format!("{prefix}-src"));
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join("m.av"), source).expect("write m.av");
+    let out = temp_output_dir(&format!("{prefix}-out"));
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("m.av"))
+        .arg("--backend")
+        .arg("dafny")
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("expected `aver proof --backend dafny` to run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let mut text = String::new();
+    for entry in std::fs::read_dir(&out).expect("read out dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().is_some_and(|e| e == "dfy") {
+            text.push_str(&std::fs::read_to_string(&path).expect("read .dfy"));
+        }
+    }
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+    text
+}
+
+const MUTUAL_PAIR: &str = "fn pingA(n: Int) -> Int\n    ? \"Bounces to its peer.\"\n    match n <= 0\n        true -> 0\n        false -> pongB(n - 1)\n\n\
+fn pongB(n: Int) -> Int\n    ? \"Bounces back.\"\n    match n <= 0\n        true -> 1\n        false -> pingA(n - 1)\n\n";
+
+fn program(module: &str, wrapper: &str) -> String {
+    format!(
+        "module {module}\n    intent =\n        \"A wrapper reaching a fuel-encoded mutual pair.\"\n\n{MUTUAL_PAIR}{wrapper}"
+    )
+}
+
+/// The wrapper's law lemma must carry the law's `given` domain as a
+/// `requires` and a `{:fuel ...}` attribute for the opaque callee it reaches.
+/// Without them the exporter states an unbounded universal it has no basis
+/// for (`wrapInterp(3) == "1"`, not `"0"`).
+fn assert_lemma_is_bounded_and_fuelled(text: &str, lemma: &str) {
+    let sig = format!("{lemma}(n: int)");
+    let at = text
+        .find(&sig)
+        .unwrap_or_else(|| panic!("no lemma `{lemma}` in emitted Dafny:\n{text}"));
+    let header_start = text[..at].rfind('\n').map_or(0, |i| i + 1);
+    let body_open = text[at..].find("\n{").map_or(text.len(), |i| at + i);
+    let lemma_text = &text[header_start..body_open];
+    assert!(
+        lemma_text.contains("{:fuel pingA"),
+        "lemma `{lemma}` lost the fuel attribute for the opaque callee:\n{lemma_text}"
+    );
+    assert!(
+        lemma_text.contains("requires n == 2"),
+        "lemma `{lemma}` lost the law's given-domain bound:\n{lemma_text}"
+    );
+}
+
+#[test]
+fn a_wrapper_reaching_a_mutual_pair_directly_gets_a_bounded_lemma() {
+    let text = export_dafny_inline(
+        &program(
+            "OpaqueDirect",
+            "fn wrapDirect(n: Int) -> Int\n    ? \"Reaches the mutual pair through a direct call.\"\n    pingA(n)\n\n\
+             verify wrapDirect law wrapDirectIsStable\n    given n: Int = [2]\n    wrapDirect(n) => 0\n",
+        ),
+        "aver-opaque-direct",
+    );
+    assert_lemma_is_bounded_and_fuelled(&text, "wrapDirect_wrapDirectIsStable");
+}
+
+#[test]
+fn a_wrapper_reaching_a_mutual_pair_through_an_interpolated_string_gets_a_bounded_lemma() {
+    let text = export_dafny_inline(
+        &program(
+            "OpaqueInterp",
+            "fn wrapInterp(n: Int) -> String\n    ? \"Reaches the mutual pair only inside an interpolated string.\"\n    \"{pingA(n)}\"\n\n\
+             verify wrapInterp law wrapInterpIsStable\n    given n: Int = [2]\n    wrapInterp(n) => \"0\"\n",
+        ),
+        "aver-opaque-interp",
+    );
+    assert_lemma_is_bounded_and_fuelled(&text, "wrapInterp_wrapInterpIsStable");
+}
+
+#[test]
+fn a_wrapper_reaching_a_mutual_pair_through_a_map_literal_gets_a_bounded_lemma() {
+    let text = export_dafny_inline(
+        &program(
+            "OpaqueMap",
+            "fn wrapMap(n: Int) -> Map<Int, Int>\n    ? \"Reaches the mutual pair only inside a map literal.\"\n    { 0 => pingA(n) }\n\n\
+             verify wrapMap law wrapMapIsStable\n    given n: Int = [2]\n    wrapMap(n) => { 0 => 0 }\n",
+        ),
+        "aver-opaque-maplit",
+    );
+    assert_lemma_is_bounded_and_fuelled(&text, "wrapMap_wrapMapIsStable");
+}


### PR DESCRIPTION
`proof_recognize::collect_called_fns` carried its own recursion over `Expr` ending in `_ => {}`, so a call that sat inside an interpolated string, a map literal or a record update was never collected. Sixteen call sites use it; the visible consequence is in the Dafny exporter: a wrapper that reaches a mutually recursive pair only through `"{pingA(n)}"` or `{ 0 => pingA(n) }` is not added to the opaque closure, `needs_bounded_form` turns off, and the emitted lemma loses both the law's `requires n == 2` and the `{:fuel pingA, ...}` attributes — an unbounded universal that is false (`wrapInterp(3) == "1"`). Z3 rejects it, so this was a spurious failure, not an unsound proof.

The descent now goes through `codegen::expr_walk::walk`, the exhaustive child walk that cannot skip a variant; the name filter is unchanged (bare names only). The same filter also drops cross-module calls like `Mod.helper` before `transitive_opaque_closure` tries to resolve them — that is a separate change, because it widens what the sixteen consumers see and needs each of them checked.

Three regression tests in `tests/proof_spec/opaque_closure.rs` export the direct, interpolated-string and map-literal wrappers to Dafny and assert the lemma keeps its `requires` and fuel; they read the emitted text, so they run without a Dafny binary. Before the fix the last two fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)