### PR TITLE
Give MirExpr one child walk and delete the nine copies

### DIFF
--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -6905,7 +6905,7 @@ fn discover_builtins_in_expr(
 /// anywhere in the program, insertion-order deduped. These are the
 /// "address-taken" fns — each needs a slot in the module's funcref
 /// table so a `Fn`-param can carry its dense index. Mirror of the
-/// full-tree walk shape `own_param.rs::visit_children` uses; built
+/// full-tree walk shape `ir::mir::expr::walk_children` uses; built
 /// here standalone so module assembly doesn't depend on optimizer
 /// internals.
 /// Refuse any fabricated intrinsic the wasm-gc family cannot lower.

--- a/src/ir/mir/expr.rs
+++ b/src/ir/mir/expr.rs
@@ -210,6 +210,175 @@ pub enum MirExpr {
     Unbox(std::boxed::Box<Spanned<MirExpr>>),
 }
 
+/// Apply `f` to every immediate sub-expression of `e` in evaluation order.
+///
+/// The exhaustive match makes adding a `MirExpr` variant a compile error here,
+/// keeping read-only MIR traversals on one canonical child enumeration.
+pub(crate) fn walk_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
+    match e {
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
+        MirExpr::Let(l) => {
+            f(&l.node.value.node);
+            f(&l.node.body.node);
+        }
+        MirExpr::Call(c) => {
+            for a in &c.node.args {
+                f(&a.node);
+            }
+        }
+        MirExpr::TailCall(tc) => {
+            for a in &tc.node.args {
+                f(&a.node);
+            }
+        }
+        MirExpr::BinOp(b) => {
+            f(&b.node.lhs.node);
+            f(&b.node.rhs.node);
+        }
+        MirExpr::Neg(inner)
+        | MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => f(&inner.node),
+        MirExpr::Match(m) => {
+            f(&m.node.subject.node);
+            for arm in &m.node.arms {
+                f(&arm.body.node);
+            }
+        }
+        MirExpr::Construct(c) => {
+            for a in &c.node.args {
+                f(&a.node);
+            }
+        }
+        MirExpr::RecordCreate(r) => {
+            for field in &r.node.fields {
+                f(&field.value.node);
+            }
+        }
+        MirExpr::RecordUpdate(u) => {
+            f(&u.node.base.node);
+            for field in &u.node.updates {
+                f(&field.value.node);
+            }
+        }
+        MirExpr::Project(p) => f(&p.node.base.node),
+        MirExpr::IfThenElse(ite) => {
+            f(&ite.node.cond.node);
+            f(&ite.node.then_branch.node);
+            f(&ite.node.else_branch.node);
+        }
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for i in items {
+                f(&i.node);
+            }
+        }
+        MirExpr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                f(&k.node);
+                f(&v.node);
+            }
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let MirStrPart::Expr(e) = p {
+                    f(&e.node);
+                }
+            }
+        }
+        MirExpr::IndependentProduct(ip) => {
+            for i in &ip.node.items {
+                f(&i.node);
+            }
+        }
+    }
+}
+
+/// Apply `f` to every immediate mutable sub-expression of `e` in evaluation
+/// order.
+///
+/// Callers supply their own recursive pass so this helper only owns the
+/// exhaustive child enumeration, not traversal policy.
+pub(crate) fn walk_children_mut(e: &mut MirExpr, f: &mut dyn FnMut(&mut Spanned<MirExpr>)) {
+    match e {
+        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
+        MirExpr::Let(l) => {
+            f(&mut l.node.value);
+            f(&mut l.node.body);
+        }
+        MirExpr::Call(c) => {
+            for a in &mut c.node.args {
+                f(a);
+            }
+        }
+        MirExpr::TailCall(tc) => {
+            for a in &mut tc.node.args {
+                f(a);
+            }
+        }
+        MirExpr::BinOp(b) => {
+            f(&mut b.node.lhs);
+            f(&mut b.node.rhs);
+        }
+        MirExpr::Neg(inner)
+        | MirExpr::Try(inner)
+        | MirExpr::Return(inner)
+        | MirExpr::Box(inner)
+        | MirExpr::Unbox(inner) => f(inner),
+        MirExpr::Match(m) => {
+            f(&mut m.node.subject);
+            for arm in &mut m.node.arms {
+                f(&mut arm.body);
+            }
+        }
+        MirExpr::Construct(c) => {
+            for a in &mut c.node.args {
+                f(a);
+            }
+        }
+        MirExpr::RecordCreate(r) => {
+            for field in &mut r.node.fields {
+                f(&mut field.value);
+            }
+        }
+        MirExpr::RecordUpdate(u) => {
+            f(&mut u.node.base);
+            for field in &mut u.node.updates {
+                f(&mut field.value);
+            }
+        }
+        MirExpr::Project(p) => f(&mut p.node.base),
+        MirExpr::IfThenElse(ite) => {
+            f(&mut ite.node.cond);
+            f(&mut ite.node.then_branch);
+            f(&mut ite.node.else_branch);
+        }
+        MirExpr::List(items) | MirExpr::Tuple(items) => {
+            for i in items {
+                f(i);
+            }
+        }
+        MirExpr::MapLiteral(pairs) => {
+            for (k, v) in pairs {
+                f(k);
+                f(v);
+            }
+        }
+        MirExpr::InterpolatedStr(parts) => {
+            for p in parts {
+                if let MirStrPart::Expr(e) = p {
+                    f(e);
+                }
+            }
+        }
+        MirExpr::IndependentProduct(ip) => {
+            for i in &mut ip.node.items {
+                f(i);
+            }
+        }
+    }
+}
+
 /// `let binding = value; body`.
 ///
 /// Phase 5 wave-Let foundation: `binding_name` carries the

