### PR TITLE
Follow the json.wasm shape the string-index pass produces in the cert tests

### DIFF
--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2084,8 +2084,12 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
         "json compile --certify failed:
 {compile_report}"
     );
+    // The denominator counts every function in json.wasm that carries no
+    // claim. It rose from 90 to 133 when the string-index pass started
+    // synthesizing index workers for the parser's recursive `String.charAt`
+    // walks; those workers are compiler-made and have no source-level claim.
     assert!(
-        compile_report.contains("(12 certified, 90 source-level-only)"),
+        compile_report.contains("(12 certified, 133 source-level-only)"),
         "json certificate KPI denominator changed:
 {compile_report}"
     );

--- a/tests/cert_whole_module_guard_iso.rs
+++ b/tests/cert_whole_module_guard_iso.rs
@@ -133,10 +133,24 @@ fn certified_opcode_offsets(bytes: &[u8]) -> (usize, u32, usize) {
         }
     }
     let (call_offset, call_target) = call.expect("jsonInt must directly call its box helper");
-    assert!(call_target < 127, "GuardIso uses a one-byte call target");
+    // The hostile artifact below adds 1 to the byte at `call_offset`, the
+    // lowest LEB128 byte of the call target, so the call lands on the next
+    // function index whatever the encoding width is. That only holds while
+    // the low seven bits do not carry into the continuation bit.
+    assert!(
+        call_target & 0x7f != 0x7f,
+        "GuardIso bumps the low LEB byte of the call target; it must not carry"
+    );
     let local_get_offset = local_get.expect("jsonEntryKey must contain local.get");
     assert_eq!(bytes[local_get_offset], 0x20);
     (call_offset, call_target, local_get_offset)
+}
+
+/// The lowest LEB128 byte of a function index: the seven low bits plus the
+/// continuation bit whenever the index needs a second byte.
+fn leb_low_byte(index: u32) -> u8 {
+    let low = (index & 0x7f) as u8;
+    if index >= 0x80 { low | 0x80 } else { low }
 }
 
 /// Five hostile artifacts leave all sibling conjuncts true, fail exactly their
@@ -279,7 +293,7 @@ fn whole_module_guards_are_isolated_and_weaken_confirmed() {
         .position(|window| window == b"console_print")
         .expect("json wasm must import aver.console_print");
     assert_eq!(wasm[capability_offset], b'c');
-    assert_eq!(wasm[call_offset], call_target as u8);
+    assert_eq!(wasm[call_offset], leb_low_byte(call_target));
     let lean = format!(
         r#"import Artifact
 


### PR DESCRIPTION
The scheduled certification run on main has been red since 12:37 today in `cert_verify_spec rest-3/8` and `cert_whole_module_guard_iso`; the pull-request lanes only run the smoke shards, so #1035 passed CI.
Both tests pinned the shape of `examples/data/json.av` compiled to wasm-gc: the string-index pass now synthesizes index workers for the parser's recursive `String.charAt` walks, so the module carries 133 uncertified functions instead of 90 and the box helper called by `jsonInt` sits past function index 127.
The KPI check now expects 133 with a comment saying why, and the guard-isolation test no longer demands a one-byte call target: its hostile artifact adds one to the byte at the call, which is the lowest LEB128 byte at any width, so the test only requires that the bump cannot carry into the continuation bit.
Both tests pass locally with `--features wasm` and `lake` (420 s and 246 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
