### PR TITLE
Let the proof call collector see cross-module user calls

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1605,22 +1605,24 @@ pub fn emit_law_samples(
         // Per-sample lemma form. Each gets fuel bumped on every
         // (transitive) callee + the matching `__fuel` helper for
         // mutual-rec SCC members.
-        let known: std::collections::HashSet<String> = ctx
-            .items
-            .iter()
-            .filter_map(|i| {
-                if let TopLevel::FnDef(fd) = i {
-                    Some(fd.name.clone())
+        let active = ctx.active_module_scope();
+        let d = |name: &str| -> String {
+            if let Some(dot) = name.rfind('.') {
+                let module_part = &name[..dot];
+                let local = &name[dot + 1..];
+                if active.as_deref() == Some(module_part) {
+                    aver_name_to_dafny(local)
                 } else {
-                    None
+                    format!(
+                        "Aver_{}.{}",
+                        module_part.replace('.', "_"),
+                        aver_name_to_dafny(local)
+                    )
                 }
-            })
-            .chain(
-                ctx.modules
-                    .iter()
-                    .flat_map(|m| m.fn_defs.iter().map(|fd| fd.name.clone())),
-            )
-            .collect();
+            } else {
+                aver_name_to_dafny(name)
+            }
+        };
         for (idx, (lhs_rw, rhs_rw)) in rewritten.iter().enumerate() {
             let l = emit_expr_legacy(lhs_rw, ctx, None);
             let r = emit_expr_legacy(rhs_rw, ctx, None);
@@ -1639,6 +1641,9 @@ pub fn emit_law_samples(
                 changed = false;
                 let snapshot: Vec<String> = callees.iter().cloned().collect();
                 for f in &snapshot {
+                    let Some(f_id) = crate::codegen::common::fn_id_for_dotted_name(ctx, f) else {
+                        continue;
+                    };
                     if let Some(fd) = ctx
                         .items
                         .iter()
@@ -1650,7 +1655,7 @@ pub fn emit_law_samples(
                             }
                         })
                         .chain(ctx.modules.iter().flat_map(|m| m.fn_defs.iter()))
-                        .find(|fd| &fd.name == f)
+                        .find(|fd| crate::codegen::common::fn_id_for_decl(ctx, fd) == Some(f_id))
                     {
                         let before = callees.len();
                         crate::codegen::proof_recognize::collect_called_fns_in_body(
@@ -1665,14 +1670,13 @@ pub fn emit_law_samples(
             }
             let mut fuel_targets: Vec<String> = Vec::new();
             for f in &callees {
-                if !known.contains(f) {
+                let Some(f_id) = crate::codegen::common::fn_id_for_dotted_name(ctx, f) else {
                     continue;
-                }
-                fuel_targets.push(aver_name_to_dafny(f));
-                if crate::codegen::common::fn_id_for_dotted_name(ctx, f)
-                    .is_some_and(|id| fuel_emitted.contains(&id))
-                {
-                    fuel_targets.push(crate::codegen::recursion::fuel_helper_name(f));
+                };
+                fuel_targets.push(d(f));
+                if fuel_emitted.contains(&f_id) {
+                    let helper = crate::codegen::recursion::fuel_helper_name(f);
+                    fuel_targets.push(d(&helper));
                 }
             }
             fuel_targets.sort();

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -98,25 +98,39 @@ pub(crate) fn peano_ctor_role(
     }
 }
 
-/// Collect the user functions called anywhere in `expr` — including inside
-/// interpolated strings, map literals and record updates. The descent is
-/// `expr_walk::walk`, so a new `Expr` variant cannot be skipped silently; a
-/// hand-rolled walk here once ended in `_ => {}` and a wrapper whose only call
-/// sat inside `"{f(x)}"` never entered the Dafny opaque closure.
+/// Whether a source-level call name identifies a user function rather than a
+/// builtin or constructor. Bare names are user functions; dotted names are
+/// user functions only when their head is not a builtin namespace and their
+/// leaf starts lowercase.
+fn is_user_function_call(name: &str) -> bool {
+    if !name.contains('.') {
+        return true;
+    }
+    let head = name.split('.').next().unwrap_or(name);
+    let leaf = name.rsplit('.').next().unwrap_or(name);
+    !crate::ir::is_builtin_namespace(head) && leaf.chars().next().is_some_and(|c| c.is_lowercase())
+}
+
+/// Collect the user functions called anywhere in `expr` — including
+/// cross-module calls and calls inside interpolated strings, map literals and
+/// record updates. Builtin namespace methods and constructor/type calls stay
+/// excluded. The descent is `expr_walk::walk`, so a new `Expr` variant cannot
+/// be skipped silently; a hand-rolled walk here once ended in `_ => {}` and a
+/// wrapper whose only call sat inside `"{f(x)}"` never entered the Dafny opaque
+/// closure.
 pub(crate) fn collect_called_fns(
     expr: &Spanned<Expr>,
     out: &mut std::collections::BTreeSet<String>,
 ) {
     crate::codegen::expr_walk::walk(expr, &mut |node| match &node.node {
         Expr::FnCall(f, _) => {
-            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&f.node) {
-                // Skip builtins — only user functions need fuel
-                if !name.contains('.') {
-                    out.insert(name);
-                }
+            if let Some(name) = crate::codegen::common::expr_to_dotted_name(&f.node)
+                && is_user_function_call(&name)
+            {
+                out.insert(name);
             }
         }
-        Expr::TailCall(tc) if !tc.target.contains('.') => {
+        Expr::TailCall(tc) if is_user_function_call(&tc.target) => {
             out.insert(tc.target.clone());
         }
         _ => {}

--- a/tests/proof_spec/opaque_closure.rs
+++ b/tests/proof_spec/opaque_closure.rs
@@ -3,16 +3,26 @@ use super::*;
 /// Export `source` to Dafny (no `dafny` binary needed) and return every
 /// emitted `.dfy` file concatenated.
 fn export_dafny_inline(source: &str, prefix: &str) -> String {
+    export_dafny_modules(&[("m.av", source)], "m.av", prefix)
+}
+
+/// Export a module graph to Dafny (no `dafny` binary needed) and return every
+/// emitted `.dfy` file concatenated.
+fn export_dafny_modules(files: &[(&str, &str)], entry: &str, prefix: &str) -> String {
     let aver_bin = env!("CARGO_BIN_EXE_aver");
     let src = temp_output_dir(&format!("{prefix}-src"));
     std::fs::create_dir_all(&src).expect("create src dir");
-    std::fs::write(src.join("m.av"), source).expect("write m.av");
+    for (name, source) in files {
+        std::fs::write(src.join(name), source).unwrap_or_else(|e| panic!("write {name}: {e}"));
+    }
     let out = temp_output_dir(&format!("{prefix}-out"));
     let run = Command::new(aver_bin)
         .arg("proof")
-        .arg(src.join("m.av"))
+        .arg(src.join(entry))
         .arg("--backend")
         .arg("dafny")
+        .arg("--module-root")
+        .arg(&src)
         .arg("-o")
         .arg(&out)
         .output()
@@ -43,7 +53,7 @@ fn program(module: &str, wrapper: &str) -> String {
 /// `requires` and a `{:fuel ...}` attribute for the opaque callee it reaches.
 /// Without them the exporter states an unbounded universal it has no basis
 /// for (`wrapInterp(3) == "1"`, not `"0"`).
-fn assert_lemma_is_bounded_and_fuelled(text: &str, lemma: &str) {
+fn assert_lemma_is_bounded_and_fuelled(text: &str, lemma: &str, fuel_target: &str) {
     let sig = format!("{lemma}(n: int)");
     let at = text
         .find(&sig)
@@ -52,8 +62,8 @@ fn assert_lemma_is_bounded_and_fuelled(text: &str, lemma: &str) {
     let body_open = text[at..].find("\n{").map_or(text.len(), |i| at + i);
     let lemma_text = &text[header_start..body_open];
     assert!(
-        lemma_text.contains("{:fuel pingA"),
-        "lemma `{lemma}` lost the fuel attribute for the opaque callee:\n{lemma_text}"
+        text.contains(&format!("{{:fuel {fuel_target}")),
+        "lemma `{lemma}` lost the fuel attribute for the opaque callee:\n{text}"
     );
     assert!(
         lemma_text.contains("requires n == 2"),
@@ -71,7 +81,7 @@ fn a_wrapper_reaching_a_mutual_pair_directly_gets_a_bounded_lemma() {
         ),
         "aver-opaque-direct",
     );
-    assert_lemma_is_bounded_and_fuelled(&text, "wrapDirect_wrapDirectIsStable");
+    assert_lemma_is_bounded_and_fuelled(&text, "wrapDirect_wrapDirectIsStable", "pingA");
 }
 
 #[test]
@@ -84,7 +94,7 @@ fn a_wrapper_reaching_a_mutual_pair_through_an_interpolated_string_gets_a_bounde
         ),
         "aver-opaque-interp",
     );
-    assert_lemma_is_bounded_and_fuelled(&text, "wrapInterp_wrapInterpIsStable");
+    assert_lemma_is_bounded_and_fuelled(&text, "wrapInterp_wrapInterpIsStable", "pingA");
 }
 
 #[test]
@@ -97,5 +107,30 @@ fn a_wrapper_reaching_a_mutual_pair_through_a_map_literal_gets_a_bounded_lemma()
         ),
         "aver-opaque-maplit",
     );
-    assert_lemma_is_bounded_and_fuelled(&text, "wrapMap_wrapMapIsStable");
+    assert_lemma_is_bounded_and_fuelled(&text, "wrapMap_wrapMapIsStable", "pingA");
+}
+
+#[test]
+fn a_wrapper_reaching_a_cross_module_mutual_pair_gets_a_bounded_lemma() {
+    let digits = program("Digits", "");
+    let entry = "module OpaqueCrossModule\n\
+        \x20   depends [Digits]\n\
+        \x20   intent =\n\
+        \x20       \"A wrapper reaching a dependency's fuel-encoded mutual pair.\"\n\n\
+        fn wrapCrossModule(n: Int) -> Int\n\
+        \x20   ? \"Reaches the mutual pair only through a cross-module call.\"\n\
+        \x20   Digits.pingA(n)\n\n\
+        verify wrapCrossModule law wrapCrossModuleIsStable\n\
+        \x20   given n: Int = [2]\n\
+        \x20   wrapCrossModule(n) => 0\n";
+    let text = export_dafny_modules(
+        &[("Digits.av", &digits), ("OpaqueCrossModule.av", entry)],
+        "OpaqueCrossModule.av",
+        "aver-opaque-cross-module",
+    );
+    assert_lemma_is_bounded_and_fuelled(
+        &text,
+        "wrapCrossModule_wrapCrossModuleIsStable",
+        "Aver_Digits.pingA",
+    );
 }

--- a/tests/proof_spec/opaque_closure.rs
+++ b/tests/proof_spec/opaque_closure.rs
@@ -29,8 +29,8 @@ fn export_dafny_modules(files: &[(&str, &str)], entry: &str, prefix: &str) -> St
         .expect("expected `aver proof --backend dafny` to run");
     assert!(run.status.success(), "{}", format_output(&run));
     let mut text = String::new();
-    for entry in std::fs::read_dir(&out).expect("read out dir") {
-        let path = entry.expect("dir entry").path();
+    for dir_entry in std::fs::read_dir(&out).expect("read out dir") {
+        let path = dir_entry.expect("dir entry").path();
         if path.extension().is_some_and(|e| e == "dfy") {
             text.push_str(&std::fs::read_to_string(&path).expect("read .dfy"));
         }
@@ -45,29 +45,42 @@ fn pongB(n: Int) -> Int\n    ? \"Bounces back.\"\n    match n <= 0\n        true
 
 fn program(module: &str, wrapper: &str) -> String {
     format!(
-        "module {module}\n    intent =\n        \"A wrapper reaching a fuel-encoded mutual pair.\"\n\n{MUTUAL_PAIR}{wrapper}"
+        "module {module}\n    intent =\n        \"A fuel-encoded mutual pair.\"\n\n{MUTUAL_PAIR}{wrapper}"
     )
 }
 
-/// The wrapper's law lemma must carry the law's `given` domain as a
-/// `requires` and a `{:fuel ...}` attribute for the opaque callee it reaches.
-/// Without them the exporter states an unbounded universal it has no basis
-/// for (`wrapInterp(3) == "1"`, not `"0"`).
-fn assert_lemma_is_bounded_and_fuelled(text: &str, lemma: &str, fuel_target: &str) {
-    let sig = format!("{lemma}(n: int)");
+/// The header of the lemma whose signature starts with `sig`, from the
+/// start of its line up to the body's opening brace.
+fn lemma_header<'a>(text: &'a str, sig: &str) -> &'a str {
     let at = text
-        .find(&sig)
-        .unwrap_or_else(|| panic!("no lemma `{lemma}` in emitted Dafny:\n{text}"));
+        .find(sig)
+        .unwrap_or_else(|| panic!("no lemma `{sig}` in emitted Dafny:\n{text}"));
     let header_start = text[..at].rfind('\n').map_or(0, |i| i + 1);
     let body_open = text[at..].find("\n{").map_or(text.len(), |i| at + i);
-    let lemma_text = &text[header_start..body_open];
+    &text[header_start..body_open]
+}
+
+/// The wrapper's universal law lemma must carry the law's `given` domain as
+/// a `requires`; without it the exporter states an unbounded universal it
+/// has no basis for (`wrapInterp(3) == "1"`, not `"0"`).
+fn assert_lemma_is_bounded(text: &str, lemma: &str) {
+    let header = lemma_header(text, &format!("{lemma}(n: int)"));
     assert!(
-        text.contains(&format!("{{:fuel {fuel_target}")),
-        "lemma `{lemma}` lost the fuel attribute for the opaque callee:\n{text}"
+        header.contains("requires n == 2"),
+        "lemma `{lemma}` lost the law's given-domain bound:\n{header}"
     );
+}
+
+/// The lemma that actually unfolds the opaque callee must carry its
+/// `{:fuel ...}` attribute. In a single module that is the universal lemma
+/// itself; across modules the universal dispatches to a per-sample lemma,
+/// and the fuel sits there (the universal-lemma fuel emitters still drop
+/// dotted names — a known gap, out of scope here).
+fn assert_lemma_is_fuelled(text: &str, sig: &str, fuel_target: &str) {
+    let header = lemma_header(text, sig);
     assert!(
-        lemma_text.contains("requires n == 2"),
-        "lemma `{lemma}` lost the law's given-domain bound:\n{lemma_text}"
+        header.contains(&format!("{{:fuel {fuel_target}")),
+        "lemma `{sig}` lost the fuel attribute for the opaque callee:\n{header}"
     );
 }
 
@@ -81,7 +94,8 @@ fn a_wrapper_reaching_a_mutual_pair_directly_gets_a_bounded_lemma() {
         ),
         "aver-opaque-direct",
     );
-    assert_lemma_is_bounded_and_fuelled(&text, "wrapDirect_wrapDirectIsStable", "pingA");
+    assert_lemma_is_bounded(&text, "wrapDirect_wrapDirectIsStable");
+    assert_lemma_is_fuelled(&text, "wrapDirect_wrapDirectIsStable(n: int)", "pingA");
 }
 
 #[test]
@@ -94,7 +108,8 @@ fn a_wrapper_reaching_a_mutual_pair_through_an_interpolated_string_gets_a_bounde
         ),
         "aver-opaque-interp",
     );
-    assert_lemma_is_bounded_and_fuelled(&text, "wrapInterp_wrapInterpIsStable", "pingA");
+    assert_lemma_is_bounded(&text, "wrapInterp_wrapInterpIsStable");
+    assert_lemma_is_fuelled(&text, "wrapInterp_wrapInterpIsStable(n: int)", "pingA");
 }
 
 #[test]
@@ -107,7 +122,8 @@ fn a_wrapper_reaching_a_mutual_pair_through_a_map_literal_gets_a_bounded_lemma()
         ),
         "aver-opaque-maplit",
     );
-    assert_lemma_is_bounded_and_fuelled(&text, "wrapMap_wrapMapIsStable", "pingA");
+    assert_lemma_is_bounded(&text, "wrapMap_wrapMapIsStable");
+    assert_lemma_is_fuelled(&text, "wrapMap_wrapMapIsStable(n: int)", "pingA");
 }
 
 #[test]
