### PR TITLE
fix(self-host): preserve opaque TCP resources

### DIFF
--- a/self_hosted/domain/builtins.av
+++ b/self_hosted/domain/builtins.av
@@ -901,49 +901,17 @@ fn builtinTcpConnectInner(hostV: Val, portV: Val) -> Result<Val, String>
         Result.Err(e) -> Result.Ok(Val.ValErr(Val.ValStr(e)))
 
 fn tcpConnToVal(conn: Tcp.Connection) -> Val
-    ? "Convert host Tcp.Connection record to Val."
-    Val.ValRecord("Tcp.Connection", [("id", Val.ValStr(conn.id)), ("host", Val.ValStr(conn.host)), ("port", Val.ValInt(conn.port))])
+    ? "Preserve an opaque host Tcp.Connection resource inside Val."
+    Val.ValTcpConnection(conn)
 
 fn valToTcpConn(v: Val) -> Result<Tcp.Connection, String>
-    ? "Extract Tcp.Connection fields from ValRecord."
+    ? "Recover an opaque host Tcp.Connection resource from Val."
     match v
-        Val.ValRecord(_, fields) -> valToTcpConnFields(fields)
-        _ -> Result.Err("expected Tcp.Connection record")
+        Val.ValTcpConnection(conn) -> Result.Ok(conn)
+        _ -> Result.Err("expected Tcp.Connection resource")
 
 verify valToTcpConn
-    valToTcpConn(Val.ValRecord("Tcp.Connection", [("id", Val.ValStr("tcp-1")), ("host", Val.ValStr("localhost")), ("port", Val.ValInt(8080))])) => Result.Ok(Tcp.Connection(id = "tcp-1", host = "localhost", port = 8080))
-    valToTcpConn(Val.ValInt(1)) => Result.Err("expected Tcp.Connection record")
-
-fn valToTcpConnFields(fields: List<Tuple<String, Val>>) -> Result<Tcp.Connection, String>
-    ? "Build Tcp.Connection from field list."
-    idVal = lookupFieldVal(fields, "id")
-    hostVal = lookupFieldVal(fields, "host")
-    portVal = lookupFieldVal(fields, "port")
-    match idVal
-        Val.ValStr(id) -> match hostVal
-            Val.ValStr(host) -> match portVal
-                Val.ValInt(port) -> Result.Ok(Tcp.Connection(id = id, host = host, port = port))
-                _ -> Result.Err("bad Tcp.Connection port")
-            _ -> Result.Err("bad Tcp.Connection host")
-        _ -> Result.Err("bad Tcp.Connection id")
-
-verify valToTcpConnFields
-    valToTcpConnFields([("id", Val.ValStr("tcp-1")), ("host", Val.ValStr("localhost")), ("port", Val.ValInt(8080))]) => Result.Ok(Tcp.Connection(id = "tcp-1", host = "localhost", port = 8080))
-    valToTcpConnFields([("id", Val.ValInt(0)), ("host", Val.ValStr("localhost")), ("port", Val.ValInt(8080))]) => Result.Err("bad Tcp.Connection id")
-
-fn lookupFieldVal(fields: List<Tuple<String, Val>>, name: String) -> Val
-    ? "Find field value by name, return ValUnit if missing."
-    match fields
-        [] -> Val.ValUnit
-        [pair, ..rest] -> match pair
-            (k, v) -> match k == name
-                true -> v
-                false -> lookupFieldVal(rest, name)
-
-verify lookupFieldVal
-    lookupFieldVal([("name", Val.ValStr("alice")), ("age", Val.ValInt(30))], "name") => Val.ValStr("alice")
-    lookupFieldVal([("name", Val.ValStr("alice"))], "missing") => Val.ValUnit
-    lookupFieldVal([], "x") => Val.ValUnit
+    valToTcpConn(Val.ValInt(1)) => Result.Err("expected Tcp.Connection resource")
 
 fn builtinTcpWriteLine(args: List<Val>) -> Result<Val, String>
     ? "Tcp.writeLine(conn, line) -> Result<Unit, String>."

--- a/self_hosted/domain/value.av
+++ b/self_hosted/domain/value.av
@@ -26,6 +26,7 @@ type Val
     ValNone
     ValTuple(List<Val>)
     ValRecord(String, List<Tuple<String, Val>>)
+    ValTcpConnection(Tcp.Connection)
     ValVariant(Int, String, List<Val>)
     ValMap(Map<String, Val>)
     ValUnit
@@ -59,6 +60,7 @@ fn valRepr(v: Val) -> String
         Val.ValSome(inner) -> "Option.Some({valReprInner(inner)})"
         Val.ValNone -> "Option.None"
         Val.ValRecord(name, _) -> "{name}(...)"
+        Val.ValTcpConnection(_) -> "Tcp.Connection(<resource>)"
         Val.ValMap(m) -> valMapRepr(Map.entries(m), "", true)
         Val.ValVariant(_, fullName, fields) -> valVariantReprTagged(fullName, fields)
         Val.ValUnit -> "()"


### PR DESCRIPTION
Fixes #1089

## Summary
- carry provider-owned Tcp.Connection directly in the self-hosted Val sum
- remove the stale field projection and reconstruction bridge
- keep the negative conversion case as a verify regression

## Validation
- AVER_SELF_HOST_REGEN=1 cargo test -p aver-lang --test rust_self_host_regen -- --ignored --nocapture (compiled 7 source files; corpus parity 3/3)
- cargo test -p aver-lang --test typechecker_spec tcp_connection (4 passed)
- cargo test -p aver-lang --test eval_spec tcp_connect_returns_provider_resource -- --include-ignored --test-threads=1 (1 passed)
- git diff --check