### PR TITLE
Align borrows in match-subject equality the same way as in expressions

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -1178,29 +1178,7 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
                 // side is a string literal, since `Rc<str>` doesn't
                 // impl `PartialEq<&str>`. Mirror that so string
                 // equality matches.
-                if let MirExpr::Literal(lit) = &bop.rhs.node
-                    && let crate::ast::Literal::Str(s) = &lit.node
-                {
-                    return Some(format!("(&*{} {} {:?})", l, op_str, s));
-                }
-                if let MirExpr::Literal(lit) = &bop.lhs.node
-                    && let crate::ast::Literal::Str(s) = &lit.node
-                {
-                    return Some(format!("({:?} {} &*{})", s, op_str, r));
-                }
-                // Borrow-by-default makes collection / wrapper / named-type
-                // parameters `&T`, while calls and constructors still produce
-                // an owned `T`. Rust does not provide `PartialEq<&T> for T`, so
-                // compare two references whenever exactly one side is a
-                // borrowed parameter. Borrowing the owned expression is
-                // temporary, allocation-free, and preserves evaluation order.
-                let lhs_borrowed = mir_expr_is_borrowed_param_read(&bop.lhs.node, emit_ctx);
-                let rhs_borrowed = mir_expr_is_borrowed_param_read(&bop.rhs.node, emit_ctx);
-                match (lhs_borrowed, rhs_borrowed) {
-                    (false, true) => Some(format!("(&({}) {} {})", l, op_str, r)),
-                    (true, false) => Some(format!("({} {} &({}))", l, op_str, r)),
-                    _ => Some(format!("({} {} {})", l, op_str, r)),
-                }
+                Some(mir_emit_equality(bop, &l, &r, op_str, emit_ctx))
             } else {
                 Some(format!("({} {} {})", l, op_str, r))
             }
@@ -3079,6 +3057,46 @@ fn lower_int_literal_subpatterns(
     }
 }
 
+/// Emit `lhs op rhs` for `==` / `!=` so that both Rust operands have the
+/// same shape. Every comparison site must go through here: the plain
+/// expression walker and the `if` lowering of a boolean `match` used to
+/// build the operator text separately, and the second site missed the
+/// borrow alignment (#1037: `match script == made()` compiled to
+/// `(script == made())`, a `&T == T` comparison Rust rejects).
+fn mir_emit_equality(
+    bop: &crate::ir::mir::MirBinOp,
+    l: &str,
+    r: &str,
+    op_str: &str,
+    emit_ctx: &MirEmitCtx<'_>,
+) -> String {
+    // `AverStr` (Rc<str>) does not implement `PartialEq<&str>`: deref the
+    // non-literal side when the other side is a string literal.
+    if let MirExpr::Literal(lit) = &bop.rhs.node
+        && let crate::ast::Literal::Str(s) = &lit.node
+    {
+        return format!("(&*{} {} {:?})", l, op_str, s);
+    }
+    if let MirExpr::Literal(lit) = &bop.lhs.node
+        && let crate::ast::Literal::Str(s) = &lit.node
+    {
+        return format!("({:?} {} &*{})", s, op_str, r);
+    }
+    // Borrow-by-default makes collection / wrapper / named-type parameters
+    // `&T`, while calls and constructors still produce an owned `T`. Rust
+    // does not provide `PartialEq<&T> for T`, so compare two references
+    // whenever exactly one side is a borrowed parameter. Borrowing the owned
+    // expression is temporary, allocation-free, and preserves evaluation
+    // order.
+    let lhs_borrowed = mir_expr_is_borrowed_param_read(&bop.lhs.node, emit_ctx);
+    let rhs_borrowed = mir_expr_is_borrowed_param_read(&bop.rhs.node, emit_ctx);
+    match (lhs_borrowed, rhs_borrowed) {
+        (false, true) => format!("(&({}) {} {})", l, op_str, r),
+        (true, false) => format!("({} {} &({}))", l, op_str, r),
+        _ => format!("({} {} {})", l, op_str, r),
+    }
+}
+
 /// Is this expression a direct read of a borrowed-param local?
 ///
 /// A direct read emits as `name`, whose Rust type is `&T`. Projections and
@@ -3788,7 +3806,13 @@ fn mir_if_cond_and_branches<'a>(
             } else {
                 (emit_mir_expr(&bop.lhs, ctx)?, emit_mir_expr(&bop.rhs, ctx)?)
             };
