### PR TITLE
Unify module visibility and declaration identity

### DIFF
--- a/src/capability.rs
+++ b/src/capability.rs
@@ -222,6 +222,57 @@ impl CapabilityRegistry {
         (declared, user_profiles.len())
     }
 
+    /// Function bodies that belong exclusively to this capability's proof
+    /// model and therefore have no place in a runtime artifact.
+    ///
+    /// Hostile declarations name model roots, but their transitive helpers
+    /// are part of the model as well.  A helper can also be reachable from an
+    /// exported ordinary function, so subtract the complete runtime closure
+    /// rather than dropping hostile roots (or private functions) by name.
+    pub(crate) fn verification_only_function_names(
+        &self,
+        module: &str,
+        fn_defs: &[FnDef],
+        exposes: &[String],
+    ) -> BTreeSet<String> {
+        let functions: BTreeMap<&str, &FnDef> =
+            fn_defs.iter().map(|fd| (fd.name.as_str(), fd)).collect();
+        let model_roots: BTreeSet<String> = self
+            .operations()
+            .filter(|operation| operation.module == module)
+            .flat_map(|operation| operation.hostile.iter().cloned())
+            .collect();
+        if model_roots.is_empty() {
+            return BTreeSet::new();
+        }
+
+        let mut errors = Vec::new();
+        let model_closure =
+            descriptor::function_closure(module, &model_roots, &functions, &mut errors);
+        debug_assert!(
+            errors.is_empty(),
+            "validated capability model closure became incomplete: {errors:?}"
+        );
+
+        let declared_exposes = crate::visibility::declared_exposes(exposes);
+        let runtime_roots: BTreeSet<String> = fn_defs
+            .iter()
+            .filter(|fd| crate::visibility::is_exposed(&fd.name, declared_exposes))
+            .map(|fd| fd.name.clone())
+            .collect();
+        let runtime_closure =
+            descriptor::function_closure(module, &runtime_roots, &functions, &mut errors);
+        debug_assert!(
+            errors.is_empty(),
+            "validated capability runtime closure became incomplete: {errors:?}"
+        );
+
+        model_closure
+            .difference(&runtime_closure)
+            .cloned()
+            .collect()
+    }
+
     pub fn merge(&mut self, other: CapabilityRegistry) {
         self.contracts.extend(other.contracts);
         self.operations.extend(other.operations);

--- a/src/capability/descriptor.rs
+++ b/src/capability/descriptor.rs
@@ -301,7 +301,7 @@ pub(super) fn render_model_descriptor(
     descriptor.into_bytes()
 }
 
-fn function_closure(
+pub(super) fn function_closure(
     scope: &str,
     roots: &BTreeSet<String>,
     functions: &BTreeMap<&str, &FnDef>,

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -1323,38 +1323,8 @@ pub fn type_key_for_name(
     name: &str,
     scope: Option<&str>,
 ) -> crate::ir::TypeKey {
-    let bare = name.rsplit('.').next().unwrap_or(name);
-    let name_is_qualified = name.contains('.');
-    if let Some(prefix) = scope
-        && !name_is_qualified
-    {
-        for m in &ctx.modules {
-            if m.prefix == prefix && m.type_defs.iter().any(|td| type_def_name(td) == bare) {
-                return crate::ir::TypeKey::in_module(prefix.to_string(), bare);
-            }
-        }
-    }
-    // Entry-declared types win the bare lookup for the entry's own code,
-    // once the current scope has had its turn.
-    if !name_is_qualified
-        && ctx.symbol_table.names_entry_scope(scope)
-        && ctx.type_defs.iter().any(|td| type_def_name(td) == bare)
-    {
-        return crate::ir::TypeKey::entry(bare);
-    }
-    if name_is_qualified
-        && let Some((prefix, bare_part)) = name.rsplit_once('.')
-        && ctx.modules.iter().any(|m| m.prefix == prefix)
-    {
-        return crate::ir::TypeKey::in_module(prefix.to_string(), bare_part);
-    }
-    if !name_is_qualified && let Some(id) = ctx.symbol_table.type_id_by_bare_name_in(bare, scope) {
+    if let Some(id) = ctx.symbol_table.resolve_type_id_in(name, scope) {
         return ctx.symbol_table.type_entry(id).key.clone();
-    }
-    for m in &ctx.modules {
-        if m.type_defs.iter().any(|td| type_def_name(td) == bare) {
-            return crate::ir::TypeKey::in_module(m.prefix.clone(), bare);
-        }
     }
     // Unresolved — fall back to entry key with the original text.
     // Callers using this typically end up with a miss in the IR

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -991,6 +991,36 @@ pub fn emit_expr_legacy(
     emit_expr(&resolved, ctx)
 }
 
+/// Source-shape adapter for a function's result expression. Capability model
+/// functions are loaded independently from the entry program, so their raw AST
+/// bodies do not always retain typechecker stamps. Carrying the declared return
+/// type through result-position matches gives Dafny enough information to pick
+/// refinement-bearing `Result` / `Option` constructor parameters without doing
+/// another name lookup in the backend.
+pub(super) fn emit_expr_legacy_with_expected(
+    expr: &crate::ast::Spanned<crate::ast::Expr>,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+    expected: &crate::types::Type,
+) -> String {
+    let active = ctx.active_module_scope();
+    let effective = scope.or(active.as_deref());
+    let resolved = ctx.resolve_expr(expr, effective);
+    stamp_result_position_type(&resolved, expected);
+    emit_expr(&resolved, ctx)
+}
+
+fn stamp_result_position_type(expr: &Spanned<ResolvedExpr>, expected: &crate::types::Type) {
+    if expr.ty().is_none() {
+        let _ = expr.ty.set(expected.clone());
+    }
+    if let ResolvedExpr::Match { arms, .. } = &expr.node {
+        for arm in arms {
+            stamp_result_position_type(&arm.body, expected);
+        }
+    }
+}
+
 /// Source-shape adapter for [`emit_pattern`]. See [`emit_expr_legacy`]
 /// for the scope-fallback rule.
 #[allow(dead_code)]

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -4,7 +4,7 @@ use crate::codegen::CodegenContext;
 use crate::codegen::common::parse_type_annotation;
 use crate::types::Type;
 
-use super::expr::{aver_name_to_dafny, emit_expr_legacy};
+use super::expr::{aver_name_to_dafny, emit_expr_legacy, emit_expr_legacy_with_expected};
 
 /// Emit a Dafny type from an Aver type annotation string.
 /// Ghost-predicate names emitted by `oracle_subtypes::dafny_subtype_predicates`
@@ -295,7 +295,7 @@ pub fn emit_fn_def(fd: &FnDef, ctx: &CodegenContext) -> String {
         .as_ref()
         .map(|lowered_fd| lowered_fd.body.as_ref())
         .unwrap_or(fd.body.as_ref());
-    let body = emit_fn_body(body_ast, ctx);
+    let body = emit_fn_body_with_expected(body_ast, ctx, &rfd.return_type);
 
     let needs_decreases = body_has_recursive_call(body_ast, &fd.name);
 
@@ -359,12 +359,18 @@ fn lower_pure_question_bang_for_emit(fd: &FnDef) -> Option<FnDef> {
 /// body inside a mutual SCC helper.
 pub(super) fn emit_fn_body(body: &FnBody, ctx: &CodegenContext) -> String {
     match body {
-        FnBody::Block(stmts) => emit_block_as_expr(stmts, ctx),
+        FnBody::Block(stmts) => emit_block_as_expr(stmts, ctx, None),
+    }
+}
+
+fn emit_fn_body_with_expected(body: &FnBody, ctx: &CodegenContext, expected: &Type) -> String {
+    match body {
+        FnBody::Block(stmts) => emit_block_as_expr(stmts, ctx, Some(expected)),
     }
 }
 
 /// Convert a block of statements into a Dafny expression.
-fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext) -> String {
+fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext, expected: Option<&Type>) -> String {
     if stmts.is_empty() {
         return "()".to_string();
     }
@@ -373,7 +379,10 @@ fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext) -> String {
     if stmts.len() == 1
         && let Stmt::Expr(expr) = &stmts[0]
     {
-        return emit_expr_legacy(expr, ctx, None);
+        return expected.map_or_else(
+            || emit_expr_legacy(expr, ctx, None),
+            |ty| emit_expr_legacy_with_expected(expr, ctx, None, ty),
+        );
     }
 
     // For blocks with bindings, collect them and emit the last expression
@@ -395,7 +404,10 @@ fn emit_block_as_expr(stmts: &[Stmt], ctx: &CodegenContext) -> String {
             }
             Stmt::Expr(expr) => {
                 if i == stmts.len() - 1 {
-                    final_expr = Some(emit_expr_legacy(expr, ctx, None));
+                    final_expr = Some(expected.map_or_else(
+                        || emit_expr_legacy(expr, ctx, None),
+                        |ty| emit_expr_legacy_with_expected(expr, ctx, None, ty),
+                    ));
                 }
             }
         }

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -565,7 +565,8 @@ fn emit_capability_resource_types(ctx: &CodegenContext, scope: Option<&str>) -> 
                 }
             };
             belongs.then(|| {
-                let declaration_name = if scope.is_some() {
+                let declaration_name = if scope.is_some() || entry_module.as_deref() == Some(module)
+                {
                     super::syntax::aver_name_to_lean(name)
                 } else {
                     super::syntax::aver_path_to_lean(canonical)

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -51,7 +51,9 @@ pub struct ModuleInfo {
     pub exposes_opaque: Vec<String>,
     /// Type definitions from the module.
     pub type_defs: Vec<TypeDef>,
-    /// Function definitions from the module (excluding `main`).
+    /// Function definitions from the module. A dependency's `main` is an
+    /// ordinary module-owned function; only the entry module's `main` has
+    /// entry-point semantics.
     pub fn_defs: Vec<FnDef>,
     /// Provider-bound declarations retained for name resolution and VM
     /// fail-closed dispatch. They have signatures but no Aver bodies.
@@ -102,7 +104,7 @@ impl ModuleInfo {
         let fn_defs = items
             .iter()
             .filter_map(|i| match i {
-                TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
+                TopLevel::FnDef(fd) => Some(fd.clone()),
                 _ => None,
             })
             .collect();

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -614,29 +614,16 @@ fn resolve_module_call<'a>(
 /// [`module_prefix_to_rust_path`], the same helpers the runtime
 /// cross-module ctor / fn-ref emit uses.
 ///
-/// Identity comes from the `MirRecordCreate.type_id` when present (the
-/// resolver's precise handle — robust against two dep modules sharing a
-/// bare type name); a `None` `type_id` falls back to the first
-/// symbol-table entry whose bare name matches.
+/// Identity comes only from `MirRecordCreate.type_id` (the resolver's precise
+/// handle — robust against two dep modules sharing a bare type name). A node
+/// without identity keeps its source spelling; codegen never searches the
+/// whole program by bare name.
 fn qualify_record_type(
     type_id: Option<crate::ir::TypeId>,
-    type_name: &str,
+    _type_name: &str,
     ctx: &MirEmitCtx<'_>,
 ) -> Option<String> {
-    let entry = match type_id {
-        Some(id) => ctx.symbol_table.type_entry(id),
-        // No identity: the source name is the only handle left. One
-        // declaration of that name is that declaration; two are two
-        // different records with two different paths, and picking the
-        // first would emit a path to the wrong one. Declining leaves
-        // `mir_record_rust_type` on the verbatim name, which rustc either
-        // accepts (entry scope) or rejects by name — never silently the
-        // other module's struct.
-        None => {
-            let id = ctx.symbol_table.unique_type_id_by_bare_name(type_name)?;
-            ctx.symbol_table.type_entry(id)
-        }
-    };
+    let entry = ctx.symbol_table.type_entry_if_present(type_id?)?;
     let canonical = entry.key.canonical();
     let (prefix, suffix) = resolve_module_call(&canonical, ctx.module_prefixes)?;
     Some(format!(

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -903,7 +903,20 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
     // per module, DAG invariant keeps them unambiguous) when the
     // analyze stage ran. Fall back to projecting `ctx.mutual_tco_members`
     // (FnId set) back to bare names for this module's scope.
-    let fn_refs: Vec<&FnDef> = module.fn_defs.iter().collect();
+    // Capability hostile profiles are executable specifications, not runtime
+    // implementation.  Drop their full model-only closure here, at the
+    // runtime-backend boundary.  The capability registry preserves helpers
+    // that are also reachable from an exported ordinary function.
+    let verification_only_fns = ctx.capabilities.verification_only_function_names(
+        &module.prefix,
+        &module.fn_defs,
+        &module.exposes,
+    );
+    let fn_refs: Vec<&FnDef> = module
+        .fn_defs
+        .iter()
+        .filter(|fd| !verification_only_fns.contains(&fd.name))
+        .collect();
     let mutual_groups = toplevel::find_mutual_tco_groups(&fn_refs);
     let module_mutual_owned: HashSet<String> = match module.analysis.as_ref() {
         Some(a) => a.mutual_tco_members.clone(),
@@ -935,7 +948,7 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
     }
 
     for fd in &module.fn_defs {
-        if module_mutual.contains(&fd.name) {
+        if verification_only_fns.contains(&fd.name) || module_mutual.contains(&fd.name) {
             continue;
         }
         // Same pair-API as the entry loop above. Module fns route
@@ -1160,7 +1173,7 @@ mod tests {
                     .items
                     .iter()
                     .filter_map(|i| match i {
-                        crate::ast::TopLevel::FnDef(fd) if fd.name != "main" => Some(fd.clone()),
+                        crate::ast::TopLevel::FnDef(fd) => Some(fd.clone()),
                         _ => None,
                     })
                     .collect();
@@ -1218,6 +1231,59 @@ mod tests {
             .iter()
             .find_map(|(name, content)| (name == path).then_some(content.as_str()))
             .unwrap_or_else(|| panic!("expected generated file '{}'", path))
+    }
+
+    #[test]
+    fn capability_model_closure_is_omitted_from_runtime_rust() {
+        let mut ctx = ctx_from_multi(
+            r#"
+module Entry
+    depends [Clock]
+
+fn main() -> Int
+    Clock.visible()
+
+verify main
+    main() => 2
+"#,
+            &[(
+                "Clock",
+                r#"
+module Clock
+    kind = capability
+    semantics = effectful
+    exposes [now, visible]
+
+operation now() -> Int
+    oracle = generative
+    replay = recorded
+    hostile = [normal]
+
+fn modelOnly() -> Int
+    40
+
+fn shared() -> Int
+    2
+
+fn normal(branch: BranchPath, call: Int) -> Int
+    modelOnly() + shared()
+
+fn visible() -> Int
+    shared()
+"#,
+            )],
+            "capability-model-runtime-boundary",
+        );
+
+        let out = transpile(&mut ctx);
+        let clock = generated_file(&out, "src/aver_generated/clock/mod.rs");
+        let verify = generated_file(&out, "src/verify.rs");
+
+        assert!(clock.contains("pub fn visible("), "{clock}");
+        assert!(clock.contains("pub fn shared("), "{clock}");
+        assert!(!clock.contains("fn normal("), "{clock}");
+        assert!(!clock.contains("fn modelOnly("), "{clock}");
+        assert!(verify.contains("fn test_main_case_1()"), "{verify}");
     }
 
     #[test]

--- a/src/codegen/wasm_gc/flatten.rs
+++ b/src/codegen/wasm_gc/flatten.rs
@@ -156,6 +156,7 @@ pub fn flatten_multimodule(
 
     let entry_ctx = RewriteCtx {
         prefixes: &prefixes,
+        qualified_type_names: &qualified_type_names,
         same_module_prefix: None,
         same_module_fns: &empty_set,
         // The entry keeps the bare spelling of every name it declares, so
@@ -210,6 +211,7 @@ pub fn flatten_multimodule(
             .collect();
         let dep_ctx = RewriteCtx {
             prefixes: &prefixes,
+            qualified_type_names: &qualified_type_names,
             same_module_prefix: Some(&dep.prefix),
             same_module_fns: &same_module_fns,
             colliding_owner: &colliding_owner,
@@ -423,6 +425,9 @@ fn attr_chain_to_dotted(expr: &Expr) -> Option<String> {
 struct RewriteCtx<'a> {
     /// Every dep module path, used to spot cross-module references.
     prefixes: &'a HashSet<String>,
+    /// Every dependency-qualified type spelling that the post-link program
+    /// may need to rewrite in annotations and inferred type stamps.
+    qualified_type_names: &'a HashSet<String>,
     /// The owning dep's path while its own fn bodies are walked.
     same_module_prefix: Option<&'a str>,
     /// Fn names declared by the module being walked.
@@ -438,6 +443,63 @@ struct RewriteCtx<'a> {
     /// Every ambiguous bare type name in the program — a reference to one
     /// of these through another module's path keeps the qualified spelling.
     colliding_bare_names: &'a HashSet<String>,
+}
+
+/// Rewrite both an expression and the typechecker stamp attached to it. The
+/// stamp belongs to the pre-flatten symbol table, so its `TypeId` must never
+/// cross the link boundary. Its source spelling is rewritten to the same
+/// post-link name as signatures and type definitions; the fresh HIR resolver
+/// then assigns an id from the flattened table.
+fn rewrite_spanned_expr(expr: &mut Spanned<Expr>, ctx: &RewriteCtx<'_>) {
+    if let Some(ty) = expr.ty.get_mut() {
+        rewrite_stamped_type(ty, ctx);
+    }
+    rewrite_expr(&mut expr.node, ctx);
+}
+
+fn rewrite_stamped_type(ty: &mut crate::ast::Type, ctx: &RewriteCtx<'_>) {
+    use crate::ast::Type;
+    match ty {
+        Type::Named { id, name } => {
+            *name = rewrite_type_spelling(name, ctx);
+            // TypeIds are table-local. `flatten_multimodule` changes the
+            // table, so carrying the old numeric id would misidentify a
+            // different declaration (or index past the new table).
+            *id = None;
+        }
+        Type::List(inner) | Type::Vector(inner) | Type::Option(inner) => {
+            rewrite_stamped_type(inner, ctx);
+        }
+        Type::Result(ok, err) | Type::Map(ok, err) => {
+            rewrite_stamped_type(ok, ctx);
+            rewrite_stamped_type(err, ctx);
+        }
+        Type::Tuple(items) => {
+            for item in items {
+                rewrite_stamped_type(item, ctx);
+            }
+        }
+        Type::Fn(params, ret, _) => {
+            for param in params {
+                rewrite_stamped_type(param, ctx);
+            }
+            rewrite_stamped_type(ret, ctx);
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_type_spelling(type_name: &str, ctx: &RewriteCtx<'_>) -> String {
+    let stripped = strip_non_colliding_prefixes(
+        type_name,
+        ctx.qualified_type_names,
+        ctx.colliding_bare_names,
+    );
+    if ctx.dep_prefix.is_empty() {
+        stripped
+    } else {
+        canonicalise_own_colliding(&stripped, ctx.colliding_owner)
+    }
 }
 
 fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
@@ -464,9 +526,9 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
             if let Some(rep) = new_callee {
                 callee.node = rep;
             }
-            rewrite_expr(&mut callee.node, ctx);
+            rewrite_spanned_expr(callee, ctx);
             for arg in args.iter_mut() {
-                rewrite_expr(&mut arg.node, ctx);
+                rewrite_spanned_expr(arg, ctx);
             }
         }
         Expr::TailCall(boxed) => {
@@ -476,21 +538,21 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
                 boxed.target = prefixed(prefix, &boxed.target);
             }
             for arg in boxed.args.iter_mut() {
-                rewrite_expr(&mut arg.node, ctx);
+                rewrite_spanned_expr(arg, ctx);
             }
         }
         Expr::BinOp(_, left, right) => {
-            rewrite_expr(&mut left.node, ctx);
-            rewrite_expr(&mut right.node, ctx);
+            rewrite_spanned_expr(left, ctx);
+            rewrite_spanned_expr(right, ctx);
         }
         Expr::Neg(inner) => {
-            rewrite_expr(&mut inner.node, ctx);
+            rewrite_spanned_expr(inner, ctx);
         }
         Expr::Match { subject, arms } => {
-            rewrite_expr(&mut subject.node, ctx);
+            rewrite_spanned_expr(subject, ctx);
             for arm in arms.iter_mut() {
                 rewrite_pattern(&mut arm.pattern, ctx);
-                rewrite_expr(&mut arm.body.node, ctx);
+                rewrite_spanned_expr(&mut arm.body, ctx);
             }
         }
         Expr::Attr(_, _) => {
@@ -510,13 +572,13 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
                 canonicalise_attr_head_for_own_colliding(expr, ctx.colliding_owner);
             }
             if let Expr::Attr(obj, _) = expr {
-                rewrite_expr(&mut obj.node, ctx);
+                rewrite_spanned_expr(obj, ctx);
             }
         }
         Expr::Constructor(name, payload) => {
             rewrite_constructor_name(name, ctx);
             if let Some(payload) = payload.as_deref_mut() {
-                rewrite_expr(&mut payload.node, ctx);
+                rewrite_spanned_expr(payload, ctx);
             }
         }
         Expr::RecordCreate { type_name, fields } => {
@@ -524,7 +586,7 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
                 canonicalise_bare_type_name(type_name, ctx.colliding_owner);
             }
             for (_, expr) in fields.iter_mut() {
-                rewrite_expr(&mut expr.node, ctx);
+                rewrite_spanned_expr(expr, ctx);
             }
         }
         Expr::RecordUpdate {
@@ -535,29 +597,29 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
             if !ctx.dep_prefix.is_empty() {
                 canonicalise_bare_type_name(type_name, ctx.colliding_owner);
             }
-            rewrite_expr(&mut base.node, ctx);
+            rewrite_spanned_expr(base, ctx);
             for (_, expr) in updates.iter_mut() {
-                rewrite_expr(&mut expr.node, ctx);
+                rewrite_spanned_expr(expr, ctx);
             }
         }
         Expr::List(items) | Expr::Tuple(items) | Expr::IndependentProduct(items, _) => {
             for item in items.iter_mut() {
-                rewrite_expr(&mut item.node, ctx);
+                rewrite_spanned_expr(item, ctx);
             }
         }
         Expr::MapLiteral(entries) => {
             for (key, value) in entries.iter_mut() {
-                rewrite_expr(&mut key.node, ctx);
-                rewrite_expr(&mut value.node, ctx);
+                rewrite_spanned_expr(key, ctx);
+                rewrite_spanned_expr(value, ctx);
             }
         }
         Expr::ErrorProp(inner) => {
-            rewrite_expr(&mut inner.node, ctx);
+            rewrite_spanned_expr(inner, ctx);
         }
         Expr::InterpolatedStr(parts) => {
             for part in parts.iter_mut() {
                 if let crate::ast::StrPart::Parsed(inner) = part {
-                    rewrite_expr(&mut inner.node, ctx);
+                    rewrite_spanned_expr(inner, ctx);
                 }
             }
         }
@@ -711,15 +773,13 @@ fn rewrite_stmts(stmts: &mut [Stmt], ctx: &RewriteCtx<'_>) {
     for stmt in stmts.iter_mut() {
         match stmt {
             Stmt::Binding(_, type_ann, expr) => {
-                if !ctx.dep_prefix.is_empty()
-                    && let Some(ty) = type_ann.as_mut()
-                {
-                    *ty = canonicalise_own_colliding(ty, ctx.colliding_owner);
+                if let Some(ty) = type_ann.as_mut() {
+                    *ty = rewrite_type_spelling(ty, ctx);
                 }
-                rewrite_expr(&mut expr.node, ctx);
+                rewrite_spanned_expr(expr, ctx);
             }
             Stmt::Expr(expr) => {
-                rewrite_expr(&mut expr.node, ctx);
+                rewrite_spanned_expr(expr, ctx);
             }
         }
     }

--- a/src/codegen/wasm_gc/flatten.rs
+++ b/src/codegen/wasm_gc/flatten.rs
@@ -52,6 +52,15 @@ use crate::ast::{Expr, FnBody, Pattern, Spanned, Stmt, TopLevel, TypeDef};
 use crate::codegen::ModuleInfo;
 use crate::codegen::common::type_def_name;
 
+/// Which capability function closure belongs in the flattened module.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CapabilityFunctionSurface {
+    /// Executable artifacts omit hostile profiles and model-only helpers.
+    Runtime,
+    /// `aver verify --wasm-gc` keeps model functions used by verify helpers.
+    Verification,
+}
+
 /// Walks each loaded `ModuleInfo`, prefixes every fn name with
 /// `{module_prefix}_`, rewrites bare same-module call sites to use the
 /// prefixed name, strips non-colliding module-qualified type refs to their
@@ -78,7 +87,36 @@ use crate::codegen::common::type_def_name;
 pub fn flatten_multimodule(
     items: &mut Vec<TopLevel>,
     dep_modules: &[ModuleInfo],
+    capabilities: &crate::capability::CapabilityRegistry,
+    capability_surface: CapabilityFunctionSurface,
 ) -> HashMap<String, String> {
+    // A capability's hostile profiles and model-only helper closure belong to
+    // verify/proof, not to an executable artifact. Rust codegen applies the
+    // same registry-derived boundary. Do it before flattening so an untyped
+    // model fixture cannot leak into wasm-gc/wasip2 lowering, while helpers
+    // shared with an exposed runtime function remain present.
+    let entry_capability = (capability_surface == CapabilityFunctionSurface::Runtime)
+        .then(|| crate::visibility::module_decl(items))
+        .flatten()
+        .and_then(|module| {
+            (module.kind.as_deref() == Some("capability"))
+                .then(|| (module.name.clone(), module.exposes.clone()))
+        });
+    if let Some((module, exposes)) = entry_capability {
+        let fn_defs: Vec<_> = items
+            .iter()
+            .filter_map(|item| match item {
+                TopLevel::FnDef(fd) => Some(fd.clone()),
+                _ => None,
+            })
+            .collect();
+        let verification_only =
+            capabilities.verification_only_function_names(&module, &fn_defs, &exposes);
+        items.retain(
+            |item| !matches!(item, TopLevel::FnDef(fd) if verification_only.contains(&fd.name)),
+        );
+    }
+
     if dep_modules.is_empty() {
         return HashMap::new();
     }
@@ -181,8 +219,19 @@ pub fn flatten_multimodule(
     }
 
     for dep in dep_modules {
-        let same_module_fns: HashSet<String> =
-            dep.fn_defs.iter().map(|fd| fd.name.clone()).collect();
+        let verification_only = if capability_surface == CapabilityFunctionSurface::Runtime
+            && dep.capability_semantics.is_some()
+        {
+            capabilities.verification_only_function_names(&dep.prefix, &dep.fn_defs, &dep.exposes)
+        } else {
+            Default::default()
+        };
+        let same_module_fns: HashSet<String> = dep
+            .fn_defs
+            .iter()
+            .filter(|fd| !verification_only.contains(&fd.name))
+            .map(|fd| fd.name.clone())
+            .collect();
         let own_types: HashSet<&str> = dep.type_defs.iter().map(type_def_name).collect();
         // What each ambiguous bare name means INSIDE this module — the
         // canonicalisation passes rewrite its references to `Owner.Name`
@@ -228,7 +277,11 @@ pub fn flatten_multimodule(
             items.push(TopLevel::TypeDef(new_td));
         }
 
-        for fd in &dep.fn_defs {
+        for fd in dep
+            .fn_defs
+            .iter()
+            .filter(|fd| !verification_only.contains(&fd.name))
+        {
             let mut new_fd = fd.clone();
             rewrite_fn_signature(&mut new_fd, &qualified_type_names, &colliding_bare_names);
             canonicalise_fn_signature_for_own_colliding(&mut new_fd, &colliding_owner);

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -82,7 +82,7 @@ mod wasip2_tcp;
 mod wat_helper;
 
 pub use body::{CoverageReport, coverage_report};
-pub use flatten::flatten_multimodule;
+pub use flatten::{CapabilityFunctionSurface, flatten_multimodule};
 
 /// Backend lowering mode — selects the host-bridge shape the wasm-gc
 /// emitter targets.

--- a/src/diagnostics/wasm_gc_verify.rs
+++ b/src/diagnostics/wasm_gc_verify.rs
@@ -191,7 +191,16 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
     };
     let mut type_aliases = std::collections::HashMap::new();
     if !dep_modules.is_empty() {
-        type_aliases = crate::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        type_aliases = crate::codegen::wasm_gc::flatten_multimodule(
+            &mut items,
+            &dep_modules,
+            &result
+                .typecheck
+                .as_ref()
+                .expect("wasm-gc verify pipeline requested typechecking")
+                .capabilities,
+            crate::codegen::wasm_gc::CapabilityFunctionSurface::Verification,
+        );
         // `_and_reannotate`: a bare post-flatten re-resolve wipes
         // `aliased_slots` and the wasm-gc in-place fast path goes
         // wrong (#950).

--- a/src/ir/hir/resolve.rs
+++ b/src/ir/hir/resolve.rs
@@ -58,7 +58,7 @@ use crate::ir::hir::{
     ResolvedFnDef, ResolvedMatchArm, ResolvedPattern, ResolvedStmt, ResolvedStrPart,
     ResolvedTopLevel,
 };
-use crate::ir::identity::{FnId, FnKey, TypeId, TypeKey};
+use crate::ir::identity::{FnId, TypeId, TypeKey};
 use crate::ir::symbol_table::SymbolTable;
 
 /// Resolver state. Carries the symbol table the pass resolves
@@ -81,100 +81,25 @@ impl<'a> ResolveCtx<'a> {
         }
     }
 
-    /// Resolve a fn reference to a `FnId`. Tries (in order):
-    ///   1. Qualified: `Module.fn` → `FnKey::in_module(Module, fn)`.
-    ///   2. Current module: `fn` → `FnKey::in_module(current, fn)`.
-    ///   3. Current-as-entry: when the qualified prefix matches the
-    ///      current module, also probe `FnKey::entry(fn)` (entry
-    ///      items live under entry scope in the symbol table even
-    ///      when they declare `module X`).
-    ///   4. Entry: `fn` → `FnKey::entry(fn)`.
+    /// Resolve a function reference through the symbol table's single module
+    /// visibility relation. `current_module` is always the canonical import
+    /// path for dependencies; only the entry may use its declared header alias.
     pub fn resolve_fn_id(&self, name: &str) -> Option<FnId> {
-        if let Some((prefix, n)) = name.rsplit_once('.') {
-            if let Some(id) = self.symbols.fn_id_of(&FnKey::in_module(prefix, n)) {
-                return Some(id);
-            }
-            if self.current_module.as_deref() == Some(prefix)
-                && let Some(id) = self.symbols.fn_id_of(&FnKey::entry(n))
-            {
-                return Some(id);
-            }
-        }
-        if let Some(prefix) = self.current_module.as_deref()
-            && let Some(id) = self.symbols.fn_id_of(&FnKey::in_module(prefix, name))
-        {
-            return Some(id);
-        }
-        self.symbols.fn_id_of(&FnKey::entry(name))
+        self.symbols
+            .resolve_fn_id_in(name, self.current_module.as_deref())
     }
 
     /// Type-side equivalent of [`Self::resolve_fn_id`].
     ///
-    /// Resolution order (first match wins):
-    /// 1. `prefix.name` matches `TypeKey::in_module(prefix, name)`.
-    /// 2. `prefix.name` written INSIDE the entry, with `prefix ==
-    ///    current_module`, matches the entry-scope `TypeKey::entry(name)`
-    ///    (Aver lets a self-referencing module spell its own type with the
-    ///    qualified form, and the entry's items are keyed under entry scope
-    ///    whatever its `module` header says).
-    /// 3. Bare `name` in `current_module` (`TypeKey::in_module(current, name)`).
-    /// 4. Bare `name` in entry scope (`TypeKey::entry(name)`) — again only
-    ///    when the asking module IS the entry.
-    /// 5. Bare `name` searched across the scopes `current_module` can see
-    ///    via [`crate::ir::SymbolTable::type_id_by_bare_name_in`] — handles
-    ///    the cross-module case where module `A` references type `Val`
-    ///    declared in a module `A` depends on, without qualification.
-    ///    Returns `None` when two visible scopes share the name (caller
-    ///    must qualify); a module `A` never imported is not consulted.
-    ///
-    /// Steps 2 and 4 are the entry's own scope, so they are gated on the
-    /// asking module being the entry. The entry is another module from a
-    /// dependency's point of view: it names its dependencies and they never
-    /// name it, so nothing it declares is in scope for the code it pulls
-    /// in. Ungated, the answer to "what does this bare name mean inside
-    /// this dependency" changed with which file the command was pointed at.
+    /// Qualified and bare names use the same precomputed export surface as
+    /// typechecking and codegen, including declaration-owner-preserving
+    /// re-exports and ambiguity handling.
     pub fn resolve_type_id(&self, name: &str) -> Option<TypeId> {
-        let in_entry = self
-            .symbols
-            .names_entry_scope(self.current_module.as_deref());
-        if let Some((prefix, n)) = name.rsplit_once('.') {
-            if let Some(id) = self.symbols.type_id_of(&TypeKey::in_module(prefix, n)) {
-                return Some(id);
-            }
-            if in_entry
-                && self.current_module.as_deref() == Some(prefix)
-                && let Some(id) = self.symbols.type_id_of(&TypeKey::entry(n))
-            {
-                return Some(id);
-            }
-        }
-        if let Some(prefix) = self.current_module.as_deref()
-            && let Some(id) = self.symbols.type_id_of(&TypeKey::in_module(prefix, name))
-        {
-            return Some(id);
-        }
-        if in_entry && let Some(id) = self.symbols.type_id_of(&TypeKey::entry(name)) {
-            return Some(id);
-        }
-        // Cross-module bare-name fallback. Phase-E ctor resolution
-        // for `Val.ValOk(x)` written from a module that doesn't host
-        // `Val` (e.g. `Domain.Eval.Core` referencing
-        // `Domain.Value.Val`).
-        //
-        // Scoped to what the asking module can actually see: its own
-        // `depends [...]`, the standard modules, and the entry. A module
-        // nobody imported must not participate — otherwise declaring a
-        // type there makes the bare name ambiguous for everyone, the
-        // lookup answers `None`, and `None` reads downstream as "not a
-        // user type" rather than as an error. Two VISIBLE scopes sharing
-        // the name still need a qualified reference, and the type checker
-        // reports that as `Ambiguous type name`.
         self.symbols
-            .type_id_by_bare_name_in(name, self.current_module.as_deref())
+            .resolve_type_id_in(name, self.current_module.as_deref())
     }
 
-    /// Re-home a type that ALREADY carried a `TypeId` into this symbol
-    /// table, by its source name.
+    /// Re-home a type that ALREADY carried a `TypeId` into this symbol table.
     ///
     /// The distinction from [`Self::resolve_type_id`] is where the name was
     /// written. A type annotation that arrives already identified was
@@ -184,22 +109,26 @@ impl<'a> ResolveCtx<'a> {
     /// only projects `.policy` off a `Rules` value carries the type without
     /// ever naming it or its owner. Answering that with the visibility rule
     /// for a bare name the programmer wrote asks the wrong question, and
-    /// answering it with the incoming id asks nothing at all — the id is
-    /// from another table.
+    /// answering it with a source-order index asks nothing at all. `TypeId`
+    /// is now derived from `TypeKey`, so an imported declaration keeps the
+    /// same identity across tables and can be retained directly.
     ///
-    /// So: the ordinary scoped resolution first, then the one declaration
-    /// of that name in the program. Two declarations leave it `None`, which
-    /// is what every consumer treats as "identity unknown".
-    fn rehome_type_id(&self, name: &str) -> Option<TypeId> {
-        if let Some(id) = self.resolve_type_id(name) {
-            return Some(id);
+    /// A dependency checked on its own temporarily keys its own declarations
+    /// as entry types. Those are the one exception: re-resolve them in the
+    /// dependency's canonical current scope. No program-wide bare-name search
+    /// is needed.
+    fn rehome_type_id(&self, incoming: TypeId, name: &str) -> Option<TypeId> {
+        let bare = name.rsplit('.').next().unwrap_or(name);
+        let temporary_entry_id = TypeId::for_key(&TypeKey::entry(bare));
+        if incoming != temporary_entry_id
+            && self
+                .symbols
+                .type_entry_if_present(incoming)
+                .is_some_and(|entry| entry.key.name == bare)
+        {
+            return Some(incoming);
         }
-        if name.contains('.') {
-            // A qualified name that did not resolve names a module this
-            // program does not have; there is nothing to fall back to.
-            return None;
-        }
-        self.symbols.unique_type_id_by_bare_name(name)
+        self.resolve_type_id(name)
     }
 
     /// Resolve a `"Type.Variant"` constructor reference to a
@@ -773,18 +702,15 @@ fn parse_builtin_ctor(name: &str) -> Option<BuiltinCtor> {
 fn canonicalise_type(ctx: &ResolveCtx<'_>, ty: crate::ast::Type) -> crate::ast::Type {
     use crate::ast::Type;
     match ty {
-        // A `TypeId` is stable only within the SymbolTable build that
-        // created it. Dependency modules are typechecked independently
-        // before codegen assembles the final whole-program table, so a
-        // correct local id can point at a different declaration here.
-        // Re-resolve by the source name; the incoming id is never kept,
-        // because in THIS table it indexes whatever declaration happens to
-        // sit at that position. `Type::Named { id, name }` where `id` names
-        // something other than `name` is not a weaker answer than `None` —
-        // it is a wrong one, and every consumer that reads a representation
-        // or a path off the id then reads it off the wrong type.
-        Type::Named { id: Some(_), name } => Type::Named {
-            id: ctx.rehome_type_id(&name),
+        // `TypeId` is the canonical TypeKey fingerprint, not a vector index,
+        // so imported declarations survive per-module → whole-program table
+        // boundaries. A module's temporary entry-scoped key still needs the
+        // canonical current-module rehome described above.
+        Type::Named {
+            id: Some(incoming),
+            name,
+        } => Type::Named {
+            id: ctx.rehome_type_id(incoming, &name),
             name,
         },
         Type::Named { id: None, name } => match ctx.resolve_type_id(&name) {
@@ -916,7 +842,7 @@ fn make() -> Shape
         match &call.node {
             ResolvedExpr::Ctor(ResolvedCtor::User { type_id, name, .. }, args) => {
                 assert_eq!(name, "Circle");
-                assert!(*type_id != crate::ir::identity::TypeId(u32::MAX));
+                assert!(*type_id != crate::ir::identity::TypeId(u64::MAX));
                 assert_eq!(args.len(), 1);
             }
             other => panic!("expected Ctor(User, _), got {:?}", other),

--- a/src/ir/identity.rs
+++ b/src/ir/identity.rs
@@ -12,17 +12,16 @@
 //! of the proof-export audit).
 //!
 //! `FnKey` / `TypeKey` / `LawKey` are the typed replacements.
-//! Identity is resolved **once** at the IR boundary (today: the
-//! `proof_lower` stage); from there backends consume the key
-//! directly. The compiler refuses to compare a key to a bare
-//! `String`, so the bug class can no longer be expressed.
+//! `SymbolTable` resolves identity once for typechecking and HIR/MIR;
+//! the VM, proof lowering, and ordinary backend paths then consume the
+//! opaque IDs directly. A few source-shape proof/codegen adapters remain
+//! as explicitly marked migration bridges tracked outside this module.
 //!
 //! These types live in `crate::ir` rather than `crate::ir::proof_ir`
 //! because identity-across-module-boundary is a general IR concern,
-//! not a proof-specific one. The proof flow is the first consumer;
-//! future cross-module identity sites (VM call-site resolution,
-//! Rust codegen multi-module module-fn lookups) will use the same
-//! types.
+//! not a proof-specific one. Typechecking, VM lowering, and every
+//! backend share these identities rather than defining local notions
+//! of which declaration a name denotes.
 
 // ---------------------------------------------------------------------------
 // Opaque IDs
@@ -45,8 +44,15 @@
 pub struct FnId(pub u32);
 
 /// Opaque, stable identity for a type declaration (record or sum).
+///
+/// Unlike the source-order IDs used for functions and constructors, a
+/// `TypeId` is derived from its canonical [`TypeKey`]. Dependency modules are
+/// typechecked in their own tables before whole-program lowering; using a
+/// vector position here let an ID for `A.Policy` silently name `Bytes` in the
+/// next table. The canonical fingerprint is table-independent, and every
+/// [`crate::ir::SymbolTable`] checks collisions when registering it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
-pub struct TypeId(pub u32);
+pub struct TypeId(pub u64);
 
 /// Opaque, stable identity for a constructor (a single variant of a
 /// sum type, or a single record's nominal constructor — record types
@@ -167,6 +173,36 @@ impl TypeKey {
 
     pub fn scope_str(&self) -> Option<&str> {
         self.scope.as_deref()
+    }
+}
+
+impl TypeId {
+    /// Derive the same opaque identity from the same canonical key in every
+    /// symbol table. FNV-1a is used only as a compact deterministic
+    /// fingerprint; `SymbolTable::build` detects a collision and fails closed
+    /// instead of allowing two declarations to share an identity.
+    pub(crate) fn for_key(key: &TypeKey) -> Self {
+        const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+        const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+        fn add(hash: &mut u64, bytes: &[u8]) {
+            for byte in bytes {
+                *hash ^= u64::from(*byte);
+                *hash = hash.wrapping_mul(PRIME);
+            }
+        }
+
+        let mut hash = OFFSET;
+        match key.scope.as_deref() {
+            Some(scope) => {
+                add(&mut hash, &[1]);
+                add(&mut hash, scope.as_bytes());
+            }
+            None => add(&mut hash, &[0]),
+        }
+        add(&mut hash, &[0xff]);
+        add(&mut hash, key.name.as_bytes());
+        TypeId(hash)
     }
 }
 

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -1384,7 +1384,7 @@ fn diag_for_build_symbols(table: &crate::ir::SymbolTable) -> PassDiagnostic {
         per_module[te.module.0 as usize].types += 1;
     }
     for ce in &table.ctors {
-        let owning_module = table.types[ce.owning_type.0 as usize].module;
+        let owning_module = table.type_entry(ce.owning_type).module;
         per_module[owning_module.0 as usize].ctors += 1;
     }
 

--- a/src/ir/symbol_table.rs
+++ b/src/ir/symbol_table.rs
@@ -36,7 +36,7 @@
 //! `symbols.fn_id_of(&fn_key)` and get a stable opaque handle
 //! back, without disturbing anything that already works.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::ast::{CapabilityItem, FnDef, TopLevel, TypeDef, TypeVariant};
 use crate::capability::{OracleDimension, ReplaySemantics};
@@ -107,6 +107,19 @@ pub struct CapabilityOperationInfo {
     pub mints_resource: bool,
 }
 
+/// One canonical module boundary for every source symbol kind.
+///
+/// Functions and types share the same dependency edge and `exposes` boundary.
+/// The payload stays typed because types additionally preserve declaration
+/// ownership across explicit re-exports (and carry opacity), while functions
+/// are exported only by their declaring module.
+#[derive(Debug, Clone, Default)]
+struct ModuleSymbolSurface {
+    depends: Vec<String>,
+    functions: HashSet<String>,
+    types: HashMap<String, crate::visibility::ExportedTypeTarget>,
+}
+
 /// Resolved-identity table for an Aver program. Built once after
 /// module load + before typecheck (eventually — today no caller
 /// invokes this yet); consumers thereafter look up IDs and never
@@ -127,6 +140,14 @@ pub struct SymbolTable {
 
     fn_index: HashMap<FnKey, FnId>,
     type_index: HashMap<TypeKey, TypeId>,
+    /// Stable `TypeId` → source-order storage position. `TypeId` is keyed by
+    /// canonical identity rather than by this vector position, so it remains
+    /// meaningful when a typed dependency crosses into a whole-program table.
+    type_positions: HashMap<TypeId, usize>,
+    /// Bare declaration name → all identities carrying that name. This is an
+    /// index, not a resolver fallback: lookups still filter the candidates
+    /// through the asking module's visibility relation.
+    type_name_index: HashMap<String, Vec<TypeId>>,
     /// Per-type lookup of `variant_name → CtorId`. The outer
     /// `TypeId` plus inner `String` lets two unrelated sum types
     /// share a variant name (`Result.Ok` vs a user's
@@ -134,24 +155,16 @@ pub struct SymbolTable {
     ctor_index: HashMap<(TypeId, String), CtorId>,
     /// Builtin canonical name → `BuiltinId` (Phase 6 wave 11).
     builtin_index: HashMap<String, BuiltinId>,
-    /// Direct `depends [...]` of each dependency module, keyed by its prefix
-    /// and by the short name its own header declares. Read by
-    /// [`SymbolTable::type_id_by_bare_name_in`] so a bare type name is
-    /// answered only by the scopes the asking module can see — the same
-    /// question the type checker asks through its own visibility map.
-    module_depends: HashMap<String, Vec<String>>,
+    /// Canonical module path → the one boundary used to resolve functions,
+    /// types, records, constructors, and their downstream identities. The
+    /// short `module User` header is validated by the loader and never becomes
+    /// a second key beside `Domain.User`.
+    module_surfaces: HashMap<String, ModuleSymbolSurface>,
     /// Direct `depends [...]` of the entry scope, and the name its `module`
     /// header declares. The entry lives under `TypeKey::entry` (no prefix),
     /// but a resolver context still spells its scope with the declared name.
     entry_depends: Vec<String>,
     entry_module_name: Option<String>,
-    /// Each dependency module's public type surface after explicit re-exports,
-    /// from [`crate::visibility::collect_type_exports`] — the same relation the
-    /// type checker resolves an owner-context bare name through
-    /// (`TypeChecker::resolve_in_owner_context`). A type is not only visible to
-    /// the module that declares it: whoever depends on a module that re-exposes
-    /// it sees it too, under the declaration owner's identity.
-    module_type_exports: crate::visibility::ModuleTypeExports,
     /// Canonical provider-bound operation name → whether the call establishes
     /// an effect. These have no `FnId` because there is no Aver body.
     capability_operations: HashMap<String, CapabilityOperationInfo>,
@@ -175,27 +188,28 @@ pub struct BuiltinEntry {
     pub name: String,
 }
 
-/// A resolver context names its module the way the source does — whatever
-/// the `module X` header says — while the symbol table keys a dependency by
-/// the path its importers spell in `depends [...]` (`Domain.X`). The two are
-/// the same module, so a scope-aware lookup has to accept either spelling.
-fn module_names_match(prefix: &str, asking: &str) -> bool {
-    prefix == asking || prefix.rsplit('.').next() == Some(asking)
-}
-
-/// The keys a dependency's `depends [...]` list is indexed under: its full
-/// path, and the short name its own header declares.
-fn module_lookup_keys(prefix: &str) -> Vec<String> {
-    let mut keys = vec![prefix.to_string()];
-    if let Some(short) = prefix.rsplit('.').next()
-        && short != prefix
-    {
-        keys.push(short.to_string());
-    }
-    keys
-}
-
 impl SymbolTable {
+    /// Reserve the stable identity for one declaration. Duplicate source
+    /// declarations are a type error reported by the checker, so symbol
+    /// discovery keeps the first declaration and remains total while error
+    /// recovery continues. A different key producing the same fingerprint is
+    /// still an internal collision and must fail loudly.
+    fn register_type_position(&mut self, id: TypeId, key: &TypeKey) -> bool {
+        if let Some(position) = self.type_positions.get(&id).copied() {
+            let existing = &self.types[position].key;
+            assert_eq!(
+                existing,
+                key,
+                "internal TypeId fingerprint collision between `{}` and `{}`",
+                existing.canonical(),
+                key.canonical()
+            );
+            return false;
+        }
+        self.type_positions.insert(id, self.types.len());
+        true
+    }
+
     /// Build a `SymbolTable` from entry items + dep modules. The
     /// build order is fully deterministic: modules in
     /// `dep_modules` walk order with the entry scope prepended,
@@ -211,16 +225,6 @@ impl SymbolTable {
             table.modules.push(ModuleEntry {
                 prefix: Some(m.prefix.clone()),
             });
-            // Indexed under both spellings a resolver context can carry:
-            // the path importers write in `depends [...]` and the name the
-            // module's own header declares. See `module_names_match`.
-            for key in module_lookup_keys(&m.prefix) {
-                table
-                    .module_depends
-                    .entry(key)
-                    .or_default()
-                    .extend(m.depends.iter().cloned());
-            }
         }
         if let Some(module) = entry_items.iter().find_map(|i| match i {
             TopLevel::Module(module) => Some(module),
@@ -248,7 +252,25 @@ impl SymbolTable {
                     .collect(),
             })
             .collect();
-        table.module_type_exports = crate::visibility::collect_type_exports(&surfaces);
+        let mut module_type_exports = crate::visibility::collect_type_exports(&surfaces);
+        for module in dep_modules {
+            let exposes = crate::visibility::declared_exposes(&module.exposes);
+            table.module_surfaces.insert(
+                module.prefix.clone(),
+                ModuleSymbolSurface {
+                    depends: module.depends.clone(),
+                    functions: module
+                        .fn_defs
+                        .iter()
+                        .filter(|fd| crate::visibility::is_exposed(&fd.name, exposes))
+                        .map(|fd| fd.name.clone())
+                        .collect(),
+                    types: module_type_exports
+                        .remove(&module.prefix)
+                        .unwrap_or_default(),
+                },
+            );
+        }
 
         // Helpful pre-traversal: gather (scope, fns, types) tuples
         // so the actual indexing pass is uniform across entry vs
@@ -342,8 +364,16 @@ impl SymbolTable {
                     Some(p) => TypeKey::in_module(p.to_string(), type_name.clone()),
                     None => TypeKey::entry(type_name.clone()),
                 };
-                let type_id = TypeId(table.types.len() as u32);
+                let type_id = TypeId::for_key(&key);
+                if !table.register_type_position(type_id, &key) {
+                    continue;
+                }
                 table.type_index.insert(key.clone(), type_id);
+                table
+                    .type_name_index
+                    .entry(type_name.clone())
+                    .or_default()
+                    .push(type_id);
                 // Register variants (sum) or single constructor
                 // (product) into the ctor table.
                 let ctor_ids: Vec<CtorId> = if is_product {
@@ -393,8 +423,16 @@ impl SymbolTable {
                         if table.type_index.contains_key(&key) {
                             continue;
                         }
-                        let type_id = TypeId(table.types.len() as u32);
+                        let type_id = TypeId::for_key(&key);
+                        if !table.register_type_position(type_id, &key) {
+                            continue;
+                        }
                         table.type_index.insert(key.clone(), type_id);
+                        table
+                            .type_name_index
+                            .entry(name.clone())
+                            .or_default()
+                            .push(type_id);
                         table.types.push(TypeEntry {
                             key,
                             module: module_id,
@@ -574,9 +612,93 @@ impl SymbolTable {
         self.fn_index.get(key).copied()
     }
 
+    /// Resolve a source function name from one canonical module scope.
+    ///
+    /// Own declarations win for bare names, including private helpers.
+    /// Cross-module functions follow Aver's explicit `Module.fn` syntax and
+    /// cross the boundary only when exposed. The entry scope is visible only
+    /// to itself; in particular a dependency's bare `main()` can never fall
+    /// through to the program entry.
+    pub fn resolve_fn_id_in(&self, name: &str, asking: Option<&str>) -> Option<FnId> {
+        let in_entry = self.names_entry_scope(asking);
+        if let Some((prefix, bare)) = name.rsplit_once('.') {
+            if in_entry && self.entry_module_name.as_deref() == Some(prefix) {
+                return self.fn_id_of(&FnKey::entry(bare));
+            }
+            if asking == Some(prefix) {
+                return self.fn_id_of(&FnKey::in_module(prefix, bare));
+            }
+            if self.depends_of(asking).iter().any(|dep| dep == prefix)
+                && self
+                    .module_surfaces
+                    .get(prefix)
+                    .is_some_and(|surface| surface.functions.contains(bare))
+            {
+                return self.fn_id_of(&FnKey::in_module(prefix, bare));
+            }
+            return None;
+        }
+
+        if in_entry {
+            if let Some(id) = self.fn_id_of(&FnKey::entry(name)) {
+                return Some(id);
+            }
+        } else if let Some(scope) = asking
+            && let Some(id) = self.fn_id_of(&FnKey::in_module(scope, name))
+        {
+            return Some(id);
+        }
+
+        None
+    }
+
     /// Resolve a `TypeKey` to its `TypeId`.
     pub fn type_id_of(&self, key: &TypeKey) -> Option<TypeId> {
         self.type_index.get(key).copied()
+    }
+
+    /// Resolve a source type name from one canonical module scope.
+    ///
+    /// Qualified dependency names and bare dependency names both traverse the
+    /// same precomputed [`crate::visibility::ModuleTypeExports`] surface, so a
+    /// facade preserves the declaration owner's `TypeId`. Private declarations
+    /// and modules outside `depends [...]` never participate.
+    pub fn resolve_type_id_in(&self, name: &str, asking: Option<&str>) -> Option<TypeId> {
+        let in_entry = self.names_entry_scope(asking);
+        if let Some((prefix, bare)) = name.rsplit_once('.') {
+            if in_entry && self.entry_module_name.as_deref() == Some(prefix) {
+                return self.type_id_of(&TypeKey::entry(bare));
+            }
+            if asking == Some(prefix) {
+                return self.type_id_of(&TypeKey::in_module(prefix, bare));
+            }
+
+            // Provider resources are language-level atoms and can occur in a
+            // lifted signature without a source `depends` edge.
+            if let Some(id) = self.type_id_of(&TypeKey::in_module(prefix, bare))
+                && self.type_entry(id).is_capability_resource
+            {
+                return Some(id);
+            }
+
+            if self.depends_of(asking).iter().any(|dep| dep == prefix)
+                || crate::stdlib::find(prefix).is_some()
+            {
+                return self.type_export_id(prefix, bare);
+            }
+            return None;
+        }
+
+        if in_entry {
+            if let Some(id) = self.type_id_of(&TypeKey::entry(name)) {
+                return Some(id);
+            }
+        } else if let Some(scope) = asking
+            && let Some(id) = self.type_id_of(&TypeKey::in_module(scope, name))
+        {
+            return Some(id);
+        }
+        self.type_id_by_bare_name_in(name, asking)
     }
 
     /// Resolve a *bare* type name (no module prefix) against the scopes
@@ -599,44 +721,16 @@ impl SymbolTable {
     /// the symbol table where the rest of identity resolution lives.
     pub fn type_id_by_bare_name_in(&self, name: &str, asking: Option<&str>) -> Option<TypeId> {
         let mut found: Option<TypeId> = None;
-        for (key, id) in &self.type_index {
-            if key.name != name || !self.type_is_visible_to(key, *id, asking) {
+        for id in self.type_name_index.get(name).into_iter().flatten() {
+            let key = &self.type_entry(*id).key;
+            if !self.type_is_visible_to(key, *id, asking) {
                 continue;
             }
-            if found.is_some() {
+            if found.is_some_and(|existing| existing != *id) {
                 // Ambiguous bare reference among the scopes the asking
                 // module can see; the caller must qualify with a module
                 // prefix. The type checker reports this as
                 // `Ambiguous type name '<name>'`.
-                return None;
-            }
-            found = Some(*id);
-        }
-        found
-    }
-
-    /// The one type declared under this bare name anywhere in the program,
-    /// or `None` when nothing declares it and when two modules do.
-    ///
-    /// This answers a different question from
-    /// [`Self::type_id_by_bare_name_in`], which decides what a bare name a
-    /// programmer WROTE is allowed to mean. Here the name is not being
-    /// looked up for the first time: it belongs to a type some
-    /// correctly-scoped resolver already accepted where it was written, and
-    /// the only task left is to say which declaration of THIS symbol table
-    /// it is. The module that wrote it may be one the asking context cannot
-    /// see — a record field whose type its owner declares next door reaches
-    /// a third module by projection, and that module names neither.
-    ///
-    /// Fail-closed on ambiguity: two declarations of the name leave the
-    /// identity unknown rather than picking one.
-    pub fn unique_type_id_by_bare_name(&self, name: &str) -> Option<TypeId> {
-        let mut found: Option<TypeId> = None;
-        for (key, id) in &self.type_index {
-            if key.name != name {
-                continue;
-            }
-            if found.is_some_and(|f| f != *id) {
                 return None;
             }
             found = Some(*id);
@@ -682,7 +776,7 @@ impl SymbolTable {
             // Entry scope. Only the entry's own code can spell these bare.
             return self.names_entry_scope(asking);
         };
-        if asking.is_some_and(|asking| module_names_match(scope, asking))
+        if asking == Some(scope)
             || crate::stdlib::find(scope).is_some()
             || self.type_entry(id).is_capability_resource
         {
@@ -690,16 +784,23 @@ impl SymbolTable {
         }
         self.depends_of(asking)
             .iter()
-            .any(|dep| dep == scope || self.dependency_re_exposes(dep, &key.name, scope))
+            .any(|dep| self.dependency_re_exposes(dep, &key.name, scope))
+    }
+
+    /// Resolve `module.alias` through that module's public type surface.
+    /// Re-exports return the original declaration identity.
+    fn type_export_id(&self, module: &str, alias: &str) -> Option<TypeId> {
+        let target = self.module_surfaces.get(module)?.types.get(alias)?;
+        self.type_id_of(&TypeKey::in_module(&target.module, &target.name))
     }
 
     /// Does `dep` hand `scope`'s type `name` on to its own importers? True for
     /// a type `dep` declares itself and for one it re-exposes from further
     /// down, since the export surface keeps the declaration owner's identity.
     fn dependency_re_exposes(&self, dep: &str, name: &str, scope: &str) -> bool {
-        self.module_type_exports
+        self.module_surfaces
             .get(dep)
-            .and_then(|exports| exports.get(name))
+            .and_then(|surface| surface.types.get(name))
             .is_some_and(|target| target.module == scope && target.name == name)
     }
 
@@ -731,8 +832,8 @@ impl SymbolTable {
             return &self.entry_depends;
         }
         asking
-            .and_then(|name| self.module_depends.get(name))
-            .map(Vec::as_slice)
+            .and_then(|name| self.module_surfaces.get(name))
+            .map(|surface| surface.depends.as_slice())
             .unwrap_or(&[])
     }
 
@@ -751,8 +852,28 @@ impl SymbolTable {
         &self.fns[id.0 as usize]
     }
 
+    /// Borrow a type entry when this table contains the canonical identity.
+    /// Foreign table-local vector positions are not interpreted as this
+    /// table's declarations.
+    pub fn type_entry_if_present(&self, id: TypeId) -> Option<&TypeEntry> {
+        if let Some(position) = self.type_positions.get(&id) {
+            return self.types.get(*position);
+        }
+        // A handful of unit-only emitter fixtures construct a minimal table by
+        // pushing entries directly. Production tables always populate
+        // `type_positions` through `build`.
+        #[cfg(test)]
+        if self.type_positions.is_empty() {
+            return usize::try_from(id.0)
+                .ok()
+                .and_then(|position| self.types.get(position));
+        }
+        None
+    }
+
     pub fn type_entry(&self, id: TypeId) -> &TypeEntry {
-        &self.types[id.0 as usize]
+        self.type_entry_if_present(id)
+            .unwrap_or_else(|| panic!("TypeId({}) does not belong to this symbol table", id.0))
     }
 
     pub fn ctor_entry(&self, id: CtorId) -> &CtorEntry {
@@ -811,10 +932,16 @@ impl SymbolTable {
             );
         }
         for (i, entry) in self.types.iter().enumerate() {
+            let id = TypeId::for_key(&entry.key);
             assert_eq!(
                 self.type_index.get(&entry.key),
-                Some(&TypeId(i as u32)),
+                Some(&id),
                 "type_index out of sync at index {i}"
+            );
+            assert_eq!(
+                self.type_positions.get(&id),
+                Some(&i),
+                "type_positions out of sync at index {i}"
             );
         }
         for (i, entry) in self.ctors.iter().enumerate() {
@@ -1193,15 +1320,11 @@ mod tests {
     }
 
     #[test]
-    fn a_module_is_recognised_by_the_name_its_own_header_declares() {
-        // A resolver context spells the module the way the source does
-        // (`module User`); the symbol table keys it by the path importers
-        // spell (`Domain.User`). Both spellings reach the resolver on the
-        // same program, so both have to give the same visibility answer —
-        // otherwise the fallback goes quiet for exactly the modules this
-        // filter was written to keep working. Measured on the first
-        // external project: matching only the path left 76 functions
-        // unrendered, matching either left none.
+    fn a_dependency_has_only_its_canonical_import_path_identity() {
+        // The loader validates `module User` against the final segment of
+        // `Domain.User`, then every compiler phase carries `Domain.User`.
+        // Accepting the short header spelling here would recreate a second
+        // identity and make a sibling `Other.User` indistinguishable.
         let mod_user = module_depending_on("Domain.User", &["Domain.State"], vec![], vec![]);
         let mod_state = module(
             "Domain.State",
@@ -1220,15 +1343,80 @@ mod tests {
         );
         assert_eq!(
             table.type_id_by_bare_name_in("Step", Some("User")),
-            from_state,
-            "the header's own spelling must resolve the same way as the path"
+            None,
+            "the short module header is validation metadata, not an alias"
         );
 
-        // A module's own type is visible to it under either spelling too.
+        // A module's own type is visible under its canonical path only.
         let from_tally = table.type_id_of(&TypeKey::in_module("Domain.Tally", "Step"));
         assert_eq!(
-            table.type_id_by_bare_name_in("Step", Some("Tally")),
+            table.type_id_by_bare_name_in("Step", Some("Domain.Tally")),
             from_tally
+        );
+    }
+
+    #[test]
+    fn one_module_surface_resolves_functions_and_records_with_the_same_boundary() {
+        let dep = module_exposing(
+            "Dep.Helper",
+            &[],
+            &["ask"],
+            vec![fn_def("ask"), fn_def("secret")],
+            vec![product("Secret", 1)],
+        );
+        let entry_items = vec![TopLevel::Module(entry_module("Main", &["Dep.Helper"]))];
+        let table = SymbolTable::build(&entry_items, &[dep]);
+
+        assert!(
+            table
+                .resolve_fn_id_in("Dep.Helper.ask", Some("Main"))
+                .is_some()
+        );
+        assert_eq!(
+            table.resolve_fn_id_in("Dep.Helper.secret", Some("Main")),
+            None,
+            "a private function must stop at the module boundary"
+        );
+        assert_eq!(
+            table.resolve_type_id_in("Dep.Helper.Secret", Some("Main")),
+            None,
+            "a private record must stop at that same module boundary"
+        );
+        assert!(
+            table
+                .resolve_fn_id_in("secret", Some("Dep.Helper"))
+                .is_some(),
+            "own private functions remain visible inside the module"
+        );
+        assert!(
+            table
+                .resolve_type_id_in("Secret", Some("Dep.Helper"))
+                .is_some(),
+            "own private records remain visible inside the module"
+        );
+    }
+
+    #[test]
+    fn dependency_main_resolves_to_the_dependency_not_the_entry() {
+        let dep = module("Dep.Helper", vec![fn_def("main"), fn_def("ask")], vec![]);
+        let entry_items = vec![
+            TopLevel::Module(entry_module("Main", &["Dep.Helper"])),
+            TopLevel::FnDef(fn_def("main")),
+        ];
+        let table = SymbolTable::build(&entry_items, &[dep]);
+
+        assert_eq!(
+            table.resolve_fn_id_in("main", Some("Dep.Helper")),
+            table.fn_id_of(&FnKey::in_module("Dep.Helper", "main"))
+        );
+        assert_eq!(
+            table.resolve_fn_id_in("main", Some("Main")),
+            table.fn_id_of(&FnKey::entry("main"))
+        );
+        assert_eq!(
+            table.resolve_fn_id_in("Main.main", Some("Dep.Helper")),
+            None,
+            "dependencies cannot see the program entry"
         );
     }
 
@@ -1255,41 +1443,28 @@ mod tests {
     }
 
     #[test]
-    fn a_name_only_one_module_declares_re_homes_even_where_it_is_invisible() {
-        // The identity of a type that reaches a module without being
-        // nameable there. `User` depends on `A` alone; `B`'s record arrives
-        // by projection off an `A` value. Asking what `B`'s bare name is
-        // ALLOWED to mean in `User` answers nothing, and rightly so — but
-        // the type still has exactly one declaration, and that is its
-        // identity.
-        let mod_user = module_depending_on("User", &["A"], vec![], vec![]);
-        let mod_a = module("A", vec![], vec![product("Holder", 1)]);
-        let mod_b = module("B", vec![], vec![product("Held", 1)]);
-        let table = SymbolTable::build(&[], &[mod_user, mod_a, mod_b]);
-        table.assert_consistent();
-
-        assert_eq!(table.type_id_by_bare_name_in("Held", Some("User")), None);
-        assert_eq!(
-            table.unique_type_id_by_bare_name("Held"),
-            table.type_id_of(&TypeKey::in_module("B", "Held")),
+    fn canonical_type_identity_is_stable_across_symbol_tables() {
+        let first = SymbolTable::build(
+            &[],
+            &[
+                module("A", vec![], vec![product("Held", 1)]),
+                module("B", vec![], vec![product("Other", 1)]),
+            ],
         );
-    }
-
-    #[test]
-    fn two_declarations_of_a_name_leave_the_identity_unknown() {
-        // Fail-closed: picking one of them would put a `TypeId` on a type
-        // it does not name, and every consumer that reads a representation
-        // or a path off that id reads it off the wrong declaration.
-        let mod_a = module("A", vec![], vec![product("T", 1)]);
-        let mod_b = module("B", vec![], vec![product("T", 1)]);
-        let table = SymbolTable::build(&[], &[mod_a, mod_b]);
-        table.assert_consistent();
-
-        assert_eq!(table.unique_type_id_by_bare_name("T"), None);
-        assert_eq!(
-            table.unique_type_id_by_bare_name("NotDeclaredAnywhere"),
-            None
+        let reversed = SymbolTable::build(
+            &[],
+            &[
+                module("B", vec![], vec![product("Other", 1)]),
+                module("A", vec![], vec![product("Held", 1)]),
+            ],
         );
+        let key = TypeKey::in_module("A", "Held");
+        let first_id = first.type_id_of(&key).expect("A.Held in first table");
+        let reversed_id = reversed.type_id_of(&key).expect("A.Held in reversed table");
+
+        assert_eq!(first_id, reversed_id);
+        assert_eq!(first.type_entry(first_id).key, key);
+        assert_eq!(reversed.type_entry(reversed_id).key, key);
     }
 
     #[test]

--- a/src/ir/symbol_table.rs
+++ b/src/ir/symbol_table.rs
@@ -665,6 +665,14 @@ impl SymbolTable {
     /// and modules outside `depends [...]` never participate.
     pub fn resolve_type_id_in(&self, name: &str, asking: Option<&str>) -> Option<TypeId> {
         let in_entry = self.names_entry_scope(asking);
+        // A linked single-module backend may preserve a dependency's canonical
+        // identity by registering a synthetic entry type whose name itself is
+        // qualified (`Palette.Colour`). Prefer that exact key before parsing a
+        // dot as a source-level module boundary. Ordinary source declarations
+        // cannot contain dots, so this branch is inert before flatten/link.
+        if in_entry && let Some(id) = self.type_id_of(&TypeKey::entry(name)) {
+            return Some(id);
+        }
         if let Some((prefix, bare)) = name.rsplit_once('.') {
             if in_entry && self.entry_module_name.as_deref() == Some(prefix) {
                 return self.type_id_of(&TypeKey::entry(bare));
@@ -1133,6 +1141,26 @@ mod tests {
         assert_ne!(circle, square);
         assert_eq!(table.ctor_entry(circle).name, "Circle");
         assert_eq!(table.ctor_entry(square).name, "Square");
+    }
+
+    #[test]
+    fn flattened_qualified_entry_type_resolves_by_its_exact_linked_name() {
+        let items = vec![
+            TopLevel::Module(entry_module("Entry", &["Palette"])),
+            TopLevel::TypeDef(sum("Palette.Colour", &["Cyan", "Blue"], 1)),
+        ];
+        let table = SymbolTable::build(&items, &[]);
+        table.assert_consistent();
+
+        let linked = table
+            .type_id_of(&TypeKey::entry("Palette.Colour"))
+            .expect("linked type missing");
+        assert_eq!(
+            table.resolve_type_id_in("Palette.Colour", Some("Entry")),
+            Some(linked),
+            "the linked canonical name is one entry key, not a module lookup"
+        );
+        assert!(table.ctor_id_of(linked, "Cyan").is_some());
     }
 
     #[test]

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4675,12 +4675,15 @@ fn render_symbol_table_dump(symbols: &aver::ir::SymbolTable) -> String {
     }
     writeln!(out).unwrap();
     writeln!(out, "## types ({})", symbols.types.len()).unwrap();
-    for (idx, te) in symbols.types.iter().enumerate() {
+    for te in &symbols.types {
         let shape = if te.is_product { "record" } else { "sum" };
+        let type_id = symbols
+            .type_id_of(&te.key)
+            .expect("listed type must have an identity");
         writeln!(
             out,
             "- TypeId({}) = {} ({}, {} ctor(s), in ModuleId({}))",
-            idx,
+            type_id.0,
             te.key.canonical(),
             shape,
             te.variants.len().max(if te.is_product { 1 } else { 0 }),
@@ -4691,7 +4694,7 @@ fn render_symbol_table_dump(symbols: &aver::ir::SymbolTable) -> String {
     writeln!(out).unwrap();
     writeln!(out, "## ctors ({})", symbols.ctors.len()).unwrap();
     for (idx, ce) in symbols.ctors.iter().enumerate() {
-        let owning = &symbols.types[ce.owning_type.0 as usize];
+        let owning = symbols.type_entry(ce.owning_type);
         writeln!(
             out,
             "- CtorId({}) = {}.{} (of TypeId({}))",

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -6326,7 +6326,15 @@ fn cmd_compile_wasm_gc(
             .capabilities,
         aver::provider::CapabilityTarget::WasmGc,
     );
-    let type_aliases = flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = flatten_multimodule(
+        &mut items,
+        &dep_modules,
+        &result
+            .typecheck
+            .as_ref()
+            .expect("wasm-gc pipeline requested typechecking")
+            .capabilities,
+    );
     // Re-run resolver after flatten so dep fns get a FnResolution
     // (slot_types). Entry items already had one from `pipeline::run`
     // above; this picks up the newly appended dep FnDefs. The
@@ -6646,7 +6654,12 @@ fn cmd_compile_wasip2(
         // the `wasm` feature) and call the wasm-gc library function
         // directly — `wasip2` enables `wasm-compile` (which exposes
         // it) but does not pull `wasm`.
-        let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+            &mut items,
+            &dep_modules,
+            capabilities,
+            aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+        );
         // `_and_reannotate`: same #950 wipe-guard as the wasm-gc
         // compile path — a bare re-resolve wipes `aliased_slots`.
         aver::ir::pipeline::resolve_and_reannotate(&mut items);
@@ -11273,8 +11286,14 @@ fn cmd_proof_dafny(file: &str, output_dir: &str, ctx: &codegen::CodegenContext) 
 pub(super) fn flatten_multimodule(
     items: &mut Vec<TopLevel>,
     dep_modules: &[ModuleInfo],
+    capabilities: &aver::capability::CapabilityRegistry,
 ) -> std::collections::HashMap<String, String> {
-    aver::codegen::wasm_gc::flatten_multimodule(items, dep_modules)
+    aver::codegen::wasm_gc::flatten_multimodule(
+        items,
+        dep_modules,
+        capabilities,
+        aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    )
 }
 
 /// Which lowering a dependency module gets, mirroring the entry-module

--- a/src/main/run_wasip2.rs
+++ b/src/main/run_wasip2.rs
@@ -207,7 +207,12 @@ fn build_component(
         );
         return Err(error);
     }
-    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+        &mut items,
+        &dep_modules,
+        capabilities,
+        aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    );
     // `_and_reannotate`: a bare post-flatten re-resolve wipes
     // `aliased_slots`, and the wasm-gc in-place fast path then mutates
     // container-held collections through extracted locals (#950).

--- a/src/main/run_wasm_gc.rs
+++ b/src/main/run_wasm_gc.rs
@@ -197,7 +197,15 @@ pub(super) fn try_run_wasm_gc(
                 required.iter().map(String::as_str),
             )?;
     }
-    let type_aliases = flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = flatten_multimodule(
+        &mut items,
+        &dep_modules,
+        &result
+            .typecheck
+            .as_ref()
+            .expect("wasm-gc run pipeline requested typechecking")
+            .capabilities,
+    );
     // Re-run resolver after multi-module flatten so the freshly
     // appended dep fns get a `FnResolution` (slot map + slot_types).
     // The first `pipeline::run` only saw entry items; without this

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -95,7 +95,12 @@ pub fn compile_project_to_wasm(
         .map(|m| loaded_to_module_info(m, false, true))
         .collect();
 
-    let type_aliases = codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let type_aliases = codegen::wasm_gc::flatten_multimodule(
+        &mut entry_items,
+        &modules,
+        &tc_result.capabilities,
+        codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    );
     // `_and_reannotate`: a bare post-flatten re-resolve wipes
     // `aliased_slots` and the wasm-gc in-place fast path goes wrong (#950).
     crate::ir::pipeline::resolve_and_reannotate(&mut entry_items);
@@ -162,7 +167,12 @@ pub fn compile_project_to_wasm_with_entry(
         .into_iter()
         .map(|m| loaded_to_module_info(m, false, true))
         .collect();
-    let type_aliases = codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let type_aliases = codegen::wasm_gc::flatten_multimodule(
+        &mut entry_items,
+        &modules,
+        &tc_result.capabilities,
+        codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    );
     // `_and_reannotate`: same #950 wipe-guard as the compile path above.
     crate::ir::pipeline::resolve_and_reannotate(&mut entry_items);
     let bytes = codegen::wasm_gc::compile_to_wasm_gc_flattened(

--- a/src/source.rs
+++ b/src/source.rs
@@ -143,8 +143,10 @@ pub fn require_module_declaration(items: &[TopLevel], file: &str) -> Result<(), 
     Ok(())
 }
 
-pub fn find_module_file(name: &str, module_root: &str) -> Option<PathBuf> {
-    let root = Path::new(module_root);
+/// The two relative paths every loader tries for one canonical module name.
+/// Keeping this derivation shared makes the browser virtual filesystem obey
+/// exactly the same module identity contract as the CLI filesystem loader.
+fn module_file_candidates(name: &str) -> Option<(String, String)> {
     let parts: Vec<&str> = name.split('.').filter(|s| !s.is_empty()).collect();
     if parts.is_empty() {
         return None;
@@ -159,6 +161,12 @@ pub fn find_module_file(name: &str, module_root: &str) -> Option<PathBuf> {
             .join("/")
     );
     let exact_rel = format!("{}.av", parts.join("/"));
+    Some((lower_rel, exact_rel))
+}
+
+pub fn find_module_file(name: &str, module_root: &str) -> Option<PathBuf> {
+    let root = Path::new(module_root);
+    let (lower_rel, exact_rel) = module_file_candidates(name)?;
 
     let lower = root.join(&lower_rel);
     if lower.exists() {
@@ -790,40 +798,13 @@ fn load_recursive_from_map(
 }
 
 fn find_file_key_in_map(dep_name: &str, files: &HashMap<String, String>) -> Option<String> {
-    let parts: Vec<&str> = dep_name.split('.').filter(|s| !s.is_empty()).collect();
-    if parts.is_empty() {
-        return None;
-    }
-    let lower_rel = format!(
-        "{}.av",
-        parts
-            .iter()
-            .map(|p| p.to_lowercase())
-            .collect::<Vec<_>>()
-            .join("/")
-    );
-    let exact_rel = format!("{}.av", parts.join("/"));
-    let last = parts.last().copied().unwrap_or(dep_name);
-    let last_lower = format!("{}.av", last.to_lowercase());
-    let last_exact = format!("{}.av", last);
-
-    for candidate in [&lower_rel, &exact_rel, &last_lower, &last_exact] {
+    let (lower_rel, exact_rel) = module_file_candidates(dep_name)?;
+    for candidate in [&lower_rel, &exact_rel] {
         if files.contains_key(candidate) {
             return Some(candidate.clone());
         }
     }
-    // Fallback: case-insensitive scan — browsers let users name files
-    // however they like, and dep names are canonical-cased anyway.
-    let wanted = last.to_lowercase();
-    files
-        .keys()
-        .find(|k| {
-            Path::new(k)
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .is_some_and(|stem| stem.eq_ignore_ascii_case(&wanted))
-        })
-        .cloned()
+    None
 }
 
 /// Load a dependency tree starting from `root_deps`.
@@ -1014,6 +995,23 @@ mod tests {
         assert_eq!(loaded.len(), 2);
         assert_eq!(loaded[0].dep_name, "Bytes");
         assert_eq!(loaded[1].dep_name, "Crypto.Digest32");
+    }
+
+    #[test]
+    fn virtual_filesystem_uses_the_same_canonical_path_as_disk() {
+        let source = "module User\n    intent = \"test\"\n".to_string();
+        let mut leaf_only = std::collections::HashMap::new();
+        leaf_only.insert("user.av".to_string(), source.clone());
+        let error = load_module_tree_from_map(&["Domain.User".to_string()], &leaf_only)
+            .expect_err("a dotted dependency must not fall back to a leaf filename");
+        assert!(error.contains("Module 'Domain.User' not found"), "{error}");
+
+        let mut canonical = std::collections::HashMap::new();
+        canonical.insert("domain/user.av".to_string(), source);
+        let loaded = load_module_tree_from_map(&["Domain.User".to_string()], &canonical)
+            .expect("canonical virtual path should load");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].dep_name, "Domain.User");
     }
 
     #[test]

--- a/src/types/checker/check.rs
+++ b/src/types/checker/check.rs
@@ -133,17 +133,6 @@ impl TypeChecker {
     /// context, not visibility: a facade may re-export a type declared several
     /// files below it without making every module in between globally visible.
     fn prepare_loaded_modules(&mut self, modules: &[crate::source::LoadedModule]) {
-        // Phase B (peer review round 6): track each dep module's own
-        // `depends` list so the per-owner type resolver
-        // (`canonicalize_named_in_module`) can walk it instead of
-        // falling back to the importer's context or to whichever
-        // siblings happen to be in the entry's loaded tree.
-        for m in modules {
-            if let Some(module_decl) = TypeChecker::module_decl(&m.items) {
-                self.module_depends
-                    .insert(m.dep_name.clone(), module_decl.depends.clone());
-            }
-        }
         let pairs: Vec<_> = modules
             .iter()
             .map(|m| (m.dep_name.clone(), m.items.clone()))
@@ -246,7 +235,6 @@ impl TypeChecker {
             let mut sub = TypeChecker::new_with_symbols(self.symbol_table.clone());
             sub.self_host_mode = self.self_host_mode;
             sub.capabilities = self.capabilities.clone();
-            sub.module_depends = self.module_depends.clone();
             sub.module_type_exports = self.module_type_exports.clone();
             // Phase B: the dep module's prefix in the symbol table is
             // its `dep_name` (the path the entry's `depends` clause

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -520,25 +520,10 @@ struct TypeChecker {
     /// map use the canonical key directly; bare→canonical resolution
     /// goes through `symbol_table.type_id_of` for type-derived keys.
     extra_sigs: HashMap<String, FnSig>,
-    /// Bare → `FnId` aliases for cross-module imports. Populated
-    /// during `integrate_registry` from visibility-exposed aliases
-    /// (and during `build_signatures` for the current module's own
-    /// fns). The typed replacement for the pre-phase-B
-    /// `sig_aliases: HashMap<String, String>`: same bare-name routing
-    /// role, but the value side now carries opaque identity instead
-    /// of a string that needed re-resolution downstream.
-    ///
-    /// When two distinct modules each expose the same bare name
-    /// (`Pricing.percent` *and* `Math.percent` both surface a bare
-    /// `percent`), the entry switches to [`Resolution::Ambiguous`]
-    /// and `resolve_fn_id` refuses to silently pick one — the user
-    /// must qualify the reference. Avoids the
-    /// "global bare alias last-wins" bug class peer review #148
-    /// flagged.
-    bare_fn_aliases: HashMap<String, Resolution<FnId>>,
-    /// Bare → `TypeId` aliases. Same role as `bare_fn_aliases`
-    /// for the type-name dimension; consumed by `resolve_type_id`
-    /// and `canonical_type_name`.
+    /// Bare → `TypeId` aliases for the type-name dimension; consumed by
+    /// ambiguity diagnostics and canonical display. Functions have no
+    /// equivalent: cross-module calls are always `Module.fn`, and own bare
+    /// calls resolve directly through `SymbolTable`.
     bare_type_aliases: HashMap<String, Resolution<TypeId>>,
     /// `FnId`s the current checker may legitimately resolve to.
     /// Populated from `build_signatures` (the current module's own
@@ -568,16 +553,6 @@ struct TypeChecker {
     /// map is resolver context; only entries whose module is in
     /// `visible_module_names` are visible to ordinary importer lookups.
     module_type_exports: crate::visibility::ModuleTypeExports,
-    /// Per-module `depends` list, keyed by the dep module's
-    /// `dep_name`. Populated by `prepare_loaded_modules` so the
-    /// per-owner type resolver (`canonicalize_named_in_module`) can
-    /// walk an owner module's *own* depends when canonicalising its
-    /// exported signatures — not the entry module's or arbitrary
-    /// loaded siblings'. Round-6 peer review caught the leak: B
-    /// depends on A; Main depends on B, C; B's bare `Shape` was
-    /// resolving against `[A, C]` (Main's loaded tree) instead of
-    /// `[A]` (B's own depends), and `Shape` came back ambiguous.
-    module_depends: HashMap<String, Vec<String>>,
     value_members: HashMap<String, Type>,
     /// Field types for record types, keyed by `(type_name, field_name)`.
     /// Populated for both user-defined `record` types and built-in records
@@ -668,13 +643,11 @@ impl TypeChecker {
             symbol_table,
             fn_sigs: HashMap::new(),
             extra_sigs: HashMap::new(),
-            bare_fn_aliases: HashMap::new(),
             bare_type_aliases: HashMap::new(),
             visible_fn_ids: HashSet::new(),
             visible_type_ids: HashSet::new(),
             visible_module_names: HashSet::new(),
             module_type_exports: crate::visibility::ModuleTypeExports::new(),
-            module_depends: HashMap::new(),
             value_members: HashMap::new(),
             record_field_types: HashMap::new(),
             type_variants,
@@ -756,50 +729,16 @@ impl TypeChecker {
     // -- Identity resolution (phase B) -------------------------------------
 
     /// Resolve a source-faithful function reference (`"foo"`,
-    /// `"Module.foo"`, `"Tcp.send"`) to a `FnId` via the symbol table.
-    /// Tries, in order: literal-as-qualified (split `"Module.foo"`
-    /// into `(Module, foo)`), current-module-scoped bare name, then
-    /// entry-scope bare name, then the typed bare-alias map.
+    /// `"Module.foo"`, `"Tcp.send"`) through the symbol table's shared
+    /// module visibility relation.
     ///
     /// Misses for builtin namespace methods and constructors — those
     /// don't live in the program symbol table; callers fall back to
     /// the `extra_sigs` string-keyed half.
     pub(crate) fn resolve_fn_id(&self, name: &str) -> Option<FnId> {
-        // Phase B (peer review round 4): every `SymbolTable`
-        // resolution path filters through `visible_fn_ids` so a
-        // qualified `C.helper()` reference can't reach into a dep
-        // module's private fn just because the symbol table
-        // unconditionally stores every dep entry. Bare-name lookup
-        // already went through `bare_fn_aliases`, which is itself
-        // populated only from visibility-exposed entries — that
-        // branch stays as-is.
-        if let Some((prefix, n)) = name.rsplit_once('.') {
-            if let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, n))
-                && self.visible_fn_ids.contains(&id)
-            {
-                return Some(id);
-            }
-            if self.current_module_prefix.as_deref() == Some(prefix)
-                && let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(n))
-                && self.visible_fn_ids.contains(&id)
-            {
-                return Some(id);
-            }
-        }
-        if let Some(prefix) = self.current_module_prefix.as_deref()
-            && let Some(id) = self.symbol_table.fn_id_of(&FnKey::in_module(prefix, name))
-            && self.visible_fn_ids.contains(&id)
-        {
-            return Some(id);
-        }
-        if let Some(id) = self.symbol_table.fn_id_of(&FnKey::entry(name))
-            && self.visible_fn_ids.contains(&id)
-        {
-            return Some(id);
-        }
-        self.bare_fn_aliases
-            .get(name)
-            .and_then(Resolution::unambiguous)
+        self.symbol_table
+            .resolve_fn_id_in(name, self.current_module_prefix.as_deref())
+            .filter(|id| self.visible_fn_ids.contains(id))
     }
 
     /// `true` when the bare alias map has recorded multiple distinct
@@ -1302,18 +1241,6 @@ impl TypeChecker {
         }
     }
 
-    /// Register a bare → `FnId` alias, marking it `Ambiguous` if a
-    /// different identity is already registered under the same bare
-    /// name. Duplicate registration of the same identity (e.g. an
-    /// item walked twice by `integrate_registry` + `build_signatures`)
-    /// is a no-op.
-    pub(super) fn merge_bare_fn_alias(&mut self, alias: String, id: FnId) {
-        self.bare_fn_aliases
-            .entry(alias)
-            .and_modify(|r| r.merge(id))
-            .or_insert(Resolution::Single(id));
-    }
-
     pub(super) fn merge_bare_type_alias(&mut self, alias: String, id: TypeId) {
         self.bare_type_aliases
             .entry(alias)
@@ -1327,46 +1254,14 @@ impl TypeChecker {
     /// resolve to a private (non-exposed) type even though the symbol
     /// table holds every dep type unconditionally.
     pub(crate) fn resolve_type_id(&self, name: &str) -> Option<TypeId> {
-        if let Some((prefix, n)) = name.rsplit_once('.') {
-            if self.current_module_prefix.as_deref() == Some(prefix) {
-                if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n))
-                    && self.visible_type_ids.contains(&id)
-                {
-                    return Some(id);
-                }
-                if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(n))
-                    && self.visible_type_ids.contains(&id)
-                {
-                    return Some(id);
-                }
-            }
-            if self.visible_module_names.contains(prefix) {
-                if let Some(id) = self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n))
-                    && self.visible_type_ids.contains(&id)
-                {
-                    return Some(id);
-                }
-                if let Some(id) = self.type_export_id(prefix, n) {
-                    return Some(id);
-                }
-            }
-        }
-        if let Some(prefix) = self.current_module_prefix.as_deref()
-            && let Some(id) = self
-                .symbol_table
-                .type_id_of(&TypeKey::in_module(prefix, name))
-            && self.visible_type_ids.contains(&id)
-        {
-            return Some(id);
-        }
-        if let Some(id) = self.symbol_table.type_id_of(&TypeKey::entry(name))
-            && self.visible_type_ids.contains(&id)
-        {
-            return Some(id);
-        }
-        self.bare_type_aliases
-            .get(name)
-            .and_then(Resolution::unambiguous)
+        self.symbol_table
+            .resolve_type_id_in(name, self.current_module_prefix.as_deref())
+            .filter(|id| self.visible_type_ids.contains(id))
+            .or_else(|| {
+                self.bare_type_aliases
+                    .get(name)
+                    .and_then(Resolution::unambiguous)
+            })
     }
 
     /// Resolve `module.alias` through that module's public type surface. The
@@ -1480,7 +1375,7 @@ impl TypeChecker {
     /// declaring module can be named (an entry-scope type in a file
     /// with no `module` declaration).
     fn declaring_module_name(&self, id: TypeId) -> Option<String> {
-        let entry = self.symbol_table.types.get(id.0 as usize)?;
+        let entry = self.symbol_table.type_entry_if_present(id)?;
         let scope = entry
             .key
             .scope_str()

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -129,18 +129,6 @@ impl TypeChecker {
                 // Phase B: routing handled by `insert_fn_sig` — user
                 // fns land in the `FnId`-keyed `fn_sigs`.
                 self.insert_fn_sig(&canonical, sig);
-                // Bare alias so source-faithful references inside this
-                // module's own bodies (`foo()`) still resolve to its
-                // FnId when the canonical name carries the module
-                // prefix (`A.foo`). Use `fn_id_for_canonical` (no
-                // visibility filter) — the fn IS visible to its own
-                // module, and `insert_fn_sig` above already added it
-                // to `visible_fn_ids`.
-                if canonical != f.name
-                    && let Some(id) = self.fn_id_for_canonical(&canonical)
-                {
-                    self.merge_bare_fn_alias(f.name.clone(), id);
-                }
             }
         }
     }
@@ -320,65 +308,8 @@ impl TypeChecker {
     /// Resolve a single type name in `owner_module`'s context. See
     /// `canonicalize_named_in_module` for the three-case ordering.
     fn resolve_in_owner_context(&self, name: &str, owner_module: &str) -> Option<TypeId> {
-        if let Some((prefix, n)) = name.rsplit_once('.') {
-            // Qualified self-reference resolves against the declaration table.
-            if prefix == owner_module {
-                return self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n));
-            }
-            // Compiler-shipped capability resources are implicit language
-            // atoms: a module does not need `depends [Tcp]` merely to thread
-            // `Tcp.Connection` through one of its public signatures.  Stamp
-            // that reference with the capability module's one canonical
-            // TypeId even while resolving the signature in its owner's
-            // isolated dependency context.  Ordinary module types (and
-            // project-defined capabilities) still follow the explicit
-            // dependency gate below.
-            if crate::stdlib::is_standard_capability(prefix)
-                && self
-                    .capabilities
-                    .resource_types()
-                    .any(|resource| resource == name)
-            {
-                return self.symbol_table.type_id_of(&TypeKey::in_module(prefix, n));
-            }
-            // A dependency-qualified reference may name either a type declared
-            // by that dependency or one it explicitly re-exports. Do not let a
-            // module elsewhere in the loaded closure become visible merely
-            // because its symbols exist in the shared table.
-            if self
-                .module_depends
-                .get(owner_module)
-                .is_some_and(|deps| deps.iter().any(|dep| dep == prefix))
-            {
-                return self.type_export_id(prefix, n);
-            }
-            return None;
-        }
-        // Bare in owner's own scope.
-        if let Some(id) = self
-            .symbol_table
-            .type_id_of(&TypeKey::in_module(owner_module, name))
-        {
-            return Some(id);
-        }
-        // Bare in any of owner's own depends — visibility-exposed
-        // only. No fallback to entry: bare references in a dep that
-        // can't be satisfied by its own scope or its own depends
-        // stay unresolved.
-        if let Some(deps) = self.module_depends.get(owner_module) {
-            let mut resolved = None;
-            for dep in deps {
-                let Some(id) = self.type_export_id(dep, name) else {
-                    continue;
-                };
-                if resolved.is_some_and(|existing| existing != id) {
-                    return None;
-                }
-                resolved = Some(id);
-            }
-            return resolved;
-        }
-        None
+        self.symbol_table
+            .resolve_type_id_in(name, Some(owner_module))
     }
 
     pub(super) fn canonicalize_named(&self, ty: Type) -> Type {
@@ -692,9 +623,6 @@ impl TypeChecker {
                         .fn_id_of(&FnKey::in_module(entry.module.clone(), fn_name.clone()))
                     {
                         self.visible_fn_ids.insert(id);
-                        if let Some(alias) = entry.alias.as_deref() {
-                            self.merge_bare_fn_alias(alias.to_string(), id);
-                        }
                     }
                 }
                 SymbolKind::OpaqueType { name }

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -5982,3 +5982,77 @@ fn a_type_reached_only_by_projection_keeps_its_representation() {
     let _ = fs::remove_dir_all(&ws);
     result.unwrap_or_else(|e| panic!("{e}"));
 }
+
+/// Regression for #1085: a dependency's bare `main()` is its own ordinary
+/// module function. It must never bind to the entry point merely because the
+/// dependency projection used to omit functions named `main`.
+#[test]
+fn dependency_calling_its_own_main_builds_and_matches_vm() {
+    let ws = temp_dir("dependency-own-main");
+    let root = ws.join("src");
+    let dep = root.join("dep/helper.av");
+    fs::create_dir_all(dep.parent().expect("dependency parent")).expect("create module dir");
+    fs::write(
+        &dep,
+        r#"module Helper
+    intent = "Keep a module-local main callable as an ordinary function."
+    exposes [ask]
+    depends []
+
+fn main() -> Int
+    111
+
+fn ask() -> Int
+    main()
+
+verify ask
+    ask() => 111
+"#,
+    )
+    .expect("write dependency");
+    let entry = root.join("main.av");
+    fs::write(
+        &entry,
+        r#"module Main
+    intent = "Print the dependency's answer without capturing its main name."
+    depends [Dep.Helper]
+    effects [Console.print]
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{Dep.Helper.ask()}")
+"#,
+    )
+    .expect("write entry");
+
+    let name = "dependency_own_main";
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        let vm_stdout = run_vm(&entry, Some(&root))?;
+        if vm_stdout != "111" {
+            return Err(format!("VM oracle returned {vm_stdout:?}, expected 111"));
+        }
+        compile_rust(&entry, &project, name, Some(&root), &[])?;
+        let bin = cargo_build(&project, name)?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "generated dependency-main binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -131,7 +131,16 @@ fn parse_pipeline_with_module_root(
     let mut type_aliases = std::collections::HashMap::new();
     if let Some(root) = module_root {
         let dep_modules = aver::source::load_compile_deps(&items, root)?;
-        type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+            &mut items,
+            &dep_modules,
+            &result
+                .typecheck
+                .as_ref()
+                .expect("typecheck requested")
+                .capabilities,
+            aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+        );
         aver::ir::pipeline::resolve(&mut items);
     }
     Ok((items, type_aliases))

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -122,7 +122,16 @@ fn parse_pipeline_with_module_root(
     let mut type_aliases = std::collections::HashMap::new();
     if let Some(root) = module_root {
         let dep_modules = aver::source::load_compile_deps(&items, root)?;
-        type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+        type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+            &mut items,
+            &dep_modules,
+            &result
+                .typecheck
+                .as_ref()
+                .expect("typecheck requested")
+                .capabilities,
+            aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+        );
         aver::ir::pipeline::resolve(&mut items);
     }
     Ok((items, type_aliases))

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -759,3 +759,45 @@ fn main()
 "#,
     );
 }
+
+/// Regression for #1084: flattening rewrites an entry signature from the
+/// dependency-qualified spelling to the linked type name. The wasm function
+/// type and the MIR body must read the same post-link identity.
+#[test]
+fn entry_returning_qualified_dependency_type_compiles_and_validates() {
+    let root = tempfile::tempdir().expect("temporary module root");
+    fs::write(
+        root.path().join("tmpreviewc.av"),
+        r#"module TmpReviewC
+    intent = "Own the Step value returned through the entry boundary."
+    exposes [Step, made]
+    depends []
+
+type Step
+    Made(Int)
+
+fn made(n: Int) -> Step
+    Step.Made(n)
+"#,
+    )
+    .expect("write dependency");
+
+    let entry = r#"module Main
+    intent = "Return a qualified dependency type from an entry function."
+    depends [TmpReviewC]
+
+fn made(n: Int) -> TmpReviewC.Step
+    TmpReviewC.made(n)
+
+fn main() -> Int
+    match made(7)
+        TmpReviewC.Step.Made(n) -> n
+"#;
+    let root_str = root.path().to_str().expect("utf-8 module root");
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(entry, Some(root_str)).expect("pipeline");
+    let bytes = compile_flattened(&items, &type_aliases).expect("wasm-gc compile");
+    wasmparser::Validator::new()
+        .validate_all(&bytes)
+        .expect("qualified dependency return must validate");
+}

--- a/tests/wasm_gc_effect_arg_overflow_regression.rs
+++ b/tests/wasm_gc_effect_arg_overflow_regression.rs
@@ -79,7 +79,16 @@ fn run_wasm_gc_with_mode(
     // This harness flattens multi-module input, so it must thread the
     // REAL alias map the flattener derived — the same production path
     // `src/main/run_wasm_gc.rs` takes.
-    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut items, &dep_modules);
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+        &mut items,
+        &dep_modules,
+        &result
+            .typecheck
+            .as_ref()
+            .expect("typecheck requested")
+            .capabilities,
+        aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    );
     aver::ir::pipeline::resolve(&mut items);
 
     let (run_res, stdout, _stderr) = aver::services::console::capture_output(|| {

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -267,7 +267,16 @@ fn compile_multi_module_bytes(entry_src: &str, dep_sources: &[(&str, &str)]) -> 
         .into_iter()
         .map(|m| aver::codegen::ModuleInfo::from_loaded(&m))
         .collect();
-    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+        &mut entry_items,
+        &modules,
+        &result
+            .typecheck
+            .as_ref()
+            .expect("typecheck requested")
+            .capabilities,
+        aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    );
     aver::ir::pipeline::resolve(&mut entry_items);
     aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
         &entry_items,
@@ -961,7 +970,13 @@ record Other
         path: std::path::PathBuf::from("Dep.av"),
     };
     let modules = vec![aver::codegen::ModuleInfo::from_loaded(&loaded)];
-    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(&mut entry_items, &modules);
+    let capabilities = aver::capability::CapabilityRegistry::default();
+    let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
+        &mut entry_items,
+        &modules,
+        &capabilities,
+        aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
+    );
     assert!(
         !type_aliases.contains_key("Dep.Octets"),
         "entry declares its own `Octets`, so the qualified dep spelling \


### PR DESCRIPTION
## Summary

- centralize function and type visibility in one canonical module symbol surface used by typechecking, HIR resolution, and codegen
- make `TypeId` a stable fingerprint of canonical `TypeKey`, with collision checks, instead of a table-local source-order index
- remove duplicated bare-function aliases, per-checker dependency maps, global type/record fallbacks, and virtual-filesystem leaf-name lookup
- preserve qualified dependency type identity through wasm-gc flattening
- compile a dependency function named `main` as an ordinary dependency function, so its own bare call cannot bind to the entry main
- keep capability model/profile-only closures out of production generated Rust while retaining helpers reachable from exported runtime functions
- carry expected result types through Dafny result-position matches and qualify capability-owned resources correctly in Lean

Fixes #1083
Fixes #1084
Fixes #1085

## Verification

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo test --features wasm-compile --test wasm_gc_codegen_regression entry_returning_qualified_dependency_type_compiles_and_validates`
- `n1bor/btc-listener`: 74 modules, 1313 verify blocks, 3657/3657 cases; generated Rust builds and tests
- project checks: workflow-engine 19/19, payment-ops 17/17, durable-promise 2/2, k5-fdiv 2/2

The checked-in generated self-host is exercised by the full Cargo suite. Direct regeneration from `self_hosted/main.av` still exposes pre-existing source drift where `Tcp.Connection` is constructed and inspected as a record even though it is now a provider-owned resource.

## Follow-ups

- #1086 tracks proof export of dependency-module verify cases and laws
- #1087 tracks removal of the remaining raw-AST to resolved-IR backend bridges in Rust, Lean, Dafny, and verify-law indexing