### PR TITLE
fix(proof): export dependency verify claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Added
 
+- **`aver proof` now checks the whole program's declared proof surface.** Every dependency module's `verify` examples and laws are lowered, emitted in that module's Lean/Dafny namespace, rooted for effectful reachability, evaluated for ground truth in the declaring module, and audited under a module-qualified identity. Visibility still controls whether another module may cite a law; it no longer makes the law itself disappear. The old “dependency verify cases were not sampled” warning is gone: unsupported cases are explicit, scoped declines, and Lean's audit and Dafny's trust counts recurse through the generated module tree. A real 28-module btc-listener proof slice now builds end to end; symbolic-provider cases crossing kernel-opaque recursion decline honestly instead of leaving an undecidable Lean theorem.
+
 - **A verify case can now cost more than the default budget, if the project says so.** `aver verify` caps each case at 1,000,000 VM opcodes. Real corpora contain cases that need more and are not runaway at all — a Bitcoin script at the consensus 10,000-byte limit, a transaction whose every input hashes the whole transaction — and until now the only thing the cap could say about them was `case aborted`, which reads as a defect and invites deleting the case. A project raises the budget for the function it knows about, in `aver.toml`, with a written reason:
 
   ```toml

--- a/src/analysis/literal_refinement.rs
+++ b/src/analysis/literal_refinement.rs
@@ -450,6 +450,7 @@ mod tests {
                         .collect(),
                     capability_items: Vec::new(),
                     capability_semantics: None,
+                    verify_blocks: Vec::new(),
                     verify_laws: Vec::new(),
                     analysis: None,
                 }

--- a/src/codegen/common.rs
+++ b/src/codegen/common.rs
@@ -3731,8 +3731,9 @@ pub(crate) fn verify_reachable_fn_names(items: &[TopLevel]) -> HashSet<String> {
 /// bodies of the entry functions those blocks reach, plus each module's own
 /// exposed laws; the closure then follows every call inside the module
 /// (bare names stay in the module, qualified names cross into the module
-/// they name). The purpose of the entry filter is kept: an effectful loop
-/// nobody proves anything about is not lifted in a dependency either.
+/// they name), plus every claim the dependency itself declares. The purpose
+/// of the entry filter is kept: an effectful loop nobody proves anything
+/// about is not lifted in a dependency either.
 pub(crate) fn dependency_reachable_fn_names(
     ctx: &CodegenContext,
 ) -> std::collections::HashMap<String, HashSet<String>> {
@@ -3761,7 +3762,7 @@ pub(crate) fn dependency_reachable_fn_names(
         }
     }
     for module in &ctx.modules {
-        for vb in &module.verify_laws {
+        for vb in &module.verify_blocks {
             let mut refs = HashSet::new();
             collect_verify_block_refs(vb, &mut refs);
             for name in refs {
@@ -4171,6 +4172,7 @@ mod tests {
             fn_defs: Vec::new(),
             capability_items: Vec::new(),
             capability_semantics: None,
+            verify_blocks: Vec::new(),
             verify_laws: Vec::new(),
             analysis: None,
         };
@@ -4263,6 +4265,7 @@ mod tests {
             fn_defs: Vec::new(),
             capability_items: Vec::new(),
             capability_semantics: None,
+            verify_blocks: Vec::new(),
             verify_laws: Vec::new(),
             analysis: None,
         };
@@ -4392,6 +4395,7 @@ mod tests {
             fn_defs: vec![make_get(ret)],
             capability_items: Vec::new(),
             capability_semantics: None,
+            verify_blocks: Vec::new(),
             verify_laws: Vec::new(),
             analysis: None,
         };

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -336,6 +336,16 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
         },
     );
 
+    // One identity-pinned recursion view for every module's laws and the
+    // entry's laws. Computing it once also prevents module-scoped proof emit
+    // from accidentally using a different opaque/fuel boundary than entry
+    // emit for the same program.
+    let direct_opaque: HashSet<crate::ir::FnId> =
+        axiom_fn_ids.union(&fuel_emitted).copied().collect();
+    let opaque_fns = toplevel::transitive_opaque_closure(ctx, &direct_opaque);
+    let native_transitive = toplevel::transitive_opaque_closure(ctx, &native_emitted);
+    let termination_opaque = toplevel::transitive_opaque_closure(ctx, &termination_axiom_ids);
+
     let mut module_files: Vec<(String, String)> = Vec::new();
     let mut union_body = String::new();
 
@@ -355,6 +365,50 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
         if let Some(fuel) = fuel_per_scope.get(&module.prefix) {
             sections.extend(fuel.clone());
         }
+        // Dafny does not evaluate concrete `verify f` blocks (the same
+        // limitation applies to the entry), but every dependency LAW belongs
+        // to the whole-program proof and is emitted in its declaring module.
+        // Active module scope makes every bare target/callee resolve through
+        // that module's `FnId`, never through an entry function sharing the
+        // same bare name.
+        ctx.with_module_scope(Some(module.prefix.as_str()), || {
+            let mut law_counter: HashMap<String, usize> = HashMap::new();
+            for vb in &module.verify_blocks {
+                let VerifyKind::Law(law) = &vb.kind else {
+                    continue;
+                };
+                let count = law_counter.entry(vb.fn_name.clone()).or_insert(0);
+                *count += 1;
+                let suffix = if *count > 1 {
+                    format!("_{}", count)
+                } else {
+                    String::new()
+                };
+                if !vb.cases.is_empty()
+                    && let Some(code) = toplevel::emit_law_samples(
+                        vb,
+                        law,
+                        ctx,
+                        &suffix,
+                        &opaque_fns,
+                        &fuel_emitted,
+                        &native_transitive,
+                        &termination_opaque,
+                    )
+                {
+                    sections.push(code);
+                }
+                sections.push(toplevel::emit_verify_law(
+                    vb,
+                    law,
+                    ctx,
+                    &opaque_fns,
+                    &native_transitive,
+                    &termination_opaque,
+                    &suffix,
+                ));
+            }
+        });
         let body = sections.join("\n");
         let module_uses_crypto_sha256 = body.contains("Aver_Crypto.sha256");
         union_body.push_str(&body);
@@ -520,21 +574,6 @@ fn transpile_unified(ctx: &CodegenContext) -> ProjectOutput {
             } else {
                 String::new()
             };
-            let direct_opaque: HashSet<crate::ir::FnId> =
-                axiom_fn_ids.union(&fuel_emitted).copied().collect();
-            let opaque_fns = toplevel::transitive_opaque_closure(ctx, &direct_opaque);
-            // Native mutual-rec members + their transitive callers
-            // also need bounded-∀ universal (true ∀ over int doesn't
-            // close even with native decreases) — but stays separate
-            // from opaque so per-sample bodies on the native path
-            // skip the fuel-magnitude cutoff.
-            let native_transitive = toplevel::transitive_opaque_closure(ctx, &native_emitted);
-            // Truly opaque `{:axiom}` fns from the termination-decline
-            // path (and their transitive callers): nothing about their
-            // value is provable, so sample asserts/lemmas over them
-            // could only fail. Suppressed with a marker comment below.
-            let termination_opaque =
-                toplevel::transitive_opaque_closure(ctx, &termination_axiom_ids);
             if !vb.cases.is_empty()
                 && let Some(code) = toplevel::emit_law_samples(
                     vb,

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1361,12 +1361,18 @@ fn sample_within_closable_range(bindings: &[(String, Spanned<Expr>)]) -> bool {
 /// - no refinement-lifted given (lemma param is the refined subset
 ///   type; sample values are carrier literals),
 /// - no oracle-bounded given (lemma adds `requires Is…(oracle)`).
+fn verify_subject_fn_id(vb: &VerifyBlock, ctx: &CodegenContext) -> Option<crate::ir::FnId> {
+    let key = match ctx.active_module_scope() {
+        Some(prefix) => crate::ir::FnKey::in_module(prefix, &vb.fn_name),
+        None => crate::ir::FnKey::entry(&vb.fn_name),
+    };
+    ctx.symbol_table.fn_id_of(&key)
+}
+
 fn sample_seed_lemma_available(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> bool {
     // Mirror of the issue-#128 "universal lemma omitted" gate in
     // `emit_verify_law` — keep in sync.
-    let vb_fn_id = ctx
-        .symbol_table
-        .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name));
+    let vb_fn_id = verify_subject_fn_id(vb, ctx);
     let pinned_strategy = vb_fn_id.and_then(|fn_id| {
         ctx.proof_ir
             .law_theorems
@@ -1388,6 +1394,7 @@ fn sample_seed_lemma_available(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenC
                 | crate::ir::ProofStrategy::IntDecimalRoundtrip { .. }
                 | crate::ir::ProofStrategy::StringEscapeRoundtrip(_)
                 | crate::ir::ProofStrategy::ConditionalComparisonBridge { .. }
+                | crate::ir::ProofStrategy::BoundedIntDomain { .. }
         )
     });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs
@@ -2983,9 +2990,7 @@ pub fn emit_verify_law(
     // BackendDispatch / Sorry don't close constant-RHS shapes;
     // anything else (Reflexive, Associative, MapUpdatePostcondition,
     // …) does and stays. Mirror of the Lean gate.
-    let vb_fn_id = ctx
-        .symbol_table
-        .fn_id_of(&crate::ir::FnKey::entry(&vb.fn_name));
+    let vb_fn_id = verify_subject_fn_id(vb, ctx);
     let ir_strategy_closes_const_rhs = vb_fn_id
         .and_then(|fn_id| {
             ctx.proof_ir
@@ -3050,6 +3055,7 @@ pub fn emit_verify_law(
                     // existing default/fallback gates until it consumes this
                     // ProofIR strategy explicitly.
                     | crate::ir::ProofStrategy::ConditionalComparisonBridge { .. }
+                    | crate::ir::ProofStrategy::BoundedIntDomain { .. }
             )
         });
     let singleton_const_rhs = !ir_strategy_closes_const_rhs

--- a/src/codegen/lean/kernel_decide.rs
+++ b/src/codegen/lean/kernel_decide.rs
@@ -238,6 +238,38 @@ impl CaseDecidability {
         hits.into_iter().collect()
     }
 
+    /// Canonical names of kernel-opaque user functions called directly by
+    /// `root`.
+    ///
+    /// A ground case may still be evaluated through a `partial def` by
+    /// `native_decide`. A case with a theorem-local symbolic capability
+    /// oracle cannot: Lean rejects native evaluation of the free function,
+    /// while reverting it produces a universally quantified proposition with
+    /// no `Decidable` instance. The caller uses this narrower query only for
+    /// that symbolic-oracle shape, so ordinary executable samples keep their
+    /// existing native-evaluation path.
+    pub(super) fn direct_opaque_dependencies(
+        &self,
+        root: &Spanned<crate::ast::Expr>,
+        ctx: &CodegenContext,
+    ) -> Vec<String> {
+        if !self.enabled || self.opaque_fns.is_empty() {
+            return Vec::new();
+        }
+
+        let scope = ctx.active_module_scope();
+        let resolved = ctx.resolve_expr(root, scope.as_deref());
+        let mut direct = HashSet::new();
+        super::decl_order::collect_resolved_fn_refs(&resolved, &mut direct);
+        let mut hits = std::collections::BTreeSet::new();
+        for fn_id in direct {
+            if self.opaque_fns.contains(&fn_id) {
+                hits.insert(ctx.symbol_table.fn_entry(fn_id).key.canonical());
+            }
+        }
+        hits.into_iter().collect()
+    }
+
     /// Tactic for one sampled case.
     ///
     /// `lhs` is the case's left side (the side that routes through the model)

--- a/src/codegen/lean/sample_literal.rs
+++ b/src/codegen/lean/sample_literal.rs
@@ -48,6 +48,7 @@ pub(super) fn decline_reason<'a>(
     global_case_idx: usize,
 ) -> Option<&'a String> {
     let key = (
+        ctx.active_module_scope(),
         crate::codegen::common::verify_block_counter_key(vb),
         global_case_idx,
     );
@@ -63,6 +64,7 @@ pub(super) fn ground_truth_rhs(
     global_case_idx: usize,
 ) -> Option<String> {
     let key = (
+        ctx.active_module_scope(),
         crate::codegen::common::verify_block_counter_key(vb),
         global_case_idx,
     );

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -174,13 +174,14 @@ pub fn emit_verify_block(
         None
     };
     if let Some(reason) = refusal {
-        let (kind, claim) = match &vb.kind {
+        let (kind, bare_claim) = match &vb.kind {
             VerifyKind::Law(law) => (
                 crate::codegen::DeclineKind::Law,
                 format!("{}.{}", vb.fn_name, law.name),
             ),
             VerifyKind::Cases => (crate::codegen::DeclineKind::Cases, vb.fn_name.clone()),
         };
+        let claim = scoped_claim(ctx, bare_claim);
         ctx.declined_claims
             .borrow_mut()
             .entry(format!("{}:{claim}", kind.as_str()))
@@ -269,6 +270,21 @@ pub fn emit_verify_block(
             agree_monads(left_str, propagates_error, right_str, right_propagates);
         match verify_mode {
             VerifyEmitMode::NativeDecide => {
+                if !theorem_params.is_empty() {
+                    let opaque = decidability.direct_opaque_dependencies(&left, ctx);
+                    if !opaque.is_empty() {
+                        lines.push(record_declined_case(
+                            vb,
+                            ctx,
+                            case_index_start + idx + 1,
+                            &format!(
+                                "the case has a symbolic capability oracle and reaches kernel-opaque Lean function(s) {}; native_decide cannot faithfully evaluate a free oracle through partial or mutual recursion",
+                                opaque.join(", ")
+                            ),
+                        ));
+                        continue;
+                    }
+                }
                 let tactic = if theorem_params.is_empty() {
                     decidability
                         .tactic_for(&left, &left_str, &right_str, has_ground_truth, ctx)
@@ -279,9 +295,18 @@ pub fn emit_verify_block(
                     // it before native evaluation; if a future case actually
                     // depends on the oracle, the remaining free variable makes
                     // `native_decide` fail closed.
+                    let unfolds = super::verify_cases::plain_case_unfold_names(&left, ctx)
+                        .into_iter()
+                        .map(|name| aver_name_to_lean(&name))
+                        .collect::<Vec<_>>()
+                        .join(", ");
                     format!(
                         "simp [{}] <;> native_decide",
-                        aver_name_to_lean(&vb.fn_name)
+                        if unfolds.is_empty() {
+                            aver_name_to_lean(&vb.fn_name)
+                        } else {
+                            unfolds
+                        }
                     )
                 };
                 lines.push(format!(
@@ -324,13 +349,14 @@ fn record_declined_case(
     case_number: usize,
     reason: &str,
 ) -> String {
-    let (kind, claim) = match &vb.kind {
+    let (kind, bare_claim) = match &vb.kind {
         VerifyKind::Law(law) => (
             crate::codegen::DeclineKind::Law,
             format!("{}.{}", vb.fn_name, law.name),
         ),
         VerifyKind::Cases => (crate::codegen::DeclineKind::Cases, vb.fn_name.clone()),
     };
+    let claim = scoped_claim(ctx, bare_claim);
     let full_reason = format!("case {}: {}", case_number, reason);
     ctx.declined_claims
         .borrow_mut()
@@ -346,6 +372,13 @@ fn record_declined_case(
         case_number,
         reason
     )
+}
+
+fn scoped_claim(ctx: &CodegenContext, claim: String) -> String {
+    match ctx.active_module_scope() {
+        Some(prefix) => format!("{prefix}.{claim}"),
+        None => claim,
+    }
 }
 
 /// Emit the left side of a verify case or a law statement, and report whether
@@ -390,15 +423,32 @@ fn emit_statement_rhs(
     ctx: &CodegenContext,
 ) -> (String, bool) {
     if let Some(literal) = ground_truth {
-        return (literal, false);
+        return (ascribe_refined_record_rhs(right, literal), false);
     }
     let scope = ctx.active_module_scope();
     let resolved = ctx.resolve_expr(right, scope.as_deref());
     if !super::expr::resolved_expr_contains_error_prop(&resolved) {
-        return (super::expr::emit_expr(&resolved, ctx), false);
+        return (
+            ascribe_refined_record_rhs(right, super::expr::emit_expr(&resolved, ctx)),
+            false,
+        );
     }
     let body = ctx.with_lean_do_block(true, || super::expr::emit_expr(&resolved, ctx));
     (format!("(do pure ({}))", body), true)
+}
+
+/// Give Lean an expected type for direct refinement-record RHS literals.
+/// These lower to subtype notation `⟨value, proof⟩`; in an equality where the
+/// LHS also reduces to that notation, neither side otherwise constrains the
+/// metavariable and elaboration fails before the proof tactic runs.
+fn ascribe_refined_record_rhs(right: &Spanned<Expr>, emitted: String) -> String {
+    match &right.node {
+        Expr::RecordCreate { type_name, .. } if emitted.trim_start().starts_with('⟨') => format!(
+            "({emitted} : {})",
+            super::types::type_annotation_to_lean(type_name)
+        ),
+        _ => emitted,
+    }
 }
 
 /// Put both sides of the equation in the same monad: whichever side is a bare
@@ -1098,8 +1148,9 @@ fn emit_verify_law_block(
         // of reverse-parsing the (mangled, `_law_`-ambiguous) theorem name.
         // Additive: the marker parser consumes only the first two fields, so
         // an older reader ignores it.
+        let law_label = scoped_claim(ctx, format!("{}.{}", vb.fn_name, law.name));
         lines.push(format!(
-            "{}{} {} {}.{}",
+            "{}{} {} {}",
             super::LAW_CLASS_MARKER_PREFIX,
             theorem_base,
             if theorem_parts.iter().any(|part| part.bounded_domain) && !floor_window_universal {
@@ -1107,8 +1158,7 @@ fn emit_verify_law_block(
             } else {
                 super::LAW_CLASS_UNIVERSAL
             },
-            vb.fn_name,
-            law.name,
+            law_label,
         ));
         // (Removed: refinement_auto_proof — Aver-specific bypass.
         // Refinement-lifted laws now flow through law_auto via the

--- a/src/codegen/lean/toplevel/verify_cases.rs
+++ b/src/codegen/lean/toplevel/verify_cases.rs
@@ -2,6 +2,41 @@
 
 use crate::ast::{Expr, Spanned, VerifyBlock, VerifyGiven, VerifyGivenDomain, VerifyLaw};
 use crate::codegen::CodegenContext;
+use crate::codegen::lean::decl_order;
+
+/// Fully-qualified user functions in a plain case's transitive call cone.
+/// Symbolic-oracle cases must simplify the concrete branch far enough to
+/// eliminate the otherwise free oracle before `native_decide`; unfolding only
+/// the subject function is insufficient when branch selection happens through
+/// a helper argument such as `get(fixture(...))`.
+pub(super) fn plain_case_unfold_names(expr: &Spanned<Expr>, ctx: &CodegenContext) -> Vec<String> {
+    let scope = ctx.active_module_scope();
+    let resolved = ctx.resolve_expr(expr, scope.as_deref());
+    let mut direct = std::collections::HashSet::new();
+    decl_order::collect_resolved_fn_refs(&resolved, &mut direct);
+    let mut pending: Vec<_> = direct.into_iter().collect();
+    let mut seen = std::collections::HashSet::new();
+    let mut names = std::collections::BTreeSet::new();
+    while let Some(fn_id) = pending.pop() {
+        if !seen.insert(fn_id) {
+            continue;
+        }
+        let Some(rfd) = ctx.resolved_program.fn_by_id(fn_id) else {
+            continue;
+        };
+        names.insert(ctx.symbol_table.fn_entry(fn_id).key.canonical());
+        for stmt in rfd.body.stmts() {
+            let expr = match stmt {
+                crate::ir::hir::ResolvedStmt::Expr(expr) => expr,
+                crate::ir::hir::ResolvedStmt::Binding { value, .. } => value,
+            };
+            let mut callees = std::collections::HashSet::new();
+            decl_order::collect_resolved_fn_refs(expr, &mut callees);
+            pending.extend(callees);
+        }
+    }
+    names.into_iter().collect()
+}
 
 /// Rewrite a cases-form assertion against an Oracle-lifted function.
 ///

--- a/src/codegen/lean/transpile.rs
+++ b/src/codegen/lean/transpile.rs
@@ -933,20 +933,20 @@ pub(super) fn transpile_unified(
     // are recorded before its `open` lines are written.
     let mut declared_fns: HashMap<String, HashSet<String>> = HashMap::new();
 
-    // Cross-file law pool: the dep-law theorems some consumer law admits.
-    // Empty for single-file files (no dep modules) → the dep-law emit loop
-    // below is a no-op → byte-identical output. Computed once for every
-    // module's emit pass.
-    let admitted_dep_laws = if matches!(emit_mode, LeanEmitMode::Proof) {
-        super::law_auto::admitted_dep_law_theorems(ctx)
-    } else {
-        std::collections::HashSet::new()
-    };
-    // Subset-invariant tripwire (see `topology_admits`): every dep-module law's
-    // emit key must be a key the citation-closure's topology order tracks — the
-    // premise that keeps its `None`-is-trusted branch fail-closed. Debug-only.
+    // Cross-file citation remains visibility/topology gated even though every
+    // declaring module now emits all of its own claims. Keep the producer and
+    // consumer key spaces tied together: an admitted citation must name a law
+    // known to the dependency theorem order. This is a debug-only integrity
+    // check; it never filters the module-owned proof surface.
     #[cfg(debug_assertions)]
-    let dep_theorem_order_keys = super::law_auto::dep_theorem_order_keys(ctx);
+    if matches!(emit_mode, LeanEmitMode::Proof) {
+        let admitted = super::law_auto::admitted_dep_law_theorems(ctx);
+        let ordered = super::law_auto::dep_theorem_order_keys(ctx);
+        debug_assert!(
+            admitted.iter().all(|key| ordered.contains(key)),
+            "cross-file citation admitted a dependency law absent from the theorem order"
+        );
+    }
 
     for (module_index, module) in ctx.modules.iter().enumerate() {
         let _emitting_guard = crate::codegen::lean::types::scope_emitting_module(&module.prefix);
@@ -1013,82 +1013,27 @@ pub(super) fn transpile_unified(
             &mut sampled_fns,
             &mut body_sections,
         );
-        // Cross-file law pool — EMIT side: a dependency module's proven
-        // `verify … law` blocks become `<fn>_law_<name>` theorems INSIDE
-        // `namespace M`, so a consumer that imports + opens this module can
-        // cite `M.<fn>_law_<name>` as a lemma. Same emit path the entry uses
-        // (`emit_verify_block`), under this module's scope so the law's
-        // expressions resolve in the dep's namespace.
-        //
-        // FAIL-CLOSED (MAJOR 4): emit a dep law's theorem ONLY when some
-        // consumer law ADMITS it (`admitted_dep_law_theorems`, the SAME gate
-        // the CONSUME side runs). A dep law no consumer can cite is a
-        // complete no-op for the consumer — emitting it would add its
-        // `first | … | sorry` proof to the consumer's file-wide `sorry`
-        // count for zero benefit. The dep's OWN standalone export
-        // (`aver proof Lib.av`) still emits + proves all its laws, charging
-        // any sorry to the dep, not to a consumer that never leaned on it.
-        // Proof mode only; runtime/standard emits skip laws.
-        if matches!(emit_mode, LeanEmitMode::Proof) {
+        // Whole-program proof surface: every dependency module emits every
+        // `verify` block it owns inside its own namespace. Visibility affects
+        // cross-file CITATION (`module.verify_laws`), never whether a module's
+        // private obligation is checked. This is the same emit path the entry
+        // uses and the active module scope pins bare names to this module's
+        // `FnId`s. Certificate model files omit verify declarations just like
+        // the entry certificate model does.
+        if matches!(emit_mode, LeanEmitMode::Proof) && !cert_model {
             ctx.with_module_scope(Some(module.prefix.as_str()), || {
                 let mut dep_verify_counters: HashMap<String, usize> = HashMap::new();
-                for vb in &module.verify_laws {
-                    // Compute this law's theorem base under the dep scope and
-                    // emit only if it is in the admitted set. The base is the
-                    // one `law_as_lemma_statement` reports when it states the law
-                    // as a plain rewrite; otherwise the canonical
-                    // `<fn>_law_<name>` the block emits anyway. The second case
-                    // covers a `when`-premised universal a consumer cites by name
-                    // (the rounded-step triangle rung's rounding bounds) — the
-                    // law-as-lemma rewrite gate declines a conditional law, but
-                    // the keystone still emits its universal theorem, so the
-                    // citation must reach it. A law no consumer admits stays
-                    // out of the set and is skipped regardless.
-                    let law_ref = match &vb.kind {
-                        crate::ast::VerifyKind::Law(l) => l,
-                        _ => continue,
-                    };
-                    let base = toplevel::law_as_lemma_statement(vb, law_ref, ctx)
-                        .map(|(base, _)| base)
-                        .unwrap_or_else(|| toplevel::law_theorem_base(vb, law_ref, ctx));
-                    // This emit key is computed from the SAME two fns under the
-                    // SAME scope as the topology order map — so it must be one of
-                    // that map's keys. If it is not, the emit-key and order-key
-                    // computations have drifted and `topology_admits`' `None`
-                    // branch could silently fail open.
-                    // A cfg block, not a bare `debug_assert!`: the macro's body is
-                    // type-checked in release builds too, where the cfg-gated
-                    // `dep_theorem_order_keys` binding above does not exist.
-                    #[cfg(debug_assertions)]
-                    {
-                        debug_assert!(
-                            dep_theorem_order_keys.contains(&(module.prefix.clone(), base.clone())),
-                            "dep-law emit key {:?} is absent from the citation-closure \
-                             topology order map; the fail-closed forward-reference guard \
-                             would degrade to fail-open",
-                            (module.prefix.clone(), base.clone())
-                        );
-                    }
-                    if !admitted_dep_laws.contains(&(module.prefix.clone(), base)) {
-                        continue;
-                    }
+                let decidability = super::kernel_decide::CaseDecidability::new(
+                    sampled_fns.opaque.clone(),
+                    sampled_fns.unbounded_fuel.clone(),
+                    recursive_types.clone(),
+                    capability_opacity.clone(),
+                );
+                for vb in &module.verify_blocks {
                     let key = verify_counter_key(vb);
                     let start_idx = *dep_verify_counters.get(&key).unwrap_or(&0);
-                    // Law blocks also need the actual unbounded-fuel set: their
-                    // sampled theorems use `native_decide`, and an exhausted
-                    // helper returns `default` just as it does in a plain case.
-                    let (emitted, next_idx) = toplevel::emit_verify_block(
-                        vb,
-                        ctx,
-                        verify_mode,
-                        start_idx,
-                        &super::kernel_decide::CaseDecidability::new(
-                            sampled_fns.opaque.clone(),
-                            sampled_fns.unbounded_fuel.clone(),
-                            recursive_types.clone(),
-                            capability_opacity.clone(),
-                        ),
-                    );
+                    let (emitted, next_idx) =
+                        toplevel::emit_verify_block(vb, ctx, verify_mode, start_idx, &decidability);
                     dep_verify_counters.insert(key, next_idx);
                     body_sections.push(emitted);
                     body_sections.push(String::new());

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -61,16 +61,21 @@ pub struct ModuleInfo {
     /// Raw module-header semantics (`pure` / `effectful`) for the retained
     /// capability items. Validation belongs to `capability::CapabilityRegistry`.
     pub capability_semantics: Option<String>,
+    /// Every `verify` block declared by this module, in source order.
+    ///
+    /// This is the module's own proof surface. Lean emits it inside the
+    /// module-scoped proof file; Dafny uses the law subset and reports the
+    /// concrete-case subset with the same whole-program accounting as the
+    /// entry module. Unlike [`Self::verify_laws`], this field is deliberately
+    /// not visibility-filtered: private claims still belong to the module that
+    /// declares them even though consumers may not cite them.
+    pub verify_blocks: Vec<crate::ast::VerifyBlock>,
     /// `verify … law` blocks of this dep module, in source order.
     ///
-    /// Carried so the Lean proof backend can (a) emit each proven dep
-    /// law as a `<fn>_law_<name>` theorem inside `namespace M`, and
-    /// (b) admit it into a consumer law's lemma pool under the same
-    /// cone ∪ subject admissibility gate as in-file sibling laws — the
-    /// cross-file law pool. Only `VerifyKind::Law` blocks are kept;
-    /// plain example-style `verify` blocks in a dep are still dropped
-    /// (module-scoped sampling is a separate feature). Read ONLY by the
-    /// Lean proof emit / pool; inert for every other backend.
+    /// This is the visibility-filtered cross-file citation pool, not the
+    /// module's own claim set: only exposed `VerifyKind::Law` blocks are kept
+    /// so a consumer may cite exactly the laws whose subject it may call.
+    /// Module-owned emission uses [`Self::verify_blocks`] instead.
     pub verify_laws: Vec<crate::ast::VerifyBlock>,
     /// IR-level analysis facts produced by the dep module's pipeline run
     /// (`analyze` stage). `None` for modules loaded via paths that skip
@@ -80,6 +85,14 @@ pub struct ModuleInfo {
     /// `src/ir/analyze.rs` for why cross-module SCCs are impossible.
     pub analysis: Option<crate::ir::AnalysisResult>,
 }
+
+/// Identity of one emitted verify case in the whole program.
+///
+/// `None` owns the entry module; `Some(prefix)` owns a dependency module.
+/// The textual counter key preserves the existing merge semantics within one
+/// module, while the scope prevents same-bare-name blocks in two modules from
+/// sharing VM ground truth or decline state.
+pub type VerifyCaseKey = (Option<String>, String, usize);
 
 impl ModuleInfo {
     /// Build the shared projection from parsed module items. Target-specific
@@ -118,6 +131,7 @@ impl ModuleInfo {
             fn_defs,
             capability_items,
             capability_semantics,
+            verify_blocks: collect_verify_blocks(items),
             verify_laws: collect_verify_laws(items),
             analysis,
         }
@@ -151,6 +165,22 @@ pub fn capability_metadata(items: &[TopLevel]) -> (Vec<CapabilityItem>, Option<S
         _ => None,
     });
     (declarations, semantics)
+}
+
+/// Every `verify` block from a module's top-level items, in source order.
+///
+/// This is the module-owned claim set used by whole-program proof export.
+/// Visibility is irrelevant here: a private function's claim is still an
+/// obligation of its own module. Cross-module citation continues to use the
+/// separately filtered [`collect_verify_laws`] pool.
+pub fn collect_verify_blocks(items: &[TopLevel]) -> Vec<crate::ast::VerifyBlock> {
+    items
+        .iter()
+        .filter_map(|item| match item {
+            TopLevel::Verify(block) => Some(block.clone()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// `verify … law` blocks from a module's top-level items, in source
@@ -489,18 +519,18 @@ pub struct CodegenContext {
     /// the CLI wired it — discovery feedback is strictly opt-in.
     pub discovered_lemmas: Vec<crate::codegen::lemma_discovery::CommittedLemma>,
     /// VM-computed ground-truth values for verify cases, keyed by
-    /// `(common::verify_block_counter_key(vb), global_case_index)` →
+    /// `(module_scope, common::verify_block_counter_key(vb), case_index)` →
     /// `aver_repr_literal` rendering of the case's expected (right-side)
     /// value. Set by the CLI on `aver proof --backend lean` from a Declared-
-    /// mode `aver verify` run over the entry items; empty everywhere else.
+    /// mode `aver verify` run over every project module; empty everywhere else.
     /// The Lean emitter literalizes the expected side of bounded sample
     /// checks from this table (model-vs-ground-truth) so that fuel
     /// exhaustion — where `panic!` returns `default` and a model-vs-model
     /// equation becomes vacuously true under `native_decide` — cannot
     /// kernel-certify a false equation. Entries exist only for cases that
     /// PASSED `aver verify`; failing/skipped cases keep the source RHS.
-    pub sample_expected: std::collections::HashMap<(String, usize), String>,
-    /// `(common::verify_block_counter_key(vb), global_case_index)` → the
+    pub sample_expected: std::collections::HashMap<VerifyCaseKey, String>,
+    /// `(module_scope, common::verify_block_counter_key(vb), case_index)` → the
     /// reason `aver verify` gave for not answering that case.
     ///
     /// The counterpart to [`Self::sample_expected`], and the reason it is a
@@ -510,7 +540,7 @@ pub struct CodegenContext {
     /// checked, in exactly the shape literalization exists to prevent, and
     /// precisely on the big inputs where the model is likeliest to exhaust
     /// fuel too. A case listed here is declined as a claim instead.
-    pub declined_cases: std::collections::HashMap<(String, usize), String>,
+    pub declined_cases: std::collections::HashMap<VerifyCaseKey, String>,
     /// `aver proof --allow-mathlib` (Lean only, opt-in): permit a generic
     /// Mathlib break-glass closing arm on laws the core strategies cannot
     /// claim. When `false` (the default) the Lean backend is BYTE-IDENTICAL to

--- a/src/codegen/program_view.rs
+++ b/src/codegen/program_view.rs
@@ -37,9 +37,8 @@
 //! - **`verify_law` helper walkers** ([`crate::verify_law`]). The
 //!   helper-law / contextual-helper hint walkers operate on
 //!   entry-only AST `FnDef`s through [`crate::verify_law::EntryFnIndex`].
-//!   The parser invariant (`verify <name>` only accepts a single
-//!   `Ident`) keeps the identity-safe contract; migration to FnId
-//!   keying is gated on module-scoped verify shipping.
+//!   Module-scoped verify export now ships, so this is active migration
+//!   debt tracked by #1087 rather than a deferred boundary.
 //! - **Lean / Dafny proof + law spec emitters**. Several recognisers
 //!   (`emit_*_spec_equivalence_law`, `direct_call` AST shape match)
 //!   keep walking `Spanned<Expr>` source-shape because the proof IR
@@ -63,10 +62,9 @@
 //!   surface (`view.fn_by_id(id).body_expr_type(span)` or similar)
 //!   would tighten the contract but adds no semantic value today —
 //!   wait for a real consumer.
-//! - **Module-scoped verify → FnId keyed `verify_law`**. The
-//!   `EntryFnIndex` newtype is the tripwire that forces the
-//!   contributor to address keying when the parser starts accepting
-//!   dotted verify targets.
+//! - **FnId-keyed `verify_law` helpers**. Dependency-owned verify blocks
+//!   are now exported under module scope; remove `EntryFnIndex` and resolve
+//!   helper-hint subjects through the canonical program view (#1087).
 //!
 //! ## Construction
 //!
@@ -308,6 +306,7 @@ mod tests {
             fn_defs: fn_names.iter().map(|n| mk_fn(n)).collect(),
             capability_items: vec![],
             capability_semantics: None,
+            verify_blocks: vec![],
             verify_laws: vec![],
             analysis: None,
         }

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -59,16 +59,14 @@
 //! Builtin matchers (`callee_is X for X ∈ {"Bool.and", "Map.set",
 //! …}`) compare against the canonical builtin namespace, which is
 //! global by spec — no per-scope identity to leak. Verify-law
-//! callsites all walk `vb.fn_name` (entry-only by parser grammar);
-//! the `EntryFnIndex` newtype in `verify_law.rs` pins the
-//! entry-only contract at the type level (PR 177).
+//! lowering now covers entry and dependency module blocks and resolves
+//! each subject under its owning module scope. The remaining
+//! `EntryFnIndex` helper-hint callsites are migration debt tracked by #1087.
 //!
 //! Full `ResolvedProofLowerView` + semantic matcher API
 //! (`callee_is_builtin`, `callee_is_fn(FnId)`, `ctor_is`,
-//! `ident_name`, `int_lit`) deferred per
-//! `project_phase_e_scope_b_deferred` memory until a real trigger
-//! lands (module-scoped verify, dotted law targets, LSP rename,
-//! cross-scope inliner).
+//! `ident_name`, `int_lit`) is now triggered by module-scoped verify;
+//! completing that resolved-view migration is tracked by #1087.
 
 use std::collections::{HashMap, HashSet};
 
@@ -2337,18 +2335,18 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
 
     // Verify-law blocks to lower, each tagged with the prefix of the
     // dep module that owns it (`None` = entry). The entry's own verify
-    // blocks come from `entry_items`; dependency modules' proven laws
-    // come from `ModuleInfo.verify_laws` (the cross-file law pool — a
-    // dep law is lowered with the SAME strategy classification an entry
-    // law of that shape gets, so it auto-proves and can be cited by a
-    // consumer). The DAG invariant keeps the bare fn name unambiguous
-    // within each scope.
+    // blocks come from `entry_items`; dependency modules' laws come from
+    // their complete module-owned `ModuleInfo.verify_blocks` surface. The
+    // separately visibility-filtered `verify_laws` pool controls what a
+    // consumer may cite, not whether the declaring module must prove its own
+    // obligation. The DAG invariant keeps the bare fn name unambiguous within
+    // each scope.
     let entry_verifies = inputs.entry_items.iter().filter_map(|item| match item {
         TopLevel::Verify(vb) => Some((None, vb)),
         _ => None,
     });
     let dep_verifies = inputs.dep_modules.iter().flat_map(|m| {
-        m.verify_laws
+        m.verify_blocks
             .iter()
             .map(move |vb| (Some(m.prefix.as_str()), vb))
     });
@@ -2616,7 +2614,7 @@ fn induction_demanded_countdown_fns(inputs: &ProofLowerInputs) -> Vec<(Option<St
         _ => None,
     });
     let dep_verifies = inputs.dep_modules.iter().flat_map(|m| {
-        m.verify_laws
+        m.verify_blocks
             .iter()
             .map(move |vb| (Some(m.prefix.clone()), vb))
     });

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -1153,6 +1153,7 @@ mod tests {
                     fn_defs,
                     capability_items,
                     capability_semantics,
+                    verify_blocks: crate::codegen::collect_verify_blocks(&lm.items),
                     verify_laws: crate::codegen::collect_verify_laws(&lm.items),
                     analysis: None,
                 }

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -47,10 +47,10 @@
 //!   law/function's owning scope before recovering an AST declaration.
 //!   Builtin matchers (`"Bool.and"`, `"Map.set"`, …) still compare
 //!   global namespace methods that have no per-scope identity.
