### PR TITLE
refactor(proof): pin comparison shape in ProofIR

### DIFF
--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1387,6 +1387,7 @@ fn sample_seed_lemma_available(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenC
                 | crate::ir::ProofStrategy::NonlinearNonneg { .. }
                 | crate::ir::ProofStrategy::IntDecimalRoundtrip { .. }
                 | crate::ir::ProofStrategy::StringEscapeRoundtrip(_)
+                | crate::ir::ProofStrategy::ConditionalComparisonBridge { .. }
         )
     });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs
@@ -3045,6 +3046,10 @@ pub fn emit_verify_law(
                     // `BackendDispatch` and its exports stay
                     // byte-identical.
                     | crate::ir::ProofStrategy::StringEscapeRoundtrip(_)
+                    // Dafny has no comparison-bridge renderer yet. Keep its
+                    // existing default/fallback gates until it consumes this
+                    // ProofIR strategy explicitly.
+                    | crate::ir::ProofStrategy::ConditionalComparisonBridge { .. }
             )
         });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/lean/law_auto/induction/keystone.rs
+++ b/src/codegen/lean/law_auto/induction/keystone.rs
@@ -87,7 +87,7 @@ pub(in crate::codegen::lean) fn recognize_pool_composition_generic(
         return false;
     }
     // Exclusive with the comparison-bridge arm (it runs first).
