### PR TITLE
refactor(proof): pin bounded Int laws in ProofIR

### DIFF
--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -523,20 +523,8 @@ fn emit_fn_call(
             }
         }
         ResolvedCallee::Fn(fn_id) => {
-            let entry = ctx.symbol_table.fn_entry(*fn_id);
-            let bare = entry.key.name.as_str();
-            let module_prefix = entry.key.scope_str();
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr_atom(a, ctx)).collect();
-            let func = match module_prefix {
-                Some(prefix) if !ctx.modules.is_empty() => {
-                    format!(
-                        "{}.{}",
-                        super::syntax::aver_path_to_lean(prefix),
-                        aver_name_to_lean(bare)
-                    )
-                }
-                _ => aver_name_to_lean(bare),
-            };
+            let func = user_fn_path(*fn_id, ctx);
             if arg_strs.is_empty() {
                 func
             } else {
@@ -566,6 +554,20 @@ fn emit_fn_call(
                 format!("{} {}", func, arg_strs.join(" "))
             }
         }
+    }
+}
+
+/// Canonical Lean spelling for a resolved user function. Every renderer with
+/// an `FnId` (ordinary expressions and ProofIR support declarations alike)
+/// uses this path instead of reconstructing module qualification locally.
+pub(crate) fn user_fn_path(fn_id: crate::ir::FnId, ctx: &CodegenContext) -> String {
+    let entry = ctx.symbol_table.fn_entry(fn_id);
+    let bare = aver_name_to_lean(&entry.key.name);
+    match entry.key.scope_str() {
+        Some(prefix) if !ctx.modules.is_empty() => {
+            format!("{}.{}", super::syntax::aver_path_to_lean(prefix), bare)
+        }
+        _ => bare,
     }
 }
 

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -168,9 +168,9 @@ pub(in crate::codegen::lean) use triangle_sum::triangle_sum_cited_deps;
 /// statement driver, kept in lockstep with `emit_transparent_chain_law`.
 pub(in crate::codegen::lean) use transparent_chain::recognize_transparent_chain;
 
-// (Defined in this module.) The finite bounded-Int-domain recognizer — see
-// `recognize_finite_int_domain` — feeds the `omit_domain` statement driver so
-// the universal statement and the enumerate-then-`decide` proof stay in lockstep.
+// The finite bounded-Int-domain ProofIR strategy feeds the `omit_domain`
+// statement driver so the universal statement and the enumerate-then-`decide`
+// proof stay in lockstep.
 
 /// `aver proof --explain` residual probe: turn an emitted main law theorem's
 /// source lines into a normalization-only twin so Lean reports its residual
@@ -462,151 +462,20 @@ fn maybe_wrap_with_grind_rung(
     }
 }
 
