### PR TITLE
Pin the packed match-subject equality and accept last-segment capability modules

### DIFF
--- a/src/main/provider_host_cmd.rs
+++ b/src/main/provider_host_cmd.rs
@@ -274,10 +274,19 @@ pub(super) fn known_project_capabilities(
         let Ok(items) = aver::source::parse_source(&source) else {
             continue;
         };
+        // A dotted binding such as `Infra.Kv` names the module by its path;
+        // the file itself declares only the last segment (`module Kv`), the
+        // same rule the loader applies to `depends [Infra.Kv]`.
+        let expected = binding
+            .capability
+            .rsplit('.')
+            .next()
+            .unwrap_or(binding.capability.as_str());
         let declares_expected_module = items.iter().any(|item| {
             matches!(
                 item,
-                aver::ast::TopLevel::Module(module) if module.name == binding.capability
+                aver::ast::TopLevel::Module(module)
+                    if module.name == binding.capability || module.name == expected
             )
         });
         if !declares_expected_module {

--- a/tests/provider_package_workflow_spec.rs
+++ b/tests/provider_package_workflow_spec.rs
@@ -189,6 +189,38 @@ fn compile_ignores_project_binding_unused_by_entry_program() {
     );
 }
 
+/// A project may bind a capability that lives in a subdirectory and declares
+/// only the last segment of its dotted name (`infra/kv.av` with `module Kv`,
+/// bound as `Infra.Kv`), exactly as `depends [Infra.Kv]` would name it. An
+/// entry program that never reaches it must still compile, with the binding
+/// left inert, instead of being told the capability has no contract.
+#[test]
+fn compile_ignores_dotted_project_binding_declared_by_its_last_segment() {
+    let temp = tempfile::tempdir().expect("temporary dotted-binding manifest root");
+    let root = temp.path().join("app");
+    fs::create_dir_all(root.join("infra")).expect("create infra dir");
+    fs::write(
+        root.join("infra").join("kv.av"),
+        "module Kv\n    kind = capability\n    semantics = pure\n    exposes [get]\n\noperation get(key: String) -> Option<String>\n    ? \"Look a key up.\"\n",
+    )
+    .expect("write dotted capability module");
+    write_project(
+        &root,
+        "module App\n\nfn main() -> Unit\n    Unit\n",
+        "[providers]\nschema = 1\n[[providers.bindings]]\ncapability='Infra.Kv'\ncrate='kv_provider'\npackage='kv-provider'\nfactory='binding'\nversion='1'\n",
+    );
+
+    let generated = temp.path().join("generated");
+    let output = compile(&root, &generated);
+    assert!(output.status.success(), "{}", report(&output));
+    let cargo_toml =
+        fs::read_to_string(generated.join("Cargo.toml")).expect("generated Cargo.toml");
+    assert!(
+        !cargo_toml.contains("kv_provider"),
+        "inactive dotted project binding leaked into the generated program:\n{cargo_toml}"
+    );
+}
+
 #[test]
 fn rust_compiler_reports_missing_factory_and_wrong_return_type() {
     let temp = tempfile::tempdir().expect("temporary invalid factory root");

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -4540,6 +4540,82 @@ fn main() -> Unit
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// #1065: the same match-subject comparison, but the call returns a list the
+/// backend carries in its packed byte representation (a SHA-256 digest
+/// turned back into `List<Int>`), compared with a borrowed parameter. The
+/// borrow alignment must not depend on which Rust representation the list
+/// takes.
+#[test]
+fn packed_list_match_subject_equality_with_borrowed_param_builds_and_matches_vm() {
+    let ws = temp_dir("packed_match_equality");
+    let source = ws.join("main.av");
+    fs::write(
+        &source,
+        r#"module Main
+    intent = "Compare a packed digest list with a borrowed parameter as a match subject."
+    depends [Bytes, Crypto.Digest32]
+    effects [Console]
+
+fn sha256Of(script: List<Int>) -> List<Int>
+    ? "A single SHA-256 of the script bytes, as a list."
+    Bytes.toList(Crypto.Digest32.toBytes(Crypto.sha256(Result.withDefault(Bytes.fromList(script), Bytes.fromList([])))))
+
+fn matched(program: List<Int>, script: List<Int>) -> String
+    ? "Does the program commit to this script?"
+    match sha256Of(script) == program
+        true -> "matched"
+        false -> "other"
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{matched(sha256Of([1, 2, 3]), [1, 2, 3])} {matched([0], [1, 2, 3])}")
+"#,
+    )
+    .expect("write packed-match-equality probe source");
+
+    let vm_stdout = run_vm(&source, None).expect("VM run");
+    assert_eq!(vm_stdout, "matched other");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(&source, &project, "packed_match_equality", None, &[])?;
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("sha256Of(script)) == program") {
+            return Err(format!(
+                "packed match-subject comparison was not aligned with the borrowed param:\n{emitted}"
+            ));
+        }
+        let bin = cargo_build(&project, "packed_match_equality")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "packed-match-equality generated binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "packed-match-equality stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 /// A qualified project type inside `Fn` is a module-owned Rust path, not a
 /// compiler-owned dotted record alias. Before #1033 the context-free type
 /// renderer flattened `Worker.Shape` to the nonexistent `Worker_Shape`, so


### PR DESCRIPTION
Closes #1065.

The match-subject comparison in the report (a SHA-256 digest turned back into a `List<Int>`, compared with a borrowed parameter as the subject of a boolean `match`) is the shape #1061 fixed an hour after the report. Verified on the reporter's project at 002db47 with the comparison inlined: the emitted Rust reads `(&(sha256Of(script)) == program)` and the whole crate builds. The differential suite now carries that exact shape, compiled and run against the VM, so the packed list representation is covered explicitly.

Reproducing it on a subtree of that project exposed a second defect: a provider manifest binding such as `Infra.Kv` was rejected with "has no capability contract in this project" whenever the entry program did not reach it, because the project-wide capability lookup required the file to declare `module Infra.Kv`, while the language names the file by its path and lets it declare only `module Kv`. The lookup now accepts the last segment, so a binding for another entry's capability stays inert, with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