-    if recognize_conditional_comparison_bridge(law, ctx) {
+    if recognize_conditional_comparison_bridge(vb, law, ctx) {
         return false;
     }
     // Decline a law the DETERMINISTIC interval-monotonicity rung already closes:

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -1647,124 +1647,60 @@ fn premise_intro_names(law: &VerifyLaw, intro_names: &[String]) -> Vec<String> {
     names
 }
 
-/// A linear `Nat` argument `omega` can reason about after the comparison
-/// bridges fire: a bare given/identifier, a Peano successor `Nat.S(x)` over
-/// another such term, the zero constructor `Nat.Z`, or a numeral. A non-`S`/`Z`
-/// CALL or any other term shape is rejected, so the conditional-bridge
-/// recognizer only matches goals that genuinely lower to linear arithmetic. A
-/// bare identifier is accepted regardless of its bound type — soundness rests on
-/// the SOLE caller, [`is_peano_compare_call`], gating these as the arguments of a
-/// recognized 2-arg Peano comparison fn (so they are `Nat` by that fn's
-/// signature); a misuse outside that gate would over-accept, but the proof's
-/// `sorry` floor + the `#print axioms` credit gate keep even that fail-closed.
-fn is_linear_nat_arg(expr: &crate::ast::Spanned<crate::ast::Expr>) -> bool {
-    use crate::ast::{Expr, Literal};
-    match &expr.node {
-        Expr::Ident(_) | Expr::Resolved { .. } => true,
-        Expr::Literal(Literal::Int(_)) => true,
-        Expr::FnCall(callee, args) => match super::shared::expr_dotted_name(callee) {
-            Some(name) => match name.rsplit('.').next().unwrap_or(name.as_str()) {
-                "S" => args.len() == 1 && is_linear_nat_arg(&args[0]),
-                "Z" => args.is_empty(),
-                _ => false,
-            },
-            None => false,
-        },
-        _ => false,
-    }
-}
-
-/// A 2-arg call to a recognized canonical Peano comparison fn (`≤` / `<` / `=`)
-/// whose arguments are both linear `Nat` terms. Returns `true` when the
-/// expression is exactly that shape — the building block of the
-/// conditional-comparison-bridge recognizer.
-fn is_peano_compare_call(
-    expr: &crate::ast::Spanned<crate::ast::Expr>,
+fn comparison_lean_names(
+    comparison: &crate::ir::proof_ir::PeanoComparison,
     ctx: &CodegenContext,
-) -> bool {
-    use crate::ast::Expr;
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return false;
-    };
-    if args.len() != 2 {
-        return false;
+) -> (String, String) {
+    let key = &ctx.symbol_table.fn_entry(comparison.fn_id).key;
+    let bare = aver_name_to_lean(&key.name);
+    let active_scope = ctx.active_module_scope();
+    match key.scope_str() {
+        Some(prefix) if active_scope.as_deref() != Some(prefix) && !ctx.modules.is_empty() => {
+            let path = super::super::syntax::aver_path_to_lean(prefix);
+            (
+                format!("{path}.{bare}"),
+                format!("{}_{}", path.replace('.', "_"), bare),
+            )
+        }
+        _ => (bare.clone(), bare),
     }
-    let Some(name) = super::shared::expr_dotted_name(callee) else {
-        return false;
-    };
-    let mut names = BTreeSet::new();
-    names.insert(name);
-    if crate::codegen::proof_recognize::collect_nat_compare_ops_for_names(&names, ctx).is_empty() {
-        return false;
-    }
-    is_linear_nat_arg(&args[0]) && is_linear_nat_arg(&args[1])
 }
 
-/// The EASY conditional-comparison shape (`prop_70 leSucc`): a `when` premise
-/// that is a canonical Peano Bool relation over linear `Nat` terms, and an
-/// atomic conclusion `<relation>(..) => true` that is another such relation.
-/// Bridging both sides to their Prop forms turns the law into a linear-`Nat`
-/// implication, which `omega` discharges. Deliberately narrow: a negated /
-/// compound premise, or a conclusion that is not a single comparison `= true`,
-/// is rejected so the law keeps the bounded guarded-domain fallback (the HARD
-/// conditional-inductive family — sortedness/insertion — is out of scope here).
-/// The inner comparison call of a NEGATED premise `Bool.not(<compare>)`, if the
-/// premise has that shape. `Bool.not` is the dotted builtin (not a prefix `not`).
-fn negated_compare_inner(
-    expr: &crate::ast::Spanned<crate::ast::Expr>,
-) -> Option<&crate::ast::Spanned<crate::ast::Expr>> {
-    use crate::ast::Expr;
-    let Expr::FnCall(callee, args) = &expr.node else {
-        return None;
-    };
-    if super::shared::expr_dotted_name(callee).as_deref() != Some("Bool.not") || args.len() != 1 {
-        return None;
-    }
-    Some(&args[0])
-}
-
-fn conditional_comparison_bridge_shape(law: &VerifyLaw, ctx: &CodegenContext) -> bool {
-    use crate::ast::{Expr, Literal};
-    let Some(when) = &law.when else {
-        return false;
-    };
-    // Conclusion is `<peano-compare>(..) => true` (the `=> true` / `holds`
-    // surface): rhs is the literal `true`, lhs a recognized comparison call.
-    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
-        return false;
-    }
-    if !is_peano_compare_call(&law.lhs, ctx) {
-        return false;
-    }
-    // Premise is a recognized comparison call, bare OR negated `Bool.not(...)`.
-    // The negated form (`le-totality`: `not(le a b) -> le b a`) bridges the
-    // premise via the FALSE bridge `(f a b = false) = (complement)`.
-    match negated_compare_inner(when) {
-        Some(inner) => is_peano_compare_call(inner, ctx),
-        None => is_peano_compare_call(when, ctx),
+fn comparison_lean_shape(
+    kind: crate::ir::proof_ir::PeanoComparisonKind,
+) -> (&'static str, &'static str, &'static str, bool) {
+    use crate::ir::proof_ir::PeanoComparisonKind;
+    match kind {
+        PeanoComparisonKind::Le => ("isNatLe", "≤", "b < a", false),
+        PeanoComparisonKind::Lt => ("isNatLt", "<", "b ≤ a", true),
+        PeanoComparisonKind::Eq => ("isNatEq", "=", "a ≠ b", false),
     }
 }
 
 /// Whether [`emit_conditional_comparison_bridge_law`] will close this law as a
 /// TRUE-universal conditional. The caller (`emit_verify_law_block`) reads this
 /// to decide whether to drop the sampled-domain disjunctions from the theorem
-/// statement (`omit_domain`), so the predicate must agree with the emit: it is
-/// exactly the recognizer, and the shape guarantees a comparison bridge exists
-/// (so the emit never declines for lack of one).
+/// statement (`omit_domain`). Proof lowering owns the shape decision; this
+/// helper is only a typed strategy lookup, so statement and proof consume the
+/// same `ProofIR` fact.
 pub(in crate::codegen::lean) fn recognize_conditional_comparison_bridge(
+    vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> bool {
-    conditional_comparison_bridge_shape(law, ctx)
+    matches!(
+        super::law_strategy_for(ctx, &vb.fn_name, &law.name),
+        Some(crate::ir::ProofStrategy::ConditionalComparisonBridge { .. })
+    )
 }
 
 /// Close an EASY conditional comparison law (`prop_70 leSucc`) as the
 /// TRUE-universal `∀ givens, <when> = true -> <claim>`. Emits the canonical
 /// Peano comparison bridges (`(f a b = true) = (a R b)`) for every relation the
-/// law mentions — seeding the scan with the premise's fns, which
-/// `lean_nat_lift_support` (lhs/rhs only) would otherwise miss — then proves
-/// the goal by rewriting the premise hypothesis and the goal through those
-/// bridges and discharging the linear-`Nat` residual with `omega`.
+/// ProofIR plan names, then proves the goal by rewriting the premise hypothesis
+/// and goal through those bridges and discharging the linear-`Nat` residual
+/// with `omega`. This renderer does not inspect relation definitions or decide
+/// whether a call is a canonical comparison; `proof_lower` already pinned both.
 ///
 /// FAIL-CLOSED on two axes: (1) any shape that is not the recognized
 /// pure-comparison conditional returns `None`, so the caller falls back to the
@@ -1781,9 +1717,14 @@ pub(in crate::codegen::lean) fn emit_conditional_comparison_bridge_law(
     ctx: &CodegenContext,
     intro_names: &[String],
 ) -> Option<AutoProof> {
-    if !conditional_comparison_bridge_shape(law, ctx) {
-        return None;
-    }
+    let (comparisons, negated_premise) = match super::law_strategy_for(ctx, &vb.fn_name, &law.name)?
+    {
+        crate::ir::ProofStrategy::ConditionalComparisonBridge {
+            comparisons,
+            negated_premise,
+        } => (comparisons, negated_premise),
+        _ => return None,
+    };
     // Law-scoped bridge name prefix, matching the other induction emits
     // (`{fn}_{law}`). Deliberately NOT the `{fn}_law_{law}` theorem base: a
     // `_law_` substring would make the audit's `is_main_law_theorem` mistake a
@@ -1793,18 +1734,23 @@ pub(in crate::codegen::lean) fn emit_conditional_comparison_bridge_law(
         aver_name_to_lean(&vb.fn_name),
         aver_name_to_lean(&law.name)
     );
-    // `lean_nat_lift_support` scans `lhs`/`rhs` for ops; seed `extra_fns` with
-    // the premise's fns so a premise-only relation still gets a bridge.
-    let mut extra: BTreeSet<String> = BTreeSet::new();
-    if let Some(when) = &law.when {
-        crate::codegen::proof_recognize::collect_called_fns(when, &mut extra);
+    let mut support = Vec::new();
+    let mut bridge_names = Vec::new();
+    for comparison in &comparisons {
+        let (f, f_tag) = comparison_lean_names(comparison, ctx);
+        let (suffix, prop, _false_prop, induct_on_second) = comparison_lean_shape(comparison.kind);
+        let name = format!("{law_uid}_{f_tag}_{suffix}");
+        let (driver, passenger) = if induct_on_second {
+            ("b", "a")
+        } else {
+            ("a", "b")
+        };
+        support.push(format!(
+            "theorem {name} : ∀ a b, ({f} a b = true) = (a {prop} b) := by\n  intro a b\n  induction {driver} generalizing {passenger} with\n  | zero => cases {passenger} <;> first | (simp [{f}]) | sorry\n  | succ k ih => cases {passenger} <;> first | (simp [{f}, ih]) | sorry"
+        ));
+        bridge_names.push(name);
     }
-    let (bridge_support, bridge_names, _bridged) =
-        lean_nat_lift_support(law, ctx, &law_uid, &extra);
-    let has_compare_bridge = bridge_names
-        .iter()
-        .any(|n| n.ends_with("_isNatLe") || n.ends_with("_isNatLt") || n.ends_with("_isNatEq"));
-    if !has_compare_bridge {
+    if bridge_names.is_empty() {
         return None;
     }
     let bridges = bridge_names.join(", ");
@@ -1817,32 +1763,20 @@ pub(in crate::codegen::lean) fn emit_conditional_comparison_bridge_law(
     // bridge the goal + premise and discharge with `omega`. The false bridge is
     // sound-by-floor like the true one (a misrecognized op fails its own induction
     // and lands on `sorry`, never a false theorem).
-    let mut support = bridge_support;
-    let close = if let Some(inner) = law.when.as_ref().and_then(negated_compare_inner) {
-        let mut premise_fns: BTreeSet<String> = BTreeSet::new();
-        crate::codegen::proof_recognize::collect_called_fns(inner, &mut premise_fns);
-        let false_bridges: Vec<String> = crate::codegen::proof_recognize::collect_nat_compare_ops_for_names(
-            &premise_fns, ctx,
-        )
-        .into_iter()
-        .map(|op| {
-            let f = aver_name_to_lean(&op.fn_name);
-            let name = format!("{law_uid}_{f}_{}False", op.kind.bridge_suffix());
-            let false_prop = op.kind.false_prop();
-            let (driver, passenger) = if op.kind.induct_on_second() {
-                ("b", "a")
-            } else {
-                ("a", "b")
-            };
-            support.push(format!(
-                "theorem {name} : ∀ a b, ({f} a b = false) = ({false_prop}) := by\n  intro a b\n  induction {driver} generalizing {passenger} with\n  | zero => cases {passenger} <;> first | (simp [{f}]) | (simp [{f}]; omega) | sorry\n  | succ k ih => cases {passenger} <;> first | (simp [{f}, ih]) | (simp [{f}, ih]; omega) | sorry"
-            ));
-            name
-        })
-        .collect();
-        let false_set = false_bridges.join(", ");
+    let close = if let Some(premise) = &negated_premise {
+        let (f, f_tag) = comparison_lean_names(premise, ctx);
+        let (suffix, _prop, false_prop, induct_on_second) = comparison_lean_shape(premise.kind);
+        let name = format!("{law_uid}_{f_tag}_{suffix}False");
+        let (driver, passenger) = if induct_on_second {
+            ("b", "a")
+        } else {
+            ("a", "b")
+        };
+        support.push(format!(
+            "theorem {name} : ∀ a b, ({f} a b = false) = ({false_prop}) := by\n  intro a b\n  induction {driver} generalizing {passenger} with\n  | zero => cases {passenger} <;> first | (simp [{f}]) | (simp [{f}]; omega) | sorry\n  | succ k ih => cases {passenger} <;> first | (simp [{f}, ih]) | (simp [{f}, ih]; omega) | sorry"
+        ));
         format!(
-            "  first | (simp only [{bridges}] at ⊢; simp only [Bool.not_eq_true', {false_set}, {bridges}] at h_when; omega) | sorry"
+            "  first | (simp only [{bridges}] at ⊢; simp only [Bool.not_eq_true', {name}, {bridges}] at h_when; omega) | sorry"
         )
     } else {
         // Un-negated premise: rewrite the premise hypothesis AND the goal through
@@ -2086,7 +2020,7 @@ pub(in crate::codegen::lean) fn recognize_conditional_inductive_generic(
     // `omit_domain` gate single-valued so the statement driver and the emit
     // agree). The membership family is now subsumed by this generic driver
     // (probe-decided, no helper-pool gate), so it flows straight through.
-    if recognize_conditional_comparison_bridge(law, ctx) {
+    if recognize_conditional_comparison_bridge(vb, law, ctx) {
         return false;
     }
     // Class-1 recursion-incompatibility (single-list only): a cone fn that

--- a/src/codegen/lean/law_auto/induction/multicite.rs
+++ b/src/codegen/lean/law_auto/induction/multicite.rs
@@ -285,7 +285,7 @@ fn deterministically_universal(
     if prev_law.when.is_some() {
         super::super::recognize_finite_int_domain(prev, prev_law, ctx)
             || super::super::recognize_interval_monotonicity(prev, prev_law, ctx)
-            || super::recognize_conditional_comparison_bridge(prev_law, ctx)
+            || super::recognize_conditional_comparison_bridge(prev, prev_law, ctx)
             || super::recognize_conditional_inductive_generic(prev, prev_law, ctx)
             || matches!(
                 super::super::law_strategy_for(ctx, &prev.fn_name, &prev_law.name),

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -906,7 +906,11 @@ fn emit_verify_law_block(
             // with the universal form, so dropping the sampled domain keeps
             // statement and proof aligned.
             || super::law_auto::recognize_clique_position_monotonicity(vb, &law_for_auto_proof, ctx)
-            || super::law_auto::recognize_conditional_comparison_bridge(&law_for_auto_proof, ctx)
+            || super::law_auto::recognize_conditional_comparison_bridge(
+                vb,
+                &law_for_auto_proof,
+                ctx,
+            )
             || super::law_auto::recognize_conditional_inductive_generic(
                 vb,
                 &law_for_auto_proof,
@@ -1568,7 +1572,7 @@ pub(crate) fn law_as_lemma_statement(
         )
     );
     if law.when.is_some()
-        && !(super::law_auto::recognize_conditional_comparison_bridge(law, ctx)
+        && !(super::law_auto::recognize_conditional_comparison_bridge(vb, law, ctx)
             || super::law_auto::recognize_conditional_inductive_generic(vb, law, ctx)
             // The exact-rational at-least-one (`F(k) >= 1` for `k >= 0`) and
             // monotonicity (`F(LO) <= F(HI)` for `LO <= HI`) conditional laws are

--- a/src/codegen/proof_lower/conditional_comparison.rs
+++ b/src/codegen/proof_lower/conditional_comparison.rs
@@ -1,0 +1,100 @@
+//! Lower the canonical Peano conditional-comparison law into `ProofIR`.
+//!
+//! This is syntax discovery, not backend rendering: source AST tells us that
+//! the premise and conclusion are single canonical Peano comparisons, while
+//! `ProofLowerInputs` resolves every called function/type to its owning symbol
+//! before the detector inspects that declaration. Lean and future proof
+//! backends consume the resulting `ProofStrategy` pin instead of independently
+//! deciding whether the law is universal.
+
+use crate::ast::{Expr, Literal, Spanned, VerifyLaw};
+use crate::codegen::common::expr_to_dotted_name;
+use crate::ir::proof_ir::{PeanoComparison, PeanoComparisonKind};
+
+use super::ProofLowerInputs;
+
+pub(super) struct Plan {
+    pub comparisons: Vec<PeanoComparison>,
+    pub negated_premise: Option<PeanoComparison>,
+}
+
+fn is_linear_nat_arg(expr: &Spanned<Expr>) -> bool {
+    match &expr.node {
+        Expr::Ident(_) | Expr::Resolved { .. } => true,
+        Expr::Literal(Literal::Int(_)) => true,
+        Expr::FnCall(callee, args) => match expr_to_dotted_name(&callee.node) {
+            Some(name) => match name.rsplit('.').next().unwrap_or(name.as_str()) {
+                "S" => args.len() == 1 && is_linear_nat_arg(&args[0]),
+                "Z" => args.is_empty(),
+                _ => false,
+            },
+            None => false,
+        },
+        _ => false,
+    }
+}
+
+fn comparison_call_plan(
+    expr: &Spanned<Expr>,
+    inputs: &ProofLowerInputs<'_>,
+    scope: Option<&str>,
+) -> Option<PeanoComparison> {
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return None;
+    };
+    if args.len() != 2 || !is_linear_nat_arg(&args[0]) || !is_linear_nat_arg(&args[1]) {
+        return None;
+    }
+    let name = expr_to_dotted_name(&callee.node)?;
+    let fn_id = inputs.symbol_table.resolve_fn_id_in(&name, scope)?;
+    let fd = inputs.find_fn_def_in_scope(&name, scope)?;
+    let (_, operand_type) = fd.params.first()?;
+    let owner_scope = inputs.fn_owning_scope(fd);
+    let type_def = inputs.find_type_def_in_scope(operand_type, owner_scope)?;
+    let peano = crate::codegen::proof_recognize::detect_canonical_peano(type_def)?;
+    let kind = match crate::codegen::proof_recognize::detect_nat_compare_op_for_peano(fd, &peano)? {
+        crate::codegen::proof_recognize::NatCompareKind::Le => PeanoComparisonKind::Le,
+        crate::codegen::proof_recognize::NatCompareKind::Lt => PeanoComparisonKind::Lt,
+        crate::codegen::proof_recognize::NatCompareKind::Eq => PeanoComparisonKind::Eq,
+    };
+    Some(PeanoComparison { fn_id, kind })
+}
+
+fn negated_premise_inner(expr: &Spanned<Expr>) -> Option<&Spanned<Expr>> {
+    let Expr::FnCall(callee, args) = &expr.node else {
+        return None;
+    };
+    (expr_to_dotted_name(&callee.node).as_deref() == Some("Bool.not") && args.len() == 1)
+        .then(|| &args[0])
+}
+
+/// Detect `when R1(a, b); R2(c, d) => true`, where both relations are
+/// canonical Peano comparisons over linear constructor terms. The plan carries
+/// the exact relation identities/kinds plus the optional negated-premise
+/// relation, so a backend has no declaration shape left to rediscover.
+pub(super) fn detect(
+    law: &VerifyLaw,
+    inputs: &ProofLowerInputs<'_>,
+    scope: Option<&str>,
+) -> Option<Plan> {
+    let when = law.when.as_ref()?;
+    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
+        return None;
+    }
+    let conclusion = comparison_call_plan(&law.lhs, inputs, scope)?;
+    let (premise, premise_negated) = match negated_premise_inner(when) {
+        Some(inner) => (comparison_call_plan(inner, inputs, scope)?, true),
+        None => (comparison_call_plan(when, inputs, scope)?, false),
+    };
+    let mut comparisons = vec![conclusion];
+    if !comparisons
+        .iter()
+        .any(|comparison| comparison.fn_id == premise.fn_id)
+    {
+        comparisons.push(premise.clone());
+    }
+    Some(Plan {
+        comparisons,
+        negated_premise: premise_negated.then_some(premise),
+    })
+}

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -339,6 +339,32 @@ impl<'a> ProofLowerInputs<'a> {
         })
     }
 
+    /// Resolve a source call through the canonical symbol table, then recover
+    /// the exact AST declaration that owns the resulting [`crate::ir::FnId`].
+    ///
+    /// Shape recognizers intentionally inspect source AST, but the choice of
+    /// *which* declaration to inspect is identity-sensitive. Keeping that
+    /// lookup here prevents proof lowering from repeating the old backend
+    /// mistake where two same-bare-name functions in different modules could
+    /// share whichever declaration a linear walk found first.
+    pub fn find_fn_def_in_scope(&self, call_name: &str, scope: Option<&str>) -> Option<&'a FnDef> {
+        let id = self.symbol_table.resolve_fn_id_in(call_name, scope)?;
+        let key = &self.symbol_table.fn_entry(id).key;
+        match key.scope_str() {
+            None => self.entry_items.iter().find_map(|item| match item {
+                TopLevel::FnDef(fd) if fd.name == key.name => Some(fd),
+                _ => None,
+            }),
+            Some(prefix) => self
+                .dep_modules
+                .iter()
+                .find(|module| module.prefix == prefix)?
+                .fn_defs
+                .iter()
+                .find(|fd| fd.name == key.name),
+        }
+    }
+
     /// Find a type def by bare name across entry + deps. None on miss
     /// or when the name resolves to a non-Product / non-Sum shape.
     pub fn find_type_def(&self, type_name: &str) -> Option<&'a TypeDef> {
@@ -350,6 +376,34 @@ impl<'a> ProofLowerInputs<'a> {
             })
             .chain(self.dep_modules.iter().flat_map(|m| m.type_defs.iter()))
             .find(|td| crate::codegen::common::type_def_name(td) == type_name)
+    }
+
+    /// Identity-safe counterpart of [`Self::find_type_def`]. Resolves the
+    /// source spelling from `scope` first, then recovers the declaration from
+    /// its canonical [`crate::ir::TypeId`]. Proof shape detection may inspect
+    /// the returned AST, but it never chooses that AST by bare name.
+    pub fn find_type_def_in_scope(
+        &self,
+        type_name: &str,
+        scope: Option<&str>,
+    ) -> Option<&'a TypeDef> {
+        let id = self.symbol_table.resolve_type_id_in(type_name, scope)?;
+        let key = &self.symbol_table.type_entry(id).key;
+        match key.scope_str() {
+            None => self.entry_items.iter().find_map(|item| match item {
+                TopLevel::TypeDef(td) if crate::codegen::common::type_def_name(td) == key.name => {
+                    Some(td)
+                }
+                _ => None,
+            }),
+            Some(prefix) => self
+                .dep_modules
+                .iter()
+                .find(|module| module.prefix == prefix)?
+                .type_defs
+                .iter()
+                .find(|td| crate::codegen::common::type_def_name(td) == key.name),
+        }
     }
 }
 
@@ -2262,7 +2316,8 @@ fn populate_fn_contracts_for_scope(
 /// ADTs), LibraryAxiom (Map set/get), MapUpdatePostcondition,
 /// MapKeyTrackedIncrement, SpecEquivalence{,SimpNormalized},
 /// LinearIntSpecEquivalence, EffectfulSpecEquivalence (with Oracle
-/// Lift), LinearArithmetic (catch-all over an unfold chain).
+/// Lift), ConditionalComparisonBridge (identity-pinned Peano relations),
+/// LinearArithmetic (catch-all over an unfold chain).
 /// Unmatched shapes pin `BackendDispatch` and fall through to the
 /// backend's residual chain (linear_recurrence2 emit + sampled /
 /// guarded-domain fallback).
@@ -2662,25 +2717,27 @@ fn induction_demanded_countdown_fns(inputs: &ProofLowerInputs) -> Vec<(Option<St
 ///    -f(b, a)` form. Sub-only (Mul has no anti-commutative law).
 /// 6. `UnaryEqualsBinary { inner_fn }` — outer fn is unary, claim
 ///    binds it to the inner binary fn at a constant.
-/// 7. `LinearArithmetic { unfold_fns, ... }` — catch-all when the
+/// 7. `ConditionalComparisonBridge` — a `when`-premised implication
+///    between canonical Peano comparisons over linear constructor terms.
+/// 8. `LinearArithmetic { unfold_fns, ... }` — catch-all when the
 ///    law reduces to linear arith after unfolding the call chain.
-/// 8. `EnumConstantFold { unfold_fns }` — ground law over fixed
+/// 9. `EnumConstantFold { unfold_fns }` — ground law over fixed
 ///    enum/ADT constructor args, scalar return (#466).
-/// 9. `FiniteDomainCases { givens }` — every given ranges over a
-///    closed finite domain (Bool / fieldless enum, product ≤ 16);
-///    closes by exhaustive `cases` enumeration.
-/// 10. `RingIdentity { unfold_fns }` — unconditional ring identity
+/// 10. `FiniteDomainCases { givens }` — every given ranges over a
+///     closed finite domain (Bool / fieldless enum, product ≤ 16);
+///     closes by exhaustive `cases` enumeration.
+/// 11. `RingIdentity { unfold_fns }` — unconditional ring identity
 ///     over Int-component records (cross-multiplication equality);
 ///     runs before the prelude-simp rung, which would otherwise claim
 ///     the shape and park it on a caught sorry.
-/// 11. `IntDecimalRoundtrip { … }` — canonical decimal-Int
+/// 12. `IntDecimalRoundtrip { … }` — canonical decimal-Int
 ///     parse/serialize roundtrip over a recognized string-pos scanner;
 ///     runs before the prelude-simp rung, which would otherwise claim
 ///     the shape and park it on a caught sorry.
-/// 12. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
+/// 13. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
 ///     Lean backend renders it AFTER its legacy chain, so it fires
 ///     exactly where the bare-`sorry` universal used to.
-/// 13. `BackendDispatch` — backend's ad-hoc chain decides.
+/// 14. `BackendDispatch` — backend's ad-hoc chain decides.
 ///
 /// (The induction/spec-equivalence/Map families detected between
 /// these rungs are documented at their detector sites below.)
@@ -2857,6 +2914,16 @@ fn classify_law_strategy(
             helper_fn,
         };
     }
+    // Conditional implication between canonical Peano comparisons. This used
+    // to be recognized twice inside Lean: once while choosing the theorem's
+    // universal statement and again while choosing its proof. Pin it here so
+    // every backend sees one decision and the statement/proof cannot drift.
+    if let Some(plan) = conditional_comparison::detect(law, inputs, scope) {
+        return ProofStrategy::ConditionalComparisonBridge {
+            comparisons: plan.comparisons,
+            negated_premise: plan.negated_premise,
+        };
+    }
     // Nonnegativity / order over a NONLINEAR Int product (`E >= 0` or
     // `prod <= prod`) — the inequality sibling of `RingIdentity`. Placed
     // BEFORE the `LinearArithmetic` catch-all because that rung claims any
@@ -2981,6 +3048,7 @@ fn classify_law_strategy(
     ProofStrategy::BackendDispatch
 }
 
+mod conditional_comparison;
 mod finite_domain;
 mod floor_window;
 mod induction;

--- a/src/codegen/proof_recognize.rs
+++ b/src/codegen/proof_recognize.rs
@@ -528,18 +528,6 @@ impl NatCompareKind {
         }
     }
 
-    /// The Prop the FALSE bridge maps `f a b = false` onto — the complement of
-    /// `prop_op`, written in the `omega`-ready form: `¬(a ≤ b)` is `b < a`,
-    /// `¬(a < b)` is `b ≤ a`, `¬(a = b)` is `a ≠ b`. Used to bridge a NEGATED
-    /// premise (`when Bool.not(le a b)`) into a linear-`Nat` fact.
-    pub(crate) fn false_prop(self) -> &'static str {
-        match self {
-            NatCompareKind::Le => "b < a",
-            NatCompareKind::Lt => "b ≤ a",
-            NatCompareKind::Eq => "a ≠ b",
-        }
-    }
-
     /// The bridge theorem's name suffix (kept distinct per relation so two
     /// bridges in one law never collide, and the both-args rung can spot them).
     pub(crate) fn bridge_suffix(self) -> &'static str {
@@ -606,19 +594,39 @@ fn detect_nat_compare_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatCompareK
     if fd.params.len() != 2 || fd.return_type.trim() != "Bool" {
         return None;
     }
+    let (_, t0) = &fd.params[0];
+    let (_, t1) = &fd.params[1];
+    if t0 != t1 {
+        return None;
+    }
+    let peano = peano_type_named(ctx, t0)?;
+    detect_nat_compare_op_for_peano(fd, &peano)
+}
+
+/// Classify a canonical Peano comparison after the caller has resolved the
+/// operand type and selected its exact declaration. `proof_lower` uses this
+/// entry point so syntax recognition is backend-neutral while declaration
+/// identity stays pinned by `SymbolTable`; backend renderers keep using the
+/// context convenience wrapper above.
+pub(crate) fn detect_nat_compare_op_for_peano(
+    fd: &FnDef,
+    peano: &PeanoType,
+) -> Option<NatCompareKind> {
+    if fd.params.len() != 2 || fd.return_type.trim() != "Bool" {
+        return None;
+    }
     let (p0, t0) = &fd.params[0];
     let (p1, t1) = &fd.params[1];
     if t0 != t1 {
         return None;
     }
-    let peano = peano_type_named(ctx, t0)?;
     let ln = crate::codegen::recursion::detect::local_name_of;
     let tail = fd.body.tail_expr()?;
     let Expr::Match { subject, arms, .. } = &tail.node else {
         return None;
     };
     let outer_on = ln(subject)?;
-    let (base_body, q, succ_body) = split_peano_match(arms, &peano)?;
+    let (base_body, q, succ_body) = split_peano_match(arms, peano)?;
 
     // The succ arm nests a match on the OTHER param; recursion strips one succ
     // from each. The base-arm bool and the inner-base bool encode `≤` vs `<`.
@@ -631,7 +639,7 @@ fn detect_nat_compare_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatCompareK
         return None;
     };
     let inner_on = ln(inner_subj)?;
-    let (inner_base, r, inner_succ) = split_peano_match(inner_arms, &peano)?;
+    let (inner_base, r, inner_succ) = split_peano_match(inner_arms, peano)?;
     let rec_ok = |first: &str, second: &str| {
         call_or_ctor(inner_succ).is_some_and(|(rc, ra)| {
             rc == fd.name && ra.len() == 2 && ln(ra[0]) == Some(first) && ln(ra[1]) == Some(second)
@@ -672,7 +680,7 @@ fn detect_nat_compare_op(fd: &FnDef, ctx: &CodegenContext) -> Option<NatCompareK
             ..
         } = &base_body.node
         && ln(base_subj) == Some(p1.as_str())
-        && let Some((bb_base, _z, bb_succ)) = split_peano_match(base_arms, &peano)
+        && let Some((bb_base, _z, bb_succ)) = split_peano_match(base_arms, peano)
         && as_bool_lit(bb_base) == Some(true)
         && as_bool_lit(bb_succ) == Some(false)
     {

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -43,17 +43,15 @@
 //!   `Map.set` axiom detection, spec-equivalence comparison); a
 //!   resolved walker would be the same logic spelled in a different
 //!   enum. Identity-sensitive sites that COULD leak across scope
-//!   were audited and are bounded today by:
-//!     1. `vb.fn_name` parses as a single `Ident` (verify blocks
-//!        target entry-only fns by current grammar)
-//!     2. Builtin matchers (`"Bool.and"`, `"Map.set"`, …) compare
-//!        global namespace methods that have no per-scope identity.
+//!   resolve their source spelling through `SymbolTable` under the
+//!   law/function's owning scope before recovering an AST declaration.
+//!   Builtin matchers (`"Bool.and"`, `"Map.set"`, …) still compare
+//!   global namespace methods that have no per-scope identity.
 //! - **Full `ResolvedProofLowerView` + semantic matcher API is
 //!   deferred** until a real trigger lands: module-scoped verify
-//!   blocks, dotted verify targets / laws over dep-module fns, LSP
-//!   rename, inliner / monomorphizer / cross-scope transforms. Each
-//!   of those unbounds the "entry-only" assumption above. When it
-//!   ships, the right architecture is a typed
+//!   targets, LSP rename, or inliner / monomorphizer transforms that
+//!   erase the source shapes discovery intentionally consumes. When
+//!   it ships, the right architecture is a typed
 //!   `ProofLowerInputs::resolved_fn_view(fd)` + matcher helpers
 //!   (`callee_is_builtin`, `callee_is_fn(fn_id)`, `ctor_is`,
 //!   `ident_name`, `int_lit`) — not a mechanical
@@ -545,6 +543,22 @@ pub enum WrapperDriver {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeanoComparisonKind {
+    Le,
+    Lt,
+    Eq,
+}
+
+/// One canonical Peano comparison declaration selected by proof lowering.
+/// `FnId` preserves module identity; the backend derives its target spelling
+/// from the symbol table instead of accepting a bare-name hint from the AST.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PeanoComparison {
+    pub fn_id: FnId,
+    pub kind: PeanoComparisonKind,
+}
+
 /// `LinearArithmetic` is named for the semantic, not the tactic.
 #[derive(Debug, Clone)]
 pub enum ProofStrategy {
@@ -595,6 +609,22 @@ pub enum ProofStrategy {
     UnaryEqualsBinary {
         /// Source-level name of the binary fn the unary one equals.
         inner_fn: String,
+    },
+    /// Conditional implication between canonical Peano comparisons:
+    /// `when R1(a, b); R2(c, d) => true`, with every argument a linear
+    /// constructor term. Proof lowering validates both relation definitions
+    /// against the canonical Peano recursion and pins this strategy once;
+    /// backends render their own comparison bridges without re-running the
+    /// source-shape decision.
+    ConditionalComparisonBridge {
+        /// Every distinct relation used by the premise/conclusion, in stable
+        /// claim-then-premise order. Backends render bridge declarations from
+        /// these exact identities and kinds; they do not rescan function bodies.
+        comparisons: Vec<PeanoComparison>,
+        /// The premise relation when the source premise is
+        /// `Bool.not(R1(...))`. Its presence selects the false/complement bridge
+        /// and also identifies the exact declaration that bridge belongs to.
+        negated_premise: Option<PeanoComparison>,
     },
     /// "Linear arithmetic over an unfold chain" — the law's two
     /// sides reduce to a flat linear equation on Int once every

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -23,7 +23,8 @@ use aver::codegen::recursion::{RecursionPlan, analyze_plans_in_scope};
 use aver::ir::proof_ir::{
     DecreaseProof, FuelMetric, Measure, PreservationProof, QuantifierType, RecursionContract,
 };
-use aver::source::parse_source;
+use aver::source::{LoadedModule, parse_source};
+use std::path::PathBuf;
 
 fn build_ctx(src: &str) -> CodegenContext {
     let mut items = parse_source(src).expect("parse");
@@ -81,6 +82,71 @@ fn build_ctx(src: &str) -> CodegenContext {
     ctx
 }
 
+fn build_ctx_with_modules(entry_src: &str, deps: &[(&str, &str)]) -> CodegenContext {
+    let mut items = parse_source(entry_src).expect("entry parse");
+    let loaded: Vec<LoadedModule> = deps
+        .iter()
+        .map(|(name, source)| LoadedModule {
+            dep_name: (*name).to_string(),
+            items: parse_source(source).unwrap_or_else(|error| panic!("{name} parse: {error}")),
+            path: PathBuf::from(format!("{name}.av")),
+        })
+        .collect();
+    let modules: Vec<aver::codegen::ModuleInfo> = loaded
+        .iter()
+        .map(aver::codegen::ModuleInfo::from_loaded)
+        .collect();
+    let mut pipeline_result = aver::ir::pipeline::run(
+        &mut items,
+        aver::ir::PipelineConfig {
+            run_tco: true,
+            typecheck: Some(aver::ir::TypecheckMode::WithLoaded(&loaded)),
+            run_interp_lower: false,
+            run_buffer_build: false,
+            run_chars_fusion: false,
+            run_string_index: false,
+            run_list_build: false,
+            run_resolve: false,
+            run_last_use: false,
+            run_analyze: true,
+            run_escape: false,
+            run_refinement_lower: true,
+            run_interval_analyze: false,
+            run_contract_lower: true,
+            run_law_lower: true,
+            run_build_symbols: true,
+            dep_modules: &modules,
+            alloc_policy: None,
+            call_ctx: None,
+            on_after_pass: None,
+        },
+    );
+    let tc = pipeline_result
+        .typecheck
+        .take()
+        .expect("typecheck requested");
+    assert!(
+        tc.errors.is_empty(),
+        "multi-module source typechecks: {:?}",
+        tc.errors
+    );
+    let proof_ir = pipeline_result.proof_ir.take();
+    let view = pipeline_result.codegen_view(items);
+    let mut ctx = aver::codegen::build_context(
+        view.items,
+        &tc,
+        view.analysis.as_ref(),
+        "diff-modules".to_string(),
+        modules,
+        view.symbol_table,
+        view.resolved_items,
+    );
+    if let Some(ir) = proof_ir {
+        ctx.proof_ir = ir;
+    }
+    ctx
+}
+
 /// Resolve a top-level fn's `FnContract` by bare name. After the
 /// FnKey → FnId migration the contracts map is keyed by opaque
 /// `FnId`, so tests resolve the identity through the symbol table
@@ -109,6 +175,21 @@ fn law_theorem<'a>(
         .law_theorems
         .iter()
         .find(|t| t.fn_id == fn_id && t.law_name == law_name)
+}
+
+fn module_law_theorem<'a>(
+    ctx: &'a CodegenContext,
+    module: &str,
+    fn_name: &str,
+    law_name: &str,
+) -> Option<&'a aver::ir::proof_ir::LawTheorem> {
+    let fn_id = ctx
+        .symbol_table
+        .fn_id_of(&aver::ir::FnKey::in_module(module, fn_name))?;
+    ctx.proof_ir
+        .law_theorems
+        .iter()
+        .find(|theorem| theorem.fn_id == fn_id && theorem.law_name == law_name)
 }
 
 fn legacy_decision(ctx: &CodegenContext, type_name: &str) -> Option<LegacyDecl> {
@@ -1176,6 +1257,184 @@ fn reflexive_law_pinned_when_lhs_equals_rhs() {
         matches!(theorem.strategy, aver::ir::ProofStrategy::Reflexive),
         "x => x must pin Reflexive, got: {:?}",
         theorem.strategy,
+    );
+}
+
+#[test]
+fn conditional_peano_comparison_is_pinned_before_the_lean_backend() {
+    let src = "module CmpBridge\n\
+         \x20   intent = \"comparison implication\"\n\
+         \n\
+         type Nat\n\
+         \x20   Z\n\
+         \x20   S(Nat)\n\
+         \n\
+         fn le(x: Nat, y: Nat) -> Bool\n\
+         \x20   match x\n\
+         \x20       Nat.Z -> true\n\
+         \x20       Nat.S(z) -> match y\n\
+         \x20           Nat.Z -> false\n\
+         \x20           Nat.S(w) -> le(z, w)\n\
+         \n\
+         verify le law leSucc\n\
+         \x20   given m: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   given n: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   when le(m, n)\n\
+         \x20   le(m, Nat.S(n)) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "le", "leSucc").expect("law theorem");
+    let aver::ir::ProofStrategy::ConditionalComparisonBridge {
+        comparisons,
+        negated_premise,
+    } = &theorem.strategy
+    else {
+        panic!(
+            "proof lowering must own the comparison-bridge decision, got {:?}",
+            theorem.strategy
+        );
+    };
+    assert!(negated_premise.is_none());
+    assert_eq!(comparisons.len(), 1);
+    assert_eq!(
+        comparisons[0].kind,
+        aver::ir::proof_ir::PeanoComparisonKind::Le
+    );
+    assert_eq!(
+        comparisons[0].fn_id,
+        ctx.symbol_table
+            .fn_id_of(&aver::ir::FnKey::entry("le"))
+            .expect("le id")
+    );
+}
+
+#[test]
+fn negated_peano_comparison_pins_the_false_bridge_plan() {
+    let src = "module CmpBridge\n\
+         \x20   intent = \"comparison implication\"\n\
+         \n\
+         type Nat\n\
+         \x20   Z\n\
+         \x20   S(Nat)\n\
+         \n\
+         fn le(x: Nat, y: Nat) -> Bool\n\
+         \x20   match x\n\
+         \x20       Nat.Z -> true\n\
+         \x20       Nat.S(z) -> match y\n\
+         \x20           Nat.Z -> false\n\
+         \x20           Nat.S(w) -> le(z, w)\n\
+         \n\
+         verify le law totality\n\
+         \x20   given m: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   given n: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   when Bool.not(le(m, n))\n\
+         \x20   le(n, m) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "le", "totality").expect("law theorem");
+    let aver::ir::ProofStrategy::ConditionalComparisonBridge {
+        comparisons,
+        negated_premise: Some(negated),
+    } = &theorem.strategy
+    else {
+        panic!(
+            "proof lowering must pin the negated-premise bridge, got {:?}",
+            theorem.strategy
+        );
+    };
+    assert_eq!(comparisons, std::slice::from_ref(negated));
+    assert_eq!(negated.kind, aver::ir::proof_ir::PeanoComparisonKind::Le);
+}
+
+#[test]
+fn comparison_shape_lookup_is_scoped_across_same_bare_names() {
+    let entry = "module Entry\n\
+         \x20   intent = \"load colliding comparison modules\"\n\
+         \x20   depends [Good, Decoy]\n\
+         \n\
+         fn main() -> Int\n\
+         \x20   0\n";
+    let good = "module Good\n\
+         \x20   intent = \"canonical comparison\"\n\
+         \x20   exposes [Nat, le]\n\
+         \n\
+         type Nat\n\
+         \x20   Z\n\
+         \x20   S(Nat)\n\
+         \n\
+         fn le(x: Nat, y: Nat) -> Bool\n\
+         \x20   match x\n\
+         \x20       Nat.Z -> true\n\
+         \x20       Nat.S(z) -> match y\n\
+         \x20           Nat.Z -> false\n\
+         \x20           Nat.S(w) -> le(z, w)\n\
+         \n\
+         verify le law successor\n\
+         \x20   given m: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   given n: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   when le(m, n)\n\
+         \x20   le(m, Nat.S(n)) => true\n";
+    let decoy = "module Decoy\n\
+         \x20   intent = \"same names, different declarations\"\n\
+         \x20   exposes [Nat, le]\n\
+         \n\
+         type Nat\n\
+         \x20   Z\n\
+         \x20   S(Int)\n\
+         \n\
+         fn le(x: Nat, y: Nat) -> Bool\n\
+         \x20   true\n\
+         \n\
+         verify le law successor\n\
+         \x20   given m: Nat = [Nat.Z, Nat.S(0)]\n\
+         \x20   given n: Nat = [Nat.Z, Nat.S(0)]\n\
+         \x20   when le(m, n)\n\
+         \x20   le(m, n) => true\n";
+    let ctx = build_ctx_with_modules(entry, &[("Good", good), ("Decoy", decoy)]);
+
+    let good_law = module_law_theorem(&ctx, "Good", "le", "successor").expect("Good law");
+    assert!(matches!(
+        good_law.strategy,
+        aver::ir::ProofStrategy::ConditionalComparisonBridge { .. }
+    ));
+
+    let decoy_law = module_law_theorem(&ctx, "Decoy", "le", "successor").expect("Decoy law");
+    assert!(
+        !matches!(
+            decoy_law.strategy,
+            aver::ir::ProofStrategy::ConditionalComparisonBridge { .. }
+        ),
+        "same-bare-name lookup must not borrow Good.le/Good.Nat for Decoy's law",
+    );
+}
+
+#[test]
+fn compound_peano_premise_stays_out_of_comparison_bridge_strategy() {
+    let src = "module CmpBridge\n\
+         \x20   intent = \"comparison implication\"\n\
+         \n\
+         type Nat\n\
+         \x20   Z\n\
+         \x20   S(Nat)\n\
+         \n\
+         fn le(x: Nat, y: Nat) -> Bool\n\
+         \x20   match x\n\
+         \x20       Nat.Z -> true\n\
+         \x20       Nat.S(z) -> match y\n\
+         \x20           Nat.Z -> false\n\
+         \x20           Nat.S(w) -> le(z, w)\n\
+         \n\
+         verify le law weakened\n\
+         \x20   given m: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   given n: Nat = [Nat.Z, Nat.S(Nat.Z)]\n\
+         \x20   when Bool.and(le(m, n), le(m, n))\n\
+         \x20   le(m, Nat.S(n)) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "le", "weakened").expect("law theorem");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::ConditionalComparisonBridge { .. }
+        ),
+        "compound premises must keep the bounded/backend fallback",
     );
 }
 


### PR DESCRIPTION
Part of #1087.

Moves the conditional Peano-comparison law decision out of the Lean backend and into proof lowering.

- pins exact relation FnIds, comparison kinds, and negated-premise data in ProofIR
- makes Lean render comparison bridges from the typed plan instead of rescanning AST/function bodies
- uses scope-aware symbol resolution for source-shape discovery
- keeps Dafny on its existing fallback behavior until it gains a renderer for this strategy
- covers false positives, negated premises, and same-bare-name collisions across dependency modules

Validation:
- cargo fmt --all -- --check
- cargo clippy -p aver-lang --lib --bin aver -- -D warnings
- cargo test -p aver-lang --lib (1397 passed)
- cargo test -p aver-lang --test proof_ir_diff (63 passed)
- live Lake negated-premise comparison proof
- demotion and regenerated-baseline ratchet tests