--- a/src/ir/mir/optimize/algebraic.rs
+++ b/src/ir/mir/optimize/algebraic.rs
@@ -14,7 +14,7 @@
 
 use crate::ast::{BinOp, Literal, Spanned};
 
-use super::super::expr::MirExpr;
+use super::super::expr::{MirExpr, walk_children_mut};
 use super::super::program::MirProgram;
 use super::dead_code::is_pure;
 
@@ -165,83 +165,7 @@ fn int_literal(node: &MirExpr) -> Option<i64> {
 }
 
 fn algebraic_walk_children(node: &mut MirExpr) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => algebraic_in_place(inner),
-        MirExpr::BinOp(spanned_bop) => {
-            algebraic_in_place(&mut spanned_bop.node.lhs);
-            algebraic_in_place(&mut spanned_bop.node.rhs);
-        }
-        MirExpr::Let(spanned_let) => {
-            algebraic_in_place(&mut spanned_let.node.value);
-            algebraic_in_place(&mut spanned_let.node.body);
-        }
-        MirExpr::Call(spanned_call) => {
-            for arg in &mut spanned_call.node.args {
-                algebraic_in_place(arg);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &mut spanned_tc.node.args {
-                algebraic_in_place(arg);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            algebraic_in_place(&mut spanned_match.node.subject);
-            for arm in &mut spanned_match.node.arms {
-                algebraic_in_place(&mut arm.body);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            algebraic_in_place(&mut spanned_ite.node.cond);
-            algebraic_in_place(&mut spanned_ite.node.then_branch);
-            algebraic_in_place(&mut spanned_ite.node.else_branch);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            for arg in &mut spanned_ctor.node.args {
-                algebraic_in_place(arg);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &mut spanned_rec.node.fields {
-                algebraic_in_place(&mut f.value);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            algebraic_in_place(&mut spanned_upd.node.base);
-            for f in &mut spanned_upd.node.updates {
-                algebraic_in_place(&mut f.value);
-            }
-        }
-        MirExpr::Project(spanned_proj) => algebraic_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => algebraic_in_place(inner),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                algebraic_in_place(item);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                algebraic_in_place(k);
-                algebraic_in_place(v);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    algebraic_in_place(e);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &mut spanned_ip.node.items {
-                algebraic_in_place(item);
-            }
-        }
-    }
+    walk_children_mut(node, &mut |child| algebraic_in_place(child));
 }
 
 #[cfg(test)]

--- a/src/ir/mir/optimize/bare_i64.rs
+++ b/src/ir/mir/optimize/bare_i64.rs
@@ -2235,90 +2235,10 @@ pub(crate) fn tests_visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
     visit_children(e, f)
 }
 
-/// Apply `f` to every immediate sub-expression of `e`. Kept in sync with
-/// the exhaustive walk in `own_param.rs` / `instantiations.rs`. `pub(crate)`
-/// so the sibling `bare_i64_rewrite` pass (the wasm-gc `mutual_recursion_box_set`
-/// call-graph walk) can reuse this one exhaustive child enumeration instead
-/// of forking a second copy.
-pub(crate) fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
-    match e {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Let(l) => {
-            f(&l.node.value.node);
-            f(&l.node.body.node);
-        }
-        MirExpr::Call(c) => {
-            for a in &c.node.args {
-                f(&a.node);
-            }
-        }
-        MirExpr::TailCall(tc) => {
-            for a in &tc.node.args {
-                f(&a.node);
-            }
-        }
-        MirExpr::BinOp(b) => {
-            f(&b.node.lhs.node);
-            f(&b.node.rhs.node);
-        }
-        MirExpr::Neg(inner)
-        | MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => f(&inner.node),
-        MirExpr::Match(m) => {
-            f(&m.node.subject.node);
-            for arm in &m.node.arms {
-                f(&arm.body.node);
-            }
-        }
-        MirExpr::Construct(c) => {
-            for a in &c.node.args {
-                f(&a.node);
-            }
-        }
-        MirExpr::RecordCreate(r) => {
-            for field in &r.node.fields {
-                f(&field.value.node);
-            }
-        }
-        MirExpr::RecordUpdate(u) => {
-            f(&u.node.base.node);
-            for field in &u.node.updates {
-                f(&field.value.node);
-            }
-        }
-        MirExpr::Project(p) => f(&p.node.base.node),
-        MirExpr::IfThenElse(ite) => {
-            f(&ite.node.cond.node);
-            f(&ite.node.then_branch.node);
-            f(&ite.node.else_branch.node);
-        }
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for i in items {
-                f(&i.node);
-            }
-        }
-        MirExpr::MapLiteral(pairs) => {
-            for (k, v) in pairs {
-                f(&k.node);
-                f(&v.node);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for p in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = p {
-                    f(&e.node);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(ip) => {
-            for i in &ip.node.items {
-                f(&i.node);
-            }
-        }
-    }
-}
+/// Compatibility name for the canonical exhaustive child walk beside
+/// [`MirExpr`] in `expr.rs`. The sibling `bare_i64_rewrite` pass and Rust
+/// codegen use this path without maintaining another variant match.
+pub(crate) use crate::ir::mir::expr::walk_children as visit_children;
 
 #[cfg(test)]
 mod tests {

--- a/src/ir/mir/optimize/bool_match.rs
+++ b/src/ir/mir/optimize/bool_match.rs
@@ -14,7 +14,7 @@
 
 use crate::ast::{Literal, Spanned};
 
-use super::super::expr::{MirExpr, MirIfThenElse, MirMatchArm, MirPattern};
+use super::super::expr::{MirExpr, MirIfThenElse, MirMatchArm, MirPattern, walk_children_mut};
 use super::super::program::MirProgram;
 
 pub fn bool_match_to_if(mut program: MirProgram) -> MirProgram {
@@ -107,83 +107,7 @@ fn bool_pattern(p: &MirPattern) -> Option<BoolPat> {
 }
 
 fn bool_match_walk_children(node: &mut MirExpr) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => bool_match_in_place(inner),
-        MirExpr::BinOp(spanned_bop) => {
-            bool_match_in_place(&mut spanned_bop.node.lhs);
-            bool_match_in_place(&mut spanned_bop.node.rhs);
-        }
-        MirExpr::Let(spanned_let) => {
-            bool_match_in_place(&mut spanned_let.node.value);
-            bool_match_in_place(&mut spanned_let.node.body);
-        }
-        MirExpr::Call(spanned_call) => {
-            for arg in &mut spanned_call.node.args {
-                bool_match_in_place(arg);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &mut spanned_tc.node.args {
-                bool_match_in_place(arg);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            bool_match_in_place(&mut spanned_match.node.subject);
-            for arm in &mut spanned_match.node.arms {
-                bool_match_in_place(&mut arm.body);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            bool_match_in_place(&mut spanned_ite.node.cond);
-            bool_match_in_place(&mut spanned_ite.node.then_branch);
-            bool_match_in_place(&mut spanned_ite.node.else_branch);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            for arg in &mut spanned_ctor.node.args {
-                bool_match_in_place(arg);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &mut spanned_rec.node.fields {
-                bool_match_in_place(&mut f.value);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            bool_match_in_place(&mut spanned_upd.node.base);
-            for f in &mut spanned_upd.node.updates {
-                bool_match_in_place(&mut f.value);
-            }
-        }
-        MirExpr::Project(spanned_proj) => bool_match_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => bool_match_in_place(inner),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                bool_match_in_place(item);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                bool_match_in_place(k);
-                bool_match_in_place(v);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    bool_match_in_place(e);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &mut spanned_ip.node.items {
-                bool_match_in_place(item);
-            }
-        }
-    }
+    walk_children_mut(node, &mut |child| bool_match_in_place(child));
 }
 
 #[cfg(test)]

--- a/src/ir/mir/optimize/branch_collapse.rs
+++ b/src/ir/mir/optimize/branch_collapse.rs
@@ -15,7 +15,7 @@
 
 use crate::ast::{Literal, Spanned};
 
-use super::super::expr::MirExpr;
+use super::super::expr::{MirExpr, walk_children_mut};
 use super::super::program::MirProgram;
 
 pub fn branch_collapse(mut program: MirProgram) -> MirProgram {
@@ -70,83 +70,7 @@ enum BranchSide {
 }
 
 fn branch_collapse_walk_children(node: &mut MirExpr) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => branch_collapse_in_place(inner),
-        MirExpr::BinOp(spanned_bop) => {
-            branch_collapse_in_place(&mut spanned_bop.node.lhs);
-            branch_collapse_in_place(&mut spanned_bop.node.rhs);
-        }
-        MirExpr::Let(spanned_let) => {
-            branch_collapse_in_place(&mut spanned_let.node.value);
-            branch_collapse_in_place(&mut spanned_let.node.body);
-        }
-        MirExpr::Call(spanned_call) => {
-            for arg in &mut spanned_call.node.args {
-                branch_collapse_in_place(arg);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &mut spanned_tc.node.args {
-                branch_collapse_in_place(arg);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            branch_collapse_in_place(&mut spanned_match.node.subject);
-            for arm in &mut spanned_match.node.arms {
-                branch_collapse_in_place(&mut arm.body);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            branch_collapse_in_place(&mut spanned_ite.node.cond);
-            branch_collapse_in_place(&mut spanned_ite.node.then_branch);
-            branch_collapse_in_place(&mut spanned_ite.node.else_branch);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            for arg in &mut spanned_ctor.node.args {
-                branch_collapse_in_place(arg);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &mut spanned_rec.node.fields {
-                branch_collapse_in_place(&mut f.value);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            branch_collapse_in_place(&mut spanned_upd.node.base);
-            for f in &mut spanned_upd.node.updates {
-                branch_collapse_in_place(&mut f.value);
-            }
-        }
-        MirExpr::Project(spanned_proj) => branch_collapse_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => branch_collapse_in_place(inner),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                branch_collapse_in_place(item);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                branch_collapse_in_place(k);
-                branch_collapse_in_place(v);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    branch_collapse_in_place(e);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &mut spanned_ip.node.items {
-                branch_collapse_in_place(item);
-            }
-        }
-    }
+    walk_children_mut(node, &mut |child| branch_collapse_in_place(child));
 }
 
 #[cfg(test)]

--- a/src/ir/mir/optimize/const_fold.rs
+++ b/src/ir/mir/optimize/const_fold.rs
@@ -36,8 +36,8 @@ use crate::ir::hir::{BuiltinCtor, BuiltinIntrinsic};
 use crate::types::Type;
 
 use super::super::expr::{
-    MirBinOp, MirCall, MirCallee, MirConstruct, MirCtor, MirExpr, MirLet, MirMatch, MirMatchArm,
-    MirPattern,
+    MirCall, MirCallee, MirConstruct, MirCtor, MirExpr, MirLet, MirMatch, MirPattern,
+    walk_children_mut,
 };
 use super::super::program::MirProgram;
 use super::dead_code::is_pure;
@@ -92,94 +92,7 @@ fn literal_span(lit: Literal, source: &Spanned<MirExpr>) -> Spanned<Literal> {
 }
 
 fn walk_children(node: &mut MirExpr, builtins: &[String]) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => fold_in_place(inner, builtins),
-        MirExpr::BinOp(spanned_bop) => {
-            let bop: &mut MirBinOp = &mut spanned_bop.node;
-            fold_in_place(&mut bop.lhs, builtins);
-            fold_in_place(&mut bop.rhs, builtins);
-        }
-        MirExpr::Let(spanned_let) => {
-            let let_node: &mut MirLet = &mut spanned_let.node;
-            fold_in_place(&mut let_node.value, builtins);
-            fold_in_place(&mut let_node.body, builtins);
-        }
-        MirExpr::Call(spanned_call) => {
-            let call: &mut MirCall = &mut spanned_call.node;
-            for arg in &mut call.args {
-                fold_in_place(arg, builtins);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &mut spanned_tc.node.args {
-                fold_in_place(arg, builtins);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            fold_in_place(&mut spanned_match.node.subject, builtins);
-            for arm in &mut spanned_match.node.arms {
-                fold_arm(arm, builtins);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            fold_in_place(&mut spanned_ite.node.cond, builtins);
-            fold_in_place(&mut spanned_ite.node.then_branch, builtins);
-            fold_in_place(&mut spanned_ite.node.else_branch, builtins);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            let ctor: &mut MirConstruct = &mut spanned_ctor.node;
-            for arg in &mut ctor.args {
-                fold_in_place(arg, builtins);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &mut spanned_rec.node.fields {
-                fold_in_place(&mut f.value, builtins);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            fold_in_place(&mut spanned_upd.node.base, builtins);
-            for f in &mut spanned_upd.node.updates {
-                fold_in_place(&mut f.value, builtins);
-            }
-        }
-        MirExpr::Project(spanned_proj) => fold_in_place(&mut spanned_proj.node.base, builtins),
-        MirExpr::Try(inner) => fold_in_place(inner, builtins),
-        MirExpr::Return(inner) => fold_in_place(inner, builtins),
-        MirExpr::Box(inner) | MirExpr::Unbox(inner) => fold_in_place(inner, builtins),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                fold_in_place(item, builtins);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                fold_in_place(k, builtins);
-                fold_in_place(v, builtins);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    fold_in_place(e, builtins);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &mut spanned_ip.node.items {
-                fold_in_place(item, builtins);
-            }
-        }
-    }
-}
-
-fn fold_arm(arm: &mut MirMatchArm, builtins: &[String]) {
-    // Don't recurse into the pattern — patterns are structural
-    // and don't contain `MirExpr` subtrees.
-    let _ = &arm.pattern;
-    let _: &MirPattern = &arm.pattern;
-    fold_in_place(&mut arm.body, builtins);
+    walk_children_mut(node, &mut |child| fold_in_place(child, builtins));
 }
 
 fn try_fold(node: &MirExpr) -> Option<Literal> {
@@ -741,6 +654,7 @@ pub(super) fn literal_eq(a: &Literal, b: &Literal) -> Option<bool> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::super::expr::{MirBinOp, MirMatchArm};
     use super::super::test_helpers::{body_of, one_fn_program, span};
     use super::*;
 

--- a/src/ir/mir/optimize/dead_code.rs
+++ b/src/ir/mir/optimize/dead_code.rs
@@ -14,7 +14,7 @@
 
 use crate::ast::{Literal, Spanned};
 
-use super::super::expr::{MirBinOp, MirExpr, MirLet};
+use super::super::expr::{MirExpr, walk_children, walk_children_mut};
 use super::super::program::{LocalId, MirProgram};
 
 pub fn dead_code(mut program: MirProgram) -> MirProgram {
@@ -54,84 +54,7 @@ fn dce_in_place(expr: &mut Spanned<MirExpr>) {
 }
 
 fn dce_walk_children(node: &mut MirExpr) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => dce_in_place(inner),
-        MirExpr::BinOp(spanned_bop) => {
-            let bop: &mut MirBinOp = &mut spanned_bop.node;
-            dce_in_place(&mut bop.lhs);
-            dce_in_place(&mut bop.rhs);
-        }
-        MirExpr::Let(spanned_let) => {
-            let let_node: &mut MirLet = &mut spanned_let.node;
-            dce_in_place(&mut let_node.value);
-            dce_in_place(&mut let_node.body);
-        }
-        MirExpr::Call(spanned_call) => {
-            for arg in &mut spanned_call.node.args {
-                dce_in_place(arg);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &mut spanned_tc.node.args {
-                dce_in_place(arg);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            dce_in_place(&mut spanned_match.node.subject);
-            for arm in &mut spanned_match.node.arms {
-                dce_in_place(&mut arm.body);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            dce_in_place(&mut spanned_ite.node.cond);
-            dce_in_place(&mut spanned_ite.node.then_branch);
-            dce_in_place(&mut spanned_ite.node.else_branch);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            for arg in &mut spanned_ctor.node.args {
-                dce_in_place(arg);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &mut spanned_rec.node.fields {
-                dce_in_place(&mut f.value);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            dce_in_place(&mut spanned_upd.node.base);
-            for f in &mut spanned_upd.node.updates {
-                dce_in_place(&mut f.value);
-            }
-        }
-        MirExpr::Project(spanned_proj) => dce_in_place(&mut spanned_proj.node.base),
-        MirExpr::Try(inner) => dce_in_place(inner),
-        MirExpr::Return(inner) => dce_in_place(inner),
-        MirExpr::Box(inner) | MirExpr::Unbox(inner) => dce_in_place(inner),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                dce_in_place(item);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                dce_in_place(k);
-                dce_in_place(v);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    dce_in_place(e);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &mut spanned_ip.node.items {
-                dce_in_place(item);
-            }
-        }
-    }
+    walk_children_mut(node, &mut |child| dce_in_place(child));
 }
 
 /// `true` when `body` contains a `MirExpr::Local` whose slot
@@ -148,84 +71,10 @@ fn local_is_read(target: LocalId, body: &Spanned<MirExpr>) -> bool {
 }
 
 fn visit_locals(node: &MirExpr, visit: &mut impl FnMut(LocalId)) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Local(spanned_local) => visit(spanned_local.node.slot),
-        MirExpr::Neg(inner) => visit_locals(&inner.node, visit),
-        MirExpr::BinOp(spanned_bop) => {
-            visit_locals(&spanned_bop.node.lhs.node, visit);
-            visit_locals(&spanned_bop.node.rhs.node, visit);
-        }
-        MirExpr::Let(spanned_let) => {
-            visit_locals(&spanned_let.node.value.node, visit);
-            visit_locals(&spanned_let.node.body.node, visit);
-        }
-        MirExpr::Call(spanned_call) => {
-            for arg in &spanned_call.node.args {
-                visit_locals(&arg.node, visit);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &spanned_tc.node.args {
-                visit_locals(&arg.node, visit);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            visit_locals(&spanned_match.node.subject.node, visit);
-            for arm in &spanned_match.node.arms {
-                visit_locals(&arm.body.node, visit);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            visit_locals(&spanned_ite.node.cond.node, visit);
-            visit_locals(&spanned_ite.node.then_branch.node, visit);
-            visit_locals(&spanned_ite.node.else_branch.node, visit);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            for arg in &spanned_ctor.node.args {
-                visit_locals(&arg.node, visit);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &spanned_rec.node.fields {
-                visit_locals(&f.value.node, visit);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            visit_locals(&spanned_upd.node.base.node, visit);
-            for f in &spanned_upd.node.updates {
-                visit_locals(&f.value.node, visit);
-            }
-        }
-        MirExpr::Project(spanned_proj) => visit_locals(&spanned_proj.node.base.node, visit),
-        MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => visit_locals(&inner.node, visit),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                visit_locals(&item.node, visit);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                visit_locals(&k.node, visit);
-                visit_locals(&v.node, visit);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    visit_locals(&e.node, visit);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &spanned_ip.node.items {
-                visit_locals(&item.node, visit);
-            }
-        }
+    if let MirExpr::Local(local) = node {
+        visit(local.node.slot);
     }
+    walk_children(node, &mut |child| visit_locals(child, visit));
 }
 
 /// Whether a division divisor is provably non-zero, so the division

--- a/src/ir/mir/optimize/inline.rs
+++ b/src/ir/mir/optimize/inline.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use crate::ast::{Literal, Spanned};
 use crate::ir::FnId;
 
-use super::super::expr::{MirCallee, MirExpr};
+use super::super::expr::{MirCallee, MirExpr, walk_children_mut};
 use super::super::program::MirProgram;
 
 pub fn inline_nullary_literals(mut program: MirProgram) -> MirProgram {
@@ -74,83 +74,7 @@ fn inline_in_place(expr: &mut Spanned<MirExpr>, candidates: &HashMap<FnId, Liter
 }
 
 fn inline_walk_children(node: &mut MirExpr, candidates: &HashMap<FnId, Literal>) {
-    match node {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Neg(inner) => inline_in_place(inner, candidates),
-        MirExpr::BinOp(spanned_bop) => {
-            inline_in_place(&mut spanned_bop.node.lhs, candidates);
-            inline_in_place(&mut spanned_bop.node.rhs, candidates);
-        }
-        MirExpr::Let(spanned_let) => {
-            inline_in_place(&mut spanned_let.node.value, candidates);
-            inline_in_place(&mut spanned_let.node.body, candidates);
-        }
-        MirExpr::Call(spanned_call) => {
-            for arg in &mut spanned_call.node.args {
-                inline_in_place(arg, candidates);
-            }
-        }
-        MirExpr::TailCall(spanned_tc) => {
-            for arg in &mut spanned_tc.node.args {
-                inline_in_place(arg, candidates);
-            }
-        }
-        MirExpr::Match(spanned_match) => {
-            inline_in_place(&mut spanned_match.node.subject, candidates);
-            for arm in &mut spanned_match.node.arms {
-                inline_in_place(&mut arm.body, candidates);
-            }
-        }
-        MirExpr::IfThenElse(spanned_ite) => {
-            inline_in_place(&mut spanned_ite.node.cond, candidates);
-            inline_in_place(&mut spanned_ite.node.then_branch, candidates);
-            inline_in_place(&mut spanned_ite.node.else_branch, candidates);
-        }
-        MirExpr::Construct(spanned_ctor) => {
-            for arg in &mut spanned_ctor.node.args {
-                inline_in_place(arg, candidates);
-            }
-        }
-        MirExpr::RecordCreate(spanned_rec) => {
-            for f in &mut spanned_rec.node.fields {
-                inline_in_place(&mut f.value, candidates);
-            }
-        }
-        MirExpr::RecordUpdate(spanned_upd) => {
-            inline_in_place(&mut spanned_upd.node.base, candidates);
-            for f in &mut spanned_upd.node.updates {
-                inline_in_place(&mut f.value, candidates);
-            }
-        }
-        MirExpr::Project(spanned_proj) => inline_in_place(&mut spanned_proj.node.base, candidates),
-        MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => inline_in_place(inner, candidates),
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for item in items {
-                inline_in_place(item, candidates);
-            }
-        }
-        MirExpr::MapLiteral(entries) => {
-            for (k, v) in entries {
-                inline_in_place(k, candidates);
-                inline_in_place(v, candidates);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for part in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = part {
-                    inline_in_place(e, candidates);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(spanned_ip) => {
-            for item in &mut spanned_ip.node.items {
-                inline_in_place(item, candidates);
-            }
-        }
-    }
+    walk_children_mut(node, &mut |child| inline_in_place(child, candidates));
 }
 
 #[cfg(test)]

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -89,7 +89,7 @@ use std::sync::Arc;
 use crate::ast::Spanned;
 use crate::ir::FnId;
 
-use super::super::expr::{MirCallee, MirExpr};
+use super::super::expr::{MirCallee, MirExpr, walk_children};
 use super::super::program::MirProgram;
 
 mod return_alias;
@@ -689,7 +689,7 @@ fn slot_owned(
 
 /// Collect every fn name referenced as a value (`MirExpr::FnValue`).
 fn collect_fn_values(e: &MirExpr, out: &mut HashSet<String>) {
-    visit_children(e, &mut |c| collect_fn_values(c, out));
+    walk_children(e, &mut |c| collect_fn_values(c, out));
     if let MirExpr::FnValue(name) = e {
         out.insert(name.clone());
     }
@@ -701,7 +701,7 @@ fn collect_let_bindings(e: &MirExpr, out: &mut HashMap<u32, Spanned<MirExpr>>) {
         out.entry(l.node.binding.0)
             .or_insert_with(|| (*l.node.value).clone());
     }
-    visit_children(e, &mut |c| collect_let_bindings(c, out));
+    walk_children(e, &mut |c| collect_let_bindings(c, out));
 }
 
 /// The set of source slots whose backing the value of `e` may share —
@@ -1347,7 +1347,7 @@ fn collect_local_reads(e: &MirExpr, out: &mut HashSet<u32>) {
     if let MirExpr::Local(l) = e {
         out.insert(l.node.slot.0);
     }
-    visit_children(e, &mut |c| collect_local_reads(c, out));
+    walk_children(e, &mut |c| collect_local_reads(c, out));
 }
 
 /// Interprocedural "fn captures param i" summary. `captures_param[f]`
@@ -1438,89 +1438,7 @@ fn collect_call_sites(caller: FnId, e: &MirExpr, out: &mut Vec<CallSite>) {
         }
         _ => {}
     }
-    visit_children(e, &mut |c| collect_call_sites(caller, c, out));
-}
-
-/// Apply `f` to every immediate sub-expression of `e`. Mirrors the
-/// exhaustive walk in `instantiations.rs`; keep in sync if MirExpr grows.
-fn visit_children(e: &MirExpr, f: &mut dyn FnMut(&MirExpr)) {
-    match e {
-        MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => {}
-        MirExpr::Let(l) => {
-            f(&l.node.value.node);
-            f(&l.node.body.node);
-        }
-        MirExpr::Call(c) => {
-            for a in &c.node.args {
-                f(&a.node);
-            }
-        }
-        MirExpr::TailCall(tc) => {
-            for a in &tc.node.args {
-                f(&a.node);
-            }
-        }
-        MirExpr::BinOp(b) => {
-            f(&b.node.lhs.node);
-            f(&b.node.rhs.node);
-        }
-        MirExpr::Neg(inner)
-        | MirExpr::Try(inner)
-        | MirExpr::Return(inner)
-        | MirExpr::Box(inner)
-        | MirExpr::Unbox(inner) => f(&inner.node),
-        MirExpr::Match(m) => {
-            f(&m.node.subject.node);
-            for arm in &m.node.arms {
-                f(&arm.body.node);
-            }
-        }
-        MirExpr::Construct(c) => {
-            for a in &c.node.args {
-                f(&a.node);
-            }
-        }
-        MirExpr::RecordCreate(r) => {
-            for field in &r.node.fields {
-                f(&field.value.node);
-            }
-        }
-        MirExpr::RecordUpdate(u) => {
-            f(&u.node.base.node);
-            for field in &u.node.updates {
-                f(&field.value.node);
-            }
-        }
-        MirExpr::Project(p) => f(&p.node.base.node),
-        MirExpr::IfThenElse(ite) => {
-            f(&ite.node.cond.node);
-            f(&ite.node.then_branch.node);
-            f(&ite.node.else_branch.node);
-        }
-        MirExpr::List(items) | MirExpr::Tuple(items) => {
-            for i in items {
-                f(&i.node);
-            }
-        }
-        MirExpr::MapLiteral(pairs) => {
-            for (k, v) in pairs {
-                f(&k.node);
-                f(&v.node);
-            }
-        }
-        MirExpr::InterpolatedStr(parts) => {
-            for p in parts {
-                if let super::super::expr::MirStrPart::Expr(e) = p {
-                    f(&e.node);
-                }
-            }
-        }
-        MirExpr::IndependentProduct(ip) => {
-            for i in &ip.node.items {
-                f(&i.node);
-            }
-        }
-    }
+    walk_children(e, &mut |c| collect_call_sites(caller, c, out));
 }
 
 #[cfg(test)]

--- a/src/ir/mir/optimize/own_param/return_alias.rs
+++ b/src/ir/mir/optimize/own_param/return_alias.rs
@@ -8,10 +8,10 @@ use std::collections::{HashMap, HashSet};
 
 use crate::ast::Spanned;
 use crate::ir::FnId;
-use crate::ir::mir::expr::{MirCallee, MirExpr};
+use crate::ir::mir::expr::{MirCallee, MirExpr, walk_children};
 use crate::ir::mir::program::MirProgram;
 
-use super::{MAX_DEPTH, OwnershipModel, visit_children};
+use super::{MAX_DEPTH, OwnershipModel};
 
 /// Named functions whose result has a complete alias proof, mapped to the
 /// parameter indices whose collection backing the result may carry.
@@ -255,7 +255,7 @@ fn collect_explicit_return_aliases(
     }
 
     let mut complete = true;
-    visit_children(expr, &mut |child| {
+    walk_children(expr, &mut |child| {
         complete &= collect_explicit_return_aliases(
             child,
             param_slots,


### PR DESCRIPTION
This moves the exhaustive immediate-child enumeration from duplicated optimizer walkers into `src/ir/mir/expr.rs` beside `MirExpr`. `walk_children` serves read-only consumers and `walk_children_mut` passes mutable `Spanned<MirExpr>` children to pass-specific callbacks. The six mutating passes keep their existing recursion, while read-only consumers share the immutable helper and the `bare_i64` re-export keeps established call sites stable. Traversal order is unchanged, so this is a mechanical refactor with no behavior change. Formatting, check, warning-denying clippy, all MIR unit tests, and the six specified differential, codegen, soundness, and VM integration suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)