-//! - **Full `ResolvedProofLowerView` + semantic matcher API is
-//!   deferred** until a real trigger lands: module-scoped verify
-//!   targets, LSP rename, or inliner / monomorphizer transforms that
-//!   erase the source shapes discovery intentionally consumes. When
+//! - **Full `ResolvedProofLowerView` + semantic matcher API is now
+//!   triggered by module-scoped verify export.** Dependency-owned verify
+//!   blocks ship as first-class proof obligations, so #1087 owns replacing
+//!   the remaining entry-only helper index and source-shape adapters. When
 //!   it ships, the right architecture is a typed
 //!   `ProofLowerInputs::resolved_fn_view(fd)` + matcher helpers
 //!   (`callee_is_builtin`, `callee_is_fn(fn_id)`, `ctor_is`,

--- a/src/ir/symbol_table.rs
+++ b/src/ir/symbol_table.rs
@@ -1024,6 +1024,7 @@ mod tests {
             fn_defs: fns,
             capability_items: Vec::new(),
             capability_semantics: None,
+            verify_blocks: Vec::new(),
             verify_laws: Vec::new(),
             analysis: None,
         }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -1580,6 +1580,7 @@ pub(super) fn reject_literal_refinement_discharge(
                     .collect(),
                 capability_items,
                 capability_semantics,
+                verify_blocks: Vec::new(),
                 verify_laws: Vec::new(),
                 analysis: None,
             }
