### PR TITLE
Carry unreleased runtime versions as dev versions on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "aver-memory"
-version = "0.2.14"
+version = "0.2.15-dev"
 dependencies = [
  "aver-rt",
  "num-bigint",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "aver-rt"
-version = "0.4.10"
+version = "0.4.11-dev"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,8 @@ playground = ["wasm-compile", "dep:wasm-bindgen", "runtime", "tty-render"]
 
 [dependencies]
 aver-cert = { path = "aver-cert", version = "=0.1.3", optional = true, default-features = false, features = ["plans"] }
-aver-memory = { path = "aver-memory", version = "=0.2.14" }
-aver-rt = { path = "aver-rt", version = "=0.4.10", optional = true }
+aver-memory = { path = "aver-memory", version = "=0.2.15-dev" }
+aver-rt = { path = "aver-rt", version = "=0.4.11-dev", optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 colored = { version = "2", optional = true }
 num-bigint = "0.4"

--- a/aver-memory/Cargo.toml
+++ b/aver-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aver-memory"
-version = "0.2.14"
+version = "0.2.15-dev"
 edition = "2024"
 license = "MIT"
 description = "NaN-boxed arena memory for the Aver language"
@@ -16,5 +16,5 @@ std = []
 runtime = ["dep:aver-rt"]
 
 [dependencies]
-aver-rt = { path = "../aver-rt", version = "=0.4.10", optional = true }
+aver-rt = { path = "../aver-rt", version = "=0.4.11-dev", optional = true }
 num-bigint = "0.4"

--- a/aver-rt/Cargo.toml
+++ b/aver-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aver-rt"
-version = "0.4.10"
+version = "0.4.11-dev"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/tools/release.py
+++ b/tools/release.py
@@ -1746,6 +1746,11 @@ def main() -> int:
     )
     print()
 
+    # 9. Move main off the versions just published. A released number is
+    #    immutable on the registry; main must not keep claiming it.
+    carry_dev_versions(new_versions, dry_run)
+    print()
+
     # 9. Optional: rebuild + deploy `tools/edge` (Cloudflare Workers
     #    Mandelbrot demo). Live deploy of a public endpoint, so opt-in.
     if args.deploy_edge:
@@ -1762,6 +1767,64 @@ def main() -> int:
 
     print(f"{'[dry-run] ' if dry_run else ''}Done! Released {new_version}")
     return 0
+
+
+def next_dev_version(crate: str, released: str) -> str:
+    """The version main carries after `released` ships.
+
+    A published version is immutable on the registry, so a repository that
+    keeps that same number describes code the registry cannot serve: cargo
+    resolves it happily and hands the consumer older sources under a matching
+    name. Main therefore carries the next unreleased number with a `-dev`
+    suffix, which no registry can satisfy — a mismatch fails loudly at resolve
+    time instead of silently compiling against the wrong tree.
+
+    `aver-lang` carries the next minor, matching how the language is versioned;
+    the runtime crates carry the next patch.
+    """
+    core = released.split("-", 1)[0]
+    parts = core.split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        raise ReleaseError(f"cannot derive a dev version from {released!r} for {crate}")
+    major, minor, patch = (int(part) for part in parts)
+    if crate == "aver-lang":
+        return f"{major}.{minor + 1}.0-dev"
+    return f"{major}.{minor}.{patch + 1}-dev"
+
+
+def carry_dev_versions(new_versions: dict[str, str], dry_run: bool) -> None:
+    """Move main onto `-dev` versions after a release is tagged.
+
+    Runs after tagging, so the tag still points at the exact published
+    versions. Without this, every commit between two releases claims a version
+    that is already on the registry under different code.
+    """
+    dev_versions = {
+        crate: next_dev_version(crate, version)
+        for crate, version in new_versions.items()
+    }
+    for crate in CRATE_ORDER:
+        released = new_versions[crate]
+        dev = dev_versions[crate]
+        prefix = "  [dry-run] " if dry_run else "  "
+        print(f"{prefix}{crate}: {released} -> {dev}")
+        if not dry_run:
+            bump_toml_version(VERSION_FILES[crate], released, dev)
+
+    if dry_run:
+        print("  [dry-run] git commit + push (carry dev versions)")
+        return
+
+    main_toml = VERSION_FILES["aver-lang"]
+    set_dep_pin(main_toml, "aver-cert", dev_versions["aver-cert"])
+    set_dep_pin(main_toml, "aver-rt", dev_versions["aver-rt"])
+    set_dep_pin(main_toml, "aver-memory", dev_versions["aver-memory"])
+    set_dep_pin(VERSION_FILES["aver-memory"], "aver-rt", dev_versions["aver-rt"])
+    set_dep_pin(VERSION_FILES["aver-lsp"], "aver-lang", dev_versions["aver-lang"])
+    run(["cargo", "metadata", "--format-version", "1"], capture=True)
+    run(["git", "add", "-A"])
+    run(["git", "commit", "-m", "Carry dev versions on main"])
+    run(["git", "push", "origin", "main"])
 
 
 def deploy_edge(dry_run: bool) -> None:


### PR DESCRIPTION
Closes the half of #1094 that #1099 did not reach.

#1099 taught the toolchain its own provenance, so a git-installed binary now emits `{git, rev}` instead of a bare version. That removes the *symptom* for git installs, but the underlying condition is still here: two different trees carry the same version number.

```
aver-rt      0.4.10   ← crates.io has 0.4.10; this repo is 22 commits past it
aver-memory  0.2.14   ← crates.io has 0.2.14
aver-lang    0.29.0-dev
```

A published version is immutable on the registry. A repository that keeps that number after publishing is describing code the registry cannot serve — cargo resolves it without complaint and hands the consumer older sources under a matching name. That is what produced "same version number, different code" and over a thousand compile errors in a downstream project, and it is the quieter of the two failures in #1094: the `-dev` mismatch on `aver-lang` at least failed loudly at resolve time.

`aver-lang` already carried the next minor as a dev version on main (#1067). The runtime crates never got the same treatment. They do now: `0.4.11-dev` and `0.2.15-dev`, with the exact pins and `Cargo.lock` moved with them.

The release script also stops depending on anyone remembering. A new step after tagging moves main onto the next dev versions — after the tag, so the tag still points at the exact published numbers:

```python
def next_dev_version(crate: str, released: str) -> str:
    ...
    if crate == "aver-lang":
        return f"{major}.{minor + 1}.0-dev"
    return f"{major}.{minor}.{patch + 1}-dev"
```

`aver-lang` carries the next minor, matching how the language is versioned; the runtime crates carry the next patch. A malformed input raises rather than guessing.

`cargo check -p aver-rt -p aver-memory` passes and `cargo metadata` regenerates the lock cleanly.