### PR TITLE
Walk every sub-expression when looking for non-tail recursive calls

### DIFF
--- a/src/tail_check.rs
+++ b/src/tail_check.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{Expr, FnBody, Spanned, Stmt, StrPart, TopLevel};
+use crate::ast::{Expr, FnBody, Spanned, Stmt, TopLevel};
 use crate::call_graph;
 #[cfg(feature = "runtime")]
 use crate::verify_law::canonical_spec_ref;
@@ -159,72 +159,18 @@ fn collect_non_tail_recursive_call_lines_expr(
     recursive: &HashSet<String>,
     out: &mut Vec<usize>,
 ) {
-    match &expr.node {
-        Expr::FnCall(func, args) => {
-            if let Some(callee) = dotted_name(func.as_ref())
-                && recursive.contains(&callee)
-            {
-                out.push(expr.line);
-            }
-            collect_non_tail_recursive_call_lines_expr(func, recursive, out);
-            for arg in args {
-                collect_non_tail_recursive_call_lines_expr(arg, recursive, out);
-            }
+    // `expr_walk::walk` descends into every sub-expression (a hand-rolled
+    // walk here once skipped `Neg`, so `-f(n)` was never reported) and into
+    // a `TailCall`'s arguments without visiting its target, which is what
+    // "tail position" means here: only `FnCall` nodes are candidate sites.
+    crate::codegen::expr_walk::walk(expr, &mut |node| {
+        if let Expr::FnCall(func, _) = &node.node
+            && let Some(callee) = dotted_name(func.as_ref())
+            && recursive.contains(&callee)
+        {
+            out.push(node.line);
         }
-        Expr::TailCall(boxed) => {
-            for arg in &boxed.args {
-                collect_non_tail_recursive_call_lines_expr(arg, recursive, out);
-            }
-        }
-        Expr::Attr(obj, _) | Expr::ErrorProp(obj) => {
-            collect_non_tail_recursive_call_lines_expr(obj, recursive, out);
-        }
-        Expr::BinOp(_, left, right) => {
-            collect_non_tail_recursive_call_lines_expr(left, recursive, out);
-            collect_non_tail_recursive_call_lines_expr(right, recursive, out);
-        }
-        Expr::Match { subject, arms } => {
-            collect_non_tail_recursive_call_lines_expr(subject, recursive, out);
-            for arm in arms {
-                collect_non_tail_recursive_call_lines_expr(&arm.body, recursive, out);
-            }
-        }
-        Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
-            for item in items {
-                collect_non_tail_recursive_call_lines_expr(item, recursive, out);
-            }
-        }
-        Expr::MapLiteral(entries) => {
-            for (key, value) in entries {
-                collect_non_tail_recursive_call_lines_expr(key, recursive, out);
-                collect_non_tail_recursive_call_lines_expr(value, recursive, out);
-            }
-        }
-        Expr::Constructor(_, maybe_arg) => {
-            if let Some(arg) = maybe_arg.as_deref() {
-                collect_non_tail_recursive_call_lines_expr(arg, recursive, out);
-            }
-        }
-        Expr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let StrPart::Parsed(expr) = part {
-                    collect_non_tail_recursive_call_lines_expr(expr, recursive, out);
-                }
-            }
-        }
-        Expr::RecordCreate { fields, .. } => {
-            for (_, val) in fields {
-                collect_non_tail_recursive_call_lines_expr(val, recursive, out);
-            }
-        }
-        Expr::RecordUpdate { base, updates, .. } => {
-            collect_non_tail_recursive_call_lines_expr(base, recursive, out);
-            for (_, val) in updates {
-                collect_non_tail_recursive_call_lines_expr(val, recursive, out);
-            }
-        }
-        _ => {}
-    }
+    });
 }
 
 fn dotted_name(expr: &Spanned<Expr>) -> Option<String> {
@@ -275,6 +221,25 @@ fn fib(n: Int) -> Int
             warnings[0].message,
             "non-tail recursion in 'fib' — 2 recursive callsite(s) remain after tail-call optimization; rewrite it to tail recursion or make it a spec"
         );
+    }
+
+    #[test]
+    fn warns_for_a_negated_recursive_call() {
+        // `-f(n)` is `Neg(FnCall)`: a non-tail recursive call that the old
+        // hand-rolled walk never descended into.
+        let src = r#"
+fn alt(n: Int) -> Int
+    match n
+        0 -> 1
+        _ -> -alt(n - 1)
+"#;
+        let mut items = parse(src);
+        crate::ir::pipeline::tco(&mut items);
+
+        let warnings = collect_non_tail_recursion_warnings(&items);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert_eq!(warnings[0].fn_name, "alt");
+        assert_eq!(warnings[0].recursive_calls, 1);
     }
 
     #[test]


### PR DESCRIPTION
`tail_check::collect_non_tail_recursive_call_lines_expr` carried its own recursion over `Expr` with a `_ => {}` arm; `Expr::Neg` was not listed, so `-f(n - 1)` — a non-tail recursive call wrapped in unary minus — was never reported by the non-tail-recursion warning. The descent now goes through `codegen::expr_walk::walk` (exhaustive by construction): only `FnCall` nodes are candidate sites, and a `TailCall`'s arguments are still visited while its target is not, which is exactly what tail position means here. Same rule as before, 66 lines fewer, one regression test for the negated call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)