### PR TITLE
refactor(rust): consume resolved functions in codegen

### DIFF
--- a/src/call_graph.rs
+++ b/src/call_graph.rs
@@ -12,7 +12,9 @@ mod codegen;
 mod flow;
 mod scc;
 
-pub use codegen::{ordered_fn_components, tailcall_scc_components};
+pub use codegen::{
+    ordered_fn_components, tailcall_scc_components, tailcall_scc_components_resolved,
+};
 pub use flow::{TOP_LEVEL_CALLER, call_components, callers_of};
 
 // ---------------------------------------------------------------------------

--- a/src/call_graph/codegen.rs
+++ b/src/call_graph/codegen.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::ast::{Expr, FnBody, FnDef, Spanned, Stmt, TailCallData};
+use crate::ir::FnId;
+use crate::ir::hir::{ResolvedExpr, ResolvedFnBody, ResolvedFnDef, ResolvedStmt};
 
 use super::collect_codegen_deps_body;
 use super::scc::{tarjan_sccs, topo_components};
@@ -99,6 +101,77 @@ pub fn tailcall_scc_components<'a>(fns: &[&'a FnDef]) -> Vec<Vec<&'a FnDef>> {
             group
         })
         .collect()
+}
+
+/// Identity-keyed tail-call SCCs for resolved-HIR consumers.
+///
+/// Unlike [`tailcall_scc_components`], graph edges come directly from the
+/// [`FnId`] stored in `ResolvedExpr::TailCall`. Backends therefore never need
+/// to recover an SCC peer by parsing or comparing a source function name.
+pub fn tailcall_scc_components_resolved<'a>(
+    fns: &[&'a ResolvedFnDef],
+) -> Vec<Vec<&'a ResolvedFnDef>> {
+    if fns.is_empty() {
+        return vec![];
+    }
+
+    let fn_map: HashMap<FnId, &ResolvedFnDef> = fns.iter().map(|fd| (fd.fn_id, *fd)).collect();
+    let nodes: Vec<FnId> = fn_map.keys().copied().collect();
+    let node_set: HashSet<FnId> = nodes.iter().copied().collect();
+
+    let mut graph: HashMap<FnId, Vec<FnId>> = HashMap::new();
+    for fd in fns {
+        let mut deps = HashSet::new();
+        collect_resolved_tailcall_deps_body(&fd.body, &node_set, &mut deps);
+        let mut sorted = deps.into_iter().collect::<Vec<_>>();
+        sorted.sort();
+        graph.insert(fd.fn_id, sorted);
+    }
+
+    crate::scc::tarjan_sccs(&nodes, &graph)
+        .into_iter()
+        .filter(|component| component.len() > 1)
+        .map(|component| {
+            let mut group: Vec<&ResolvedFnDef> = component
+                .iter()
+                .filter_map(|id| fn_map.get(id).copied())
+                .collect();
+            group.sort_by_key(|fd| fd.fn_id);
+            group
+        })
+        .collect()
+}
+
+fn collect_resolved_tailcall_deps_body(
+    body: &ResolvedFnBody,
+    fn_ids: &HashSet<FnId>,
+    out: &mut HashSet<FnId>,
+) {
+    for stmt in body.stmts() {
+        match stmt {
+            ResolvedStmt::Expr(expr) | ResolvedStmt::Binding { value: expr, .. } => {
+                collect_resolved_tailcall_deps_expr(expr, fn_ids, out);
+            }
+        }
+    }
+}
+
+fn collect_resolved_tailcall_deps_expr(
+    expr: &Spanned<ResolvedExpr>,
+    fn_ids: &HashSet<FnId>,
+    out: &mut HashSet<FnId>,
+) {
+    match &expr.node {
+        ResolvedExpr::TailCall { target, .. } if fn_ids.contains(target) => {
+            out.insert(*target);
+        }
+        ResolvedExpr::Match { arms, .. } => {
+            for arm in arms {
+                collect_resolved_tailcall_deps_expr(&arm.body, fn_ids, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn collect_tailcall_deps_body(

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -634,6 +634,14 @@ pub fn build_context(
 
     let module_prefixes: HashSet<String> = modules.iter().map(|m| m.prefix.clone()).collect();
 
+    // Build the canonical resolved view before any codegen analysis. Fallback
+    // SCC discovery below reads the same FnId-keyed bodies the backends emit.
+    let resolved_program = crate::codegen::program_view::ResolvedProgramView::build(
+        resolved_items,
+        &modules,
+        &symbol_table,
+    );
+
     // Mutual-TCO membership unions per-scope sets from the analyze
     // stage (entry's `entry_analysis` + each dep module's
     // `module.analysis`); falls back to recomputing per-scope via
@@ -650,23 +658,13 @@ pub fn build_context(
             None,
         )),
         None => {
-            // No entry analysis: compute the per-scope SCC set inline
-            // via `call_graph` and project to FnIds. Same effect as
-            // running the analyze stage's mutual-TCO discovery.
-            // **syntax-discovery-only** (epic #170 Phase 8 guardrail):
-            // `entry_fns` is filtered from `fn_defs` — the entry-scope
-            // FnDef vec — so `FnKey::entry(&fd.name)` below is the
-            // correct keying by construction (every `fd` here is
-            // entry-scope).
-            let entry_fns: Vec<&FnDef> = fn_defs.iter().filter(|fd| fd.name != "main").collect();
-            for group in crate::call_graph::tailcall_scc_components(&entry_fns) {
-                if group.len() < 2 {
-                    continue;
-                }
+            let entry_fns: Vec<&crate::ir::hir::ResolvedFnDef> = resolved_program
+                .entry_fns()
+                .filter(|fd| fd.name != "main")
+                .collect();
+            for group in crate::call_graph::tailcall_scc_components_resolved(&entry_fns) {
                 for fd in group {
-                    if let Some(id) = symbol_table.fn_id_of(&crate::ir::FnKey::entry(&fd.name)) {
-                        mutual_tco_members.insert(id);
-                    }
+                    mutual_tco_members.insert(fd.fn_id);
                 }
             }
         }
@@ -679,18 +677,11 @@ pub fn build_context(
                 Some(&module.prefix),
             )),
             None => {
-                let mod_fns: Vec<&FnDef> = module.fn_defs.iter().collect();
-                for group in crate::call_graph::tailcall_scc_components(&mod_fns) {
-                    if group.len() < 2 {
-                        continue;
-                    }
+                let mod_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
+                    resolved_program.module_fns(&module.prefix).collect();
+                for group in crate::call_graph::tailcall_scc_components_resolved(&mod_fns) {
                     for fd in group {
-                        if let Some(id) = symbol_table.fn_id_of(&crate::ir::FnKey::in_module(
-                            module.prefix.clone(),
-                            &fd.name,
-                        )) {
-                            mutual_tco_members.insert(id);
-                        }
+                        mutual_tco_members.insert(fd.fn_id);
                     }
                 }
             }
@@ -768,19 +759,8 @@ pub fn build_context(
         .cloned()
         .collect();
 
-    // Epic #170 Phase 1: build the canonical `ResolvedProgramView`
-    // once, from the pipeline's already-resolved entry items + the
-    // dep modules' AST fn defs. The view does the module-side
-    // resolution (pinning `ResolveCtx.current_module = Some(prefix)`)
-    // — that's the only producer in the codebase. `resolved_fn_defs`
-    // / `resolved_module_fn_defs` then project FROM the view rather
-    // than running an independent second resolve, eliminating the
-    // "two truths" hazard build_context carried since PR 9.
-    let resolved_program = crate::codegen::program_view::ResolvedProgramView::build(
-        resolved_items,
-        &modules,
-        &symbol_table,
-    );
+    // Legacy projection fields remain for consumers still migrating, but
+    // both project from the one resolved view built above.
     let resolved_fn_defs: Vec<crate::ir::hir::ResolvedFnDef> =
         resolved_program.entry_fns().cloned().collect();
     let resolved_module_fn_defs: Vec<Vec<crate::ir::hir::ResolvedFnDef>> = resolved_program
@@ -1030,37 +1010,29 @@ impl CodegenContext {
         // keyed sets below resolve through it, same shape as the
         // production `build_context` flow.
         let symbol_table = crate::ir::SymbolTable::build(&self.items, &self.modules);
-        let entry_fn_id = |name: &str| -> Option<crate::ir::FnId> {
-            symbol_table.fn_id_of(&crate::ir::FnKey::entry(name))
-        };
-        let module_fn_id = |prefix: &str, name: &str| -> Option<crate::ir::FnId> {
-            symbol_table.fn_id_of(&crate::ir::FnKey::in_module(prefix.to_string(), name))
-        };
-
-        let entry_fn_refs: Vec<&FnDef> =
-            self.fn_defs.iter().filter(|fd| fd.name != "main").collect();
+        let entry_resolved_items = crate::ir::hir::resolve_program(&symbol_table, &self.items);
+        let resolved_program = crate::codegen::program_view::ResolvedProgramView::build(
+            entry_resolved_items,
+            &self.modules,
+            &symbol_table,
+        );
+        let entry_fn_refs: Vec<&crate::ir::hir::ResolvedFnDef> = resolved_program
+            .entry_fns()
+            .filter(|fd| fd.name != "main")
+            .collect();
 
         let mut mutual_tco_members: HashSet<crate::ir::FnId> = HashSet::new();
-        for group in crate::call_graph::tailcall_scc_components(&entry_fn_refs) {
-            if group.len() < 2 {
-                continue;
-            }
+        for group in crate::call_graph::tailcall_scc_components_resolved(&entry_fn_refs) {
             for fd in group {
-                if let Some(id) = entry_fn_id(&fd.name) {
-                    mutual_tco_members.insert(id);
-                }
+                mutual_tco_members.insert(fd.fn_id);
             }
         }
         for module in &self.modules {
-            let mod_fns: Vec<&FnDef> = module.fn_defs.iter().collect();
-            for group in crate::call_graph::tailcall_scc_components(&mod_fns) {
-                if group.len() < 2 {
-                    continue;
-                }
+            let mod_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
+                resolved_program.module_fns(&module.prefix).collect();
+            for group in crate::call_graph::tailcall_scc_components_resolved(&mod_fns) {
                 for fd in group {
-                    if let Some(id) = module_fn_id(&module.prefix, &fd.name) {
-                        mutual_tco_members.insert(id);
-                    }
+                    mutual_tco_members.insert(fd.fn_id);
                 }
             }
         }
@@ -1094,20 +1066,9 @@ impl CodegenContext {
         // need for `recursive_fns` / `mutual_tco_members`.
         self.symbol_table = symbol_table;
 
-        // Rebuild the canonical resolved view from the current items
-        // + modules (post-PR-A: this is the single source for resolved
-        // bodies). Entry-side resolved items are produced by
-        // `resolve_program`, then the view runs the per-dep-module
-        // resolve internally and indexes everything by `FnId`. The
-        // `resolved_fn_defs` / `resolved_module_fn_defs` mirrors below
-        // are projections of this view, kept for callsites that still
-        // walk them directly during the #170 backend-migration arc.
-        let entry_resolved_items = crate::ir::hir::resolve_program(&self.symbol_table, &self.items);
-        self.resolved_program = crate::codegen::program_view::ResolvedProgramView::build(
-            entry_resolved_items,
-            &self.modules,
-            &self.symbol_table,
-        );
+        // Publish the one view used for SCC discovery above. Projection
+        // fields remain for consumers still migrating.
+        self.resolved_program = resolved_program;
         self.resolved_fn_defs = self.resolved_program.entry_fns().cloned().collect();
         self.resolved_module_fn_defs = self
             .resolved_program

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -3458,9 +3458,9 @@ fn ty_is_int(ty: Option<&Type>) -> bool {
 //
 // The ownership / borrow facts (rc pass-through params Arc-wrapped on
 // the self-loop / `&T` extra trampoline args; non-rc owned params `mut`
-// with NO borrow-by-default) are re-derived from the AST `FnDef` via
-// `compute_rc_params` / `compute_self_passthrough_params`; those are
-// name/structure based and SCC discovery reuses `find_mutual_tco_groups`.
+// with NO borrow-by-default) come from the matching function substrate:
+// self-TCO still uses its AST metadata helper, while mutual-TCO derives
+// membership, types, and pass-through parameters from resolved HIR.
 // Get the ownership wrong → rustc rejects, which the build gate catches.
 
 /// Emit a self-TCO fn entirely from MIR: the public signature
@@ -3857,37 +3857,35 @@ fn mir_if_cond_and_branches<'a>(
 /// and thin wrapper fns. The member bodies are walked from MIR
 /// (`MirFn.body`).
 ///
-/// `group_fns` is the SCC (from the AST-based `find_mutual_tco_groups`);
-/// `mir_fns` are the matching `MirFn`s in the same order. Returns `None`
+/// `group_fns` is the resolved-HIR SCC; `mir_fns` are the matching `MirFn`s
+/// in the same order. Returns `None`
 /// (→ the caller emits a hard codegen diagnostic for the whole block)
 /// when any member body can't render — the block is all-or-nothing
 /// because the members share one trampoline.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn emit_mir_mutual_tco_block(
     group_id: usize,
-    group_fns: &[&crate::ast::FnDef],
+    group_fns: &[&crate::ir::hir::ResolvedFnDef],
     mir_fns: &[&crate::ir::mir::MirFn],
-    resolved_fns: &[&crate::ir::hir::ResolvedFnDef],
     ctx: &CodegenContext,
     scope: Option<&str>,
     visibility: &str,
 ) -> Option<String> {
-    use super::toplevel::{compute_rc_params, fn_name_to_variant, rc_param_names};
+    use super::toplevel::{compute_resolved_rc_params, fn_name_to_variant};
 
     if group_fns.is_empty() {
         return None;
     }
     let enum_name = format!("__MutualTco{}", group_id);
     let trampoline_name = format!("__mutual_tco_trampoline_{}", group_id);
-    let ret_type = if group_fns[0].return_type.is_empty() {
-        "()".to_string()
-    } else {
-        super::types::type_annotation_to_rust_scoped(&group_fns[0].return_type, ctx, scope)
-    };
+    let ret_type = super::types::type_to_rust_scoped(&group_fns[0].return_type, ctx, scope);
 
     let member_fn_ids: HashSet<crate::ir::FnId> = mir_fns.iter().map(|m| m.fn_id).collect();
-    let rc_indices = compute_rc_params(group_fns, ctx);
-    let rc_names = rc_param_names(&group_fns[0].params, &rc_indices);
+    let rc_indices = compute_resolved_rc_params(group_fns);
+    let rc_names: HashSet<String> = rc_indices
+        .iter()
+        .filter_map(|&i| group_fns[0].params.get(i).map(|(name, _)| name.clone()))
+        .collect();
 
     // Render every member's trampoline-arm body FIRST — bail before
     // emitting anything if a member can't render (all-or-nothing block).
@@ -3902,7 +3900,7 @@ pub(super) fn emit_mir_mutual_tco_block(
         // flagship `vector_ops` is self-TCO, handled in `emit_mir_tco_fn`).
         // Keeping borrow-by-default is always sound — not graduating never
         // skips a clone.
-        let mut policy = MirFnEmitPolicy::from_resolved(resolved_fns[i], scope, false);
+        let mut policy = MirFnEmitPolicy::from_resolved(group_fns[i], scope, false);
         policy.rc_wrapped = rc_names.clone();
         let arm_ctx = MirEmitCtx::for_fn(ctx, &policy);
         let body = emit_mir_trampoline_body(
@@ -3927,7 +3925,7 @@ pub(super) fn emit_mir_mutual_tco_block(
             .params
             .iter()
             .filter(|(name, _)| !rc_names.contains(name))
-            .map(|(_, ty)| super::types::type_annotation_to_rust_scoped(ty, ctx, scope))
+            .map(|(_, ty)| super::types::type_to_rust_scoped(ty, ctx, scope))
             .collect();
         if param_types.is_empty() {
             enum_lines.push(format!("    {},", variant));
@@ -3974,15 +3972,14 @@ pub(super) fn emit_mir_mutual_tco_block(
     for fd in group_fns {
         let fn_name = aver_name_to_rust(&fd.name);
         let variant = fn_name_to_variant(&fd.name);
-        let params = super::toplevel::emit_fn_params_pub(&fd.params, false, ctx, scope);
+        let params = emit_resolved_fn_params(&fd.params, ctx, scope);
         let variant_arg_names: Vec<String> = fd
             .params
             .iter()
             .filter(|(name, _)| !rc_names.contains(name))
-            .map(|(name, type_ann)| {
+            .map(|(name, ty)| {
                 let rust_name = aver_name_to_rust(name);
-                let ty = crate::types::parse_type_str(type_ann);
-                if should_borrow_param(&ty) {
+                if should_borrow_param(ty) {
                     format!("{}.clone()", rust_name)
                 } else {
                     rust_name
@@ -4034,7 +4031,7 @@ pub(super) fn emit_mir_mutual_tco_block(
 /// Build the rc-param extra `&T` argument list for the mutual
 /// trampoline signature (`, x: &T, y: &U`), or empty when no rc params.
 fn mutual_rc_param_sig(
-    fd: &crate::ast::FnDef,
+    fd: &crate::ir::hir::ResolvedFnDef,
     rc_names: &HashSet<String>,
     ctx: &CodegenContext,
     scope: Option<&str>,
@@ -4050,7 +4047,7 @@ fn mutual_rc_param_sig(
             format!(
                 "{}: &{}",
                 aver_name_to_rust(name),
-                super::types::type_annotation_to_rust_scoped(ty, ctx, scope)
+                super::types::type_to_rust_scoped(ty, ctx, scope)
             )
         })
         .collect();
@@ -4059,6 +4056,26 @@ fn mutual_rc_param_sig(
     } else {
         format!(", {}", parts.join(", "))
     }
+}
+
+fn emit_resolved_fn_params(
+    params: &[(String, crate::types::Type)],
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> String {
+    params
+        .iter()
+        .map(|(name, ty)| {
+            let rust_name = aver_name_to_rust(name);
+            let rust_type = super::types::type_to_rust_scoped(ty, ctx, scope);
+            if should_borrow_param(ty) {
+                format!("{rust_name}: &{rust_type}")
+            } else {
+                format!("{rust_name}: {rust_type}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Emit one trampoline arm body from MIR: leads with

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -188,18 +188,18 @@ fn transpile_project(
     let has_http_server_types = has_http_server_runtime || needs_named_type(ctx, "HttpRequest");
     let has_terminal_types = has_terminal_runtime || needs_terminal_types;
 
-    // `main` fn lookup is identity-safe by parser invariant — only
-    // entry scope can declare it, and at most once. The view's
-    // `entry_fns()` enumerates the same set in the same source order,
-    // so iterating either substrate yields the same answer here.
-    // temporary-migration-bridge: downstream `render_root_main` still
-    // takes `Option<&FnDef>`; signature swap is a PR D follow-up.
+    // The generated entry module still pairs the AST declaration with its
+    // resolved body for source metadata. Root dispatch only needs the return
+    // type, so resolve `main` once by its entry-scope identity and hand the
+    // typed declaration to `render_root_main`.
     let main_fn = ctx.fn_defs.iter().find(|fd| fd.name == "main");
+    let resolved_main_fn = ctx
+        .symbol_table
+        .fn_id_of(&crate::ir::FnKey::entry("main"))
+        .and_then(|id| ctx.resolved_program.fn_by_id(id));
     debug_assert_eq!(
         main_fn.is_some(),
-        ctx.resolved_program
-            .entry_fns()
-            .any(|rfd| rfd.name == "main"),
+        resolved_main_fn.is_some(),
         "ctx.fn_defs and ctx.resolved_program.entry_fns() must agree on \
          main fn presence (epic #170 Phase 1 invariant)"
     );
@@ -241,7 +241,7 @@ fn transpile_project(
         (
             "src/main.rs".to_string(),
             render_root_main(
-                main_fn,
+                resolved_main_fn,
                 has_embedded_policy,
                 ctx.emit_replay_runtime,
                 ctx.guest_entry.as_deref(),
@@ -443,7 +443,7 @@ fn render_root_library(has_policy: bool, has_replay: bool, has_self_host_support
 }
 
 fn render_root_main(
-    main_fn: Option<&FnDef>,
+    main_fn: Option<&crate::ir::hir::ResolvedFnDef>,
     has_policy: bool,
     has_replay: bool,
     guest_entry: Option<&str>,
@@ -504,9 +504,14 @@ fn render_root_main(
 
     // Spawn main on a thread with 256 MB stack to avoid overflow in deep recursion.
     sections.push(String::new());
-    let returns_result = main_fn.is_some_and(|fd| fd.return_type.starts_with("Result<"));
-    let result_unit_string =
-        main_fn.is_some_and(|fd| fd.return_type.replace(' ', "") == "Result<Unit,String>");
+    let returns_result = main_fn.is_some_and(|fd| matches!(&fd.return_type, Type::Result(_, _)));
+    let result_unit_string = main_fn.is_some_and(|fd| {
+        matches!(
+            &fd.return_type,
+            Type::Result(ok, err)
+                if matches!(ok.as_ref(), Type::Unit) && matches!(err.as_ref(), Type::Str)
+        )
+    });
     // `aver bench --target rust` sets `AVER_BENCH_ITER` (and optionally
     // `AVER_BENCH_WARMUP`) to drive an in-process benchmark loop that
     // calls `aver_generated::entry::main` N times under one process.
@@ -567,7 +572,7 @@ fn render_root_main(
             sections.push("        }".to_string());
             sections.push("    }".to_string());
         } else {
-            let ret_type = types::type_annotation_to_rust(&main_fn.unwrap().return_type);
+            let ret_type = types::type_to_rust(&main_fn.unwrap().return_type);
             sections.push(format!("fn main() -> {} {{", ret_type));
             if has_provider_runtime {
                 sections.push("    bootstrap_provider_bindings().unwrap_or_else(|error| panic!(\"{}\", error));".to_string());
@@ -701,37 +706,22 @@ fn codegen_depends(
 /// regen), not by byte-parity.
 fn emit_mutual_tco_block_routed(
     group_id: usize,
-    group_fns: &[&FnDef],
+    group_fns: &[&crate::ir::hir::ResolvedFnDef],
     ctx: &CodegenContext,
     scope: Option<&str>,
     visibility: &str,
 ) -> String {
-    // Resolve every member to its (MirFn, ResolvedFnDef) pair.
-    let resolved: Option<Vec<(&crate::ir::mir::MirFn, &crate::ir::hir::ResolvedFnDef)>> =
-        ctx.mir_program.as_ref().and_then(|prog| {
+    // Every member already carries its canonical FnId. MIR lookup is the
+    // only remaining join and cannot accidentally cross a same-name scope.
+    let mir_fns: Option<Vec<&crate::ir::mir::MirFn>> =
+        ctx.mir_program.as_ref().and_then(|program| {
             group_fns
                 .iter()
-                .map(|fd| {
-                    let fn_id = crate::codegen::common::fn_id_for_decl(ctx, fd)?;
-                    let mir_fn = prog.fn_by_id(fn_id)?;
-                    let resolved_fd = ctx.resolved_program.fn_by_id(fn_id)?;
-                    Some((mir_fn, resolved_fd))
-                })
+                .map(|fd| program.fn_by_id(fd.fn_id))
                 .collect()
         });
-    let code = resolved.and_then(|pairs| {
-        let mir_fns: Vec<&crate::ir::mir::MirFn> = pairs.iter().map(|(m, _)| *m).collect();
-        let resolved_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
-            pairs.iter().map(|(_, r)| *r).collect();
-        from_mir::emit_mir_mutual_tco_block(
-            group_id,
-            group_fns,
-            &mir_fns,
-            &resolved_fns,
-            ctx,
-            scope,
-            visibility,
-        )
+    let code = mir_fns.and_then(|mir_fns| {
+        from_mir::emit_mir_mutual_tco_block(group_id, group_fns, &mir_fns, ctx, scope, visibility)
     });
     code.unwrap_or_else(|| {
         let names = group_fns
@@ -745,11 +735,7 @@ fn emit_mutual_tco_block_routed(
         // it points at every function except the one at fault.
         let message = group_fns
             .iter()
-            .filter_map(|fd| {
-                let fn_id = crate::codegen::common::fn_id_for_decl(ctx, fd)?;
-                let resolved_fd = ctx.resolved_program.fn_by_id(fn_id)?;
-                toplevel::unresolved_name_reason(resolved_fd, scope)
-            })
+            .filter_map(|fd| toplevel::unresolved_name_reason(fd, scope))
             .next()
             .unwrap_or_else(|| format!("MIR walker could not render mutual-TCO block [{names}]"));
         ctx.substituted_compile_errors
@@ -760,6 +746,20 @@ fn emit_mutual_tco_block_routed(
             visibility, group_id, message
         )
     })
+}
+
+fn missing_resolved_fn_error(fd: &FnDef, scope: Option<&str>, ctx: &CodegenContext) -> String {
+    let qualified = scope
+        .map(|prefix| format!("{prefix}.{}", fd.name))
+        .unwrap_or_else(|| fd.name.clone());
+    let message = format!(
+        "Rust codegen requires resolved HIR for function `{qualified}`; \
+         all synthesis and rewriting must finish before CodegenContext is built"
+    );
+    ctx.substituted_compile_errors
+        .borrow_mut()
+        .push(message.clone());
+    format!("compile_error!({message:?});")
 }
 
 fn entry_module_sections(
@@ -782,21 +782,17 @@ fn entry_module_sections(
         }
     }
 
-    // Detect mutual TCO groups among non-main functions. Set-form membership
-    // is read from `ctx.mutual_tco_members` (populated by the analyze stage's
-    // unioned per-module sets); the index-keyed `groups` form still comes
-    // from `find_mutual_tco_groups` because trampoline emission needs the
-    // structural shape, not just the names.
-    // temporary-migration-bridge: `find_mutual_tco_groups` walks
-    // `&[&FnDef]` to detect tail-call SCCs against the raw AST body
-    // shape. Position-aligned with `ctx.resolved_program.entry_fns()`
-    // (both iterate the same source-ordered set). PR D migrates the
-    // SCC analyser to consume `ResolvedFnDef` bodies directly.
-    let non_main_fns: Vec<&FnDef> = ctx.fn_defs.iter().filter(|fd| fd.name != "main").collect();
+    // Detect mutual TCO groups directly from resolved tail-call identities.
+    let non_main_fns: Vec<&crate::ir::hir::ResolvedFnDef> = ctx
+        .resolved_program
+        .entry_fns()
+        .filter(|fd| fd.name != "main")
+        .collect();
     let mutual_groups = toplevel::find_mutual_tco_groups(&non_main_fns);
 
     for (group_id, group_indices) in mutual_groups.iter().enumerate() {
-        let group_fns: Vec<&FnDef> = group_indices.iter().map(|&idx| non_main_fns[idx]).collect();
+        let group_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
+            group_indices.iter().map(|&idx| non_main_fns[idx]).collect();
         sections.push(emit_mutual_tco_block_routed(
             group_id + 1,
             &group_fns,
@@ -814,25 +810,19 @@ fn entry_module_sections(
     // is the identity-keyed lookup — no bare-name walk over the
     // resolved list.
     for fd in &ctx.fn_defs {
+        if fd.name == "main" {
+            continue;
+        }
         let Some(fn_id) = crate::codegen::common::fn_id_for_decl(ctx, fd) else {
+            sections.push(missing_resolved_fn_error(fd, None, ctx));
             continue;
         };
         let is_mutual = ctx.mutual_tco_members.contains(&fn_id);
-        if fd.name == "main" || is_mutual {
+        if is_mutual {
             continue;
         }
         let Some(resolved_fd) = ctx.resolved_program.fn_by_id(fn_id) else {
-            // Synthetic FnDefs (TCO hoists) inserted post-pipeline don't
-            // have a resolved twin yet — fall back to on-demand resolve
-            // for those. `temporary-migration-bridge`: PR E moves
-            // synthetic-fn resolve into a typed builder.
-            let resolved_owned = ctx.resolve_fn_def(fd, None);
-            sections.push(toplevel::emit_public_fn_def(
-                fd,
-                resolved_owned.as_ref(),
-                ctx,
-                None,
-            ));
+            sections.push(missing_resolved_fn_error(fd, None, ctx));
             continue;
         };
         sections.push(toplevel::emit_public_fn_def(fd, resolved_fd, ctx, None));
@@ -897,12 +887,6 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
         }
     }
 
-    // Same shape as the entry path: groups (with indices) come from
-    // `find_mutual_tco_groups`, set-form membership reads from
-    // `module.analysis.mutual_tco_members` (bare names, scope-local
-    // per module, DAG invariant keeps them unambiguous) when the
-    // analyze stage ran. Fall back to projecting `ctx.mutual_tco_members`
-    // (FnId set) back to bare names for this module's scope.
     // Capability hostile profiles are executable specifications, not runtime
     // implementation.  Drop their full model-only closure here, at the
     // runtime-backend boundary.  The capability registry preserves helpers
@@ -912,32 +896,16 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
         &module.fn_defs,
         &module.exposes,
     );
-    let fn_refs: Vec<&FnDef> = module
-        .fn_defs
-        .iter()
+    let fn_refs: Vec<&crate::ir::hir::ResolvedFnDef> = ctx
+        .resolved_program
+        .module_fns(&module.prefix)
         .filter(|fd| !verification_only_fns.contains(&fd.name))
         .collect();
     let mutual_groups = toplevel::find_mutual_tco_groups(&fn_refs);
-    let module_mutual_owned: HashSet<String> = match module.analysis.as_ref() {
-        Some(a) => a.mutual_tco_members.clone(),
-        None => ctx
-            .mutual_tco_members
-            .iter()
-            .filter_map(|id| {
-                let entry = ctx.symbol_table.fn_entry(*id);
-                entry
-                    .key
-                    .scope
-                    .as_deref()
-                    .filter(|s| *s == module.prefix)
-                    .map(|_| entry.key.name.clone())
-            })
-            .collect(),
-    };
-    let module_mutual = &module_mutual_owned;
 
     for (group_id, group_indices) in mutual_groups.iter().enumerate() {
-        let group_fns: Vec<&FnDef> = group_indices.iter().map(|&idx| fn_refs[idx]).collect();
+        let group_fns: Vec<&crate::ir::hir::ResolvedFnDef> =
+            group_indices.iter().map(|&idx| fn_refs[idx]).collect();
         sections.push(emit_mutual_tco_block_routed(
             group_id + 1,
             &group_fns,
@@ -948,27 +916,23 @@ fn module_sections(module: &crate::codegen::ModuleInfo, ctx: &CodegenContext) ->
     }
 
     for fd in &module.fn_defs {
-        if verification_only_fns.contains(&fd.name) || module_mutual.contains(&fd.name) {
+        if verification_only_fns.contains(&fd.name) {
             continue;
         }
-        // Same pair-API as the entry loop above. Module fns route
-        // through `fn_id_for_decl` (pointer-eq scope on `&FnDef`) →
-        // `resolved_program.fn_by_id(fn_id)` so a same-bare-name
-        // entry-scope twin never accidentally provides this body.
-        let resolved_fd = crate::codegen::common::fn_id_for_decl(ctx, fd)
-            .and_then(|id| ctx.resolved_program.fn_by_id(id));
-        let resolved_owned = if resolved_fd.is_some() {
-            None
-        } else {
-            // temporary-migration-bridge: synthetic / mid-rewrite fns
-            // fall back to on-demand resolve in the dep scope.
-            Some(ctx.resolve_fn_def(fd, Some(&module.prefix)))
+        let Some(fn_id) = crate::codegen::common::fn_id_for_decl(ctx, fd) else {
+            sections.push(missing_resolved_fn_error(fd, Some(&module.prefix), ctx));
+            continue;
         };
-        let resolved_ref: &crate::ir::hir::ResolvedFnDef =
-            resolved_fd.unwrap_or_else(|| resolved_owned.as_ref().unwrap().as_ref());
+        if ctx.mutual_tco_members.contains(&fn_id) {
+            continue;
+        }
+        let Some(resolved_fd) = ctx.resolved_program.fn_by_id(fn_id) else {
+            sections.push(missing_resolved_fn_error(fd, Some(&module.prefix), ctx));
+            continue;
+        };
         sections.push(toplevel::emit_public_fn_def(
             fd,
-            resolved_ref,
+            resolved_fd,
             ctx,
             Some(&module.prefix),
         ));
@@ -1549,6 +1513,32 @@ fn isOdd(n: Int) -> Bool
 
         // Should NOT contain direct recursive calls between the two
         assert!(!entry.contains("isOdd((n - 1i64))"));
+    }
+
+    #[test]
+    fn missing_resolved_function_is_a_hard_codegen_error() {
+        let mut ctx = ctx_from_source(
+            r#"
+module Demo
+
+fn helper(n: Int) -> Int
+    n + 1
+"#,
+            "missing-resolved-fn",
+        );
+        ctx.resolved_program = crate::codegen::program_view::ResolvedProgramView::default();
+
+        let out = transpile(&mut ctx);
+        let entry = generated_rust_entry_file(&out);
+
+        assert!(entry.contains("compile_error!"), "{entry}");
+        assert!(
+            out.generated_compile_errors()
+                .iter()
+                .any(|error| error.contains("resolved HIR for function `helper`")),
+            "{:?}",
+            out.generated_compile_errors()
+        );
     }
 
     #[test]

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -841,36 +841,6 @@ fn emit_fn_def_with_visibility(
     lines.join("\n")
 }
 
-fn emit_fn_params(
-    params: &[(String, String)],
-    mutable: bool,
-    ctx: &CodegenContext,
-    scope: Option<&str>,
-) -> String {
-    emit_fn_params_with_rc(params, mutable, &HashSet::new(), ctx, scope)
-}
-
-/// `pub(super)` shim so the MIR walker's mutual-TCO wrapper emits the
-/// same borrow-by-default param signature as the HIR emitter's wrappers.
-pub(super) fn emit_fn_params_pub(
-    params: &[(String, String)],
-    mutable: bool,
-    ctx: &CodegenContext,
-    scope: Option<&str>,
-) -> String {
-    emit_fn_params(params, mutable, ctx, scope)
-}
-
-fn emit_fn_params_with_rc(
-    params: &[(String, String)],
-    mutable: bool,
-    rc_indices: &HashSet<usize>,
-    ctx: &CodegenContext,
-    scope: Option<&str>,
-) -> String {
-    emit_fn_params_inner(params, mutable, rc_indices, &HashSet::new(), ctx, scope)
-}
-
 /// Emit the non-TCO param signature, graduating `own_param`-proven
 /// collection params (Rust-mangled names in `owned_params`) from `&T`
 /// borrow-by-default to `mut p: T` owned-by-value. The body's
@@ -1041,6 +1011,190 @@ pub(super) fn compute_rc_params(group_fns: &[&FnDef], _ctx: &CodegenContext) -> 
     // Different arities: use name+type-based detection.
     // Find params (name, type) that appear in ALL functions and are pass-through.
     compute_rc_params_by_name(group_fns)
+}
+
+/// Resolved-HIR equivalent used by mutual-TCO emission. Tail-call membership
+/// and parameter types are identity-bearing, so this path never reconstructs
+/// either fact from AST strings.
+pub(super) fn compute_resolved_rc_params(
+    group_fns: &[&crate::ir::hir::ResolvedFnDef],
+) -> HashSet<usize> {
+    if group_fns.is_empty() {
+        return HashSet::new();
+    }
+
+    let arity = group_fns[0].params.len();
+    if group_fns.iter().all(|fd| fd.params.len() == arity) {
+        return compute_resolved_rc_params_by_index(group_fns);
+    }
+
+    compute_resolved_rc_params_by_name(group_fns)
+}
+
+fn compute_resolved_rc_params_by_index(
+    group_fns: &[&crate::ir::hir::ResolvedFnDef],
+) -> HashSet<usize> {
+    let arity = group_fns[0].params.len();
+    let member_ids: HashSet<crate::ir::FnId> = group_fns.iter().map(|fd| fd.fn_id).collect();
+    let mut candidates: HashSet<usize> = (0..arity)
+        .filter(|&i| {
+            let ty = &group_fns[0].params[i].1;
+            group_fns.iter().all(|fd| fd.params[i].1 == *ty) && is_expensive_clone_type(ty)
+        })
+        .collect();
+
+    for fd in group_fns {
+        check_resolved_tailcalls_for_rc(&fd.body, &member_ids, &fd.params, &mut candidates);
+        if candidates.is_empty() {
+            break;
+        }
+    }
+    candidates
+}
+
+fn compute_resolved_rc_params_by_name(
+    group_fns: &[&crate::ir::hir::ResolvedFnDef],
+) -> HashSet<usize> {
+    let fn_param_map: HashMap<crate::ir::FnId, HashMap<&str, (usize, &crate::types::Type)>> =
+        group_fns
+            .iter()
+            .map(|fd| {
+                let params = fd
+                    .params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (name, ty))| (name.as_str(), (i, ty)))
+                    .collect();
+                (fd.fn_id, params)
+            })
+            .collect();
+    let member_ids: HashSet<crate::ir::FnId> = group_fns.iter().map(|fd| fd.fn_id).collect();
+
+    let shared_params: Vec<&str> = group_fns[0]
+        .params
+        .iter()
+        .filter(|(name, ty)| {
+            is_expensive_clone_type(ty)
+                && group_fns
+                    .iter()
+                    .all(|fd| fd.params.iter().any(|(n, t)| n == name && t == ty))
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    let valid_params: HashSet<&str> = shared_params
+        .into_iter()
+        .filter(|param_name| {
+            group_fns.iter().all(|fd| {
+                check_resolved_param_passthrough_by_name(
+                    &fd.body,
+                    &member_ids,
+                    param_name,
+                    &fn_param_map,
+                )
+            })
+        })
+        .collect();
+
+    group_fns[0]
+        .params
+        .iter()
+        .enumerate()
+        .filter(|(_, (name, _))| valid_params.contains(name.as_str()))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn resolved_expr_is_param(expr: &crate::ir::hir::ResolvedExpr, param_name: &str) -> bool {
+    matches!(
+        expr,
+        crate::ir::hir::ResolvedExpr::Resolved { name, .. }
+            | crate::ir::hir::ResolvedExpr::Ident(name)
+            if name == param_name
+    )
+}
+
+fn check_resolved_tailcalls_for_rc(
+    body: &crate::ir::hir::ResolvedFnBody,
+    member_ids: &HashSet<crate::ir::FnId>,
+    params: &[(String, crate::types::Type)],
+    candidates: &mut HashSet<usize>,
+) {
+    for stmt in body.stmts() {
+        let expr = match stmt {
+            crate::ir::hir::ResolvedStmt::Expr(expr)
+            | crate::ir::hir::ResolvedStmt::Binding { value: expr, .. } => expr,
+        };
+        check_resolved_expr_tailcalls_for_rc(&expr.node, member_ids, params, candidates);
+    }
+}
+
+fn check_resolved_expr_tailcalls_for_rc(
+    expr: &crate::ir::hir::ResolvedExpr,
+    member_ids: &HashSet<crate::ir::FnId>,
+    params: &[(String, crate::types::Type)],
+    candidates: &mut HashSet<usize>,
+) {
+    match expr {
+        crate::ir::hir::ResolvedExpr::TailCall { target, args }
+            if member_ids.contains(target) && args.len() == params.len() =>
+        {
+            candidates.retain(|&i| resolved_expr_is_param(&args[i].node, &params[i].0));
+        }
+        crate::ir::hir::ResolvedExpr::Match { arms, .. } => {
+            for arm in arms {
+                check_resolved_expr_tailcalls_for_rc(
+                    &arm.body.node,
+                    member_ids,
+                    params,
+                    candidates,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn check_resolved_param_passthrough_by_name(
+    body: &crate::ir::hir::ResolvedFnBody,
+    member_ids: &HashSet<crate::ir::FnId>,
+    param_name: &str,
+    fn_param_map: &HashMap<crate::ir::FnId, HashMap<&str, (usize, &crate::types::Type)>>,
+) -> bool {
+    body.stmts().iter().all(|stmt| {
+        let expr = match stmt {
+            crate::ir::hir::ResolvedStmt::Expr(expr)
+            | crate::ir::hir::ResolvedStmt::Binding { value: expr, .. } => expr,
+        };
+        check_resolved_expr_passthrough_by_name(&expr.node, member_ids, param_name, fn_param_map)
+    })
+}
+
+fn check_resolved_expr_passthrough_by_name(
+    expr: &crate::ir::hir::ResolvedExpr,
+    member_ids: &HashSet<crate::ir::FnId>,
+    param_name: &str,
+    fn_param_map: &HashMap<crate::ir::FnId, HashMap<&str, (usize, &crate::types::Type)>>,
+) -> bool {
+    match expr {
+        crate::ir::hir::ResolvedExpr::TailCall { target, args } if member_ids.contains(target) => {
+            fn_param_map
+                .get(target)
+                .and_then(|params| params.get(param_name))
+                .is_some_and(|(target_idx, _)| {
+                    args.get(*target_idx)
+                        .is_some_and(|arg| resolved_expr_is_param(&arg.node, param_name))
+                })
+        }
+        crate::ir::hir::ResolvedExpr::Match { arms, .. } => arms.iter().all(|arm| {
+            check_resolved_expr_passthrough_by_name(
+                &arm.body.node,
+                member_ids,
+                param_name,
+                fn_param_map,
+            )
+        }),
+        _ => true,
+    }
 }
 
 /// Index-based Rc detection: all fns have same arity, check same position.
@@ -1261,20 +1415,20 @@ pub(super) fn compute_self_passthrough_params(fd: &FnDef) -> HashSet<usize> {
 
 // --- Mutual TCO (trampoline) support ---
 
-/// Find groups of mutually tail-calling functions (SCCs of size > 1).
-/// Returns indices into `fn_defs`.
-pub fn find_mutual_tco_groups(fn_defs: &[&FnDef]) -> Vec<Vec<usize>> {
-    let name_to_idx: HashMap<&str, usize> = fn_defs
+/// Find groups of mutually tail-calling functions (SCCs of size > 1) from
+/// resolved-HIR tail-call identities. Returns indices into `fn_defs`.
+pub fn find_mutual_tco_groups(fn_defs: &[&crate::ir::hir::ResolvedFnDef]) -> Vec<Vec<usize>> {
+    let id_to_idx: HashMap<crate::ir::FnId, usize> = fn_defs
         .iter()
         .enumerate()
-        .map(|(i, fd)| (fd.name.as_str(), i))
+        .map(|(i, fd)| (fd.fn_id, i))
         .collect();
-    crate::call_graph::tailcall_scc_components(fn_defs)
+    crate::call_graph::tailcall_scc_components_resolved(fn_defs)
         .into_iter()
         .map(|group| {
             let mut indices: Vec<usize> = group
                 .iter()
-                .filter_map(|fd| name_to_idx.get(fd.name.as_str()).copied())
+                .filter_map(|fd| id_to_idx.get(&fd.fn_id).copied())
                 .collect();
             indices.sort();
             indices
@@ -1791,6 +1945,21 @@ mod tests {
         }
     }
 
+    fn resolve_test_fns(fn_defs: Vec<FnDef>) -> Vec<crate::ir::hir::ResolvedFnDef> {
+        let items: Vec<crate::ast::TopLevel> = fn_defs
+            .into_iter()
+            .map(crate::ast::TopLevel::FnDef)
+            .collect();
+        let symbols = crate::ir::SymbolTable::build(&items, &[]);
+        crate::ir::hir::resolve_program(&symbols, &items)
+            .into_iter()
+            .filter_map(|item| match item {
+                crate::ir::hir::ResolvedTopLevel::FnDef(fd) => Some(fd),
+                _ => None,
+            })
+            .collect()
+    }
+
     #[test]
     fn a_substituted_compile_error_is_recorded_where_it_is_made() {
         // The emitter is the only thing that knows it refused. `compile
@@ -1862,7 +2031,8 @@ mod tests {
             resolution: None,
         };
 
-        let fn_defs: Vec<&FnDef> = vec![&a, &b, &c];
+        let resolved = resolve_test_fns(vec![a, b, c]);
+        let fn_defs: Vec<&crate::ir::hir::ResolvedFnDef> = resolved.iter().collect();
         let groups = find_mutual_tco_groups(&fn_defs);
         assert!(
             groups.is_empty(),
@@ -1888,7 +2058,8 @@ mod tests {
             resolution: None,
         };
 
-        let fn_defs: Vec<&FnDef> = vec![&self_rec];
+        let resolved = resolve_test_fns(vec![self_rec]);
+        let fn_defs: Vec<&crate::ir::hir::ResolvedFnDef> = resolved.iter().collect();
         let groups = find_mutual_tco_groups(&fn_defs);
         assert!(
             groups.is_empty(),


### PR DESCRIPTION
Part of #1087

## Summary
- derive Rust mutual-tail-call SCCs from ResolvedProgramView and FnId
- render root main and mutual-TCO signatures from ResolvedFnDef and resolved Type values
- remove the on-demand resolve_fn_def fallback and the dead AST parameter shims
- turn a missing resolved function into a hard generated compile error

This is the Rust backend slice. Lean, Dafny, and EntryFnIndex remain tracked in #1087.

## Validation
- cargo check -p aver-lang --all-targets
- cargo test -p aver-lang --lib (1397 passed)
- cargo test -p aver-lang --lib codegen::rust::toplevel::tests (6 passed)
- cargo test -p aver-lang --lib codegen::rust::tests::mutual_tco (4 passed)
- cargo test -p aver-lang --test rust_codegen_differential rust_keyword_named_mutual_recursion_builds_and_matches_vm -- --nocapture
- AVER_SELF_HOST_REGEN=1 cargo test -p aver-lang --test rust_self_host_regen -- --ignored --nocapture (compiled 7 source files; corpus parity 3/3)
- cargo fmt --check
- git diff --check