### PR TITLE
Stop scheduled workflows from running in forks

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -24,6 +24,11 @@ jobs:
   decide:
     name: Decide lanes
     runs-on: ubuntu-latest
+    # Scheduled runs belong to this repository. A fork with Actions enabled
+    # otherwise runs our cron on its owner's account and mails them about any
+    # failure. Every other trigger still works in a fork, so a contributor can
+    # run this workflow on their own branch.
+    if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
     outputs:
       lanes: ${{ steps.pick.outputs.lanes }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
   check:
     name: Check & Test
     runs-on: ubuntu-latest
+    # Scheduled runs belong to this repository. A fork with Actions enabled
+    # otherwise runs our cron on its owner's account and mails them about any
+    # failure. Every other trigger still works in a fork, so a contributor can
+    # run this workflow on their own branch.
+    if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
     steps:
       - uses: actions/checkout@v5
 
@@ -111,6 +116,11 @@ jobs:
   wasm:
     name: WASM
     runs-on: ubuntu-latest
+    # Scheduled runs belong to this repository. A fork with Actions enabled
+    # otherwise runs our cron on its owner's account and mails them about any
+    # failure. Every other trigger still works in a fork, so a contributor can
+    # run this workflow on their own branch.
+    if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
     env:
       # The wasm/wasip2 feature set pulls in wasmtime + component-model
       # crates and several large integration-test binaries. Keep this job's

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -78,7 +78,7 @@ env:
 jobs:
   nightly:
     name: Fuzz nightly (${{ matrix.target }})
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'schedule' && github.repository == 'jasisz/aver') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # 90 min (was 60, before that 45). The "Fuzz (30 min)" step is
     # `-V 1800` of fuzzing time, but AFL first calibrates every seed

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -37,6 +37,11 @@ jobs:
   proof-export:
     name: Proof Export (Lean + Dafny)
     runs-on: ubuntu-latest
+    # Scheduled runs belong to this repository. A fork with Actions enabled
+    # otherwise runs our cron on its owner's account and mails them about any
+    # failure. Every other trigger still works in a fork, so a contributor can
+    # run this workflow on their own branch.
+    if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/rust-codegen.yml
+++ b/.github/workflows/rust-codegen.yml
@@ -34,6 +34,11 @@ jobs:
   rust-codegen:
     name: Rust codegen regression
     runs-on: ubuntu-latest
+    # Scheduled runs belong to this repository. A fork with Actions enabled
+    # otherwise runs our cron on its owner's account and mails them about any
+    # failure. Every other trigger still works in a fork, so a contributor can
+    # run this workflow on their own branch.
+    if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
All five workflows carry a `schedule:` trigger and none of them checked which repository they were running in. A fork with Actions enabled runs this project's entire cron on its owner's account, and GitHub attributes a scheduled run to the fork owner — so it also mails them about every failure.

This is not hypothetical: the one existing fork has accumulated 70 such runs. Nightly `ci`, `proof`, `rust-codegen` and `fuzz` at 03:00 UTC, plus `cert` every six hours. Four of them pass silently; `fuzz` fails there because it assumes queue state that only exists here, so that is the only one whose owner ever hears about it — roughly 88 minutes of someone else's Actions minutes per day, for weeks.

Scheduled jobs now run only in this repository:

```yaml
if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
```

`fuzz.yml` already had a trigger guard, so its condition was extended rather than duplicated.

Coverage is complete without touching every job: `cert-kernel` inherits the skip through `needs: decide`, and `wasm_release_build` and `bench` are already restricted to `push` on `main`, so neither can fire on a schedule.

Every other trigger is untouched. A contributor can still run any of these workflows on a branch in their own fork, or by hand through `workflow_dispatch`.