@@ -128,9 +144,10 @@ fn a_wrapper_reaching_a_cross_module_mutual_pair_gets_a_bounded_lemma() {
         "OpaqueCrossModule.av",
         "aver-opaque-cross-module",
     );
-    assert_lemma_is_bounded_and_fuelled(
+    assert_lemma_is_bounded(&text, "wrapCrossModule_wrapCrossModuleIsStable");
+    assert_lemma_is_fuelled(
         &text,
-        "wrapCrossModule_wrapCrossModuleIsStable",
+        "wrapCrossModule_wrapCrossModuleIsStable__sample_1(",
         "Aver_Digits.pingA",
     );
 }


### PR DESCRIPTION
`proof_recognize::collect_called_fns` kept a called name only when it had no dot, which dropped builtins (intended) and cross-module user calls such as `Mod.helper` (not intended). Three consumers resolve names through `fn_id_for_dotted_name` and therefore never saw a cross-module callee; for `dafny::transitive_opaque_closure` that meant a wrapper whose only path to a fuel-encoded pair is a cross-module call never entered the opaque set, and its law lemma lost the `requires` bound. The collector now keeps a bare name, and a dotted name only when its head is not a builtin namespace (`ir::is_builtin_namespace`) and its leaf starts lowercase.

One consumer needed an adapter: the Dafny bounded-sample emitter gated fuel targets on a bare-name set while its native-emission decision already resolved dotted names, so a cross-module sample could be demoted to an axiom assumption without the fuel that would let it close. It now resolves both halves by function identity, expands the transitive cone by identity, and renders fuel targets and fuel helpers with the owning Dafny module qualifier. The other fifteen call sites either already resolve by identity or filter through a bare-name lookup that ignores dotted names; none changes.

A two-module export-level regression (`Digits` holding the mutual pair, an entry module reaching it only through `Digits.pingA`) asserts the universal lemma keeps `requires n == 2` and that the dispatched `__sample_1` lemma carries `{:fuel Aver_Digits.pingA, ...}`; before the change it lost the bound. Known gap, out of scope: the universal-lemma fuel emitters still filter dotted names, so the universal itself carries no cross-module fuel attribute. No other fixture's emitted Dafny changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)