@@ -3610,7 +3611,6 @@ fn build_codegen_context(
     run_refinement_lower: bool,
     run_contract_lower: bool,
     run_law_lower: bool,
-    dependency_cases: DependencyCases<'_>,
 ) -> (codegen::CodegenContext, String) {
     let module_root = resolve_module_root(module_root_override);
     let source = match read_file(file) {
@@ -3674,11 +3674,10 @@ fn build_codegen_context(
     // module-spanning call graphs). load_compile_deps only reads
     // `TopLevel::Module(m).depends`, which TCO never touches, so it's
     // safe to run pre-pipeline.
-    let modules = load_compile_deps_reporting(
+    let modules = load_compile_deps(
         &items,
         &module_root,
         DepLowering::fully_lowered(dep_lowering, with_self_host_support),
-        dependency_cases,
     );
 
     let mut pipeline_result = aver::ir::pipeline::run(
@@ -6175,7 +6174,6 @@ pub(super) fn cmd_compile(opts: CompileOptions<'_>) {
         false, // run_refinement_lower — runtime backend, doesn't need ProofIR
         false, // run_contract_lower — same
         false, // run_law_lower — same
-        DependencyCases::Silent,
     );
     reject_unsupported_capability_targets(
         &ctx.items,
@@ -6459,7 +6457,6 @@ fn emit_artifact_certificate(
         true,  // run_refinement_lower
         true,  // run_contract_lower
         true,  // run_law_lower
-        DependencyCases::Silent,
     );
     let model_out = lean_codegen::transpile_for_cert_model(&mut mctx);
 
@@ -7170,7 +7167,6 @@ pub(super) fn cmd_proof(
         true,  // run_refinement_lower — proof backends need ProofIR
         true,  // run_contract_lower — same
         true,  // run_law_lower — same
-        DependencyCases::UnsampledByProof { entry: file },
     );
 
     // `--allow-mathlib` is Lean-only. On Dafny it is a no-op (Z3 already carries
@@ -7424,7 +7420,7 @@ pub(super) fn cmd_proof(
         // parsed items are in hand) and handed to the ratchet so it can fail
         // CLOSED rather than collapse two distinct law blocks into one manifest
         // entry — see `duplicate_law_identities`.
-        let duplicate_laws = duplicate_law_identities(&ctx.items);
+        let duplicate_laws = duplicate_program_law_identities(&ctx);
         // `fn.law` identities that had a hand-proof sidecar spliced for this
         // backend — the credit channel (a spliced law that reaches Universal
         // tier is credited `hand`, else `open`; fail-closed). Derived from the
@@ -7456,11 +7452,12 @@ pub(super) fn cmd_proof(
     }
 }
 
-/// Run the Declared-mode VM verify pass over `file`'s entry items and build
+/// Run the Declared-mode VM verify pass over every project module reached by
+/// `file` and build
 /// the ground-truth table for `CodegenContext::sample_expected`: for every
 /// case that PASSES, the VM-computed expected (right-side) value, rendered
 /// with `aver_repr_literal`, keyed by
-/// `(verify_block_counter_key, global_case_index)`.
+/// `(module_scope, verify_block_counter_key, module_local_case_index)`.
 ///
 /// The index space mirrors the Lean emitter exactly: per-key running
 /// counters over the merged blocks (plain `verify <fn>` blocks coalesce per
@@ -7478,82 +7475,79 @@ pub(super) fn cmd_proof(
 /// - values whose strings contain characters the lexer would misread when
 ///   parsed back (`"`, `\`, interpolation braces, control chars).
 ///
-/// Any failure (unreadable file, parse/typecheck error, VM error) returns an
-/// empty table — emission then behaves exactly as before this feature.
+/// A module that cannot run contributes no entries; successfully verified
+/// modules still keep their ground truth. Emission falls back to the source
+/// RHS for every miss, as before.
 fn collect_verify_ground_truth(file: &str, module_root: &str) -> VerifyGroundTruth {
     use aver::checker::{VerifyCaseOutcome, merge_verify_blocks};
 
     let mut out = VerifyGroundTruth::default();
-    let Ok(source) = read_file(file) else {
+    let mut reported = HashSet::new();
+    let Ok(units) = collect_program_units(file, module_root, &mut reported) else {
         return out;
     };
-    let Ok(items) = aver::source::parse_project_source(&source, module_root, file) else {
-        return out;
-    };
-    let merged = merge_verify_blocks(&items);
-    if merged.is_empty() {
-        return out;
-    }
     let config = match load_runtime_policy(module_root) {
         Ok(c) => c,
         Err(_) => return out,
     };
-    let results = match aver::diagnostics::vm_verify::run_verify_for_items_vm(
-        items,
-        config,
-        Some(module_root),
-        file,
-    ) {
-        Ok(r) => r,
-        Err(_) => return out,
-    };
-    // One result per merged block, in order — the runner builds its plans
-    // from the same `merge_verify_blocks` output. Anything else means the
-    // pairing below would be guesswork; return empty (fall back to source).
-    if results.len() != merged.len() {
-        return out;
-    }
-
-    let mut counters: HashMap<String, usize> = HashMap::new();
-    for (block, result) in merged.iter().zip(&results) {
-        let key = aver::codegen::common::verify_block_counter_key(block);
-        let base = *counters.get(&key).unwrap_or(&0);
-        counters.insert(key.clone(), base + block.cases.len());
-        if block.trace {
+    let unit_count = units.len();
+    for (unit_index, (path, _source, items)) in units.into_iter().enumerate() {
+        let merged = merge_verify_blocks(&items);
+        if merged.is_empty() {
             continue;
         }
-        for cr in &result.case_results {
-            // Exhaustive on purpose. The `Pass` filter this used to be
-            // silently dropped a declined case into the "no entry" bucket,
-            // whose documented fallback is the source RHS — turning "we did
-            // not check this" into a theorem stating the author's own
-            // expected expression.
-            match &cr.outcome {
-                VerifyCaseOutcome::Pass => {}
-                VerifyCaseOutcome::Declined { reason, .. } => {
-                    out.declined
-                        .insert((key.clone(), base + cr.case_index), reason.clone());
+        let scope = if unit_index + 1 == unit_count {
+            None
+        } else {
+            aver::visibility::module_decl(&items).map(|module| module.name.clone())
+        };
+        let results = match aver::diagnostics::vm_verify::run_verify_for_items_vm(
+            items,
+            config.clone(),
+            Some(module_root),
+            &path,
+        ) {
+            Ok(results) if results.len() == merged.len() => results,
+            _ => continue,
+        };
+
+        let mut counters: HashMap<String, usize> = HashMap::new();
+        for (block, result) in merged.iter().zip(&results) {
+            let block_key = aver::codegen::common::verify_block_counter_key(block);
+            let base = *counters.get(&block_key).unwrap_or(&0);
+            counters.insert(block_key.clone(), base + block.cases.len());
+            if block.trace {
+                continue;
+            }
+            for cr in &result.case_results {
+                let key = (scope.clone(), block_key.clone(), base + cr.case_index);
+                // Exhaustive on purpose. A decline is not an absent value: the
+                // emitter must refuse the theorem rather than fall back to the
+                // author's expected expression.
+                match &cr.outcome {
+                    VerifyCaseOutcome::Pass => {}
+                    VerifyCaseOutcome::Declined { reason, .. } => {
+                        out.declined.insert(key, reason.clone());
+                        continue;
+                    }
+                    VerifyCaseOutcome::Skipped
+                    | VerifyCaseOutcome::SkippedAfterBaseFail
+                    | VerifyCaseOutcome::Mismatch { .. }
+                    | VerifyCaseOutcome::RuntimeError { .. }
+                    | VerifyCaseOutcome::UnexpectedErr { .. } => continue,
+                }
+                let Some(value) = &cr.expected_value else {
+                    continue;
+                };
+                if value_contains_float(value)
+                    || value_contains_map(value)
+                    || !value_strings_are_literal_safe(value)
+                {
                     continue;
                 }
-                VerifyCaseOutcome::Skipped
-                | VerifyCaseOutcome::SkippedAfterBaseFail
-                | VerifyCaseOutcome::Mismatch { .. }
-                | VerifyCaseOutcome::RuntimeError { .. }
-                | VerifyCaseOutcome::UnexpectedErr { .. } => continue,
+                out.expected
+                    .insert(key, aver::value::aver_repr_literal(value));
             }
-            let Some(value) = &cr.expected_value else {
-                continue;
-            };
-            if value_contains_float(value)
-                || value_contains_map(value)
-                || !value_strings_are_literal_safe(value)
-            {
-                continue;
-            }
-            out.expected.insert(
-                (key.clone(), base + cr.case_index),
-                aver::value::aver_repr_literal(value),
-            );
         }
     }
     out
@@ -7564,9 +7558,9 @@ fn collect_verify_ground_truth(file: &str, module_root: &str) -> VerifyGroundTru
 #[derive(Default)]
 struct VerifyGroundTruth {
     /// Cases that passed, with their VM-computed expected value.
-    expected: std::collections::HashMap<(String, usize), String>,
+    expected: std::collections::HashMap<aver::codegen::VerifyCaseKey, String>,
     /// Cases that were declined, with the reason.
-    declined: std::collections::HashMap<(String, usize), String>,
+    declined: std::collections::HashMap<aver::codegen::VerifyCaseKey, String>,
 }
 
 /// Structural Float scan for ground-truth literalization: any embedded
@@ -8521,6 +8515,7 @@ fn verify_law_source_line(
 /// originates, rather than after the manifest has already deduped by identity.
 /// Returns the colliding identities sorted, so the harness-error message is
 /// deterministic.
+#[cfg(test)]
 fn duplicate_law_identities(items: &[TopLevel]) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut dups: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
@@ -8533,6 +8528,39 @@ fn duplicate_law_identities(items: &[TopLevel]) -> Vec<String> {
                 dups.insert(identity);
             }
         }
+    }
+    dups.into_iter().collect()
+}
+
+/// Whole-program form of [`duplicate_law_identities`]. Dependency identities
+/// are module-qualified, so `A.f.refl` and `B.f.refl` remain distinct while
+/// two declarations inside `A` still fail closed.
+fn duplicate_program_law_identities(ctx: &codegen::CodegenContext) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut dups: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut collect = |scope: Option<&str>, blocks: &[aver::ast::VerifyBlock]| {
+        for vb in blocks {
+            let VerifyKind::Law(law) = &vb.kind else {
+                continue;
+            };
+            let bare = format!("{}.{}", vb.fn_name, law.name);
+            let identity = scope.map_or(bare.clone(), |prefix| format!("{prefix}.{bare}"));
+            if !seen.insert(identity.clone()) {
+                dups.insert(identity);
+            }
+        }
+    };
+    let entry_blocks: Vec<_> = ctx
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            TopLevel::Verify(vb) => Some(vb.clone()),
+            _ => None,
+        })
+        .collect();
+    collect(None, &entry_blocks);
+    for module in &ctx.modules {
+        collect(Some(&module.prefix), &module.verify_blocks);
     }
     dups.into_iter().collect()
 }
@@ -8864,18 +8892,7 @@ fn parse_dafny_error_count(stdout: &str) -> Option<usize> {
 /// modules count too. (Opaque `function {:axiom}` declarations are not
 /// counted; see the note at the pass-decision site.)
 fn count_dafny_axioms(dir: &str) -> usize {
-    let mut total = 0;
-    if let Ok(rd) = std::fs::read_dir(dir) {
-        for entry in rd.flatten() {
-            let name = entry.file_name();
-            if name.to_string_lossy().ends_with(".dfy")
-                && let Ok(contents) = std::fs::read_to_string(entry.path())
-            {
-                total += contents.matches("assume {:axiom}").count();
-            }
-        }
-    }
-    total
+    count_marker_in_generated_files(std::path::Path::new(dir), "dfy", "assume {:axiom}")
 }
 
 /// Count laws whose universal `∀` lemma was DROPPED to sample-only across
@@ -8890,14 +8907,28 @@ fn count_dafny_axioms(dir: &str) -> usize {
 /// too. (The deliberate trace-projection `runtime-only` gate is NOT a
 /// coverage claim and carries a different marker, so it is not counted.)
 fn count_dafny_omitted_universals(dir: &str) -> usize {
+    count_marker_in_generated_files(
+        std::path::Path::new(dir),
+        "dfy",
+        "(universal lemma omitted)",
+    )
+}
+
+/// Count a marker in generated files recursively. Dotted Aver module names are
+/// emitted under matching directories (`Infra.Store` -> `Infra/Store.dfy`), so
+/// a top-level `read_dir` would miss exactly the dependency obligations these
+/// gates are meant to charge.
+fn count_marker_in_generated_files(dir: &std::path::Path, extension: &str, marker: &str) -> usize {
     let mut total = 0;
     if let Ok(rd) = std::fs::read_dir(dir) {
         for entry in rd.flatten() {
-            let name = entry.file_name();
-            if name.to_string_lossy().ends_with(".dfy")
-                && let Ok(contents) = std::fs::read_to_string(entry.path())
+            let path = entry.path();
+            if path.is_dir() {
+                total += count_marker_in_generated_files(&path, extension, marker);
+            } else if path.extension().and_then(|e| e.to_str()) == Some(extension)
+                && let Ok(contents) = std::fs::read_to_string(path)
             {
-                total += contents.matches("(universal lemma omitted)").count();
+                total += contents.matches(marker).count();
             }
         }
     }
@@ -9148,14 +9179,14 @@ impl LeanLawAudit {
 /// before the counts existed.
 fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
     use std::process::Command;
-    // The first lakefile root is the entry module. Its law theorem source names
-    // stay stable, while Lean declarations are qualified by that root.
+    // Every lakefile root is part of the program proof. The first is the entry;
+    // later roots include dependency modules (plus shared support roots, which
+    // simply carry no law markers). The audit keys declarations by their full
+    // root-qualified name so same-bare-name laws in two modules cannot collide.
     let roots = lean_lakefile_roots(dir);
     if roots.is_empty() {
         return LeanLawAudit::FAIL_CLOSED;
     }
-    let entry_root = &roots[0];
-    let entry_file_name = format!("{entry_root}.lean");
     // Collect the main universal law theorems across the emitted sources,
     // plus the emitter's per-theorem statement-class markers.
     let mut law_thms: Vec<String> = Vec::new();
@@ -9163,65 +9194,68 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
     // `theorem -> fn.law` identity, read off the marker's third field — the
     // stable key the proof manifest is keyed on.
     let mut labels: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    if let Ok(rd) = std::fs::read_dir(dir) {
-        for entry in rd.flatten() {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            if name != entry_file_name {
+    for root in &roots {
+        let relative = format!("{}.lean", root.replace('.', "/"));
+        let path = std::path::Path::new(dir).join(&relative);
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            // `DiscoveredLemmas.lean` WITH a cone-hash header is the
+            // committed `--discover` ARTIFACT, not an emitted proof file:
+            // lake doesn't build it (it's not a lakefile root), so
+            // theorems scanned from it wouldn't resolve in the
+            // axiom-checker environment — the lemmas that actually joined
+            // a proof are embedded in the entry root and scanned there.
+            // The header check keeps an entry MODULE legitimately named
+            // `DiscoveredLemmas` (whose emitted root has no such header)
+            // in the scan instead of silently zeroing its universal
+            // metric.
+            if relative == "DiscoveredLemmas.lean" && contents.contains("-- cone-hash:") {
                 continue;
             }
-            if let Ok(contents) = std::fs::read_to_string(entry.path()) {
-                // `DiscoveredLemmas.lean` WITH a cone-hash header is the
-                // committed `--discover` ARTIFACT, not an emitted proof file:
-                // lake doesn't build it (it's not a lakefile root), so
-                // theorems scanned from it wouldn't resolve in the
-                // axiom-checker environment — the lemmas that actually joined
-                // a proof are embedded in the entry root and scanned there.
-                // The header check keeps an entry MODULE legitimately named
-                // `DiscoveredLemmas` (whose emitted root has no such header)
-                // in the scan instead of silently zeroing its universal
-                // metric.
-                if name == "DiscoveredLemmas.lean" && contents.contains("-- cone-hash:") {
+            // User declarations live one level below their file namespace.
+            // Ignore any deeper helper namespace while retaining those laws.
+            let mut namespace_depth = 0usize;
+            for line in contents.lines() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with("namespace ") {
+                    namespace_depth += 1;
+                } else if trimmed == "end" || trimmed.starts_with("end ") {
+                    namespace_depth = namespace_depth.saturating_sub(1);
+                }
+                if let Some(rest) = line.strip_prefix(lean_codegen::LAW_CLASS_MARKER_PREFIX) {
+                    let mut parts = rest.split_whitespace();
+                    if let (Some(thm), Some(class)) = (parts.next(), parts.next()) {
+                        let qualified = format!("{root}.{thm}");
+                        classes.insert(qualified.clone(), class.to_string());
+                        // Third field (optional on older emissions): the
+                        // `fn.law` identity label for the manifest.
+                        if let Some(label) = parts.next() {
+                            labels.insert(qualified, label.to_string());
+                        }
+                    }
                     continue;
                 }
-                // Entry declarations live one level below the entry namespace.
-                // Ignore any deeper helper namespace while retaining those laws.
-                let mut namespace_depth = 0usize;
-                for line in contents.lines() {
-                    let trimmed = line.trim_start();
-                    if trimmed.starts_with("namespace ") {
-                        namespace_depth += 1;
-                    } else if trimmed == "end" || trimmed.starts_with("end ") {
-                        namespace_depth = namespace_depth.saturating_sub(1);
-                    }
-                    if let Some(rest) = line.strip_prefix(lean_codegen::LAW_CLASS_MARKER_PREFIX) {
-                        let mut parts = rest.split_whitespace();
-                        if let (Some(thm), Some(class)) = (parts.next(), parts.next()) {
-                            classes.insert(thm.to_string(), class.to_string());
-                            // Third field (optional on older emissions): the
-                            // `fn.law` identity label for the manifest.
-                            if let Some(label) = parts.next() {
-                                labels.insert(thm.to_string(), label.to_string());
-                            }
-                        }
-                        continue;
-                    }
-                    if namespace_depth > 1 {
-                        continue;
-                    }
-                    if let Some(rest) = line.strip_prefix("theorem ") {
-                        let thm = rest
-                            .split_whitespace()
-                            .next()
-                            .unwrap_or("")
-                            .trim_end_matches(':');
-                        if is_main_law_theorem(thm) {
-                            law_thms.push(thm.to_string());
-                        }
+                if namespace_depth > 1 {
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix("theorem ") {
+                    let thm = rest
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("")
+                        .trim_end_matches(':');
+                    if is_main_law_theorem(thm) {
+                        law_thms.push(format!("{root}.{thm}"));
                     }
                 }
             }
         }
     }
+    // Every law theorem emitted by this compiler has a class marker (chunked
+    // parts inherit their base marker). Roots such as `AverCommon` also contain
+    // helper theorems whose ordinary names happen to include `_eq_`; importing
+    // those roots into the whole-program audit must not promote support lemmas
+    // into user law obligations.
+    law_thms.retain(|thm| law_class_for_theorem(thm, &classes).is_some());
     if law_thms.is_empty() {
         return LeanLawAudit::FAIL_CLOSED;
     }
@@ -9316,11 +9350,9 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
         src.push_str(r);
         src.push('\n');
     }
-    for t in &law_thms {
+    for theorem in &law_thms {
         src.push_str("#print axioms ");
-        src.push_str(entry_root);
-        src.push('.');
-        src.push_str(t);
+        src.push_str(theorem);
         src.push('\n');
     }
     let checker = std::path::Path::new(dir).join("_aver_axcheck.lean");
@@ -9371,7 +9403,7 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
             let universal_laws = if o.status.success() {
                 universal_classed
                     .iter()
-                    .filter(|t| theorem_credit_from_axioms(&combined, &format!("{entry_root}.{t}")))
+                    .filter(|theorem| theorem_credit_from_axioms(&combined, theorem))
                     .count()
             } else {
                 0
@@ -9388,15 +9420,13 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
             for thm in &universal_classed {
                 let key = law_dedup_key(thm, &classes);
                 let label = manifest_label_for(key, &labels);
-                let qualified = format!("{entry_root}.{thm}");
-                let credited =
-                    o.status.success() && theorem_credit_from_axioms(&combined, &qualified);
+                let credited = o.status.success() && theorem_credit_from_axioms(&combined, thm);
                 let tier = if credited {
                     LawTier::Universal
                 } else {
                     LawTier::Failed
                 };
-                let axioms = axioms_for_theorem(&combined, &qualified).unwrap_or_default();
+                let axioms = axioms_for_theorem(&combined, thm).unwrap_or_default();
                 let record = ManifestLaw {
                     law: label.clone(),
                     backend: "lean".to_string(),
@@ -9429,17 +9459,19 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
 }
 
 /// Parse `<path>.lean:<line>` out of a Lean/lake diagnostic line, returning the
-/// file BASENAME and the 1-based line number. Tolerant of a leading `warning:`
-/// and a `././` / directory prefix on the path (`lake build` and `lake env lean`
-/// render the path differently). `None` if the line carries no `.lean:<digits>`.
+/// normalized project-relative file path and the 1-based line number. Tolerant
+/// of a leading `warning:` and repeated `./` prefixes (`lake build` and
+/// `lake env lean` render paths differently). Keeping subdirectories is
+/// identity-relevant: `A/Foo.lean` and `B/Foo.lean` are different modules.
+/// `None` if the line carries no `.lean:<digits>`.
 fn parse_lean_decl_location(line: &str) -> Option<(String, usize)> {
     let idx = line.find(".lean:")?;
     let before = &line[..idx];
     let start = before
-        .rfind(|c: char| c == '/' || c.is_whitespace())
+        .rfind(char::is_whitespace)
         .map(|p| p + 1)
         .unwrap_or(0);
-    let stem = &before[start..];
+    let stem = before[start..].trim_start_matches("./");
     if stem.is_empty() {
         return None;
     }
@@ -9468,25 +9500,20 @@ fn lean_sorry_laws(dir: &str, build_output: &str) -> Vec<String> {
     if locations.is_empty() {
         return Vec::new();
     }
-    let Some(entry_root) = lean_lakefile_roots(dir).into_iter().next() else {
+    let roots = lean_lakefile_roots(dir);
+    if roots.is_empty() {
         return Vec::new();
-    };
-    let entry_file_name = format!("{entry_root}.lean");
-    // In the entry file: its `theorem <name>` declarations as
-    // `(1-based line, name)`, plus the global `theorem -> fn.law` label map read
-    // off the class markers (same shape `emitted_main_law_theorems` reads).
+    }
+    // In every program root: its `theorem <name>` declarations as
+    // `(1-based line, root-qualified name)`, plus the global qualified-theorem
+    // → `fn.law` label map read off the class markers.
     let mut labels: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     let mut file_thms: std::collections::HashMap<String, Vec<(usize, String)>> =
         std::collections::HashMap::new();
-    if let Ok(rd) = std::fs::read_dir(dir) {
-        for entry in rd.flatten() {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            if name != entry_file_name {
-                continue;
-            }
-            let Ok(contents) = std::fs::read_to_string(entry.path()) else {
-                continue;
-            };
+    for root in &roots {
+        let relative = format!("{}.lean", root.replace('.', "/"));
+        let path = std::path::Path::new(dir).join(&relative);
+        if let Ok(contents) = std::fs::read_to_string(path) {
             let mut thms: Vec<(usize, String)> = Vec::new();
             for (idx, line) in contents.lines().enumerate() {
                 if let Some(rest) = line.strip_prefix(lean_codegen::LAW_CLASS_MARKER_PREFIX) {
@@ -9494,7 +9521,7 @@ fn lean_sorry_laws(dir: &str, build_output: &str) -> Vec<String> {
                     if let (Some(thm), Some(_class)) = (parts.next(), parts.next())
                         && let Some(label) = parts.next()
                     {
-                        labels.insert(thm.to_string(), label.to_string());
+                        labels.insert(format!("{root}.{thm}"), label.to_string());
                     }
                     continue;
                 }
@@ -9505,11 +9532,11 @@ fn lean_sorry_laws(dir: &str, build_output: &str) -> Vec<String> {
                         .unwrap_or("")
                         .trim_end_matches(':');
                     if !thm.is_empty() {
-                        thms.push((idx + 1, thm.to_string())); // Lean lines are 1-based
+                        thms.push((idx + 1, format!("{root}.{thm}"))); // Lean lines are 1-based
                     }
                 }
             }
-            file_thms.insert(name, thms);
+            file_thms.insert(relative, thms);
         }
     }
     let mut out: Vec<String> = Vec::new();
@@ -11253,18 +11280,42 @@ fn cmd_proof_dafny(file: &str, output_dir: &str, ctx: &codegen::CodegenContext) 
     // case-form verify and only proves law-form `verify`. Warn so the
     // silence isn't mistaken for a Dafny-verified pass (law blocks ARE
     // proven; the Lean backend and `aver verify` cover the examples).
-    let unchecked_case_blocks = ctx
+    let entry_case_blocks = ctx
         .items
         .iter()
         .filter(|i| matches!(i, TopLevel::Verify(vb) if matches!(vb.kind, VerifyKind::Cases)))
         .count();
+    let dependency_case_blocks: usize = ctx
+        .modules
+        .iter()
+        .map(|module| {
+            module
+                .verify_blocks
+                .iter()
+                .filter(|vb| matches!(vb.kind, VerifyKind::Cases))
+                .count()
+        })
+        .sum();
+    let unchecked_case_blocks = entry_case_blocks + dependency_case_blocks;
+    let unchecked_modules = usize::from(entry_case_blocks > 0)
+        + ctx
+            .modules
+            .iter()
+            .filter(|module| {
+                module
+                    .verify_blocks
+                    .iter()
+                    .any(|vb| matches!(vb.kind, VerifyKind::Cases))
+            })
+            .count();
     if unchecked_case_blocks > 0 {
         eprintln!(
             "{}",
             format!(
-                "warning: {unchecked_case_blocks} example-based `verify` block(s) are NOT \
-                 checked by the Dafny backend (Dafny proves laws, not concrete examples) — \
-                 they are verified by `aver proof --backend lean` and `aver verify`"
+                "warning: {unchecked_case_blocks} example-based `verify` block(s) across \
+                 {unchecked_modules} module(s) are NOT checked by the Dafny backend \
+                 (Dafny proves laws, not concrete examples) — they are verified by \
+                 `aver proof --backend lean` and `aver verify {file}`"
             )
             .yellow()
         );
@@ -11357,21 +11408,6 @@ impl DepLowering {
     }
 }
 
-/// Whether the loader should say how many dependency verify cases the
-/// caller leaves unsampled. Only `aver proof` has that gap: its export
-/// samples the entry module's cases and carries dependency laws, but
-/// dependency cases are not sampled yet. Every other command either
-/// samples them (`verify`) or samples nothing at all (`run`, `compile`).
-#[derive(Clone, Copy)]
-pub(super) enum DependencyCases<'a> {
-    Silent,
-    /// Warn once per program, naming the `aver verify` invocation that
-    /// does check them.
-    UnsampledByProof {
-        entry: &'a str,
-    },
-}
-
 /// Load dependent modules for codegen: every module of the program behind
 /// `items`, typechecked and lowered with the target's matrix. Any problem is
 /// fatal here — printed in red, exit 1 — exactly as it always was.
@@ -11379,16 +11415,6 @@ pub(super) fn load_compile_deps(
     items: &[TopLevel],
     module_root: &str,
     lowering: DepLowering,
-) -> Vec<ModuleInfo> {
-    load_compile_deps_reporting(items, module_root, lowering, DependencyCases::Silent)
-}
-
-/// [`load_compile_deps`] with an explicit say on unsampled dependency cases.
-pub(super) fn load_compile_deps_reporting(
-    items: &[TopLevel],
-    module_root: &str,
-    lowering: DepLowering,
-    dependency_cases: DependencyCases<'_>,
 ) -> Vec<ModuleInfo> {
     fn fail(message: String) -> ! {
         eprintln!("{}", message.red());
@@ -11407,20 +11433,6 @@ pub(super) fn load_compile_deps_reporting(
         )),
         Err(error) => fail(error.to_string()),
     };
-    if let DependencyCases::UnsampledByProof { entry } = dependency_cases {
-        let (cases, modules) = program.unsampled_dependency_cases();
-        if cases > 0 {
-            eprintln!(
-                "{}",
-                format!(
-                    "warning: {cases} non-law verify case{} across {modules} dependency module{} are not sampled by `aver proof` yet; `aver verify {entry}` checks them",
-                    if cases == 1 { "" } else { "s" },
-                    if modules == 1 { "" } else { "s" },
-                )
-                .yellow()
-            );
-        }
-    }
     let mut lowered = BTreeMap::new();
 
     // Parent before child, the order the walk met the modules in: the first
@@ -12261,10 +12273,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_lean_decl_location_extracts_basename_and_line() {
-        // The gate-build sorry warning `lean_sorry_laws` keys on. Basename + line
-        // must survive a `warning:` prefix, a `././` build path prefix, and the
-        // backtick glyph — the line is mapped to the enclosing theorem by number.
+    fn parse_lean_decl_location_extracts_relative_path_and_line() {
+        // The gate-build sorry warning `lean_sorry_laws` keys on. Relative path
+        // + line must survive a `warning:` prefix, a `././` build path prefix,
+        // and the backtick glyph — the line is mapped to the enclosing theorem.
         assert_eq!(
             super::parse_lean_decl_location(
                 "warning: Warehouse.lean:105:8: declaration uses `sorry`"
@@ -12277,8 +12289,41 @@ mod tests {
             ),
             Some(("Warehouse.lean".to_string(), 105))
         );
+        assert_eq!(
+            super::parse_lean_decl_location(
+                "warning: ././Infra/Store.lean:27:8: declaration uses 'sorry'"
+            ),
+            Some(("Infra/Store.lean".to_string(), 27))
+        );
         // A line with no `.lean:<digits>` is not a location.
         assert_eq!(super::parse_lean_decl_location("error: build failed"), None);
+    }
+
+    #[test]
+    fn dafny_trust_escape_counts_recurse_into_module_directories() {
+        let root =
+            std::env::temp_dir().join(format!("aver-dafny-recursive-count-{}", std::process::id()));
+        let nested = root.join("Infra");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(
+            root.join("Main.dfy"),
+            "assume {:axiom} true;\n// sample-only (universal lemma omitted)\n",
+        )
+        .unwrap();
+        std::fs::write(
+            nested.join("Store.dfy"),
+            "assume {:axiom} true;\nassume {:axiom} true;\n\
+             // sample-only (universal lemma omitted)\n",
+        )
+        .unwrap();
+        std::fs::write(nested.join("Ignored.txt"), "assume {:axiom}").unwrap();
+
+        assert_eq!(super::count_dafny_axioms(root.to_str().unwrap()), 3);
+        assert_eq!(
+            super::count_dafny_omitted_universals(root.to_str().unwrap()),
+            2
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/source.rs
+++ b/src/source.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use crate::ast::{TopLevel, VerifyKind};
+use crate::ast::TopLevel;
 use crate::config::VerifyCaseCeiling;
 use crate::lexer::Lexer;
 use crate::parser::Parser;
@@ -486,30 +486,6 @@ impl Program {
     /// own `verify` blocks are checked per release, not per program.
     pub fn report_units(&self) -> impl Iterator<Item = &ProgramModule> {
         self.modules.iter().filter(|module| !module.is_stdlib)
-    }
-
-    /// Non-law verify cases declared by project dependencies, with the
-    /// number of dependency modules declaring any: what a per-program export
-    /// that only samples the entry leaves unsampled.
-    pub fn unsampled_dependency_cases(&self) -> (usize, usize) {
-        self.report_units()
-            .filter(|module| !module.is_entry)
-            .map(|module| {
-                module
-                    .items
-                    .iter()
-                    .filter_map(|item| match item {
-                        TopLevel::Verify(block) if !matches!(block.kind, VerifyKind::Law(_)) => {
-                            Some(block.cases.len())
-                        }
-                        _ => None,
-                    })
-                    .sum::<usize>()
-            })
-            .filter(|&cases| cases > 0)
-            .fold((0, 0), |(cases, modules), module_cases| {
-                (cases + module_cases, modules + 1)
-            })
     }
 }
 

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -156,7 +156,8 @@ fn symbols_dep_modules_from_loaded(
                 capability_items,
                 capability_semantics,
                 // Symbol-table build only — the typechecker never reads
-                // verify_laws (it is a proof-emit-only field).
+                // verify blocks (they are proof-emit-only fields).
+                verify_blocks: Vec::new(),
                 verify_laws: Vec::new(),
                 analysis: None,
             }

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -1407,6 +1407,46 @@ fn comparison_shape_lookup_is_scoped_across_same_bare_names() {
 }
 
 #[test]
+fn private_dependency_law_is_lowered_for_its_own_module() {
+    let entry = "module Entry\n\
+         \x20   intent = \"load a module with a private obligation\"\n\
+         \x20   depends [Secret]\n\
+         \n\
+         fn main() -> Int\n\
+         \x20   Secret.public(0)\n";
+    let secret = "module Secret\n\
+         \x20   intent = \"prove private helpers without exporting them\"\n\
+         \x20   exposes [public]\n\
+         \n\
+         fn hidden(n: Int) -> Int\n\
+         \x20   n\n\
+         \n\
+         fn public(n: Int) -> Int\n\
+         \x20   hidden(n)\n\
+         \n\
+         verify hidden law reflexive\n\
+         \x20   given n: Int = -1..1\n\
+         \x20   hidden(n) => hidden(n)\n";
+    let ctx = build_ctx_with_modules(entry, &[("Secret", secret)]);
+    let theorem = module_law_theorem(&ctx, "Secret", "hidden", "reflexive")
+        .expect("the declaring module must lower its private law");
+    assert!(matches!(
+        theorem.strategy,
+        aver::ir::ProofStrategy::Reflexive
+    ));
+    let secret_module = ctx
+        .modules
+        .iter()
+        .find(|module| module.prefix == "Secret")
+        .expect("Secret module");
+    assert_eq!(secret_module.verify_blocks.len(), 1);
+    assert!(
+        secret_module.verify_laws.is_empty(),
+        "private law must be proved locally but remain absent from the consumer citation pool"
+    );
+}
+
+#[test]
 fn compound_peano_premise_stays_out_of_comparison_bridge_strategy() {
     let src = "module CmpBridge\n\
          \x20   intent = \"comparison implication\"\n\

--- a/tests/proof_spec/check_gates.rs
+++ b/tests/proof_spec/check_gates.rs
@@ -250,26 +250,30 @@ fn proof_dependency_law_verify_is_carried_not_warned() {
          pool, not dropped — the unsampled-cases warning must not fire for it:\n{}",
         format_output(&run)
     );
+    let dep = std::fs::read_to_string(out.join("Dep.dfy")).expect("read Dep.dfy");
+    assert!(
+        dep.contains("// Law: ident.refl") && dep.contains(" ident_refl(n: int)"),
+        "the dependency's own law must be emitted in its Dafny module even when \
+         no entry law cites it:\n{dep}"
+    );
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);
 }
 
 #[test]
-fn proof_warns_once_per_program_about_unsampled_dependency_cases() {
-    // A NON-law (example / cases-form) `verify` block in a dependency
-    // module is still not sampled by the proof export — that is the one
-    // command which has not caught up with `aver verify`, which checks
-    // every module of the program. The export says so once, for the whole
-    // program (not once per module, and not on `run`/`compile`), counting
-    // cases and naming the command that does check them. Pure codegen, no
-    // verifier binary needed.
+fn proof_carries_dependency_cases_into_their_lean_modules() {
+    // Whole-program proof export owns every reached module's claims. Concrete
+    // dependency cases are emitted inside the declaring module's namespace;
+    // no `--deps` replacement and no "unsampled" warning remain. Pure codegen,
+    // no Lean binary needed.
     let aver_bin = env!("CARGO_BIN_EXE_aver");
     let src = temp_output_dir("aver-dep-verify-warn-src");
     std::fs::create_dir_all(&src).expect("create src dir");
     std::fs::write(
         src.join("dep.av"),
         "module Dep\n    depends []\n\nfn ident(n: Int) -> Int\n    ? \"id\"\n    n\n\n\
-         verify ident\n    ident(1) => 1\n    ident(2) => 2\n",
+         verify ident\n    ident(1) => 1\n    ident(2) => 2\n\n\
+         verify ident law refl\n    given n: Int = -1..1\n    ident(n) => n\n",
     )
     .expect("write dep.av");
     std::fs::write(
@@ -291,7 +295,7 @@ fn proof_warns_once_per_program_about_unsampled_dependency_cases() {
         .arg("proof")
         .arg(&entry)
         .arg("--backend")
-        .arg("dafny")
+        .arg("lean")
         .arg("--module-root")
         .arg(&src)
         .arg("-o")
@@ -299,23 +303,27 @@ fn proof_warns_once_per_program_about_unsampled_dependency_cases() {
         .output()
         .expect("expected `aver proof` to run");
     let stderr = String::from_utf8_lossy(&run.stderr);
-    let expected = format!(
-        "warning: 3 non-law verify cases across 2 dependency modules are not sampled by `aver proof` yet; `aver verify {}` checks them",
-        entry.display()
+    assert!(
+        run.status.success() && !stderr.contains("not sampled") && !stderr.contains("NOT checked"),
+        "dependency cases should be exported without an unsampled warning:\n{}",
+        format_output(&run)
+    );
+    let dep = std::fs::read_to_string(out.join("Dep.lean")).expect("read Dep.lean");
+    let other = std::fs::read_to_string(out.join("Other.lean")).expect("read Other.lean");
+    assert_eq!(
+        dep.matches("example :").count(),
+        2,
+        "Dep.lean must carry both of Dep's concrete cases:\n{dep}"
     );
     assert_eq!(
-        stderr
-            .lines()
-            .filter(|line| line.contains(&expected))
-            .count(),
+        other.matches("example :").count(),
         1,
-        "expected exactly one program-level warning about unsampled dependency cases, got:\n{}",
-        format_output(&run)
+        "Other.lean must carry Other's concrete case:\n{other}"
     );
     assert!(
-        !stderr.contains("NOT checked"),
-        "the old per-module warning must be gone:\n{}",
-        format_output(&run)
+        dep.contains("theorem ident_law_refl"),
+        "Dep.lean must carry Dep's law even though the entry declares no law \
+         that cites it:\n{dep}"
     );
 
     // `aver run` samples nothing, so it has nothing to warn about.
@@ -331,6 +339,132 @@ fn proof_warns_once_per_program_about_unsampled_dependency_cases() {
         !run_stderr.contains("not sampled") && !run_stderr.contains("NOT checked"),
         "`aver run` must not warn about dependency verify cases:\n{}",
         format_output(&run_cmd)
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn proof_dependency_case_ground_truth_is_module_scoped() {
+    // Same bare verify key in entry and dependency must never share the VM
+    // literalization slot. Both RHS expressions deliberately call a helper so
+    // the generated constants prove which module's runtime result was used.
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-dep-ground-truth-scope-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("dep.av"),
+        "module Dep\n    depends []\n    exposes [ident]\n\n\
+         fn expected(n: Int) -> Int\n    ? \"Dependency expectation.\"\n    n\n\n\
+         fn ident(n: Int) -> Int\n    ? \"Dependency identity.\"\n    n\n\n\
+         verify ident\n    ident(1) => expected(1)\n",
+    )
+    .expect("write dep.av");
+    std::fs::write(
+        src.join("entry.av"),
+        "module Entry\n    depends [Dep]\n\n\
+         fn expected(n: Int) -> Int\n    ? \"Entry expectation.\"\n    n + 100\n\n\
+         fn ident(n: Int) -> Int\n    ? \"Entry function sharing the dependency name.\"\n    n + 100\n\n\
+         verify ident\n    ident(1) => expected(1)\n",
+    )
+    .expect("write entry.av");
+    let out = temp_output_dir("aver-dep-ground-truth-scope-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("entry.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("--module-root")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("expected `aver proof` to run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let dep = std::fs::read_to_string(out.join("Dep.lean")).expect("read Dep.lean");
+    let entry = std::fs::read_to_string(out.join("Entry.lean")).expect("read Entry.lean");
+    assert!(
+        dep.contains("example : Dep.ident 1 = 1 := by")
+            && !dep.contains("example : Dep.ident 1 = 101 := by"),
+        "Dep's case must use Dep's VM result, not Entry's same-key result:\n{dep}"
+    );
+    assert!(
+        entry.contains("example : ident 1 = 101 := by"),
+        "Entry's case must keep Entry's own VM result:\n{entry}"
+    );
+    let _ = std::fs::remove_dir_all(&src);
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn proof_check_covers_dependency_cases_and_law_as_one_program() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping dependency whole-proof check: `lake` not available");
+        return;
+    }
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let src = temp_output_dir("aver-dep-whole-proof-src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(
+        src.join("lib.av"),
+        "module Lib\n    intent = \"Owns cases and a law.\"\n    exposes [double]\n    effects []\n\n\
+         fn double(n: Int) -> Int\n    ? \"Doubles n.\"\n    n * 2\n\n\
+         verify double\n    double(3) => 6\n    double(0) => 0\n    double(-4) => -8\n\n\
+         verify double law doubleAdditive\n    given a: Int = [0, 1, 7]\n    given b: Int = [0, 2, 5]\n    double(a + b) => double(a) + double(b)\n",
+    )
+    .expect("write lib.av");
+    std::fs::write(
+        src.join("entry.av"),
+        "module Entry\n    intent = \"Thin entry.\"\n    depends [Lib]\n    exposes [quad]\n    effects []\n\n\
+         fn quad(n: Int) -> Int\n    ? \"Quadruples n.\"\n    Lib.double(Lib.double(n))\n\n\
+         verify quad\n    quad(2) => 8\n",
+    )
+    .expect("write entry.av");
+    let out = temp_output_dir("aver-dep-whole-proof-out");
+    let run = Command::new(aver_bin)
+        .arg("proof")
+        .arg(src.join("entry.av"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("--module-root")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("expected whole-program proof check");
+    let json_line = run
+        .stdout
+        .split(|&byte| byte == b'\n')
+        .rev()
+        .find_map(|line| {
+            std::str::from_utf8(line)
+                .ok()
+                .filter(|s| s.starts_with('{'))
+        })
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)));
+    let summary: serde_json::Value = serde_json::from_str(json_line)
+        .unwrap_or_else(|error| panic!("bad JSON ({error}):\n{json_line}"));
+    assert_eq!(
+        (
+            run.status.success(),
+            summary["passed"].as_bool(),
+            summary["sorries"].as_u64(),
+            summary["build_errors"].as_u64(),
+        ),
+        (true, Some(true), Some(0), Some(0)),
+        "the thin entry must check every dependency claim:\n{}",
+        format_output(&run)
+    );
+    let lib = std::fs::read_to_string(out.join("Lib.lean")).expect("read Lib.lean");
+    assert_eq!(lib.matches("example :").count(), 3, "{lib}");
+    assert!(lib.contains("theorem double_law_doubleAdditive"), "{lib}");
+    let manifest =
+        std::fs::read_to_string(out.join("proof_manifest.json")).expect("read proof manifest");
+    assert!(
+        manifest.contains("Lib.double.doubleAdditive"),
+        "dependency law identity must be module-qualified in the manifest:\n{manifest}"
     );
     let _ = std::fs::remove_dir_all(&src);
     let _ = std::fs::remove_dir_all(&out);

--- a/tests/proof_spec/cross_file.rs
+++ b/tests/proof_spec/cross_file.rs
@@ -399,7 +399,8 @@ pub(super) fn run_multi(
 // `qrev`/`rev` mentions would be a subset of the (bare) cone and the
 // unrelated module's law would be wrongly admitted. The qualified-identity
 // gate compares `Other.qrev` against a cone holding `Lib.qrev`, so the
-// unrelated dep law is REJECTED — never cited, never emitted.
+// unrelated dep law is REJECTED as a citation. It is still emitted and checked
+// as `Other`'s own obligation.
 // ---------------------------------------------------------------------------
 
 /// `Other` coincidentally exposes the SAME bare fn names + law identity as
@@ -438,9 +439,9 @@ fn cross_file_bare_name_collision_dep_law_not_admitted() {
     // A law from an UNRELATED module that merely shares a bare fn name with a
     // fn in the consumer's cone must NOT be admitted. The qualified-identity
     // gate keys on `Module.fn`, so `Other.qrev` ≠ the cone's `Lib.qrev`:
-    // `Other.qrev_law_qrevSpec` is never cited in the consumer's proof, and
-    // (being un-admitted) is never emitted into `Other.lean` at all. Only the
-    // GENUINELY in-cone `Lib.qrev_law_qrevSpec` is admitted + emitted.
+    // `Other.qrev_law_qrevSpec` is never cited in the consumer's proof. Both
+    // dependency laws are nevertheless emitted in their declaring modules;
+    // admission controls proof reuse, not whether a module is checked.
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping cross-file bare-name-collision test: `lake` not available");
         return;
@@ -464,12 +465,12 @@ fn cross_file_bare_name_collision_dep_law_not_admitted() {
         "an UNRELATED module's same-bare-name law must NOT be admitted via a \
          bare-name collision — qualified `Module.fn` identity rejects it\nConsumer.lean:\n{consumer}"
     );
-    // Un-admitted ⇒ not emitted into the build at all (no sorry contribution).
+    // The unrelated law remains `Other`'s own proof obligation.
     let other = &leans["Other.lean"];
     assert!(
-        !other.contains("theorem qrev_law_qrevSpec"),
-        "the unrelated `Other` law is admitted by no consumer, so it must not be \
-         emitted into the build\nOther.lean:\n{other}"
+        other.contains("theorem qrev_law_qrevSpec"),
+        "an unrelated dependency law must still be emitted and checked in its \
+         declaring module\nOther.lean:\n{other}"
     );
     // The genuinely-cited dep law IS emitted in its own module file.
     let lib = &leans["Lib.lean"];
@@ -531,8 +532,8 @@ fn cross_file_private_dep_law_not_admitted() {
     // it is filtered at collection (`collect_verify_laws` honours the same
     // `exposes` rule as `collect_module_exports`). Even though the consumer's
     // cone reaches `revAcc` transitively (through the exposed `rev`), the
-    // private law never reaches the pool: not cited in the consumer's proof,
-    // not emitted as a theorem in `Lib.lean`.
+    // private law never reaches the consumer citation pool. It is still emitted
+    // and checked as a declaration owned by `Lib`.
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping cross-file visibility test: `lake` not available");
         return;
@@ -553,9 +554,9 @@ fn cross_file_private_dep_law_not_admitted() {
     );
     let lib = &leans["Lib.lean"];
     assert!(
-        !lib.contains("theorem revAcc_law_revAccSpec"),
-        "a private dependency law is admitted by no consumer, so it must not be \
-         emitted as a theorem in the dependency's file\nLib.lean:\n{lib}"
+        lib.contains("theorem revAcc_law_revAccSpec"),
+        "a private dependency law must still be checked inside its declaring \
+         module even though consumers cannot cite it\nLib.lean:\n{lib}"
     );
 }
 
@@ -573,9 +574,9 @@ const CONSUMER_OWN_LADDER: &str = "module Consumer\n\
     \x20   myRev(x) => List.concat(Lib.rev(x), [])\n";
 
 // ---------------------------------------------------------------------------
-// MAJOR 4 — an UNPROVEN dependency law the consumer does NOT cite must not
-// inflate the consumer's file-wide `sorry` count. An un-admitted dep law is a
-// complete no-op for the consumer: it is never emitted into the build.
+// MAJOR 4 — every dependency law is an obligation of the project that declares
+// it, even when no consumer cites it. A false law must fail its own module
+// instead of disappearing from the whole-program proof export.
 // ---------------------------------------------------------------------------
 
 /// `Lib` exposes a FALSE law (`bogus(n) = n` for `bogus(n) = n + 1`) about a
@@ -595,14 +596,13 @@ const LIB_WITH_UNCITED_FALSE_LAW: &str = "module Lib\n\
     \x20   bogus(n) => n\n";
 
 #[test]
-fn cross_file_uncited_unproven_dep_law_no_sorry_inflation() {
+fn cross_file_uncited_unproven_dep_law_fails_its_own_module() {
     // The consumer proves a clean own law (rev-append-nil) and never mentions
-    // `Lib.bogus`. `Lib.bogus law bogusBad` is FALSE and would fall to `sorry`
-    // if emitted. Because no consumer law ADMITS it, it is not emitted into
-    // the build at all — so it contributes ZERO to the consumer's file-wide
-    // sorry count. The consumer therefore still passes universally. (Contrast
-    // `cross_file_unproven_dep_law_grants_no_false_credit`, where the consumer
-    // DOES cite the unproven law and correctly inherits its gap.)
+    // `Lib.bogus`. That does not erase `Lib.bogus law bogusBad`: proof export
+    // covers every module's own verify declarations, so the false dependency
+    // law is emitted, falls to `sorry`, and is charged to its qualified
+    // identity. Consumer citation still controls which law may help another
+    // proof; it no longer controls whether the declaring module is checked.
     if Command::new("lake").arg("--version").output().is_err() {
         eprintln!("skipping cross-file uncited-unproven test: `lake` not available");
         return;
@@ -617,20 +617,31 @@ fn cross_file_uncited_unproven_dep_law_no_sorry_inflation() {
     );
     let lib = &leans["Lib.lean"];
     assert!(
-        !lib.contains("bogus_law_bogusBad"),
-        "an unproven dep law no consumer cites must not be emitted into the \
-         build (else its `sorry` inflates the consumer's count)\nLib.lean:\n{lib}"
+        lib.contains("bogus_law_bogusBad"),
+        "every dependency law must be emitted in its declaring module even \
+         when no consumer cites it\nLib.lean:\n{lib}"
     );
     assert_eq!(
-        (
-            summary["passed"].as_bool(),
-            summary["universal"].as_bool(),
-            summary["sorries"].as_u64(),
-        ),
-        (Some(true), Some(true), Some(0)),
-        "an un-cited unproven dep law must not inflate the consumer's sorry \
-         count — the consumer's own clean law still passes universally\n{}",
+        summary["passed"].as_bool(),
+        Some(false),
+        "{}",
         format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(false),
+        "{}",
+        format_output(&run)
+    );
+    assert!(
+        summary["build_errors"].as_u64().unwrap_or(0) > 0,
+        "the false dependency samples must fail Lean's checked-domain/sample \
+         theorems\n{}",
+        format_output(&run)
+    );
+    assert!(
+        lib.contains("universal Lib.bogus.bogusBad"),
+        "the emitted obligation must carry its module-qualified identity\nLib.lean:\n{lib}"
     );
 }
 
@@ -996,8 +1007,8 @@ fn cross_file_reserved_module_name_dep_law_is_admitted_and_cited() {
     let dep_lean = &leans["Type'.lean"];
     assert!(
         dep_lean.contains("theorem qrev_law_qrevSpec :"),
-        "the reserved-name dep module's cited law must be ADMITTED and therefore \
-         emitted as a theorem; empty mentions drop it silently\nType'.lean:\n{dep_lean}"
+        "the reserved-name dep module's own law must be emitted as a theorem; \
+         citation admission is checked separately\nType'.lean:\n{dep_lean}"
     );
     let consumer_lean = &leans["Consumer.lean"];
     assert!(
@@ -1017,9 +1028,9 @@ fn cross_file_reserved_module_name_dep_law_is_admitted_and_cited() {
             summary["universal_laws"].as_u64(),
             summary["sorries"].as_u64(),
         ),
-        (Some(true), Some(true), Some(1), Some(0)),
-        "the reserved-name dep must give the consumer the SAME universal credit \
-         the `Lib`-named split probe gets\n{}",
+        (Some(true), Some(true), Some(2), Some(0)),
+        "both the dependency's own law and the consumer law must receive \
+         universal credit under the escaped module identity\n{}",
         format_output(&run)
     );
 }

--- a/tests/proof_spec/dependency_effects.rs
+++ b/tests/proof_spec/dependency_effects.rs
@@ -226,6 +226,58 @@ fn dependency_effectful_fn_is_exported_with_the_entrys_oracle_threading() {
     );
 }
 
+#[test]
+fn dependency_own_verify_case_roots_its_effectful_proof_cone() {
+    // The entry deliberately cites no function from DepClaim. Its own verify
+    // block is the only reachability root, so dropping dependency cases would
+    // omit `named` and leave the generated example with no lifted callee.
+    let dep_claim = r#"module DepClaim
+    intent = "Owns an effectful example independently of the entry."
+    exposes [named]
+    depends [Infra.Kv, Infra.Store]
+    effects [Infra.Kv.get]
+
+fn named(store: Store, key: String) -> Result<Option<String>, String>
+    ? "Reads one name."
+    ! [Infra.Kv.get]
+    Infra.Store.get(store, key)
+
+verify named
+    given stub: Infra.Kv.get = [fixedGet]
+    named(Infra.Store.fixture([("k", "v")]), "k") => Result.Ok(Option.Some("v"))
+
+fn fixedGet(path: BranchPath, n: Int, key: String) -> Result<Option<String>, String>
+    ? "Proof-side database stub."
+    Result.Ok(Option.None)
+"#;
+    let entry = r#"module Main
+    intent = "Loads DepClaim without adding an entry claim."
+    depends [DepClaim, Infra.Kv, Infra.Store]
+    effects []
+
+fn main() -> Unit
+    ? "No-op entry."
+    Unit
+"#;
+    let leans = emit_multi(
+        &[
+            ("infra/kv.av", KV),
+            ("infra/store.av", STORE),
+            ("depclaim.av", dep_claim),
+            ("main.av", entry),
+        ],
+        "main.av",
+        &["DepClaim.lean"],
+    );
+    let dep = &leans["DepClaim.lean"];
+    assert!(
+        dep.contains("def named (path : BranchPath)")
+            && dep.contains("example")
+            && dep.contains("DepClaim.named"),
+        "a dependency's own case must root lifting and emission in that module:\n{dep}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // (b) A dependency helper no `verify` block reaches, but the entry's cone
 // ---------------------------------------------------------------------------
@@ -449,6 +501,66 @@ fn entry_effectful_loop_over_a_dependency_read_forwards_path_and_oracles() {
     assert!(
         prune.contains("heightsHeld path rnd_Infra_Kv_get store (height + 1)"),
         "the entry's tail call must forward `path` and the oracles:\n{prune}"
+    );
+}
+
+#[test]
+fn symbolic_oracle_case_over_partial_recursion_is_explicitly_declined() {
+    // A symbolic oracle can be simplified away from a concrete non-recursive
+    // branch, but `partial def` exposes no equation theorem for the simplifier
+    // to use. Native evaluation rejects the remaining free function, and
+    // reverting it leaves a function-quantified proposition without a
+    // Decidable instance. This shape came from btc-listener's Chain module:
+    // keep it an attributed decline instead of a generated Lean build error.
+    let capability = r#"module Probe
+    intent = "A capability whose unreachable branch is enough to lift the subject."
+    kind = capability
+    semantics = effectful
+    exposes [get]
+
+operation get(key: String) -> Result<String, String>
+    ? "Read a value."
+    oracle = generative
+    replay = recorded
+"#;
+    let entry = r#"module Main
+    intent = "Exercises a base case of an intentionally non-terminating shape."
+    exposes [main, climb]
+    depends [Probe]
+    effects [Probe.get]
+
+fn climb(n: Int) -> Result<Int, String>
+    ? "Return at zero; the other branch grows forever."
+    ! [Probe.get]
+    match n
+        0 -> Result.Ok(0)
+        _ -> climbOne(n)
+
+fn climbOne(n: Int) -> Result<Int, String>
+    ? "Read once and return to the growing loop."
+    ! [Probe.get]
+    seen = Probe.get("x")?
+    climb(n + 1)
+
+verify climb
+    climb(0) => Result.Ok(0)
+
+fn main() -> Unit
+    ? "Entry point."
+    Unit
+"#;
+
+    let leans = emit_multi(
+        &[("probe.av", capability), ("main.av", entry)],
+        "main.av",
+        &["Main.lean"],
+    );
+    let main = &leans["Main.lean"];
+    assert!(
+        main.contains("verify climb case 1: the case has a symbolic capability oracle")
+            && main.contains("kernel-opaque Lean function(s) climb")
+            && main.contains("no theorem emitted"),
+        "the unprovable symbolic-oracle/partial-recursion case must be an explicit decline:\n{main}"
     );
 }
 

--- a/tests/stdlib_spec.rs
+++ b/tests/stdlib_spec.rs
@@ -307,6 +307,7 @@ fn the_vm_bytecode_reads_the_codepoint_at_the_cursor() {
             .collect(),
         capability_items: vec![],
         capability_semantics: None,
+        verify_blocks: aver::codegen::collect_verify_blocks(&dep_items),
         verify_laws: aver::codegen::collect_verify_laws(&dep_items),
         analysis: dep_result.analysis,
     }];
@@ -436,6 +437,7 @@ fn the_vm_bytecode_collects_bytes_at_the_cursor() {
             .collect(),
         capability_items: vec![],
         capability_semantics: None,
+        verify_blocks: aver::codegen::collect_verify_blocks(&dep_items),
         verify_laws: aver::codegen::collect_verify_laws(&dep_items),
         analysis: dep_result.analysis,
     }];


### PR DESCRIPTION
Fixes #1086.

## What changed
- treat every module verify block as part of whole-program proof export while keeping cross-module law citation visibility-gated
- collect VM ground truth and decline state per module-qualified case identity
- emit dependency examples/laws in Lean and dependency laws in Dafny, with recursive trust audits over generated module trees
- root dependency-owned claims for effectful reachability and remove the obsolete unsampled-dependency warning
- fail closed on symbolic capability cases crossing kernel-opaque recursion

## Validation
- cargo test -p aver-lang --test proof_spec (306 passed)
- cargo test -p aver-lang --test proof_ir_diff (66 passed)
- cargo test -p aver-lang --lib (1399 passed)
- cargo clippy -p aver-lang --lib --bin aver -- -D warnings
- cargo fmt --all -- --check
- btc-listener Chain slice: generated 28-module Lean project, lake build green
- self-host: whole-program export exercised; separate existing Lean-model gaps identified
- vera-bench pair-sum: proof --check green