-/// A finite bounded-Int-domain law: a SINGLE `Int` given quantified by a
-/// `when LO <= var` + `when var < HI` guard pair (constant literal bounds,
-/// `LO < HI`) whose conclusion is an atomic `holds` claim `subject(var) =>
-/// true` for a pure NON-RECURSIVE `Bool` fn. The closed integer interval
-/// `[LO, HI)` IS the finite domain — the guards are load-bearing, not
-/// decoration: drop them and the claim quantifies over all of `ℤ`, where a
-/// table `lookup` outside its range returns the out-of-domain default and the
-/// bound is false. Name-blind: the recognizer keys on the guard/claim SHAPE,
-/// never on a table-specific fn name.
-struct FiniteIntDomain {
-    /// The single given variable (source name).
-    var: String,
-    /// Inclusive lower bound from `when LO <= var` / `when var >= LO`.
-    lo: i64,
-    /// Exclusive upper bound from `when var < HI` / `when HI > var`.
-    hi: i64,
-    /// The `holds` subject fn, already mapped to its Lean name.
-    subject_lean: String,
-}
-
-/// Read an integer literal `Expr`, accepting a unary-negated literal (`-7`).
-fn finite_domain_int_literal(expr: &crate::ast::Spanned<crate::ast::Expr>) -> Option<i64> {
-    use crate::ast::{Expr, Literal};
-    match &expr.node {
-        Expr::Literal(Literal::Int(n)) => Some(*n),
-        Expr::Neg(inner) => match &inner.node {
-            Expr::Literal(Literal::Int(n)) => Some(-*n),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-/// Classify one conjunct of the `when` guard as a lower or upper bound on
-/// `var`, returning `(is_upper, bound)`. Lower: `LO <= var` / `var >= LO`.
-/// Upper: `var < HI` / `HI > var`.
-fn finite_domain_bound(
-    expr: &crate::ast::Spanned<crate::ast::Expr>,
-    var: &str,
-) -> Option<(bool, i64)> {
-    use crate::ast::{BinOp, Expr};
-    let Expr::BinOp(op, l, r) = &expr.node else {
-        return None;
-    };
-    let l_is_var = shared::expr_dotted_name(l).as_deref() == Some(var);
-    let r_is_var = shared::expr_dotted_name(r).as_deref() == Some(var);
-    match op {
-        // LO <= var
-        BinOp::Lte if r_is_var => finite_domain_int_literal(l).map(|n| (false, n)),
-        // var >= LO
-        BinOp::Gte if l_is_var => finite_domain_int_literal(r).map(|n| (false, n)),
-        // var < HI
-        BinOp::Lt if l_is_var => finite_domain_int_literal(r).map(|n| (true, n)),
-        // HI > var
-        BinOp::Gt if r_is_var => finite_domain_int_literal(l).map(|n| (true, n)),
-        _ => None,
-    }
-}
-
-/// Recognize the finite bounded-Int-domain shape. Pure / name-blind — see
-/// [`FiniteIntDomain`]. Declines (so the law keeps its bounded sampled-domain
-/// fallback) unless EVERY structural gate holds: one `Int` given, a
-/// `Bool.and(lower, upper)` guard with constant literal bounds `LO < HI`, a
-/// `subject(var) => true` conclusion over a non-recursive cone, and a domain
-/// size within the kernel `decide` budget.
-fn recognize_finite_int_domain_shape(
-    vb: &VerifyBlock,
-    law: &VerifyLaw,
-    ctx: &CodegenContext,
-) -> Option<FiniteIntDomain> {
-    use crate::ast::{Expr, Literal};
-    // Exactly one given, of carrier type `Int`.
-    if law.givens.len() != 1 {
-        return None;
-    }
-    let given = &law.givens[0];
-    if given.type_name.trim() != "Int" {
-        return None;
-    }
-    let var = given.name.clone();
-    // Conclusion: `subject(var) => true` (the `holds` surface lowers `holds`
-    // to `lhs = true`). The subject takes the given as its only argument.
-    if !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true))) {
-        return None;
-    }
-    let Expr::FnCall(callee, args) = &law.lhs.node else {
-        return None;
-    };
-    if args.len() != 1 || shared::expr_dotted_name(&args[0]).as_deref() != Some(var.as_str()) {
-        return None;
-    }
-    let subject_src = shared::expr_dotted_name(callee)?;
-    // Guard: `Bool.and(<bound>, <bound>)` — one lower, one upper, both on `var`.
-    let when = law.when.as_ref()?;
-    let Expr::FnCall(wcallee, wargs) = &when.node else {
-        return None;
-    };
-    if shared::expr_dotted_name(wcallee).as_deref() != Some("Bool.and") || wargs.len() != 2 {
-        return None;
-    }
-    let mut lo: Option<i64> = None;
-    let mut hi: Option<i64> = None;
-    for conjunct in wargs {
-        match finite_domain_bound(conjunct, &var)? {
-            (false, n) => lo = Some(n),
-            (true, n) => hi = Some(n),
-        }
-    }
-    let (lo, hi) = (lo?, hi?);
-    if hi <= lo {
-        return None;
-    }
-    // Domain-size budget: the kernel `decide` enumerates `HI - LO` ground
-    // cases. 128 (the K5 reciprocal table) is comfortable; cap generously so a
-    // pathological range can never wedge the build (it keeps its fallback).
-    if hi - lo > 4096 {
-        return None;
-    }
-    // Reduction gate: the subject's whole unfold cone must be NON-RECURSIVE, so
-    // each ground case computes out under kernel `decide` (a recursive fn would
-    // stay stuck on an opaque fuel/`partial` term). Same cone ∩ recursion test
-    // the grind rung uses.
-    let cone = shared::law_simp_source_names(ctx, vb, law);
-    let recursive = recursive_pure_fn_names(ctx);
-    if cone.iter().any(|name| recursive.contains(name)) {
-        return None;
-    }
-    Some(FiniteIntDomain {
-        var,
-        lo,
-        hi,
-        subject_lean: aver_name_to_lean(&subject_src),
-    })
-}
-
 /// Whether the finite bounded-Int-domain emit will close this law UNIVERSALLY.
 /// The statement builder reads this (alongside the other conditional
 /// recognizers) to drop the sampled-domain disjunctions (`omit_domain`) and