-            let cond = format!("({} {} {})", l, op_str, r);
+            let cond = if matches!(bop.op, BinOp::Eq | BinOp::Neq)
+                && !(mir_expr_is_bare_i64(&bop.lhs, ctx) && mir_expr_is_bare_i64(&bop.rhs, ctx))
+            {
+                mir_emit_equality(bop, &l, &r, op_str, ctx)
+            } else {
+                format!("({} {} {})", l, op_str, r)
+            };
             if invert {
                 Some((cond, &ite.else_branch, &ite.then_branch))
             } else {
@@ -6816,11 +6840,11 @@ mod tests {
     }
 
     #[test]
-    fn if_then_else_cond_does_not_deref_string_literal() {
-        // HIR's bool-if-else condition uses a plain `emit_expr` — it
-        // does NOT apply the `BinOp` arm's `&*name == "lit"` deref. So
-        // `match name == "_"` emits `name == AverStr::from("_")` in the
-        // cond, matching HIR byte-for-byte.
+    fn if_then_else_cond_aligns_string_literal_like_expression_equality() {
+        // The `if` lowering of a boolean match goes through the same
+        // equality emitter as a plain expression (#1037 / #1060), so a
+        // string literal on one side derefs the other side exactly as
+        // `name == "_"` does outside a match subject.
         let name = MirLocal {
             slot: LocalId(0),
             last_use: false,
@@ -6842,7 +6866,7 @@ mod tests {
         let emit = emit_mir_expr(&expr, &empty_ctx()).expect("if emits");
         assert_eq!(
             emit,
-            "if (name == AverStr::from(\"_\")) { aver_rt::AverInt::from_i64(1) } else { aver_rt::AverInt::from_i64(0) }"
+            "if (&*name == \"_\") { aver_rt::AverInt::from_i64(1) } else { aver_rt::AverInt::from_i64(0) }"
         );
     }
 }

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -4443,6 +4443,103 @@ fn main() -> Unit
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Second half of #1037: the same owned-versus-borrowed comparison as the
+/// subject of a boolean `match`, which the Rust backend lowers to an `if`
+/// through its own comparison emitter. That path skipped the borrow
+/// alignment, so `match script == made()` compiled to `(script == made())`.
+#[test]
+fn match_subject_equality_with_borrowed_param_builds_and_matches_vm() {
+    let ws = temp_dir("borrowed_match_equality");
+    let source = ws.join("main.av");
+    fs::write(
+        &source,
+        r#"module Main
+    intent = "Compare an owned call result with a borrowed parameter as a match subject."
+    effects [Console]
+
+fn made() -> List<Int>
+    ? "Return a freshly built list by value."
+    [1, 2]
+
+fn paramLeft(script: List<Int>) -> String
+    ? "Borrowed parameter on the left of the match subject."
+    match script == made()
+        true -> "same"
+        false -> "other"
+
+fn paramRight(script: List<Int>) -> String
+    ? "Borrowed parameter on the right of the match subject."
+    match made() == script
+        true -> "same"
+        false -> "other"
+
+fn differs(script: List<Int>) -> String
+    ? "Inequality as a match subject across the same boundary."
+    match script != made()
+        true -> "differs"
+        false -> "same"
+
+fn named(name: String) -> String
+    ? "A string literal on the right of a match subject."
+    match name == "anchor"
+        true -> "yes"
+        false -> "no"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("left={paramLeft([1, 2])} right={paramRight([3])} neq={differs([3])} str={named("anchor")}")
+"#,
+    )
+    .expect("write borrowed-match-equality probe source");
+
+    let vm_stdout = run_vm(&source, None).expect("VM run");
+    assert_eq!(vm_stdout, "left=same right=other neq=differs str=yes");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(&source, &project, "borrowed_match_equality", None, &[])?;
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("script == &(made())")
+            || !emitted.contains("&(made()) == script")
+            || !emitted.contains("script == &(made())")
+            || !emitted.contains("&*name == \"anchor\"")
+        {
+            return Err(format!(
+                "match-subject comparisons were not aligned with the borrowed params:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, "borrowed_match_equality")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "borrowed-match-equality generated binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "borrowed-match-equality stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 /// A qualified project type inside `Fn` is a module-owned Rust path, not a
 /// compiler-owned dotted record alias. Before #1033 the context-free type
 /// renderer flattened `Worker.Shape` to the nonexistent `Worker_Shape`, so


### PR DESCRIPTION
Closes #1060. Completes #1037.

A boolean `match` lowers to an `if` whose condition is built by a second comparison emitter in the Rust backend, and that emitter never received the borrow alignment that #1038 added for plain expressions: `match script == made()` still compiled to `(script == made())`, a `&T == T` comparison Rust rejects, while the same comparison outside a match subject was already fixed this morning.
Both sites now share one equality emitter, which also applies the string-literal deref uniformly instead of only in expressions.
The differential suite gains the match-subject shape in both operand orders, plus inequality and a string literal, compiled and run against the VM result.
Neither this nor #1038 is in 0.28.1; both land in the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
