### PR TITLE
perf(verify): reuse the program graph and run cases in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Added
 
+- **`aver verify` now uses the machine instead of repeatedly rebuilding the same program.** The command resolves and parses one deterministic project graph, checks and prepares each project module once, and runs independent files and declared cases in one bounded Rayon pool. `-j N` / `--jobs N` selects the worker count, the default is the machine's available parallelism, and `-j 1` keeps the same graph-reuse path without concurrency. Module ownership, summaries, failures, and JSON remain collected in input/case order, so `-j 1` and `-j N` are byte-identical. On btc-listener's public 98-file corpus (6,016 cases), the full provider-backed command fell from 307.17 s to 7.17 s at `-j 1`, then to 3.98 s at `-j 8`; most of the win was eliminating repeated compiler/provider preflight work, not parallel execution. The same graph input cache now serves whole-directory `check` and `audit`, and provider-host planning no longer performs a second full pipeline per entry. Reported by Robin Owens ([@n1bor](https://github.com/n1bor)).
+
 - **Generated Cargo projects now inherit the toolchain's actual source.** A path-built Aver emits path dependencies, a git-installed Aver pins both `aver-lang` and `aver-rt` to the build repository and exact revision, and a registry installation emits exact registry versions. The generated Rust project and cached provider host share this one build-time provenance, so a git development build no longer pairs its generated code with an older same-version runtime from crates.io.
 
 - **Code generation now keeps stable identities all the way to backend rendering.** Rust root-main and tail-call paths consume resolved functions directly; Lean and Dafny resolve proof rewrites once at their producer boundary and no longer carry source-expression rendering adapters. Module-scoped verify reachability is a single transitive `FnId` walk over `ResolvedProgram`, so same-bare-name functions and types in entry and dependency modules cannot cross-wire through a backend cache or name lookup.
@@ -236,6 +238,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
   This is breaking for one shape: a top-level binding written *indented*, directly under the header, used to be accepted and now is not. The fix is to unindent it — bindings belong at column 0, outside the header — and the error says so.
 
 ### Fixed
+
+- **A source file with many diagnostics is linear to render again.** Diagnostic construction now indexes the file's lines once and shares that table across every finding instead of splitting and rescanning the complete source for every error. A half-written large module no longer turns `aver check` diagnostics into quadratic work.
 
 - **The nightly wasm-gc/wasip2 fuzz lanes build again.** The production multi-module flattener gained capability-registry and runtime/verification-surface arguments, but its three fuzz callers kept the old two-argument call and failed during compilation before AFL started. The codegen and VM↔wasm-gc parity targets now pass the typechecked program registry and runtime surface, matching the production compile path they exercise.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proptest",
+ "rayon",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ required-features = ["runtime"]
 
 [features]
 default = ["runtime", "runtime-net", "terminal", "tty-render"]
-runtime = ["dep:aver-rt", "aver-memory/runtime", "aver-rt/random", "dep:clap", "dep:toml"]
+runtime = ["dep:aver-rt", "aver-memory/runtime", "aver-rt/random", "dep:clap", "dep:rayon", "dep:toml"]
 runtime-net = ["runtime", "aver-rt/http"]
 terminal = ["aver-rt/terminal"]
 tty-render = ["dep:colored"]
@@ -74,6 +74,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 colored = { version = "2", optional = true }
 num-bigint = "0.4"
 num-traits = "0.2"
+rayon = { version = "1", optional = true }
 thiserror = "1"
 toml = { version = "0.8", optional = true }
 url = "2"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -75,6 +75,7 @@ reason code.
 
 ```bash
 aver verify file-or-dir --module-root .
+aver verify file-or-dir -j 8
 aver verify file-or-dir --wasm-gc
 ```
 
@@ -86,6 +87,17 @@ rooted at each file, each module verified once. Embedded standard modules
 are not sampled (their blocks are verified per release). A failing case in
 any module fails the command; pointing at a single module is still the fast
 way to iterate on it.
+
+VM verification resolves one project graph and prepares each project module
+once, then runs independent files and declared cases in a bounded worker pool.
+`-j N` / `--jobs N` sets that pool's maximum size; it defaults to the machine's
+available parallelism. `-j 1` disables concurrency without giving up graph
+reuse, which makes it the useful comparison/debugging mode. Reports are always
+collected in input, module, block, and case order, so sequential and parallel
+runs emit identical text/JSON and failure coordinates. `--hostile` keeps the
+base/profile cases of a block sequential, and `--wasm-gc` keeps cases within a
+module sequential; independent input files may still share the bounded pool.
+
 It fails on:
 - mismatched examples
 - parse/type errors

--- a/src/cli_entry.rs
+++ b/src/cli_entry.rs
@@ -235,6 +235,7 @@ fn main_impl(
             json,
             hostile,
             wasm_gc,
+            jobs,
         } => {
             commands::cmd_verify(
                 file,
@@ -243,6 +244,7 @@ fn main_impl(
                 *json,
                 *hostile,
                 *wasm_gc,
+                jobs.as_ref().map(|jobs| jobs.get()),
                 provider_bindings,
             );
         }

--- a/src/diagnostics/analyze.rs
+++ b/src/diagnostics/analyze.rs
@@ -8,9 +8,12 @@
 //! exposes, config suppression, dependency resolution) stay in CLI / LSP
 //! callers.
 
+use super::classify::SourceIndex;
 #[cfg(feature = "runtime")]
 use super::factories::verify_provider_setup_diagnostic;
-use super::factories::{from_check_finding, from_type_error, unused_binding_diagnostic};
+use super::factories::{
+    from_check_finding_with_index, from_type_error_with_index, unused_binding_diagnostic_with_index,
+};
 use super::model::{AnalysisReport, Diagnostic, Severity, Span};
 use crate::checker::{
     CheckFinding, check_module_intent_with_sigs_in, collect_cse_warnings_in,
@@ -194,9 +197,15 @@ fn analyze_source_impl(
     let tc_result = crate::ir::pipeline::typecheck_gate(&items, &mode, &items);
 
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let source_index = SourceIndex::new(source);
 
     for te in &tc_result.errors {
-        diagnostics.push(from_type_error(te, source, &options.file_label));
+        diagnostics.push(from_type_error_with_index(
+            te,
+            &source_index,
+            source,
+            &options.file_label,
+        ));
     }
 
     let findings = if options.include_intent_warnings {
@@ -211,10 +220,10 @@ fn analyze_source_impl(
 
     if let Some(ref findings) = findings {
         for e in &findings.errors {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Error,
                 e,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -222,11 +231,11 @@ fn analyze_source_impl(
 
     if options.include_unused_bindings {
         for (binding, fn_name, line) in &tc_result.unused_bindings {
-            diagnostics.push(unused_binding_diagnostic(
+            diagnostics.push(unused_binding_diagnostic_with_index(
                 binding,
                 fn_name,
                 *line,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -234,10 +243,10 @@ fn analyze_source_impl(
 
     if let Some(ref findings) = findings {
         for w in &findings.warnings {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -245,10 +254,10 @@ fn analyze_source_impl(
 
     if options.include_coverage_warnings {
         for w in collect_verify_coverage_warnings_in(&items, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -272,10 +281,10 @@ fn analyze_source_impl(
                 message: crate::source::stdlib_shadow_message(dep_name, shadowed_path),
                 extra_spans: vec![],
             };
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &finding,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -287,10 +296,10 @@ fn analyze_source_impl(
     // effects no fn uses) is a softer hint — still worth surfacing so
     // the module header documents what the code actually does.
     for w in collect_module_effects_warnings_in(&items, None) {
-        diagnostics.push(from_check_finding(
+        diagnostics.push(from_check_finding_with_index(
             Severity::Warning,
             &w,
-            source,
+            &source_index,
             &options.file_label,
         ));
     }
@@ -298,10 +307,10 @@ fn analyze_source_impl(
     #[cfg(feature = "runtime")]
     if options.include_law_dependency_warnings {
         for w in collect_verify_law_dependency_warnings_in(&items, &tc_result.fn_sigs, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -309,10 +318,10 @@ fn analyze_source_impl(
 
     if options.include_cse_warnings {
         for w in collect_cse_warnings_in(&transformed, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -320,10 +329,10 @@ fn analyze_source_impl(
 
     if options.include_perf_warnings {
         for w in collect_perf_warnings_in(&transformed, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -331,10 +340,10 @@ fn analyze_source_impl(
 
     if options.include_traversal_warnings {
         for w in collect_traversal_warnings_in(&transformed, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -342,10 +351,10 @@ fn analyze_source_impl(
 
     if options.include_independence_warnings {
         for w in collect_independence_warnings_in(&transformed, &tc_result.fn_sigs, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -353,10 +362,10 @@ fn analyze_source_impl(
 
     if options.include_naming_warnings {
         for w in collect_naming_warnings_in(&items, None) {
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }
@@ -453,10 +462,10 @@ fn analyze_source_impl(
                 message: w.message.clone(),
                 extra_spans,
             };
-            diagnostics.push(from_check_finding(
+            diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &finding,
-                source,
+                &source_index,
                 &options.file_label,
             ));
         }

--- a/src/diagnostics/classify.rs
+++ b/src/diagnostics/classify.rs
@@ -6,31 +6,147 @@ use super::model::{AnnotatedRegion, SourceLine};
 
 // ─── Source extraction ───────────────────────────────────────────────────────
 
+/// One line table shared by every diagnostic produced for a source file.
+/// Building it once keeps a file with `F` findings and `L` lines at O(L + F)
+/// source lookup cost instead of collecting or scanning all `L` lines for
+/// every finding.
+pub(crate) struct SourceIndex<'a> {
+    lines: Vec<&'a str>,
+}
+
+impl<'a> SourceIndex<'a> {
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self {
+            lines: source.lines().collect(),
+        }
+    }
+
+    pub(crate) fn line(&self, line: usize) -> &'a str {
+        self.lines
+            .get(line.saturating_sub(1))
+            .copied()
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn extract(&self, line: usize, context: usize) -> Vec<SourceLine> {
+        let start = line.saturating_sub(context + 1);
+        let end = (line + context).min(self.lines.len());
+        (start..end)
+            .map(|i| SourceLine {
+                line_num: i + 1,
+                text: self.lines[i].to_string(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn extract_range(&self, from: usize, to: usize) -> Vec<SourceLine> {
+        let start = from.saturating_sub(1);
+        let end = to.min(self.lines.len());
+        (start..end)
+            .map(|i| SourceLine {
+                line_num: i + 1,
+                text: self.lines[i].to_string(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn fill_small_region_gaps(&self, regions: &mut Vec<AnnotatedRegion>) {
+        if regions.len() < 2 {
+            return;
+        }
+        let mut i = 0;
+        while i + 1 < regions.len() {
+            let last_of_prev = regions[i]
+                .source_lines
+                .last()
+                .map(|sl| sl.line_num)
+                .unwrap_or(0);
+            let first_of_next = regions[i + 1]
+                .source_lines
+                .first()
+                .map(|sl| sl.line_num)
+                .unwrap_or(0);
+            if first_of_next > last_of_prev + 1 && first_of_next <= last_of_prev + 3 {
+                let bridge: Vec<SourceLine> = ((last_of_prev + 1)..first_of_next)
+                    .filter_map(|ln| {
+                        self.lines.get(ln.saturating_sub(1)).map(|text| SourceLine {
+                            line_num: ln,
+                            text: (*text).to_string(),
+                        })
+                    })
+                    .collect();
+                if !bridge.is_empty() {
+                    regions.insert(
+                        i + 1,
+                        AnnotatedRegion {
+                            source_lines: bridge,
+                            underline: None,
+                        },
+                    );
+                    i += 1;
+                }
+            }
+            i += 1;
+        }
+    }
+
+    pub(crate) fn find_block_header_line(&self, name: &str, before_line: usize) -> Option<usize> {
+        let needles = [
+            format!("fn {}", name),
+            format!("verify {}", name),
+            format!("decision {}", name),
+        ];
+        let mut best = None;
+        for (i, line) in self
+            .lines
+            .iter()
+            .enumerate()
+            .take(before_line.saturating_sub(1))
+        {
+            let trimmed = line.trim_start();
+            if needles.iter().any(|needle| trimmed.starts_with(needle)) {
+                best = Some(i + 1);
+            }
+        }
+        best
+    }
+
+    pub(crate) fn find_preamble_end(&self, header_line: usize, before_line: usize) -> usize {
+        let mut end = header_line;
+        for (i, line) in self.lines.iter().enumerate() {
+            let line_num = i + 1;
+            if line_num <= header_line {
+                continue;
+            }
+            if line_num >= before_line {
+                break;
+            }
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('?')
+                || trimmed.starts_with('!')
+                || trimmed.starts_with('"')
+                || trimmed.starts_with('[')
+                || trimmed.is_empty()
+                || (line.starts_with("    ") && trimmed.contains(" = "))
+            {
+                end = line_num;
+            } else {
+                break;
+            }
+        }
+        end
+    }
+}
+
 /// Extract source lines around `line` (1-based) with `context` lines of
 /// surrounding context on each side.
 pub(crate) fn extract_source_lines(source: &str, line: usize, context: usize) -> Vec<SourceLine> {
-    let lines: Vec<&str> = source.lines().collect();
-    let start = line.saturating_sub(context + 1);
-    let end = (line + context).min(lines.len());
-    (start..end)
-        .map(|i| SourceLine {
-            line_num: i + 1,
-            text: lines[i].to_string(),
-        })
-        .collect()
+    SourceIndex::new(source).extract(line, context)
 }
 
 /// Extract source lines for an inclusive range [from..to] (1-based).
 pub(crate) fn extract_source_lines_range(source: &str, from: usize, to: usize) -> Vec<SourceLine> {
-    let lines: Vec<&str> = source.lines().collect();
-    let start = from.saturating_sub(1);
-    let end = to.min(lines.len());
-    (start..end)
-        .map(|i| SourceLine {
-            line_num: i + 1,
-            text: lines[i].to_string(),
-        })
-        .collect()
+    SourceIndex::new(source).extract_range(from, to)
 }
 
 /// Extract the declared return type from a "declared return type is X" message.
@@ -53,106 +169,6 @@ pub(crate) fn estimate_span_len(line: &str, col: usize) -> usize {
         .take_while(|c| !c.is_whitespace() && !matches!(c, '(' | ')' | '[' | ']' | ',' | ':'))
         .count();
     if len == 0 { 1 } else { len }
-}
-
-/// Fill small gaps (≤2 lines) between sorted regions with bridging source
-/// lines. Avoids a `...` separator for tiny jumps.
-pub(crate) fn fill_small_region_gaps(regions: &mut Vec<AnnotatedRegion>, source: &str) {
-    if regions.len() < 2 {
-        return;
-    }
-    let lines: Vec<&str> = source.lines().collect();
-    let mut i = 0;
-    while i + 1 < regions.len() {
-        let last_of_prev = regions[i]
-            .source_lines
-            .last()
-            .map(|sl| sl.line_num)
-            .unwrap_or(0);
-        let first_of_next = regions[i + 1]
-            .source_lines
-            .first()
-            .map(|sl| sl.line_num)
-            .unwrap_or(0);
-        if first_of_next > last_of_prev + 1 && first_of_next <= last_of_prev + 3 {
-            let bridge: Vec<SourceLine> = ((last_of_prev + 1)..first_of_next)
-                .filter_map(|ln| {
-                    lines.get(ln.saturating_sub(1)).map(|t| SourceLine {
-                        line_num: ln,
-                        text: t.to_string(),
-                    })
-                })
-                .collect();
-            if !bridge.is_empty() {
-                regions.insert(
-                    i + 1,
-                    AnnotatedRegion {
-                        source_lines: bridge,
-                        underline: None,
-                    },
-                );
-                i += 1;
-            }
-        }
-        i += 1;
-    }
-}
-
-/// Find the line number of the block header (`fn`, `verify`, `decision`) for
-/// `name`, searching forward from the start up to (but not including)
-/// `before_line`.
-pub(crate) fn find_block_header_line(
-    source: &str,
-    name: &str,
-    before_line: usize,
-) -> Option<usize> {
-    let needles = [
-        format!("fn {}", name),
-        format!("verify {}", name),
-        format!("decision {}", name),
-    ];
-    let mut best: Option<usize> = None;
-    for (i, line) in source.lines().enumerate() {
-        let line_num = i + 1;
-        if line_num >= before_line {
-            break;
-        }
-        let trimmed = line.trim_start();
-        for needle in &needles {
-            if trimmed.starts_with(needle.as_str()) {
-                best = Some(line_num);
-            }
-        }
-    }
-    best
-}
-
-/// Find where the block preamble ends. Returns the last preamble line
-/// number (1-based), capped before `before_line`.
-pub(crate) fn find_preamble_end(source: &str, header_line: usize, before_line: usize) -> usize {
-    let mut end = header_line;
-    for (i, line) in source.lines().enumerate() {
-        let line_num = i + 1;
-        if line_num <= header_line {
-            continue;
-        }
-        if line_num >= before_line {
-            break;
-        }
-        let trimmed = line.trim_start();
-        if trimmed.starts_with('?')
-            || trimmed.starts_with('!')
-            || trimmed.starts_with('"')
-            || trimmed.starts_with('[')
-            || trimmed.is_empty()
-            || (line.starts_with("    ") && trimmed.contains(" = "))
-        {
-            end = line_num;
-        } else {
-            break;
-        }
-    }
-    end
 }
 
 /// Try to find a precise (col, len) span by extracting the first quoted
@@ -412,7 +428,7 @@ pub(crate) fn extract_fn_name_from_finding(msg: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::classify_finding;
+    use super::{SourceIndex, classify_finding};
 
     #[test]
     fn classifies_independence_hazard_warning() {
@@ -421,5 +437,22 @@ mod tests {
         );
         assert_eq!(slug, "independence-hazard");
         assert!(repair.is_some());
+    }
+
+    #[test]
+    fn source_index_serves_lines_ranges_and_block_preambles() {
+        let source = "module Demo\n\nfn work(x: Int) -> Int\n    ? \"Does work.\"\n    value = x + 1\n    value\n";
+        let index = SourceIndex::new(source);
+        assert_eq!(index.line(5), "    value = x + 1");
+        assert_eq!(
+            index
+                .extract_range(3, 5)
+                .into_iter()
+                .map(|line| line.line_num)
+                .collect::<Vec<_>>(),
+            vec![3, 4, 5]
+        );
+        assert_eq!(index.find_block_header_line("work", 6), Some(3));
+        assert_eq!(index.find_preamble_end(3, 6), 5);
     }
 }

--- a/src/diagnostics/factories.rs
+++ b/src/diagnostics/factories.rs
@@ -4,9 +4,8 @@
 //! return a `Diagnostic`. No IO, no globals, wasm-safe.
 
 use super::classify::{
-    classify_finding, classify_type_error, estimate_span_len, extract_fn_name_from_finding,
-    extract_return_type, extract_source_lines, extract_source_lines_range, fill_small_region_gaps,
-    find_block_header_line, find_preamble_end, find_precise_span,
+    SourceIndex, classify_finding, classify_type_error, estimate_span_len,
+    extract_fn_name_from_finding, extract_return_type, extract_source_lines, find_precise_span,
 };
 use super::model::{AnnotatedRegion, Diagnostic, Repair, Severity, Span, Underline};
 use crate::checker::{CheckFinding, VerifyLawContext};
@@ -39,6 +38,16 @@ pub fn verify_provider_setup_diagnostic(file: &str, error: &str) -> Diagnostic {
 
 /// Build a `Diagnostic` from a `TypeError` (from the typechecker).
 pub fn from_type_error(te: &TypeError, source: &str, file: &str) -> Diagnostic {
+    let source_index = SourceIndex::new(source);
+    from_type_error_with_index(te, &source_index, source, file)
+}
+
+pub(crate) fn from_type_error_with_index(
+    te: &TypeError,
+    source_index: &SourceIndex<'_>,
+    source: &str,
+    file: &str,
+) -> Diagnostic {
     let (source, file) = match &te.origin {
         Some(origin) => (
             origin.source.as_deref().unwrap_or_default(),
@@ -46,16 +55,25 @@ pub fn from_type_error(te: &TypeError, source: &str, file: &str) -> Diagnostic {
         ),
         None => (source, file),
     };
+    if te.origin.is_some() {
+        let origin_index = SourceIndex::new(source);
+        return from_type_error_indexed(te, &origin_index, file);
+    }
+    from_type_error_indexed(te, source_index, file)
+}
+
+fn from_type_error_indexed(
+    te: &TypeError,
+    source_index: &SourceIndex<'_>,
+    file: &str,
+) -> Diagnostic {
     let msg = &te.message;
     let line = te.line;
     let col = te.col;
 
     let (slug, conflict, fields, repair_text) = classify_type_error(msg);
 
-    let source_line_text = source
-        .lines()
-        .nth(line.saturating_sub(1))
-        .unwrap_or_default();
+    let source_line_text = source_index.line(line);
     let (ul_col, ul_len) = if col > 0 {
         (col, estimate_span_len(source_line_text, col))
     } else {
@@ -101,17 +119,14 @@ pub fn from_type_error(te: &TypeError, source: &str, file: &str) -> Diagnostic {
     };
 
     let mut regions = vec![AnnotatedRegion {
-        source_lines: extract_source_lines(source, line, 0),
+        source_lines: source_index.extract(line, 0),
         underline: primary_underline,
     }];
 
     if let Some(ref sec) = te.secondary
         && sec.line != line
     {
-        let sec_source_text = source
-            .lines()
-            .nth(sec.line.saturating_sub(1))
-            .unwrap_or_default();
+        let sec_source_text = source_index.line(sec.line);
         let (sec_col, sec_len) = if sec.col > 0 {
             (sec.col, estimate_span_len(sec_source_text, sec.col))
         } else {
@@ -119,7 +134,7 @@ pub fn from_type_error(te: &TypeError, source: &str, file: &str) -> Diagnostic {
             (indent + 1, sec_source_text.trim().len())
         };
         regions.push(AnnotatedRegion {
-            source_lines: extract_source_lines(source, sec.line, 0),
+            source_lines: source_index.extract(sec.line, 0),
             underline: Some(Underline {
                 col: sec_col,
                 len: sec_len,
@@ -129,7 +144,7 @@ pub fn from_type_error(te: &TypeError, source: &str, file: &str) -> Diagnostic {
     }
 
     regions.sort_by_key(|r| r.source_lines.first().map(|sl| sl.line_num).unwrap_or(0));
-    fill_small_region_gaps(&mut regions, source);
+    source_index.fill_small_region_gaps(&mut regions);
 
     Diagnostic {
         severity: Severity::Error,
@@ -159,6 +174,17 @@ pub fn unused_binding_diagnostic(
     source: &str,
     file: &str,
 ) -> Diagnostic {
+    let source_index = SourceIndex::new(source);
+    unused_binding_diagnostic_with_index(binding, fn_name, line, &source_index, file)
+}
+
+pub(crate) fn unused_binding_diagnostic_with_index(
+    binding: &str,
+    fn_name: &str,
+    line: usize,
+    source_index: &SourceIndex<'_>,
+    file: &str,
+) -> Diagnostic {
     Diagnostic {
         severity: Severity::Warning,
         slug: "unused-binding",
@@ -173,7 +199,7 @@ pub fn unused_binding_diagnostic(
         fields: vec![("binding", binding.to_string())],
         conflict: None,
         repair: Repair::primary(format!("Remove the binding or prefix with _: _{}", binding)),
-        regions: AnnotatedRegion::single(extract_source_lines(source, line, 0), None),
+        regions: AnnotatedRegion::single(source_index.extract(line, 0), None),
         related: Vec::new(),
         from_hostile: false,
     }
@@ -294,6 +320,16 @@ pub fn from_check_finding(
     source: &str,
     file: &str,
 ) -> Diagnostic {
+    let source_index = SourceIndex::new(source);
+    from_check_finding_with_index(severity, finding, &source_index, file)
+}
+
+pub(crate) fn from_check_finding_with_index(
+    severity: Severity,
+    finding: &CheckFinding,
+    source_index: &SourceIndex<'_>,
+    file: &str,
+) -> Diagnostic {
     let (slug, repair_text) = classify_finding(&finding.message);
     let fn_name = finding
         .fn_name
@@ -311,10 +347,7 @@ pub fn from_check_finding(
         finding.message.clone()
     };
 
-    let source_line_text = source
-        .lines()
-        .nth(finding.line.saturating_sub(1))
-        .unwrap_or_default();
+    let source_line_text = source_index.line(finding.line);
     let (col, span_len) = find_precise_span(source_line_text, &summary).unwrap_or_else(|| {
         let indent = source_line_text.len() - source_line_text.trim_start().len();
         (indent + 1, source_line_text.trim().len())
@@ -330,15 +363,12 @@ pub fn from_check_finding(
         None
     };
     let mut regions = vec![AnnotatedRegion {
-        source_lines: extract_source_lines(source, finding.line, 0),
+        source_lines: source_index.extract(finding.line, 0),
         underline: primary_underline,
     }];
 
     for extra in &finding.extra_spans {
-        let extra_source_line = source
-            .lines()
-            .nth(extra.line.saturating_sub(1))
-            .unwrap_or_default();
+        let extra_source_line = source_index.line(extra.line);
         let (extra_col, extra_len) = if extra.col > 0 && extra.len > 0 {
             (extra.col, extra.len)
         } else {
@@ -348,7 +378,7 @@ pub fn from_check_finding(
             })
         };
         regions.push(AnnotatedRegion {
-            source_lines: extract_source_lines(source, extra.line, 0),
+            source_lines: source_index.extract(extra.line, 0),
             underline: Some(Underline {
                 col: extra_col,
                 len: extra_len,
@@ -362,12 +392,12 @@ pub fn from_check_finding(
         || source_line_text.trim_start().starts_with("decision ");
     if !finding_is_header
         && let Some(ref name) = fn_name
-        && let Some(header_line) = find_block_header_line(source, name, finding.line)
+        && let Some(header_line) = source_index.find_block_header_line(name, finding.line)
         && header_line < finding.line
     {
-        let preamble_end = find_preamble_end(source, header_line, finding.line);
+        let preamble_end = source_index.find_preamble_end(header_line, finding.line);
         let capped_end = preamble_end.min(header_line + 3);
-        let header_lines = extract_source_lines_range(source, header_line, capped_end);
+        let header_lines = source_index.extract_range(header_line, capped_end);
         if !header_lines.is_empty() {
             regions.insert(
                 0,
@@ -380,7 +410,7 @@ pub fn from_check_finding(
     }
 
     regions.sort_by_key(|r| r.source_lines.first().map(|sl| sl.line_num).unwrap_or(0));
-    fill_small_region_gaps(&mut regions, source);
+    source_index.fill_small_region_gaps(&mut regions);
 
     Diagnostic {
         severity,

--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -664,12 +664,185 @@ pub fn run_verify_for_items_vm_with_mode(
 /// `given` stubs remain per-case overrides because dispatch checks the oracle
 /// map before consulting this registry.
 pub fn run_verify_for_items_vm_with_mode_and_bindings(
+    items: Vec<TopLevel>,
+    config: Option<ProjectConfig>,
+    base_dir: Option<&str>,
+    source_file: &str,
+    mode: ExpansionMode,
+    provider_bindings: &[crate::provider::ProviderBinding],
+) -> Result<Vec<VerifyResult>, String> {
+    run_verify_for_items_vm_impl(
+        items,
+        config,
+        base_dir,
+        source_file,
+        mode,
+        provider_bindings,
+        false,
+    )
+}
+
+/// Parallel VM verify used by the CLI's bounded Rayon pool.
+///
+/// File jobs and case jobs run in the same pool, so nested case expansion
+/// cannot create more threads than `aver verify -j` allowed. Hostile runs
+/// retain their sequential base/profile dependency; declared cases are
+/// independent and may use separate VM execution states.
+#[cfg(feature = "runtime")]
+pub fn run_verify_for_items_vm_parallel_with_mode_and_bindings(
+    items: Vec<TopLevel>,
+    config: Option<ProjectConfig>,
+    base_dir: Option<&str>,
+    source_file: &str,
+    mode: ExpansionMode,
+    provider_bindings: &[crate::provider::ProviderBinding],
+) -> Result<Vec<VerifyResult>, String> {
+    run_verify_for_items_vm_impl(
+        items,
+        config,
+        base_dir,
+        source_file,
+        mode,
+        provider_bindings,
+        true,
+    )
+}
+
+/// Immutable setup shared by all declared verify cases of one module.
+///
+/// Directory verification constructs this once, leaves-first, before the
+/// Rayon phase. Dependency bodies have therefore already passed their own
+/// checks; this module's preparation rebuilds their visible surfaces but does
+/// not recursively type-check them again.
+pub struct PreparedVmVerify {
+    machine: Option<vm::VM>,
+    capabilities: crate::capability::CapabilityRegistry,
+    plans: Vec<VmVerifyPlan>,
+}
+
+/// Prepare one module after every project dependency in `loaded` has already
+/// passed preparation. Embedded standard modules are release-validated and
+/// participate as signatures/capabilities without a per-command body rerun.
+#[cfg(feature = "runtime")]
+pub fn prepare_verify_for_items_vm_with_checked_loaded(
+    items: Vec<TopLevel>,
+    loaded: Vec<crate::source::LoadedModule>,
+    source_file: &str,
+) -> Result<PreparedVmVerify, String> {
+    prepare_verify_for_items_vm_with_loaded(items, loaded, source_file)
+}
+
+#[cfg(feature = "runtime")]
+fn prepare_verify_for_items_vm_with_loaded(
+    mut items: Vec<TopLevel>,
+    loaded: Vec<crate::source::LoadedModule>,
+    source_file: &str,
+) -> Result<PreparedVmVerify, String> {
+    crate::ir::pipeline::tco(&mut items);
+    let mode = crate::ir::TypecheckMode::WithCheckedLoaded(&loaded);
+    let typecheck = crate::ir::pipeline::typecheck_gate(&items, &mode, &items);
+    if !typecheck.errors.is_empty() {
+        return Err(format_type_errors(&typecheck.errors));
+    }
+
+    let verify_blocks = merge_verify_blocks(&items);
+    let plans = build_verify_vm_plans(&mut items, &verify_blocks);
+    crate::ir::pipeline::resolve(&mut items);
+    if plans.is_empty() {
+        return Ok(PreparedVmVerify {
+            machine: None,
+            capabilities: typecheck.capabilities,
+            plans,
+        });
+    }
+
+    // Finish the module-owned work while preparation is independently
+    // schedulable. The resulting VM is an immutable base for case forks, and
+    // retaining it lets us drop the otherwise quadratic collection of cloned
+    // dependency ASTs before case execution starts.
+    let dep_modules = loaded
+        .iter()
+        .map(crate::codegen::ModuleInfo::from_loaded)
+        .collect::<Vec<_>>();
+    let mut arena = Arena::new();
+    vm::register_service_types(&mut arena);
+    let mut symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
+    symbol_table.merge_capability_registry(&typecheck.capabilities);
+    let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
+    let (code, globals) = vm::compile_program_with_loaded_modules(
+        &resolved_items,
+        &symbol_table,
+        &mut arena,
+        loaded,
+        source_file,
+        None,
+    )
+    .map_err(|error| format!("VM compile error: {error}"))?;
+    Ok(PreparedVmVerify {
+        machine: Some(vm::VM::new(code, globals, arena)),
+        capabilities: typecheck.capabilities,
+        plans,
+    })
+}
+
+/// Compile and execute a module whose graph and type information were prepared
+/// once by [`prepare_verify_for_items_vm_with_checked_loaded`].
+#[cfg(feature = "runtime")]
+pub fn run_prepared_verify_vm_with_bindings(
+    prepared: PreparedVmVerify,
+    config: Option<ProjectConfig>,
+    base_dir: Option<&str>,
+    source_file: &str,
+    provider_bindings: &[crate::provider::ProviderBinding],
+    parallel_cases: bool,
+) -> Result<Vec<VerifyResult>, String> {
+    let PreparedVmVerify {
+        machine,
+        capabilities,
+        plans,
+    } = prepared;
+    if plans.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut machine = machine.expect("non-empty prepared plans own a VM");
+    configure_verify_capabilities(&mut machine, &capabilities, provider_bindings)?;
+    let budgets = budgets_for_plans(&plans, config.as_ref(), source_file, base_dir);
+    let raised_by = budgets
+        .iter()
+        .map(|budget| budget.raised_by_fn(config.as_ref()))
+        .collect::<Vec<_>>();
+    if let Some(config) = config {
+        machine.set_runtime_policy(config);
+    }
+
+    let case_count = plans.iter().map(|plan| plan.cases.len()).sum::<usize>();
+    if parallel_cases && case_count > 1 {
+        return Ok(run_verify_vm_plans_parallel(
+            &plans,
+            &machine,
+            &capabilities,
+            &budgets,
+            &raised_by,
+        ));
+    }
+    Ok(plans
+        .iter()
+        .zip(&budgets)
+        .zip(&raised_by)
+        .map(|((plan, budget), raised)| {
+            run_verify_vm(plan, &mut machine, &capabilities, budget, raised.as_deref())
+        })
+        .collect())
+}
+
+fn run_verify_for_items_vm_impl(
     mut items: Vec<TopLevel>,
     config: Option<ProjectConfig>,
     base_dir: Option<&str>,
     source_file: &str,
     mode: ExpansionMode,
     provider_bindings: &[crate::provider::ProviderBinding],
+    parallel_cases: bool,
 ) -> Result<Vec<VerifyResult>, String> {
     crate::ir::pipeline::tco(&mut items);
 
@@ -785,7 +958,18 @@ pub fn run_verify_for_items_vm_with_mode_and_bindings(
         machine.set_runtime_policy(cfg);
     }
 
-    let mut results = Vec::new();
+    let case_count: usize = plans.iter().map(|plan| plan.cases.len()).sum();
+    if parallel_cases && mode == ExpansionMode::Declared && case_count > 1 {
+        return Ok(run_verify_vm_plans_parallel(
+            &plans,
+            &machine,
+            &tc_result.capabilities,
+            &budgets,
+            &raised_by,
+        ));
+    }
+
+    let mut results = Vec::with_capacity(plans.len());
     for ((plan, budget), raised) in plans.iter().zip(&budgets).zip(&raised_by) {
         results.push(run_verify_vm(
             plan,
@@ -1099,12 +1283,14 @@ pub(crate) fn format_type_errors(errors: &[crate::types::checker::TypeError]) ->
 
 // ─── Plan synthesis ───────────────────────────────────────────────────────────
 
+#[derive(Clone)]
 struct VmVerifyCaseFns {
     left: String,
     right: String,
     guard: Option<String>,
 }
 
+#[derive(Clone)]
 struct VmVerifyPlan {
     block: VerifyBlock,
     cases: Vec<VmVerifyCaseFns>,
@@ -1802,6 +1988,141 @@ fn build_case_oracle_stubs(
 }
 
 // ─── Case runner ──────────────────────────────────────────────────────────────
+
+#[cfg(feature = "runtime")]
+fn single_case_plan(plan: &VmVerifyPlan, index: usize) -> VmVerifyPlan {
+    let mut block = plan.block.clone();
+    block.cases = vec![block.cases[index].clone()];
+    block.case_spans = block.case_spans.get(index).cloned().into_iter().collect();
+    block.case_givens = block.case_givens.get(index).cloned().into_iter().collect();
+    block.case_hostile_origins = block
+        .case_hostile_origins
+        .get(index)
+        .copied()
+        .into_iter()
+        .collect();
+    block.case_hostile_profiles = block
+        .case_hostile_profiles
+        .get(index)
+        .cloned()
+        .into_iter()
+        .collect();
+    block.case_reverse_order = block
+        .case_reverse_order
+        .get(index)
+        .copied()
+        .into_iter()
+        .collect();
+    VmVerifyPlan {
+        block,
+        cases: vec![plan.cases[index].clone()],
+    }
+}
+
+#[cfg(feature = "runtime")]
+fn empty_verify_result(
+    plan: &VmVerifyPlan,
+    budget: &CaseBudget,
+    raised_by: Option<&str>,
+) -> VerifyResult {
+    let block = &plan.block;
+    let block_label = match &block.kind {
+        VerifyKind::Law(law) => format!("{} law {}", block.fn_name, law.name),
+        VerifyKind::Cases => block.fn_name.clone(),
+    };
+    VerifyResult {
+        fn_name: block.fn_name.clone(),
+        is_law: matches!(&block.kind, VerifyKind::Law(_)),
+        block_label,
+        passed: 0,
+        failed: 0,
+        skipped: 0,
+        declined: 0,
+        budget: VerifyBudgetInfo {
+            limit: budget.limit,
+            default_limit: budget.default_limit,
+            raised_by: raised_by.map(str::to_string),
+        },
+        case_results: Vec::with_capacity(plan.cases.len()),
+        failures: Vec::new(),
+    }
+}
+
+#[cfg(feature = "runtime")]
+fn merge_verify_result(target: &mut VerifyResult, mut case: VerifyResult) {
+    target.passed += case.passed;
+    target.failed += case.failed;
+    target.skipped += case.skipped;
+    target.declined += case.declined;
+    target.case_results.append(&mut case.case_results);
+    target.failures.append(&mut case.failures);
+}
+
+#[cfg(feature = "runtime")]
+fn run_verify_vm_plans_parallel(
+    plans: &[VmVerifyPlan],
+    machine: &vm::VM,
+    capabilities: &crate::capability::CapabilityRegistry,
+    budgets: &[CaseBudget],
+    raised_by: &[Option<String>],
+) -> Vec<VerifyResult> {
+    use rayon::prelude::*;
+
+    // One indexed queue for the whole module. Besides allowing one-case
+    // blocks to share workers, this creates each worker VM once per module
+    // instead of once per block. Collection preserves (block, case) order.
+    let tasks = plans
+        .iter()
+        .enumerate()
+        .flat_map(|(plan_index, plan)| {
+            (0..plan.cases.len()).map(move |case_index| (plan_index, case_index))
+        })
+        .collect::<Vec<_>>();
+    let per_case: Vec<(usize, VerifyResult)> = tasks
+        .into_par_iter()
+        .map_init(
+            || machine.fork_for_verify(),
+            |case_machine, (plan_index, case_index)| {
+                let plan = &plans[plan_index];
+                let case_total = plan.cases.len();
+                let single = single_case_plan(plan, case_index);
+                let mut result = run_verify_vm(
+                    &single,
+                    case_machine,
+                    capabilities,
+                    &budgets[plan_index],
+                    raised_by[plan_index].as_deref(),
+                );
+                for case in &mut result.case_results {
+                    case.case_index = case_index;
+                    case.case_total = case_total;
+                }
+                if result.is_law {
+                    for (case, _, _) in &mut result.failures {
+                        let expr = result
+                            .case_results
+                            .first()
+                            .map(|result| result.case_expr.as_str())
+                            .unwrap_or_default();
+                        *case = format!("case {}/{} [{}]", case_index + 1, case_total, expr);
+                    }
+                }
+                (plan_index, result)
+            },
+        )
+        .collect();
+
+    let mut merged = plans
+        .iter()
+        .zip(budgets)
+        .zip(raised_by)
+        .map(|((plan, budget), raised)| empty_verify_result(plan, budget, raised.as_deref()))
+        .collect::<Vec<_>>();
+    for (plan_index, result) in per_case {
+        merge_verify_result(&mut merged[plan_index], result);
+    }
+    merged
+}
 
 fn run_verify_vm(
     plan: &VmVerifyPlan,

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -44,7 +44,8 @@ use crate::ir::{AllocPolicy, AnalysisResult, CallLowerCtx};
 use crate::source::LoadedModule;
 use crate::types::checker::{
     TypeCheckResult, run_type_check_full, run_type_check_full_self_host,
-    run_type_check_with_loaded, run_type_check_with_loaded_self_host,
+    run_type_check_with_checked_loaded, run_type_check_with_loaded,
+    run_type_check_with_loaded_self_host,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -160,6 +161,9 @@ pub enum TypecheckMode<'a> {
     /// `run_type_check_with_loaded(items, loaded)` for in-memory module trees
     /// (playground virtual fs, multi-file ad-hoc compiles).
     WithLoaded(&'a [LoadedModule]),
+    /// Whole-program report preparation already checked every dependency body
+    /// leaves-first. Rebuild importer-visible surfaces but check only `items`.
+    WithCheckedLoaded(&'a [LoadedModule]),
     /// Self-host variant of [`Full`] — bypasses opaque-type checks
     /// (construct, field access, pattern match). Used exclusively by
     /// `aver compile --with-self-host-support` so `domain/builtins.av`
@@ -695,6 +699,9 @@ pub fn typecheck(items: &[TopLevel], mode: &TypecheckMode<'_>) -> TypeCheckResul
     match mode {
         TypecheckMode::Full { base_dir } => run_type_check_full(items, *base_dir),
         TypecheckMode::WithLoaded(loaded) => run_type_check_with_loaded(items, loaded),
+        TypecheckMode::WithCheckedLoaded(loaded) => {
+            run_type_check_with_checked_loaded(items, loaded)
+        }
         TypecheckMode::FullSelfHost { base_dir } => run_type_check_full_self_host(items, *base_dir),
         TypecheckMode::WithLoadedSelfHost(loaded) => {
             run_type_check_with_loaded_self_host(items, loaded)

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -292,6 +292,9 @@ pub(super) enum Commands {
         /// back to plain `aver verify` (VM).
         #[arg(long = "wasm-gc")]
         wasm_gc: bool,
+        /// Maximum verify worker threads (default: available CPU parallelism)
+        #[arg(short = 'j', long)]
+        jobs: Option<std::num::NonZeroUsize>,
     },
     /// Run check + verify + format-check in one pass over every module of the program
     Audit {
@@ -840,6 +843,18 @@ mod tests {
             Commands::Verify { file, .. } => assert_eq!(file, "examples/modules/app.av"),
             _ => panic!("expected verify command"),
         }
+    }
+
+    #[test]
+    fn verify_accepts_positive_jobs_and_rejects_zero() {
+        let cli = Cli::parse_from(["aver", "verify", "examples/core/lists.av", "-j", "4"]);
+        match cli.command {
+            Commands::Verify { jobs, .. } => assert_eq!(jobs.map(|jobs| jobs.get()), Some(4)),
+            _ => panic!("expected verify command"),
+        }
+        assert!(
+            Cli::try_parse_from(["aver", "verify", "examples/core/lists.av", "-j", "0"]).is_err()
+        );
     }
 
     #[test]

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -222,6 +222,36 @@ pub(super) fn collect_program_units(
     module_root: &str,
     reported: &mut HashSet<PathBuf>,
 ) -> Result<Vec<ReportUnit>, String> {
+    let mut cache = aver::source::ProgramLoadCache::default();
+    collect_program_units_with_cache(file, module_root, reported, &mut cache)
+}
+
+fn collect_program_units_with_cache(
+    file: &str,
+    module_root: &str,
+    reported: &mut HashSet<PathBuf>,
+    cache: &mut aver::source::ProgramLoadCache,
+) -> Result<Vec<ReportUnit>, String> {
+    let program = load_report_program_with_cache(file, module_root, cache)?;
+    Ok(program
+        .report_units()
+        .filter(|module| reported.insert(aver::source::canonicalize_path(&module.path)))
+        .map(|module| {
+            let path = if module.is_entry {
+                file.to_string()
+            } else {
+                module.path.to_string_lossy().to_string()
+            };
+            (path, module.source.clone(), module.items.clone())
+        })
+        .collect())
+}
+
+pub(super) fn load_report_program_with_cache(
+    file: &str,
+    module_root: &str,
+    cache: &mut aver::source::ProgramLoadCache,
+) -> Result<aver::source::Program, String> {
     let source = read_file(file)?;
     // Parse failure shouldn't abort `check`: its analysis pass owns the
     // canonical line/column diagnostic. `verify` re-parses an empty item set
@@ -235,12 +265,13 @@ pub(super) fn collect_program_units(
     // The tolerant walk keeps a dependency that fails to parse or lacks its
     // declaration as a unit of its own, so each file reports its diagnostics
     // in place; only an unresolvable dependency stops the walk.
-    let program = aver::source::load_program(
+    aver::source::load_program_with_cache(
         Path::new(file),
         &source,
         &items,
         module_root,
         LoadMode::Tolerant,
+        cache,
     )
     .map_err(|error| match error {
         LoadError::Missing {
@@ -254,19 +285,7 @@ pub(super) fn collect_program_units(
             required_by.unwrap_or_default().display()
         ),
         other => other.to_string(),
-    })?;
-    Ok(program
-        .report_units()
-        .filter(|module| reported.insert(aver::source::canonicalize_path(&module.path)))
-        .map(|module| {
-            let path = if module.is_entry {
-                file.to_string()
-            } else {
-                module.path.to_string_lossy().to_string()
-            };
-            (path, module.source.clone(), module.items.clone())
-        })
-        .collect())
+    })
 }
 
 /// Canonical key of the file a diagnostic span names, resolved against the
@@ -1918,12 +1937,18 @@ pub(super) fn cmd_audit(
     // Every module of every input's program, each collected once: a module
     // reached from an earlier input is not a unit of a later one.
     let mut reported = HashSet::new();
+    let mut load_cache = aver::source::ProgramLoadCache::default();
     let programs = inputs
         .iter()
         .map(|file| {
             (
                 file,
-                collect_program_units(file, &module_root, &mut reported),
+                collect_program_units_with_cache(
+                    file,
+                    &module_root,
+                    &mut reported,
+                    &mut load_cache,
+                ),
             )
         })
         .collect::<Vec<_>>();
@@ -2291,12 +2316,18 @@ pub(super) fn cmd_check(path: &str, module_root_override: Option<&str>, verbose:
     // Every module of every input's program, each collected once: a module
     // reached from an earlier input is not a unit of a later one.
     let mut reported = HashSet::new();
+    let mut load_cache = aver::source::ProgramLoadCache::default();
     let programs = inputs
         .iter()
         .map(|file| {
             (
                 file,
-                collect_program_units(file, &module_root, &mut reported),
+                collect_program_units_with_cache(
+                    file,
+                    &module_root,
+                    &mut reported,
+                    &mut load_cache,
+                ),
             )
         })
         .collect::<Vec<_>>();
@@ -2548,6 +2579,21 @@ struct VerifyRun {
     stop: Option<VerifyStop>,
 }
 
+struct PlannedVerifyInput {
+    file: String,
+    units: Result<Vec<VerifyReportUnit>, String>,
+}
+
+struct VerifyReportUnit {
+    path: String,
+    source: String,
+    items: Vec<TopLevel>,
+    loaded: Vec<aver::source::LoadedModule>,
+    project_dependencies: Vec<(PathBuf, String)>,
+    fault: Option<String>,
+    prepared: Option<Result<aver::diagnostics::vm_verify::PreparedVmVerify, String>>,
+}
+
 /// Bucket a message `verify` could not get past. `Engine` is the bucket that
 /// makes a claim — that `aver check` passes on the file and has nothing to
 /// add — so it is only ever chosen for a message verify itself is known to
@@ -2612,29 +2658,29 @@ fn verify_stopped_before_any_module(
 
 /// Verify every not-yet-reported module of the program named by `file`,
 /// leaves-first.
-fn run_verify_for_file(
-    file: &str,
-    module_root: &str,
+struct VerifyRunOptions<'a> {
+    module_root: &'a str,
     hostile: bool,
     wasm_gc: bool,
-    provider_bindings: &[aver::provider::ProviderBinding],
-    reported: &mut HashSet<PathBuf>,
+    parallel_cases: bool,
+    provider_bindings: &'a [aver::provider::ProviderBinding],
+    config: &'a Result<Option<aver::config::ProjectConfig>, String>,
+}
+
+fn run_verify_for_units(
+    file: &str,
+    units: Vec<VerifyReportUnit>,
+    options: VerifyRunOptions<'_>,
 ) -> VerifyRun {
     use aver::verify_law::expand::ExpansionMode;
-
-    let units = match collect_program_units(file, module_root, reported) {
-        Ok(units) => units,
-        // A module that cannot be found or read is a project error, and
-        // `aver check` reports it the same way.
-        Err(e) => {
-            return verify_stopped_before_any_module(
-                file,
-                module_root,
-                VerifySkipReason::Source,
-                e,
-            );
-        }
-    };
+    let VerifyRunOptions {
+        module_root,
+        hostile,
+        wasm_gc,
+        parallel_cases,
+        provider_bindings,
+        config,
+    } = options;
     // Counted before anything runs — and before anything else can fail: once a
     // module stops the walk, the modules from that one on carry blocks nobody
     // checked, and the summary has to say how many. A stop that happens here,
@@ -2642,9 +2688,9 @@ fn run_verify_for_file(
     // unchecked.
     let mut unchecked: Vec<VerifyUncheckedFile> = units
         .iter()
-        .map(|(path, _, items)| VerifyUncheckedFile {
-            path: path.clone(),
-            blocks: aver::checker::merge_verify_blocks(items).len(),
+        .map(|unit| VerifyUncheckedFile {
+            path: unit.path.clone(),
+            blocks: aver::checker::merge_verify_blocks(&unit.items).len(),
         })
         .collect();
 
@@ -2664,15 +2710,15 @@ fn run_verify_for_file(
     // what the loader parsed these units under, and the re-parse below has to
     // agree with it. An unreadable `aver.toml` is a project error like any
     // other, so it stops the walk and leaves every module above unchecked.
-    let config = match load_runtime_policy(module_root) {
-        Ok(config) => config,
+    let config = match config {
+        Ok(config) => config.clone(),
         Err(e) => {
             return VerifyRun {
                 results: Vec::new(),
                 stop: Some(VerifyStop {
                     at: file.to_string(),
                     reason: VerifySkipReason::Source,
-                    message: e,
+                    message: e.clone(),
                     unchecked,
                 }),
             };
@@ -2685,7 +2731,16 @@ fn run_verify_for_file(
     } else {
         ExpansionMode::Declared
     };
-    for (index, (path, source, items)) in units.into_iter().enumerate() {
+    for (index, unit) in units.into_iter().enumerate() {
+        let VerifyReportUnit {
+            path,
+            source,
+            items,
+            loaded: _,
+            project_dependencies: _,
+            fault: _,
+            prepared,
+        } = unit;
         // `collect_program_units` swallows a parse error into empty `items` so
         // that `aver check` can surface it as a canonical line/col diagnostic
         // via its own analysis pass. `verify` has no such pass, so an
@@ -2732,14 +2787,36 @@ fn run_verify_for_file(
                 Err("verify --wasm-gc requires building with --features wasm".to_string())
             }
         } else {
-            aver::diagnostics::vm_verify::run_verify_for_items_vm_with_mode_and_bindings(
-                items,
-                config.clone(),
-                Some(module_root),
-                &path,
-                mode,
-                provider_bindings,
-            )
+            if let Some(prepared) = prepared {
+                prepared.and_then(|prepared| {
+                    aver::diagnostics::vm_verify::run_prepared_verify_vm_with_bindings(
+                        prepared,
+                        config.clone(),
+                        Some(module_root),
+                        &path,
+                        provider_bindings,
+                        parallel_cases,
+                    )
+                })
+            } else if parallel_cases {
+                aver::diagnostics::vm_verify::run_verify_for_items_vm_parallel_with_mode_and_bindings(
+                    items,
+                    config.clone(),
+                    Some(module_root),
+                    &path,
+                    mode,
+                    provider_bindings,
+                )
+            } else {
+                aver::diagnostics::vm_verify::run_verify_for_items_vm_with_mode_and_bindings(
+                    items,
+                    config.clone(),
+                    Some(module_root),
+                    &path,
+                    mode,
+                    provider_bindings,
+                )
+            }
         };
         match outcome {
             Ok(blocks) => results.push(VerifyFileResult {
@@ -2767,6 +2844,47 @@ fn run_verify_for_file(
         results,
         stop: None,
     }
+}
+
+fn collect_verify_program_units_with_cache(
+    file: &str,
+    module_root: &str,
+    reported: &mut HashSet<PathBuf>,
+    cache: &mut aver::source::ProgramLoadCache,
+) -> Result<Vec<VerifyReportUnit>, String> {
+    let program = load_report_program_with_cache(file, module_root, cache)?;
+    Ok(program
+        .report_units()
+        .filter(|module| reported.insert(aver::source::canonicalize_path(&module.path)))
+        .map(|module| {
+            let (loaded, graph_fault) = match program.loaded_dependencies_for(module) {
+                Ok(loaded) => (loaded, None),
+                Err(error) => (Vec::new(), Some(error.to_string())),
+            };
+            let project_dependencies = loaded
+                .iter()
+                .filter(|dependency| !dependency.path.starts_with("<aver-stdlib>"))
+                .map(|dependency| (dependency.path.clone(), dependency.dep_name.clone()))
+                .collect();
+            VerifyReportUnit {
+                path: if module.is_entry {
+                    file.to_string()
+                } else {
+                    module.path.to_string_lossy().to_string()
+                },
+                source: module.source.clone(),
+                items: module.items.clone(),
+                loaded,
+                project_dependencies,
+                fault: module
+                    .fault
+                    .as_ref()
+                    .map(ToString::to_string)
+                    .or(graph_fault),
+                prepared: None,
+            }
+        })
+        .collect())
 }
 
 /// Bucket case outcomes by `from_hostile` for the per-block summary
@@ -3266,6 +3384,7 @@ pub(super) fn cmd_verify(
     json: bool,
     hostile: bool,
     wasm_gc: bool,
+    jobs: Option<usize>,
     provider_bindings: &[aver::provider::ProviderBinding],
 ) {
     // 0.13 Limit: --hostile reruns each `verify ... law` against an adversarial
@@ -3280,25 +3399,163 @@ pub(super) fn cmd_verify(
             process::exit(1);
         }
     };
+    let input_count = inputs.len();
+    let jobs = jobs.unwrap_or_else(|| {
+        std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1)
+    });
+
+    // Ownership is decided once, in sorted input order, before any worker
+    // starts. The shared loader cache makes overlapping dependency cones pay
+    // for filesystem IO and parsing once while preserving each walk's own
+    // cycle detection and leaves-first order.
+    let mut reported = HashSet::new();
+    let mut load_cache = aver::source::ProgramLoadCache::default();
+    let mut plans: Vec<PlannedVerifyInput> = inputs
+        .into_iter()
+        .map(|file| PlannedVerifyInput {
+            units: collect_verify_program_units_with_cache(
+                &file,
+                &module_root,
+                &mut reported,
+                &mut load_cache,
+            ),
+            file,
+        })
+        .collect();
+    let config = load_runtime_policy(&module_root);
+    let pool = if jobs > 1 {
+        match rayon::ThreadPoolBuilder::new().num_threads(jobs).build() {
+            Ok(pool) => Some(pool),
+            Err(error) => {
+                eprintln!("{}", format!("Cannot start verify workers: {error}").red());
+                process::exit(1);
+            }
+        }
+    } else {
+        None
+    };
+
+    // Declared VM verification prepares each unique project module once in
+    // the same bounded pool used by its cases. Every job checks only its own
+    // body against immutable surfaces from the one graph walk above. Once all
+    // jobs join, dependency errors are propagated through the transitive
+    // closure before any report runs, retaining leaves-first fail-closed
+    // semantics without serializing otherwise independent preparation.
+    if !hostile && !wasm_gc {
+        let prepare_unit = |unit: &mut VerifyReportUnit| {
+            let prepared = if let Some(fault) = &unit.fault {
+                Err(fault.clone())
+            } else {
+                aver::diagnostics::vm_verify::prepare_verify_for_items_vm_with_checked_loaded(
+                    unit.items.clone(),
+                    std::mem::take(&mut unit.loaded),
+                    &unit.path,
+                )
+            };
+            unit.prepared = Some(prepared);
+        };
+        if let Some(pool) = &pool {
+            use rayon::prelude::*;
+            pool.install(|| {
+                plans.par_iter_mut().for_each(|plan| {
+                    if let Ok(units) = &mut plan.units {
+                        units.par_iter_mut().for_each(prepare_unit);
+                    }
+                })
+            });
+        } else {
+            for plan in &mut plans {
+                if let Ok(units) = &mut plan.units {
+                    units.iter_mut().for_each(&prepare_unit);
+                }
+            }
+        }
+
+        let own_errors = plans
+            .iter()
+            .filter_map(|plan| plan.units.as_ref().ok())
+            .flatten()
+            .filter_map(|unit| {
+                unit.prepared
+                    .as_ref()
+                    .and_then(|prepared| prepared.as_ref().err())
+                    .map(|error| {
+                        (
+                            aver::source::canonicalize_path(Path::new(&unit.path)),
+                            error.clone(),
+                        )
+                    })
+            })
+            .collect::<HashMap<_, _>>();
+        for unit in plans
+            .iter_mut()
+            .filter_map(|plan| plan.units.as_mut().ok())
+            .flatten()
+        {
+            let failed_dependency =
+                unit.project_dependencies
+                    .iter()
+                    .find_map(|(dependency_path, dependency_name)| {
+                        own_errors
+                            .get(&aver::source::canonicalize_path(dependency_path))
+                            .map(|error| (dependency_name, error))
+                    });
+            if let Some((dependency, error)) = failed_dependency {
+                unit.prepared = Some(Err(format!(
+                    "Type errors in dependency module '{dependency}':\n{error}"
+                )));
+            }
+        }
+    }
+
+    let execute = |plan: PlannedVerifyInput, parallel_cases: bool| {
+        let file = plan.file;
+        let run = match plan.units {
+            Ok(units) => run_verify_for_units(
+                &file,
+                units,
+                VerifyRunOptions {
+                    module_root: &module_root,
+                    hostile,
+                    wasm_gc,
+                    parallel_cases,
+                    provider_bindings,
+                    config: &config,
+                },
+            ),
+            Err(error) => verify_stopped_before_any_module(
+                &file,
+                &module_root,
+                VerifySkipReason::Source,
+                error,
+            ),
+        };
+        (file, run)
+    };
+
+    let runs: Vec<(String, VerifyRun)> = if let Some(pool) = &pool {
+        use rayon::prelude::*;
+        pool.install(|| {
+            plans
+                .into_par_iter()
+                .map(|plan| execute(plan, !wasm_gc))
+                .collect()
+        })
+    } else {
+        plans.into_iter().map(|plan| execute(plan, false)).collect()
+    };
 
     let mut all_file_results: Vec<VerifyFileResult> = Vec::new();
     let mut failed_files = Vec::new();
     let mut stops: Vec<VerifyStop> = Vec::new();
     let mut printed_any = false;
-    // Every module of every input's program, each verified once.
-    let mut reported = HashSet::new();
-
-    for file in &inputs {
-        let run = run_verify_for_file(
-            file,
-            &module_root,
-            hostile,
-            wasm_gc,
-            provider_bindings,
-            &mut reported,
-        );
-        // Render immediately — streaming output. Modules verified before a
-        // stop are reported like any other: their cases really ran.
+    for (file, run) in runs {
+        // Rayon preserves indexed-iterator collection order. Rendering only
+        // here makes `-jN` byte-identical to `-j1` even when a later input
+        // finishes first. Modules completed before a per-program stop remain
+        // reportable: their cases really ran.
         let has_blocks = run.results.iter().any(|fr| !fr.blocks.is_empty());
         if has_blocks && printed_any && !json {
             println!();
@@ -3321,7 +3578,7 @@ pub(super) fn cmd_verify(
                 display_check_path(&stop.at, &module_root).red(),
                 stop.message
             );
-            failed_files.push(file.clone());
+            failed_files.push(file);
             stops.push(stop);
         }
     }
@@ -3450,7 +3707,7 @@ pub(super) fn cmd_verify(
         };
         println!(
             "{{\"schema_version\":1,\"kind\":\"summary\",\"files\":{},\"modules\":{},\"blocks\":{},\"cases_passed\":{},\"cases_failed\":{}{},\"files_skipped\":{},\"blocks_unchecked\":{}}}",
-            inputs.len(),
+            input_count,
             total_modules,
             total_blocks,
             total_passed,

--- a/src/main/provider_host_cmd.rs
+++ b/src/main/provider_host_cmd.rs
@@ -6,15 +6,15 @@
 //! capability; a backend that cannot host a Rust provider refuses instead of
 //! running without it.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::ffi::OsString;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
 use aver::codegen::rust as rust_codegen;
 
 use super::cli::Commands;
-use super::commands::{collect_program_units, resolve_av_inputs};
+use super::commands::{load_report_program_with_cache, resolve_av_inputs};
 
 /// Where a command executes the program, seen from the provider host.
 enum HostBackend {
@@ -198,31 +198,69 @@ fn plan_for_programs(
     let mut capabilities = aver::capability::CapabilityRegistry::default();
     let mut required = BTreeSet::new();
     let mut planned = HashSet::new();
+    let mut load_cache = aver::source::ProgramLoadCache::default();
+    let mut checked: HashMap<PathBuf, Result<(), String>> = HashMap::new();
     for input in inputs {
-        let Ok(units) = collect_program_units(input, module_root, &mut planned) else {
+        let Ok(program) = load_report_program_with_cache(input, module_root, &mut load_cache)
+        else {
             continue;
         };
-        for (_path, _source, mut items) in units {
-            aver::ir::pipeline::tco(&mut items);
-            let Ok(modules) = aver::source::load_compile_deps(&items, module_root) else {
+        for module in program
+            .report_units()
+            .filter(|module| planned.insert(aver::source::canonicalize_path(&module.path)))
+        {
+            let key = aver::source::canonicalize_path(&module.path);
+            if let Some(fault) = &module.fault {
+                checked.insert(key, Err(fault.to_string()));
                 continue;
+            }
+            let loaded = match program.loaded_dependencies_for(module) {
+                Ok(loaded) => loaded,
+                Err(error) => {
+                    checked.insert(key, Err(error.to_string()));
+                    continue;
+                }
             };
+            let failed_dependency = loaded.iter().find_map(|dependency| {
+                checked
+                    .get(&aver::source::canonicalize_path(&dependency.path))
+                    .and_then(|status| status.as_ref().err())
+            });
+            if let Some(error) = failed_dependency {
+                checked.insert(key, Err(error.clone()));
+                continue;
+            }
+
+            let mut items = module.items.clone();
+            aver::ir::pipeline::tco(&mut items);
             let tc = aver::ir::pipeline::typecheck_gate(
                 &items,
-                &aver::ir::TypecheckMode::Full {
-                    base_dir: Some(module_root),
-                },
+                &aver::ir::TypecheckMode::WithCheckedLoaded(&loaded),
                 &items,
             );
             if !tc.errors.is_empty() {
+                checked.insert(
+                    key,
+                    Err(tc
+                        .errors
+                        .iter()
+                        .map(|error| error.message.as_str())
+                        .collect::<Vec<_>>()
+                        .join("\n")),
+                );
                 continue;
             }
+            let modules = loaded
+                .iter()
+                .map(aver::codegen::ModuleInfo::from_loaded)
+                .collect::<Vec<_>>();
             required.extend(aver::provider::required_capability_operations(
                 &items,
                 &modules,
                 &tc.capabilities,
             ));
             capabilities.merge(tc.capabilities);
+            checked.insert(key, Ok(()));
         }
     }
 

--- a/src/provider_vm_host.rs
+++ b/src/provider_vm_host.rs
@@ -15,7 +15,7 @@ use sha2::{Digest, Sha256};
 use crate::codegen::rust::composition::{ProviderComposition, ProviderCompositionSource};
 use crate::toolchain_source::ToolchainSource;
 
-const HOST_SCHEMA: &str = "aver-provider-vm-host-v4";
+const HOST_SCHEMA: &str = "aver-provider-vm-host-v5";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProviderHostBackend {
@@ -303,7 +303,7 @@ fn aver_dependency_line(backend: ProviderHostBackend) -> Result<String, String> 
 
 fn render_cargo_toml(binary_name: &str, dependencies: &[String]) -> String {
     format!(
-        "[package]\nname = {}\nversion = \"0.0.0\"\nedition = \"2024\"\npublish = false\n\n[dependencies]\n{}\n\n[profile.dev]\ndebug = 0\n",
+        "[package]\nname = {}\nversion = \"0.0.0\"\nedition = \"2024\"\npublish = false\n\n[dependencies]\n{}\n\n[profile.dev]\ndebug = 0\n\n[profile.dev.package.\"*\"]\nopt-level = 2\n",
         toml_string(binary_name),
         dependencies.join("\n")
     )
@@ -488,5 +488,14 @@ mod tests {
         hash_source_tree(root.path(), root.path(), &mut after).unwrap();
         let after = format!("{:x}", after.finalize());
         assert_ne!(before, after);
+    }
+
+    #[test]
+    fn provider_host_optimizes_linked_runtime_dependencies() {
+        let manifest = render_cargo_toml(
+            "aver-provider-host-test",
+            &["aver = { version = \"=1.2.3\" }".to_string()],
+        );
+        assert!(manifest.contains("[profile.dev.package.\"*\"]\nopt-level = 2"));
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -487,6 +487,103 @@ impl Program {
     pub fn report_units(&self) -> impl Iterator<Item = &ProgramModule> {
         self.modules.iter().filter(|module| !module.is_stdlib)
     }
+
+    /// Parsed dependency closure of one module already present in this
+    /// program, in the program's canonical leaves-first order.
+    ///
+    /// Whole-program reports use this after their single graph walk so each
+    /// module can be type-checked and compiled without asking the filesystem
+    /// loader to rediscover its dependency cone. `module` may be the entry or
+    /// any project dependency returned by [`Self::report_units`].
+    pub fn loaded_dependencies_for(
+        &self,
+        module: &ProgramModule,
+    ) -> Result<Vec<LoadedModule>, LoadError> {
+        let by_name = self
+            .modules
+            .iter()
+            .map(|candidate| (candidate.dep_name.as_str(), candidate))
+            .collect::<HashMap<_, _>>();
+        let target_key = canonicalize_path(&module.path);
+        let mut reachable = HashSet::new();
+        let mut loading = vec![target_key];
+        validate_program_module_name(module, &module.dep_name)?;
+        collect_dependency_keys(module, &by_name, &mut reachable, &mut loading)?;
+        Ok(self
+            .modules
+            .iter()
+            .filter(|candidate| reachable.contains(&canonicalize_path(&candidate.path)))
+            .map(ProgramModule::as_loaded)
+            .collect())
+    }
+}
+
+fn validate_program_module_name(module: &ProgramModule, dep_name: &str) -> Result<(), LoadError> {
+    let Some(declaration) = visibility::module_decl(&module.items) else {
+        return Ok(());
+    };
+    let expected = dep_name.rsplit('.').next().unwrap_or(dep_name);
+    if declaration.name == expected {
+        return Ok(());
+    }
+    Err(LoadError::NameMismatch {
+        expected: expected.to_string(),
+        dep_name: dep_name.to_string(),
+        found: declaration.name.clone(),
+        path: module.path.clone(),
+    })
+}
+
+fn collect_dependency_keys(
+    module: &ProgramModule,
+    by_name: &HashMap<&str, &ProgramModule>,
+    reachable: &mut HashSet<PathBuf>,
+    loading: &mut Vec<PathBuf>,
+) -> Result<(), LoadError> {
+    let Some(declaration) = visibility::module_decl(&module.items) else {
+        return Ok(());
+    };
+    let explicit = declaration.depends.iter().cloned().collect::<HashSet<_>>();
+    let mut names = declaration.depends.clone();
+    for implied in crate::stdlib::implicit_stdlib_deps(&module.items) {
+        if !explicit.contains(&implied) {
+            names.push(implied);
+        }
+    }
+
+    let module_key = canonicalize_path(&module.path);
+    for name in names {
+        let Some(dependency) = by_name.get(name.as_str()).copied() else {
+            // A tolerant walk still resolves every edge before constructing a
+            // Program. A missing node here therefore means the graph itself
+            // is inconsistent, rather than another filesystem miss.
+            return Err(LoadError::Missing {
+                name,
+                root: "<loaded program>".to_string(),
+                required_by: Some(module.path.clone()),
+            });
+        };
+        let key = canonicalize_path(&dependency.path);
+        // Source-typed standard modules may imply themselves through their
+        // own builtins. The disk walk excludes that ownership edge too; an
+        // explicitly written `depends [Self]` remains a real cycle.
+        if key == module_key && !explicit.contains(&name) {
+            continue;
+        }
+        validate_program_module_name(dependency, &name)?;
+        if let Some(start) = loading.iter().position(|candidate| candidate == &key) {
+            let mut chain = loading[start..].to_vec();
+            chain.push(key);
+            return Err(LoadError::Cycle { chain });
+        }
+        if !reachable.insert(key.clone()) {
+            continue;
+        }
+        loading.push(key);
+        collect_dependency_keys(dependency, by_name, reachable, loading)?;
+        loading.pop();
+    }
+    Ok(())
 }
 
 /// Load the program named by an already parsed entry module.
@@ -500,7 +597,63 @@ pub fn load_program(
     module_root: &str,
     mode: LoadMode,
 ) -> Result<Program, LoadError> {
-    let mut walk = Walk::new(module_root, mode);
+    let mut cache = ProgramLoadCache::default();
+    load_program_with_cache(
+        entry_path,
+        entry_source,
+        entry_items,
+        module_root,
+        mode,
+        &mut cache,
+    )
+}
+
+/// Sources and parsed dependency modules shared by several program walks.
+///
+/// Directory reports often name every project file as an entry. Their
+/// dependency cones overlap heavily, so rebuilding each cone from disk turns
+/// a linear project walk into repeated IO and parsing. A command creates one
+/// cache for one module root and passes it to [`load_program_with_cache`];
+/// individual walks still own discovery order, and each whole-program graph
+/// view explicitly validates dependency names and cycles before reuse.
+#[derive(Default)]
+pub struct ProgramLoadCache {
+    resolved: HashMap<String, Result<Option<ModuleSource>, String>>,
+    parsed: HashMap<PathBuf, CachedProgramModule>,
+    verify_config: Option<Option<crate::config::ProjectConfig>>,
+}
+
+#[derive(Clone)]
+struct CachedProgramModule {
+    source: String,
+    items: Vec<TopLevel>,
+    path: PathBuf,
+    is_stdlib: bool,
+    fault: Option<CachedModuleFault>,
+}
+
+#[derive(Clone)]
+enum CachedModuleFault {
+    Parse(String),
+    Declaration(String),
+}
+
+/// [`load_program`] with a command-scoped dependency cache.
+///
+/// The cache is deliberately only the immutable input layer. Each call still
+/// performs its own graph walk, while [`Program::loaded_dependencies_for`]
+/// validates names and cycles before a report reuses the resulting graph.
+/// Sharing the cache therefore cannot make ownership depend on execution
+/// order.
+pub fn load_program_with_cache(
+    entry_path: &Path,
+    entry_source: &str,
+    entry_items: &[TopLevel],
+    module_root: &str,
+    mode: LoadMode,
+    cache: &mut ProgramLoadCache,
+) -> Result<Program, LoadError> {
+    let mut walk = Walk::new(module_root, mode, cache);
     walk.follow_edges(entry_path, entry_items)?;
     let mut modules = walk.modules;
     let entry_name = visibility::module_decl(entry_items)
@@ -538,20 +691,28 @@ struct Walk<'a> {
     loading: Vec<PathBuf>,
     modules: Vec<ProgramModule>,
     next_discovery_index: usize,
+    cache: &'a mut ProgramLoadCache,
 }
 
 impl<'a> Walk<'a> {
-    fn new(module_root: &'a str, mode: LoadMode) -> Self {
+    fn new(module_root: &'a str, mode: LoadMode, cache: &'a mut ProgramLoadCache) -> Self {
+        let verify_config = cache
+            .verify_config
+            .get_or_insert_with(|| {
+                crate::config::ProjectConfig::load_from_dir(Path::new(module_root))
+                    .ok()
+                    .flatten()
+            })
+            .clone();
         Self {
             module_root,
             mode,
-            verify_config: crate::config::ProjectConfig::load_from_dir(Path::new(module_root))
-                .ok()
-                .flatten(),
+            verify_config,
             loaded: HashSet::new(),
             loading: Vec::new(),
             modules: Vec::new(),
             next_discovery_index: 1,
+            cache,
         }
     }
 
@@ -563,8 +724,18 @@ impl<'a> Walk<'a> {
         }
     }
 
-    fn resolve(&self, name: &str, required_by: Option<&Path>) -> Result<ModuleSource, LoadError> {
-        resolve_module_source(name, self.module_root)
+    fn resolve(
+        &mut self,
+        name: &str,
+        required_by: Option<&Path>,
+    ) -> Result<ModuleSource, LoadError> {
+        let resolved = self
+            .cache
+            .resolved
+            .entry(name.to_string())
+            .or_insert_with(|| resolve_module_source(name, self.module_root))
+            .clone();
+        resolved
             .map_err(LoadError::Read)?
             .ok_or_else(|| LoadError::Missing {
                 name: name.to_string(),
@@ -623,29 +794,39 @@ impl<'a> Walk<'a> {
         let discovery_index = self.next_discovery_index;
         self.next_discovery_index += 1;
         let ModuleSource { path, source } = resolved;
-        let is_stdlib = path.starts_with("<aver-stdlib>");
-
-        let (items, fault) =
-            match parse_source_with_verify_ceiling(&source, self.verify_ceiling(&path)) {
+        let ceiling = self.verify_ceiling(&path);
+        let cached = self.cache.parsed.entry(key.clone()).or_insert_with(|| {
+            let is_stdlib = path.starts_with("<aver-stdlib>");
+            let (items, fault) = match parse_source_with_verify_ceiling(&source, ceiling) {
                 Ok(items) => match require_module_declaration(&items, &path.to_string_lossy()) {
                     Ok(()) => (items, None),
-                    Err(message) => (
-                        items,
-                        Some(LoadError::Declaration {
-                            path: path.clone(),
-                            message,
-                        }),
-                    ),
+                    Err(message) => (items, Some(CachedModuleFault::Declaration(message))),
                 },
-                Err(error) => (
-                    Vec::new(),
-                    Some(LoadError::Parse {
-                        name: dep_name.to_string(),
-                        path: path.clone(),
-                        error,
-                    }),
-                ),
+                Err(error) => (Vec::new(), Some(CachedModuleFault::Parse(error))),
             };
+            CachedProgramModule {
+                source,
+                items,
+                path,
+                is_stdlib,
+                fault,
+            }
+        });
+        let source = cached.source.clone();
+        let items = cached.items.clone();
+        let path = cached.path.clone();
+        let is_stdlib = cached.is_stdlib;
+        let fault = cached.fault.as_ref().map(|fault| match fault {
+            CachedModuleFault::Parse(error) => LoadError::Parse {
+                name: dep_name.to_string(),
+                path: path.clone(),
+                error: error.clone(),
+            },
+            CachedModuleFault::Declaration(message) => LoadError::Declaration {
+                path: path.clone(),
+                message: message.clone(),
+            },
+        });
         if self.mode == LoadMode::Strict {
             if let Some(fault) = fault {
                 return Err(fault);
@@ -790,7 +971,8 @@ pub fn load_module_tree(
     root_deps: &[String],
     module_root: &str,
 ) -> Result<Vec<LoadedModule>, String> {
-    let mut walk = Walk::new(module_root, LoadMode::Strict);
+    let mut cache = ProgramLoadCache::default();
+    let mut walk = Walk::new(module_root, LoadMode::Strict, &mut cache);
     for name in root_deps {
         let resolved = walk.resolve(name, None)?;
         walk.load(name, resolved)?;
@@ -940,9 +1122,9 @@ pub fn load_compile_deps(
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_stdlib_shadowed, collect_stdlib_shadowed_in_map, load_module_tree,
-        load_module_tree_from_map, parse_source, require_module_declaration, resolve_module_source,
-        stdlib_shadowed_project_file,
+        LoadMode, ProgramLoadCache, collect_stdlib_shadowed, collect_stdlib_shadowed_in_map,
+        load_module_tree, load_module_tree_from_map, load_program_with_cache, parse_source,
+        require_module_declaration, resolve_module_source, stdlib_shadowed_project_file,
     };
 
     #[test]
@@ -995,6 +1177,50 @@ mod tests {
         let resolved =
             resolve_module_source("DefinitelyNotARealModule", ".").expect("resolve unknown module");
         assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn program_cache_reuses_dependency_source_and_parse_across_entries() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dep_path = dir.path().join("shared.av");
+        std::fs::write(
+            &dep_path,
+            "module Shared\n    intent = \"shared\"\nfn value() -> Int\n    1\n",
+        )
+        .expect("write dependency");
+        let root = dir.path().to_str().expect("utf8 root");
+        let first_source = "module First\n    intent = \"first\"\n    depends [Shared]\n";
+        let second_source = "module Second\n    intent = \"second\"\n    depends [Shared]\n";
+        let first_items = parse_source(first_source).expect("parse first");
+        let second_items = parse_source(second_source).expect("parse second");
+        let mut cache = ProgramLoadCache::default();
+
+        let first = load_program_with_cache(
+            &dir.path().join("first.av"),
+            first_source,
+            &first_items,
+            root,
+            LoadMode::Tolerant,
+            &mut cache,
+        )
+        .expect("first program");
+        assert_eq!(first.dependencies().len(), 1);
+
+        // A command sees one immutable project snapshot. Changing the file
+        // after its first walk must not make a later entry parse it again.
+        std::fs::write(&dep_path, "this is no longer Aver").expect("replace dependency");
+        let second = load_program_with_cache(
+            &dir.path().join("second.av"),
+            second_source,
+            &second_items,
+            root,
+            LoadMode::Tolerant,
+            &mut cache,
+        )
+        .expect("second program");
+        assert_eq!(second.dependencies().len(), 1);
+        assert!(second.dependencies()[0].fault.is_none());
+        assert!(second.dependencies()[0].source.contains("fn value"));
     }
 
     #[test]

--- a/src/types/checker/check.rs
+++ b/src/types/checker/check.rs
@@ -54,6 +54,30 @@ impl TypeChecker {
         items: &[TopLevel],
         loaded: &[crate::source::LoadedModule],
     ) {
+        self.check_with_loaded_mode(items, loaded, true);
+    }
+
+    /// Type-check an entry against dependency surfaces whose bodies were
+    /// already checked by the command's leaves-first program preparation.
+    ///
+    /// This is deliberately narrower than `check_with_loaded`: capabilities,
+    /// exported types, signatures and visibility are still rebuilt for this
+    /// importer. Only the recursive body walk is omitted. Callers must never
+    /// use this as a trust boundary for arbitrary preloaded modules.
+    pub(super) fn check_with_checked_loaded(
+        &mut self,
+        items: &[TopLevel],
+        loaded: &[crate::source::LoadedModule],
+    ) {
+        self.check_with_loaded_mode(items, loaded, false);
+    }
+
+    fn check_with_loaded_mode(
+        &mut self,
+        items: &[TopLevel],
+        loaded: &[crate::source::LoadedModule],
+        check_dependency_bodies: bool,
+    ) {
         // Phase B: track the entry module's prefix (see `check`).
         self.current_module_prefix = Self::module_decl(items).map(|m| m.name.clone());
         // Dependency aliases come in before local signatures so
@@ -67,7 +91,9 @@ impl TypeChecker {
         let visible_roots = Self::visible_module_roots(items);
         self.integrate_loaded_modules(&loaded, &visible_roots);
         self.build_signatures(items);
-        self.check_loaded_module_bodies(&loaded, None);
+        if check_dependency_bodies {
+            self.check_loaded_module_bodies(&loaded, None);
+        }
         self.check_body(items);
     }
 

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -178,6 +178,22 @@ pub fn run_type_check_with_loaded(
     finalize_check_result(checker, items)
 }
 
+/// Type-check `items` against dependency modules whose bodies have already
+/// passed type checking in a leaves-first command preparation.
+///
+/// Dependency signatures, capabilities and visibility remain part of this
+/// check. Only their bodies are not walked again. This is an internal
+/// performance seam for whole-program reporting; ordinary embedders should
+/// continue to use [`run_type_check_with_loaded`].
+pub(crate) fn run_type_check_with_checked_loaded(
+    items: &[TopLevel],
+    loaded: &[crate::source::LoadedModule],
+) -> TypeCheckResult {
+    let mut checker = TypeChecker::new_with_symbols(build_symbols_with_loaded(items, loaded));
+    checker.check_with_checked_loaded(items, loaded);
+    finalize_check_result(checker, items)
+}
+
 /// Self-host variant of [`run_type_check_full`]: bypasses the
 /// opaque-type checks (construction, field access, pattern match).
 /// Used exclusively by `aver compile --with-self-host-support` so

--- a/src/vm/compiler/classify.rs
+++ b/src/vm/compiler/classify.rs
@@ -387,4 +387,28 @@ mod tests {
         let leaf = chunk_with_code(vec![LIST_LEN, RETURN]);
         assert!(classify_leaf_chunk(&leaf).unwrap());
     }
+
+    #[test]
+    fn bytecode_walk_skips_all_tail_call_operands() {
+        // The owned-mask bytes deliberately spell dispatch opcodes. A walker
+        // that undercounts either tail-call shape would interpret them as
+        // instructions and lose the real RETURN boundary.
+        let chunk = chunk_with_code(vec![
+            TAIL_CALL_SELF,
+            0x01,
+            MATCH_DISPATCH,
+            TAIL_CALL_KNOWN,
+            0x00,
+            0x02,
+            0x01,
+            MATCH_DISPATCH_CONST,
+            RETURN,
+        ]);
+
+        assert_eq!(opcode_operand_width(TAIL_CALL_SELF, &chunk.code, 1), 2);
+        assert_eq!(opcode_operand_width(TAIL_CALL_KNOWN, &chunk.code, 4), 4);
+        assert_eq!(find_opcode_positions(&chunk, RETURN), vec![8]);
+        assert!(find_opcode_positions(&chunk, MATCH_DISPATCH).is_empty());
+        assert!(find_opcode_positions(&chunk, MATCH_DISPATCH_CONST).is_empty());
+    }
 }

--- a/src/vm/execute/mod.rs
+++ b/src/vm/execute/mod.rs
@@ -260,6 +260,24 @@ impl VM {
         self.runtime.provider_registry()
     }
 
+    /// Fresh execution state over this VM's compiled, immutable program.
+    ///
+    /// Verify cases are independent observations. Parallel verify workers use
+    /// a private stack, arena and runtime scratch state while sharing only the
+    /// thread-safe provider registry and cloning the project policy.
+    pub(crate) fn fork_for_verify(&self) -> Self {
+        let (code, globals, arena) = self.build_parallel_base_context();
+        let mut child = Self::new(code, globals, arena);
+        child.set_provider_registry(self.provider_registry());
+        if let Some(config) = self.runtime.runtime_policy().cloned() {
+            child.set_runtime_policy(config);
+        }
+        child.defer_missing_capability_providers_to_dispatch(
+            self.defer_missing_capability_providers_to_dispatch,
+        );
+        child
+    }
+
     /// Start recording effectful calls.
     pub fn start_recording(&mut self) {
         self.runtime.start_recording();

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -184,10 +184,10 @@ pub const CALL_BUILTIN_OWNED: u8 = 0x46; // symbol_id:u32, argc:u8, owned:u8
 pub const CALL_KNOWN_OWNED: u8 = 0x47; // fn_id:u16, argc:u8, owned:u8
 
 /// Self tail-call: reuse current frame with new args.
-pub const TAIL_CALL_SELF: u8 = 0x43; // argc:u8
+pub const TAIL_CALL_SELF: u8 = 0x43; // argc:u8, owned:u8
 
 /// Mutual tail-call to a known function: reuse frame, switch target.
-pub const TAIL_CALL_KNOWN: u8 = 0x44; // fn_id:u16, argc:u8
+pub const TAIL_CALL_KNOWN: u8 = 0x44; // fn_id:u16, argc:u8, owned:u8
 
 /// Return top of stack to caller.
 pub const RETURN: u8 = 0x50;
@@ -753,11 +753,11 @@ pub fn opcode_operand_width(op: u8, code: &[u8], ip: usize) -> usize {
 
         // 1-byte
         LOAD_LOCAL | MOVE_LOCAL | STORE_LOCAL | CALL_VALUE | RECORD_GET | EXTRACT_FIELD
-        | EXTRACT_TUPLE_ITEM | WRAP | TAIL_CALL_SELF | TAIL_CALL_SELF_THIN => 1,
+        | EXTRACT_TUPLE_ITEM | WRAP => 1,
 
         // 2-byte (u16 or u8+u8)
         LOAD_CONST | LOAD_GLOBAL | STORE_GLOBAL | JUMP | JUMP_IF_FALSE | MATCH_FAIL | MATCH_NIL
-        | MATCH_CONS | LOAD_LOCAL_2 | VECTOR_GET_OR => 2,
+        | MATCH_CONS | LOAD_LOCAL_2 | VECTOR_GET_OR | TAIL_CALL_SELF | TAIL_CALL_SELF_THIN => 2,
 
         // owned:u8 + target_slot:u8. The slot is the target's own local cell,
         // which the runtime fence must exempt: the fusion deletes the
@@ -771,7 +771,7 @@ pub fn opcode_operand_width(op: u8, code: &[u8], ip: usize) -> usize {
         | LOAD_LOCAL_CONST => 3,
 
         // 4-byte
-        CALL_KNOWN_OWNED => 4, // fn_id:u16 + argc:u8 + owned:u8
+        CALL_KNOWN_OWNED | TAIL_CALL_KNOWN => 4, // fn_id:u16 + argc:u8 + owned:u8
 
         // 4-byte
         MATCH_VARIANT | RECORD_GET_NAMED | LIST_NEW | TUPLE_NEW => 4,

--- a/tests/program_fold_spec.rs
+++ b/tests/program_fold_spec.rs
@@ -181,6 +181,140 @@ fn directory_verify_reports_each_module_once() {
 }
 
 #[test]
+fn parallel_verify_matches_j1_bytes_and_keeps_shared_module_ownership() {
+    let project = Project::new("verify-parallel-deterministic");
+    project
+        .write("lib.av", SHARED_LIB_AV)
+        .write("entry.av", ENTRY_AV)
+        .write("other.av", OTHER_AV);
+
+    let sequential = project.run(&["verify", ".", "--json", "-j", "1"]);
+    let parallel = project.run(&["verify", ".", "--json", "-j", "4"]);
+    assert!(sequential.status.success(), "{}", report(&sequential));
+    assert!(parallel.status.success(), "{}", report(&parallel));
+    assert_eq!(parallel.status.code(), sequential.status.code());
+    assert_eq!(
+        parallel.stdout, sequential.stdout,
+        "parallel stdout drifted"
+    );
+    assert_eq!(
+        parallel.stderr, sequential.stderr,
+        "parallel stderr drifted"
+    );
+
+    let stdout = String::from_utf8_lossy(&parallel.stdout);
+    assert_eq!(
+        stdout.matches("\"kind\":\"analysis\"").count(),
+        3,
+        "{stdout}"
+    );
+    assert_eq!(
+        stdout.matches("\"file_label\":\"./lib.av\"").count(),
+        1,
+        "{stdout}"
+    );
+}
+
+#[test]
+fn parallel_verify_preserves_failure_coordinates_and_rendering() {
+    let project = Project::new("verify-parallel-failure");
+    project
+        .write(
+            "lib.av",
+            &LIB_AV.replace("double(-4) => -8", "double(-4) => -7"),
+        )
+        .write("entry.av", ENTRY_AV);
+
+    let sequential = project.run(&["verify", ".", "--json", "-j", "1"]);
+    let parallel = project.run(&["verify", ".", "--json", "-j", "4"]);
+    assert!(
+        !sequential.status.success(),
+        "sequential unexpectedly passed"
+    );
+    assert!(!parallel.status.success(), "parallel unexpectedly passed");
+    assert_eq!(parallel.status.code(), sequential.status.code());
+    assert_eq!(
+        parallel.stdout, sequential.stdout,
+        "parallel stdout drifted"
+    );
+    assert_eq!(
+        parallel.stderr, sequential.stderr,
+        "parallel stderr drifted"
+    );
+    assert!(
+        String::from_utf8_lossy(&parallel.stdout).contains("\"slug\":\"verify-mismatch\""),
+        "{}",
+        report(&parallel)
+    );
+}
+
+#[test]
+fn reused_verify_graph_still_rejects_a_dependency_name_mismatch() {
+    let project = Project::new("verify-name-mismatch");
+    project
+        .write("lib.av", &LIB_AV.replace("module Lib", "module Wrong"))
+        .write("entry.av", ENTRY_AV);
+
+    let sequential = project.run(&["verify", "entry.av", "-j", "1"]);
+    let parallel = project.run(&["verify", "entry.av", "-j", "4"]);
+    assert!(!sequential.status.success(), "{}", report(&sequential));
+    assert!(!parallel.status.success(), "{}", report(&parallel));
+    assert_eq!(parallel.stdout, sequential.stdout);
+    assert_eq!(parallel.stderr, sequential.stderr);
+    assert!(
+        String::from_utf8_lossy(&sequential.stderr).contains("Module name mismatch"),
+        "{}",
+        report(&sequential)
+    );
+}
+
+#[test]
+fn reused_verify_graph_propagates_dependency_type_errors_deterministically() {
+    let project = Project::new("verify-dependency-type-error");
+    project
+        .write("lib.av", &LIB_AV.replace("n * 2", "n * \"two\""))
+        .write("entry.av", ENTRY_AV);
+
+    let sequential = project.run(&["verify", "entry.av", "-j", "1"]);
+    let parallel = project.run(&["verify", "entry.av", "-j", "4"]);
+    assert!(!sequential.status.success(), "{}", report(&sequential));
+    assert!(!parallel.status.success(), "{}", report(&parallel));
+    assert_eq!(parallel.stdout, sequential.stdout);
+    assert_eq!(parallel.stderr, sequential.stderr);
+    assert!(
+        String::from_utf8_lossy(&sequential.stderr).contains("Arithmetic operator requires"),
+        "{}",
+        report(&sequential)
+    );
+}
+
+#[test]
+fn reused_verify_graph_still_rejects_a_dependency_cycle() {
+    let project = Project::new("verify-cycle");
+    project
+        .write(
+            "a.av",
+            "module A\n    intent = \"First half of an invalid dependency cycle.\"\n    depends [B]\n    exposes [a]\n    effects []\n\nfn a(n: Int) -> Int\n    ? \"Returns the input.\"\n    n\n\nverify a\n    a(1) => 1\n",
+        )
+        .write(
+            "b.av",
+            "module B\n    intent = \"Second half of an invalid dependency cycle.\"\n    depends [A]\n    exposes [b]\n    effects []\n\nfn b(n: Int) -> Int\n    ? \"Returns the input.\"\n    n\n",
+        );
+
+    let sequential = project.run(&["verify", "a.av", "-j", "1"]);
+    let parallel = project.run(&["verify", "a.av", "-j", "4"]);
+    assert!(!sequential.status.success(), "{}", report(&sequential));
+    assert!(!parallel.status.success(), "{}", report(&parallel));
+    assert_eq!(parallel.stdout, sequential.stdout);
+    assert_eq!(parallel.stderr, sequential.stderr);
+    assert!(
+        String::from_utf8_lossy(&sequential.stderr).contains("Circular import"),
+        "{}",
+        report(&sequential)
+    );
+}
+
+#[test]
 fn directory_check_reports_each_module_once() {
     let project = Project::new("check-dir");
     project.write("lib.av", LIB_AV).write("entry.av", ENTRY_AV);


### PR DESCRIPTION
Closes #1095.

## What changed

- add `aver verify -j N` / `--jobs N`, defaulting to available parallelism, with a single bounded Rayon pool for module preparation, files, and declared cases
- settle module ownership and collect output before workers start, preserving byte-identical input/module/block/case order between `-j 1` and `-j N`
- resolve and parse the project graph once per command; reuse it in `verify`, directory `check`/`audit`, and provider-host planning
- type-check each project module body once, rebuild only importer-visible surfaces for parents, and prepare each module's compiled VM once for all of its cases
- retain strict cycle, dependency-name, parse, and transitive type-error handling on the reused graph
- make provider-host preflight use the same graph instead of replaying the full compiler pipeline, and optimize linked runtime/provider dependencies while keeping the tiny generated launcher in the dev profile
- index source lines once per analyzed file, removing quadratic diagnostic rendering for files with many findings
- fix the bytecode operand walker widths for owned tail calls, exposed by VM classification during the work

## Measured result

Release build, btc-listener public tree at the tested revision: 98 input files, 95 reported modules, 1,411 verify blocks, 6,016 passing cases, configured native providers.

| command | wall time |
|---|---:|
| old `aver verify . --json --module-root . -j 1` | 307.17 s |
| new `-j 1` | 7.17 s |
| new `-j 8` | 3.98 s |

The old and new commands produce the same report SHA-256 when invoked with the same module-root spelling. The surprising part is the split: removing repeated compiler/provider preparation accounts for roughly 43x before Rayon contributes the remaining ~1.8x.

Self-host smoke remains byte-identical (`3e3065b4…`) and moves from 0.70 s at `-j 1` to 0.35 s at `-j 8`. A repository proof-corpus smoke is also byte-identical between both job counts.

## Verification

- `cargo test --workspace` — 3,557 passed, 26 ignored (149 suites)
- `cargo test --test program_fold_spec --features runtime` — 19 passed, including deterministic failures, dependency type errors, name mismatch, and cycles
- CI-equivalent clippy for the workspace and aver binary — clean with `-D warnings`
- wasm + wasip2 clippy — clean with `-D warnings`
- release build and provider-host integration tests