-/// class the law `universal`, keeping statement and proof in lockstep.
+/// class the law `universal`. This is a ProofIR strategy lookup; shape
+/// recognition and the non-recursive-cone gate already ran in `proof_lower`.
 pub(in crate::codegen::lean) fn recognize_finite_int_domain(
     vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> bool {
-    recognize_finite_int_domain_shape(vb, law, ctx).is_some()
+    matches!(
+        law_strategy_for(ctx, &vb.fn_name, &law.name),
+        Some(crate::ir::ProofStrategy::BoundedIntDomain { .. })
+    )
 }
 
 /// Close a finite bounded-Int-domain law by pure-kernel enumeration: lower the
@@ -630,12 +499,16 @@ fn emit_finite_int_domain_law(
     ctx: &CodegenContext,
     theorem_base: &str,
 ) -> Option<AutoProof> {
-    let FiniteIntDomain {
+    let crate::ir::ProofStrategy::BoundedIntDomain {
         var,
         lo,
         hi,
-        subject_lean,
-    } = recognize_finite_int_domain_shape(vb, law, ctx)?;
+        subject,
+    } = law_strategy_for(ctx, &vb.fn_name, &law.name)?
+    else {
+        return None;
+    };
+    let subject_lean = super::expr::user_fn_path(subject, ctx);
     let v = aver_name_to_lean(&var);
     let count = hi - lo;
     let text = format!(
@@ -686,9 +559,9 @@ fn emit_verify_law_forall_auto_proof_inner(
 
     // Finite bounded-Int-domain laws (the K5 reciprocal seed table): a single
     // `Int` given guarded into a closed interval `[LO, HI)`, closed by pure-
-    // kernel enumeration (`decide` over a bounded-`Nat` forall). Tried first
-    // among the `when`-arms — its guard shape (`LO <= var && var < HI`) is
-    // disjoint from the Peano comparison-bridge / inductive shapes below.
+    // kernel enumeration (`decide` over a bounded-`Nat` forall). ProofIR already
+    // validated its guard/call/cone shape; this first `when` arm only renders
+    // the pinned plan.
     if law.when.is_some()
         && let Some(proof) = emit_finite_int_domain_law(vb, law, ctx, theorem_base)
     {
@@ -715,10 +588,9 @@ fn emit_verify_law_forall_auto_proof_inner(
 
     // Conditional comparison-bridge laws (the `prop_70 leSucc` family):
     // `when <R1(..)> -> <R2(..)> = true` over canonical Peano relations
-    // (`≤`/`<`/`=`). Tried BEFORE the pinned-strategy dispatch because
-    // `classify_law_strategy` never pins `Induction` on a `when`-law (it routes
-    // them to `LinearArithmetic` / `BackendDispatch`), so this is the only point
-    // a conditional law reaches a genuine universal closer. For exactly this
+    // (`≤`/`<`/`=`). Proof lowering pins the comparison plan; this early arm
+    // keeps the specialized bridge stack ahead of generic proof dispatch. For
+    // exactly this
     // recognized shape `emit_verify_law_block` emits the unbounded
     // `∀ givens, when = true -> claim` statement (see
     // `recognize_conditional_comparison_bridge`); every other conditional shape

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -1653,17 +1653,15 @@ fn comparison_lean_names(
 ) -> (String, String) {
     let key = &ctx.symbol_table.fn_entry(comparison.fn_id).key;
     let bare = aver_name_to_lean(&key.name);
-    let active_scope = ctx.active_module_scope();
-    match key.scope_str() {
-        Some(prefix) if active_scope.as_deref() != Some(prefix) && !ctx.modules.is_empty() => {
+    let call = super::super::expr::user_fn_path(comparison.fn_id, ctx);
+    let tag = match key.scope_str() {
+        Some(prefix) if !ctx.modules.is_empty() => {
             let path = super::super::syntax::aver_path_to_lean(prefix);
-            (
-                format!("{path}.{bare}"),
-                format!("{}_{}", path.replace('.', "_"), bare),
-            )
+            format!("{}_{}", path.replace('.', "_"), bare)
         }
-        _ => (bare.clone(), bare),
-    }
+        _ => bare,
+    };
+    (call, tag)
 }
 
 fn comparison_lean_shape(

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -1203,6 +1203,33 @@ verify le law leSucc
 }
 
 #[test]
+fn transpile_renders_bounded_int_domain_from_proof_ir_plan() {
+    let mut ctx = ctx_from_source(
+        r#"
+module BoundedInt
+    intent = "finite guarded integer law"
+
+fn inRange(i: Int) -> Bool
+    i >= 0
+
+verify inRange law seedTable
+    given i: Int = [0, 1, 2, 3]
+    when Bool.and(i >= 0, i < 4)
+    inRange(i) => true
+"#,
+        "bounded_int",
+    );
+    let out = transpile(&mut ctx);
+    let lean = generated_lean_file(&out);
+
+    assert!(lean.contains("-- aver:law-class inRange_law_seedTable universal inRange.seedTable"));
+    assert!(lean.contains(
+        "theorem inRange_law_seedTable : ∀ (i : Int), 0 ≤ i → i < 4 → inRange i = true := by"
+    ));
+    assert!(lean.contains("exact (by decide : ∀ m : Nat, m < 4 → inRange (0 + (m : Int)) = true)"));
+}
+
+#[test]
 fn transpile_proves_conditional_inductive_membership_law_as_universal() {
     // `prop_36 elemConcat`: `when elem(x,y) -> elem(x, y ++ z) => true` (append
     // monotonicity). The GENERIC conditional-inductive driver (no bespoke

--- a/src/codegen/proof_lower/bounded_int_domain.rs
+++ b/src/codegen/proof_lower/bounded_int_domain.rs
@@ -1,0 +1,158 @@
+//! Lower finite guarded-`Int` laws into a backend-neutral proof plan.
+//!
+//! The source shape is one `Int` given, a `Bool.and` guard spelling a
+//! half-open literal interval, and a unary Bool subject asserted `true`.
+//! Declaration selection and the non-recursive-cone gate use `FnId`; backends
+//! receive the validated bounds and subject identity without rescanning AST.
+
+use std::collections::BTreeSet;
+
+use crate::ast::{BinOp, Expr, Literal, Spanned, VerifyLaw};
+use crate::codegen::common::expr_to_dotted_name;
+use crate::ir::FnId;
+
+use super::{ProofLowerInputs, collect_fn_calls_expr};
+
+pub(super) struct Plan {
+    pub var: String,
+    pub lo: i64,
+    pub hi: i64,
+    pub subject: FnId,
+}
+
+fn int_literal(expr: &Spanned<Expr>) -> Option<i64> {
+    match &expr.node {
+        Expr::Literal(Literal::Int(value)) => Some(*value),
+        Expr::Neg(inner) => match &inner.node {
+            Expr::Literal(Literal::Int(value)) => Some(-*value),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Return `(is_upper, bound)` for `LO <= var`, `var >= LO`, `var < HI`,
+/// or `HI > var`.
+fn bound(expr: &Spanned<Expr>, var: &str) -> Option<(bool, i64)> {
+    let Expr::BinOp(op, left, right) = &expr.node else {
+        return None;
+    };
+    let left_is_var = expr_to_dotted_name(&left.node).as_deref() == Some(var);
+    let right_is_var = expr_to_dotted_name(&right.node).as_deref() == Some(var);
+    match op {
+        BinOp::Lte if right_is_var => int_literal(left).map(|value| (false, value)),
+        BinOp::Gte if left_is_var => int_literal(right).map(|value| (false, value)),
+        BinOp::Lt if left_is_var => int_literal(right).map(|value| (true, value)),
+        BinOp::Gt if right_is_var => int_literal(left).map(|value| (true, value)),
+        _ => None,
+    }
+}
+
+fn insert_pure_callee(
+    name: &str,
+    scope: Option<&str>,
+    inputs: &ProofLowerInputs<'_>,
+    cone: &mut BTreeSet<FnId>,
+) {
+    let Some(id) = inputs.symbol_table.resolve_fn_id_in(name, scope) else {
+        return;
+    };
+    let Some(fd) = inputs.find_fn_def_by_id(id) else {
+        return;
+    };
+    if crate::codegen::common::is_pure_fn(fd) {
+        cone.insert(id);
+    }
+}
+
+fn cone_is_non_recursive(target: FnId, subject: FnId, inputs: &ProofLowerInputs<'_>) -> bool {
+    let mut cone = BTreeSet::from([target, subject]);
+    loop {
+        let before = cone.len();
+        let snapshot: Vec<FnId> = cone.iter().copied().collect();
+        for id in snapshot {
+            let Some(fd) = inputs.find_fn_def_by_id(id) else {
+                return false;
+            };
+            if !crate::codegen::common::is_pure_fn(fd) {
+                continue;
+            }
+            let owner_scope = inputs.fn_owning_scope(fd);
+            let mut called = BTreeSet::new();
+            for stmt in fd.body.stmts() {
+                match stmt {
+                    crate::ast::Stmt::Binding(_, _, expr) | crate::ast::Stmt::Expr(expr) => {
+                        collect_fn_calls_expr(expr, &mut called);
+                    }
+                }
+            }
+            for name in called {
+                insert_pure_callee(&name, owner_scope, inputs, &mut cone);
+            }
+        }
+        if cone.len() == before {
+            break;
+        }
+    }
+    !cone.iter().any(|id| inputs.recursive_fns.contains(id))
+}
+
+pub(super) fn detect(
+    law: &VerifyLaw,
+    fn_name: &str,
+    inputs: &ProofLowerInputs<'_>,
+    scope: Option<&str>,
+) -> Option<Plan> {
+    let [given] = law.givens.as_slice() else {
+        return None;
+    };
+    if given.type_name.trim() != "Int"
+        || !matches!(&law.rhs.node, Expr::Literal(Literal::Bool(true)))
+    {
+        return None;
+    }
+    let var = given.name.clone();
+
+    let Expr::FnCall(callee, args) = &law.lhs.node else {
+        return None;
+    };
+    if args.len() != 1 || expr_to_dotted_name(&args[0].node).as_deref() != Some(var.as_str()) {
+        return None;
+    }
+    let subject_name = expr_to_dotted_name(&callee.node)?;
+    let subject = inputs.symbol_table.resolve_fn_id_in(&subject_name, scope)?;
+    let subject_def = inputs.find_fn_def_by_id(subject)?;
+    if !crate::codegen::common::is_pure_fn(subject_def) || subject_def.return_type.trim() != "Bool"
+    {
+        return None;
+    }
+
+    let when = law.when.as_ref()?;
+    let Expr::FnCall(guard, conjuncts) = &when.node else {
+        return None;
+    };
+    if expr_to_dotted_name(&guard.node).as_deref() != Some("Bool.and") || conjuncts.len() != 2 {
+        return None;
+    }
+    let mut lo = None;
+    let mut hi = None;
+    for conjunct in conjuncts {
+        match bound(conjunct, &var)? {
+            (false, value) => lo = Some(value),
+            (true, value) => hi = Some(value),
+        }
+    }
+    let (lo, hi) = (lo?, hi?);
+    let width = hi.checked_sub(lo)?;
+    if width <= 0 || width > 4096 {
+        return None;
+    }
+
+    let target = inputs.symbol_table.resolve_fn_id_in(fn_name, scope)?;
+    cone_is_non_recursive(target, subject, inputs).then_some(Plan {
+        var,
+        lo,
+        hi,
+        subject,
+    })
+}

--- a/src/codegen/proof_lower/conditional_comparison.rs
+++ b/src/codegen/proof_lower/conditional_comparison.rs
@@ -47,7 +47,7 @@ fn comparison_call_plan(
     }
     let name = expr_to_dotted_name(&callee.node)?;
     let fn_id = inputs.symbol_table.resolve_fn_id_in(&name, scope)?;
-    let fd = inputs.find_fn_def_in_scope(&name, scope)?;
+    let fd = inputs.find_fn_def_by_id(fn_id)?;
     let (_, operand_type) = fd.params.first()?;
     let owner_scope = inputs.fn_owning_scope(fd);
     let type_def = inputs.find_type_def_in_scope(operand_type, owner_scope)?;

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -349,6 +349,13 @@ impl<'a> ProofLowerInputs<'a> {
     /// share whichever declaration a linear walk found first.
     pub fn find_fn_def_in_scope(&self, call_name: &str, scope: Option<&str>) -> Option<&'a FnDef> {
         let id = self.symbol_table.resolve_fn_id_in(call_name, scope)?;
+        self.find_fn_def_by_id(id)
+    }
+
+    /// Recover the exact source declaration for an already-resolved function.
+    /// Shape discovery remains AST-based, while declaration selection stays
+    /// entirely on the typed identity path.
+    pub fn find_fn_def_by_id(&self, id: crate::ir::FnId) -> Option<&'a FnDef> {
         let key = &self.symbol_table.fn_entry(id).key;
         match key.scope_str() {
             None => self.entry_items.iter().find_map(|item| match item {
@@ -2317,7 +2324,8 @@ fn populate_fn_contracts_for_scope(
 /// MapKeyTrackedIncrement, SpecEquivalence{,SimpNormalized},
 /// LinearIntSpecEquivalence, EffectfulSpecEquivalence (with Oracle
 /// Lift), ConditionalComparisonBridge (identity-pinned Peano relations),
-/// LinearArithmetic (catch-all over an unfold chain).
+/// BoundedIntDomain (identity-pinned finite enumeration), LinearArithmetic
+/// (catch-all over an unfold chain).
 /// Unmatched shapes pin `BackendDispatch` and fall through to the
 /// backend's residual chain (linear_recurrence2 emit + sampled /
 /// guarded-domain fallback).
@@ -2719,25 +2727,27 @@ fn induction_demanded_countdown_fns(inputs: &ProofLowerInputs) -> Vec<(Option<St
 ///    binds it to the inner binary fn at a constant.
 /// 7. `ConditionalComparisonBridge` — a `when`-premised implication
 ///    between canonical Peano comparisons over linear constructor terms.
-/// 8. `LinearArithmetic { unfold_fns, ... }` — catch-all when the
+/// 8. `BoundedIntDomain` — a unary Bool subject over one literal-bounded
+///    half-open Int interval with a non-recursive call cone.
+/// 9. `LinearArithmetic { unfold_fns, ... }` — catch-all when the
 ///    law reduces to linear arith after unfolding the call chain.
-/// 9. `EnumConstantFold { unfold_fns }` — ground law over fixed
-///    enum/ADT constructor args, scalar return (#466).
-/// 10. `FiniteDomainCases { givens }` — every given ranges over a
+/// 10. `EnumConstantFold { unfold_fns }` — ground law over fixed
+///     enum/ADT constructor args, scalar return (#466).
+/// 11. `FiniteDomainCases { givens }` — every given ranges over a
 ///     closed finite domain (Bool / fieldless enum, product ≤ 16);
 ///     closes by exhaustive `cases` enumeration.
-/// 11. `RingIdentity { unfold_fns }` — unconditional ring identity
+/// 12. `RingIdentity { unfold_fns }` — unconditional ring identity
 ///     over Int-component records (cross-multiplication equality);
 ///     runs before the prelude-simp rung, which would otherwise claim
 ///     the shape and park it on a caught sorry.
-/// 12. `IntDecimalRoundtrip { … }` — canonical decimal-Int
+/// 13. `IntDecimalRoundtrip { … }` — canonical decimal-Int
 ///     parse/serialize roundtrip over a recognized string-pos scanner;
 ///     runs before the prelude-simp rung, which would otherwise claim
 ///     the shape and park it on a caught sorry.
-/// 13. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
+/// 14. `SimpOverPreludeLemmas { … }` — builtin-roundtrip shape; the
 ///     Lean backend renders it AFTER its legacy chain, so it fires
 ///     exactly where the bare-`sorry` universal used to.
-/// 14. `BackendDispatch` — backend's ad-hoc chain decides.
+/// 15. `BackendDispatch` — backend's ad-hoc chain decides.
 ///
 /// (The induction/spec-equivalence/Map families detected between
 /// these rungs are documented at their detector sites below.)
@@ -2924,6 +2934,17 @@ fn classify_law_strategy(
             negated_premise: plan.negated_premise,
         };
     }
+    // Literal-bounded Int enumeration. Proof lowering validates the guard,
+    // unary Bool subject, exact subject identity, and non-recursive call cone;
+    // Lean only chooses its bounded-Nat enumeration syntax from this plan.
+    if let Some(plan) = bounded_int_domain::detect(law, fn_name, inputs, scope) {
+        return ProofStrategy::BoundedIntDomain {
+            var: plan.var,
+            lo: plan.lo,
+            hi: plan.hi,
+            subject: plan.subject,
+        };
+    }
     // Nonnegativity / order over a NONLINEAR Int product (`E >= 0` or
     // `prod <= prod`) — the inequality sibling of `RingIdentity`. Placed
     // BEFORE the `LinearArithmetic` catch-all because that rung claims any
@@ -3048,6 +3069,7 @@ fn classify_law_strategy(
     ProofStrategy::BackendDispatch
 }
 
+mod bounded_int_domain;
 mod conditional_comparison;
 mod finite_domain;
 mod floor_window;

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -626,6 +626,16 @@ pub enum ProofStrategy {
         /// and also identifies the exact declaration that bridge belongs to.
         negated_premise: Option<PeanoComparison>,
     },
+    /// A single `Int` given guarded into the finite half-open interval
+    /// `[lo, hi)`, with conclusion `subject(var) = true`. Proof lowering pins
+    /// the exact non-recursive subject identity and validated bounds; a backend
+    /// may enumerate the interval without re-reading guard/call syntax.
+    BoundedIntDomain {
+        var: String,
+        lo: i64,
+        hi: i64,
+        subject: FnId,
+    },
     /// "Linear arithmetic over an unfold chain" — the law's two
     /// sides reduce to a flat linear equation on Int once every
     /// reachable user fn is unfolded. Generic catch-all for Int

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1439,6 +1439,64 @@ fn compound_peano_premise_stays_out_of_comparison_bridge_strategy() {
 }
 
 #[test]
+fn bounded_int_domain_plan_is_pinned_before_lean_enumeration() {
+    let src = "module Bounded\n\
+         \x20   intent = \"finite guarded integer law\"\n\
+         \n\
+         fn inRange(i: Int) -> Bool\n\
+         \x20   i >= 0\n\
+         \n\
+         verify inRange law seedTable\n\
+         \x20   given i: Int = [0, 1, 2, 3]\n\
+         \x20   when Bool.and(i >= 0, i < 4)\n\
+         \x20   inRange(i) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "inRange", "seedTable").expect("law theorem");
+    let subject_id = ctx
+        .symbol_table
+        .fn_id_of(&aver::ir::FnKey::entry("inRange"))
+        .expect("inRange id");
+    assert!(
+        matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::BoundedIntDomain {
+                ref var,
+                lo: 0,
+                hi: 4,
+                subject,
+            } if var == "i" && subject == subject_id
+        ),
+        "proof lowering must pin bounds and exact subject identity, got {:?}",
+        theorem.strategy,
+    );
+}
+
+#[test]
+fn recursive_bounded_int_subject_stays_out_of_enumeration_strategy() {
+    let src = "module Bounded\n\
+         \x20   intent = \"recursive near miss\"\n\
+         \n\
+         fn eventually(n: Int) -> Bool\n\
+         \x20   match n <= 0\n\
+         \x20       true -> true\n\
+         \x20       false -> eventually(n - 1)\n\
+         \n\
+         verify eventually law sampledOnly\n\
+         \x20   given n: Int = [0, 1, 2, 3]\n\
+         \x20   when Bool.and(n >= 0, n < 4)\n\
+         \x20   eventually(n) => true\n";
+    let ctx = build_ctx(src);
+    let theorem = law_theorem(&ctx, "eventually", "sampledOnly").expect("law theorem");
+    assert!(
+        !matches!(
+            theorem.strategy,
+            aver::ir::ProofStrategy::BoundedIntDomain { .. }
+        ),
+        "recursive cones must retain the bounded/backend fallback",
+    );
+}
+
+#[test]
 fn wrapper_associative_pinned_on_three_int_givens_assoc_shape() {
     // `add(add(a,b),c) => add(a,add(b,c))` over `fn add(a,b) -> a+b`
     // — Step 25 pins `Associative { op: Add }`.


### PR DESCRIPTION
Part of #1087.

- pin bounded Int law shape, bounds, variable, exact subject FnId, and the nonrecursive pure cone in ProofIR
- delete the duplicate Lean-side shape/cone recognizer so statement and proof consume one plan
- centralize FnId-to-Lean function spelling for ordinary calls and generated law support
- add positive, recursive fail-closed, and Lean rendering regressions

Validation:
- cargo fmt --all -- --check
- cargo clippy -p aver-lang --lib --bin aver -- -D warnings
- cargo test -p aver-lang --lib (1398 passed)
- cargo test -p aver-lang --test proof_ir_diff (65 passed)
- real K5 table proof: 128 cases, 4 universal laws, 0 sorries