### PR TITLE
Carry the next minor as a dev version on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
 
 [[package]]
 name = "aver-lang"
-version = "0.28.1"
+version = "0.29.0-dev"
 dependencies = [
  "aver-cert",
  "aver-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["tools/wasm-runner", "fuzz"]
 
 [package]
 name = "aver-lang"
-version = "0.28.1"
+version = "0.29.0-dev"
 edition = "2024"
 default-run = "aver"
 description = "VM and transpiler for Aver, a statically-typed language designed for AI-assisted development"

--- a/aver-lsp/Cargo.toml
+++ b/aver-lsp/Cargo.toml
@@ -16,7 +16,7 @@ name = "aver-lsp"
 path = "src/main.rs"
 
 [dependencies]
-aver = { path = "..", version = "=0.28.1", package = "aver-lang" }
+aver = { path = "..", version = "=0.29.0-dev", package = "aver-lang" }
 tower-lsp-server = "0.23"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"


### PR DESCRIPTION
A binary built from main reported the last released version, so a patched checkout and a stale install both said `aver 0.28.1`; the only way to tell them apart was the commit it was built from (the confusion behind #1060 and #1065). Main now carries the next minor with a dev suffix, `0.29.0-dev`, and the language-server pin follows it. `tools/release.py --dry-run 0.29.0` plans `0.29.0-dev -> 0.29.0` unchanged, so cutting the release works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)