### PR TITLE
Tail-call lowering: keep loop-carried values alive, and align mutual-trampoline equality

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -108,6 +108,12 @@ pub struct MirEmitCtx<'a> {
     pub local_types: &'a HashMap<String, Type>,
     /// Params passed as `Rc<T>` (self-TCO) / `&T` (mutual-TCO).
     pub rc_wrapped: &'a HashSet<String>,
+    /// Whether `rc_wrapped` params are represented as `&T`. This is true
+    /// only while emitting mutual-TCO trampoline arms; self-TCO wraps the
+    /// same policy class in `Arc<T>` instead. Equality uses this distinction
+    /// to align an owned operand with a borrowed invariant without changing
+    /// clone policy for either TCO shape.
+    pub rc_wrapped_are_borrowed_refs: bool,
     /// Params emitted as `&T` (borrow-by-default for non-Copy,
     /// non-Str params).
     pub borrowed_params: &'a HashSet<String>,
@@ -173,6 +179,7 @@ impl<'a> MirEmitCtx<'a> {
             codegen: None,
             local_types: EMPTY_TYPES.get_or_init(HashMap::new),
             rc_wrapped: EMPTY_SET.get_or_init(HashSet::new),
+            rc_wrapped_are_borrowed_refs: false,
             borrowed_params: EMPTY_SET.get_or_init(HashSet::new),
             loop_carried_params: EMPTY_SET.get_or_init(HashSet::new),
             owned_params: EMPTY_SET.get_or_init(HashSet::new),
@@ -220,6 +227,7 @@ impl<'a> MirEmitCtx<'a> {
             codegen: Some(ctx),
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
+            rc_wrapped_are_borrowed_refs: false,
             borrowed_params: &policy.borrowed_params,
             loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
@@ -242,6 +250,7 @@ impl<'a> MirEmitCtx<'a> {
             codegen: Some(ctx),
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
+            rc_wrapped_are_borrowed_refs: false,
             borrowed_params: &policy.borrowed_params,
             loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
@@ -3117,12 +3126,12 @@ fn mir_emit_equality(
     {
         return format!("({:?} {} &*{})", s, op_str, r);
     }
-    // Borrow-by-default makes collection / wrapper / named-type parameters
-    // `&T`, while calls and constructors still produce an owned `T`. Rust
-    // does not provide `PartialEq<&T> for T`, so compare two references
-    // whenever exactly one side is a borrowed parameter. Borrowing the owned
-    // expression is temporary, allocation-free, and preserves evaluation
-    // order.
+    // Borrow-by-default and mutual-TCO invariant hoisting make collection /
+    // wrapper / named-type parameters `&T`, while calls and constructors still
+    // produce an owned `T`. Rust does not provide `PartialEq<&T> for T`, so
+    // compare two references whenever exactly one side is a borrowed
+    // parameter. Borrowing the owned expression is temporary, allocation-free,
+    // and preserves evaluation order.
     let lhs_borrowed = mir_expr_is_borrowed_param_read(&bop.lhs.node, emit_ctx);
     let rhs_borrowed = mir_expr_is_borrowed_param_read(&bop.rhs.node, emit_ctx);
     match (lhs_borrowed, rhs_borrowed) {
@@ -3132,13 +3141,17 @@ fn mir_emit_equality(
     }
 }
 
-/// Is this expression a direct read of a borrowed-param local?
+/// Is this expression a direct read whose emitted Rust representation is `&T`?
 ///
-/// A direct read emits as `name`, whose Rust type is `&T`. Projections and
-/// compound expressions have their own ownership rules and deliberately do
-/// not count as borrowed-param reads here.
+/// This includes both ordinary borrow-by-default params and mutual-TCO
+/// invariants hoisted out of the state enum. A direct read emits as `name`,
+/// whose Rust type is `&T`. Projections and compound expressions have their own
+/// ownership rules and deliberately do not count as borrowed-param reads here.
 fn mir_expr_is_borrowed_param_read(expr: &MirExpr, emit_ctx: &MirEmitCtx<'_>) -> bool {
-    local_of(expr).is_some_and(|local| emit_ctx.is_borrowed_param(&local.name))
+    local_of(expr).is_some_and(|local| {
+        emit_ctx.is_borrowed_param(&local.name)
+            || (emit_ctx.rc_wrapped_are_borrowed_refs && emit_ctx.is_rc_wrapped(&local.name))
+    })
 }
 
 /// Emit the FULL function body the MIR walker produces, in the
@@ -3929,7 +3942,12 @@ pub(super) fn emit_mir_mutual_tco_block(
         // skips a clone.
         let mut policy = MirFnEmitPolicy::from_resolved(group_fns[i], scope, false);
         policy.rc_wrapped = rc_names.clone();
-        let arm_ctx = MirEmitCtx::for_fn(ctx, &policy);
+        let mut arm_ctx = MirEmitCtx::for_fn(ctx, &policy);
+        // Mutual invariants are `rc_wrapped` for owning reads, but unlike
+        // self-TCO's `Arc<T>` representation they are extra `&T` trampoline
+        // parameters. Tell equality's operand-shape classifier about that
+        // representation; no general clone policy changes.
+        arm_ctx.rc_wrapped_are_borrowed_refs = true;
         let body = emit_mir_trampoline_body(
             &mir_fn.body,
             &member_fn_ids,
@@ -5600,6 +5618,7 @@ mod tests {
             codegen: None,
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
+            rc_wrapped_are_borrowed_refs: false,
             borrowed_params: &policy.borrowed_params,
             loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
@@ -6650,6 +6669,7 @@ mod tests {
             codegen: None,
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
+            rc_wrapped_are_borrowed_refs: false,
             borrowed_params: &policy.borrowed_params,
             loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -89,6 +89,7 @@ use super::syntax::aver_name_to_rust;
 /// - **production parity gate** (`for_fn`): carries the full
 ///   `&CodegenContext` plus the per-fn borrow policy
 ///   (`local_types` / `rc_wrapped` / `borrowed_params` /
+///   `loop_carried_params` /
 ///   `current_module_scope`), recomputed from the `ResolvedFnDef`
 ///   the HIR walker uses. This is the slice of
 ///   [`super::emit_ctx::EmitCtx`] the covered arms need so their
@@ -110,6 +111,12 @@ pub struct MirEmitCtx<'a> {
     /// Params emitted as `&T` (borrow-by-default for non-Copy,
     /// non-Str params).
     pub borrowed_params: &'a HashSet<String>,
+    /// Self-TCO params whose identity rebind is elided for the tail call
+    /// currently being emitted. Their source value remains live in the next
+    /// loop iteration, so a syntactic `last_use` inside another tail-call
+    /// argument is not a real move point. Owning positions clone these
+    /// params; non-owning reads remain allocation-free.
+    pub loop_carried_params: &'a HashSet<String>,
     /// Collection (`Vector`/`Map`) params that the `own_param` MIR pass
     /// PROVED uniquely owned (cleared their `aliased_slots` bit). These
     /// are emitted owned-by-value (`mut p: T`, NOT `&T`) and, at a
@@ -167,6 +174,7 @@ impl<'a> MirEmitCtx<'a> {
             local_types: EMPTY_TYPES.get_or_init(HashMap::new),
             rc_wrapped: EMPTY_SET.get_or_init(HashSet::new),
             borrowed_params: EMPTY_SET.get_or_init(HashSet::new),
+            loop_carried_params: EMPTY_SET.get_or_init(HashSet::new),
             owned_params: EMPTY_SET.get_or_init(HashSet::new),
             current_module_scope: None,
             // No builtin table on the coverage path: `Call(Builtin)`
@@ -213,6 +221,7 @@ impl<'a> MirEmitCtx<'a> {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins,
@@ -234,6 +243,7 @@ impl<'a> MirEmitCtx<'a> {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             // The builtin table the parity gate already built into the
@@ -264,9 +274,18 @@ impl<'a> MirEmitCtx<'a> {
         self.borrowed_params.contains(name)
     }
 
+    fn is_loop_carried_param(&self, name: &str) -> bool {
+        self.loop_carried_params.contains(name)
+    }
+
     fn is_owned_param(&self, name: &str) -> bool {
         self.owned_params.contains(name)
     }
+}
+
+fn empty_string_set() -> &'static HashSet<String> {
+    static EMPTY: std::sync::OnceLock<HashSet<String>> = std::sync::OnceLock::new();
+    EMPTY.get_or_init(HashSet::new)
 }
 
 /// A shared empty `FnBareFacts` (all-`Boxed`) for the coverage / test /
@@ -3732,8 +3751,33 @@ fn emit_mir_self_tco_continue(
     passthrough: &std::collections::HashSet<usize>,
     ctx: &MirEmitCtx<'_>,
 ) -> Option<String> {
-    let mut arg_strs = Vec::with_capacity(args.len());
+    // An identity arg is not emitted at all: the loop keeps the current
+    // binding. That binding is nevertheless live into the next iteration.
+    // Make that hidden loop-edge liveness visible to the ordinary owning-
+    // position clone policy while rendering the other args. This matters
+    // when a later arg moves the same param into a helper call.
+    let identity: Vec<bool> = params
+        .iter()
+        .enumerate()
+        .map(|(i, (name, _))| {
+            passthrough.contains(&i)
+                || local_of(&args[i].node).is_some_and(|local| local.name == *name)
+        })
+        .collect();
+    let loop_carried_params: HashSet<String> = params
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| identity[*i])
+        .map(|(_, (name, _))| name.clone())
+        .collect();
+    let mut tail_ctx = *ctx;
+    tail_ctx.loop_carried_params = &loop_carried_params;
+
+    let mut arg_strs = vec![None; args.len()];
     for (i, a) in args.iter().enumerate() {
+        if identity[i] {
+            continue;
+        }
         // ETAP-2 SLICE 1: the rebind-value representation boundary is now
         // EXPLICIT — the `bare_i64_rewrite` pass already wrapped each
         // self-tail-call arg for the self-fn's i-th param representation
@@ -3745,37 +3789,25 @@ fn emit_mir_self_tco_continue(
         //   - boxed param: `emit_mir_expr` (lowering any `Box` node), then
         //     the clone policy.
         if ctx.bare.param_is_bare(i) {
-            let rendered = emit_bare_i64(a).or_else(|| emit_mir_expr(a, ctx));
-            arg_strs.push(rendered?);
+            let rendered = emit_bare_i64(a).or_else(|| emit_mir_expr(a, &tail_ctx));
+            arg_strs[i] = Some(rendered?);
         } else {
-            let code = emit_mir_expr(a, ctx)?;
-            arg_strs.push(mir_clone_arg(code, &a.node, ctx));
+            let code = emit_mir_expr(a, &tail_ctx)?;
+            arg_strs[i] = Some(mir_clone_arg(code, &a.node, &tail_ctx));
         }
-    }
-
-    // Which positions are actually rebound (non-passthrough, non-identity)?
-    let mut rebind: Vec<bool> = vec![false; params.len()];
-    for (i, (name, _)) in params.iter().enumerate() {
-        if passthrough.contains(&i) {
-            continue;
-        }
-        if arg_strs[i] == aver_name_to_rust(name) {
-            continue; // identity — no-op
-        }
-        rebind[i] = true;
     }
 
     let mut lines = Vec::new();
     lines.push("{".to_string());
     // Phase 1: snapshot ALL rebound args into temps (always-snapshot).
     for (i, arg_str) in arg_strs.iter().enumerate() {
-        if rebind[i] {
+        if let Some(arg_str) = arg_str {
             lines.push(format!("            let __tco{} = {};", i, arg_str));
         }
     }
     // Phase 2: assign temps back to params, in order.
     for (i, (name, _)) in params.iter().enumerate() {
-        if rebind[i] {
+        if arg_strs[i].is_some() {
             lines.push(format!(
                 "            {} = __tco{};",
                 aver_name_to_rust(name),
@@ -4223,6 +4255,16 @@ fn mir_expr_skip_clone(expr: &MirExpr, ctx: &MirEmitCtx<'_>) -> bool {
         Some(local) => {
             let name = local.name.as_str();
             if ctx.is_rc_wrapped(name) || ctx.is_borrowed_param(name) {
+                return false;
+            }
+            // A self-TCO identity arg is absent from the emitted Rust, so
+            // MIR's syntactic `last_use` does not include the next loop
+            // iteration. Preserve that hidden use only at owning positions;
+            // bare i64 and genuinely Copy params still need no clone.
+            if ctx.is_loop_carried_param(name)
+                && !ctx.is_copy(name)
+                && !ctx.bare.is_bare(local.slot)
+            {
                 return false;
             }
             local.last_use || ctx.is_copy(name)
@@ -5559,6 +5601,7 @@ mod tests {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins: BUILTINS.get_or_init(Vec::new),
@@ -6608,6 +6651,7 @@ mod tests {
             local_types: &policy.local_types,
             rc_wrapped: &policy.rc_wrapped,
             borrowed_params: &policy.borrowed_params,
+            loop_carried_params: empty_string_set(),
             owned_params: &policy.owned_params,
             current_module_scope: policy.current_module_scope.as_deref(),
             mir_builtins: BUILTINS.get_or_init(Vec::new),

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -105,9 +105,13 @@ fn format_output(output: &std::process::Output) -> String {
 /// process so the (slow) dependency compile amortises — the first
 /// example pays it, the rest are seconds.
 fn shared_target_dir() -> PathBuf {
-    repo_root()
-        .join("target")
-        .join("rust-codegen-differential-shared")
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            repo_root()
+                .join("target")
+                .join("rust-codegen-differential-shared")
+        })
 }
 
 fn binary_name(name: &str) -> String {
@@ -4524,6 +4528,88 @@ fn main() -> Unit
                 "borrowed-equality stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
             ));
         }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
+/// A self-TCO identity argument is elided from the Rust loop rather than
+/// evaluated. If a later tail-call argument moves that same non-Copy param
+/// into a helper, the value is still live on the hidden loop edge and must be
+/// cloned at that owning use. Pure identity pass-through itself stays
+/// clone-free.
+#[test]
+fn self_tco_clones_loop_carried_param_only_at_later_owning_use() {
+    let ws = temp_dir("self_tco_loop_carried_move");
+    let source = ws.join("main.av");
+    fs::write(
+        &source,
+        r#"module Repro
+    exposes [entriesFor]
+    intent =
+        "Tail-recursive accumulator that also passes a non-Copy parameter to a helper."
+    effects []
+
+fn entryFor(txid: String, index: Int) -> String
+    ? "Build one entry from the shared id and the position."
+    "{txid}:{index}"
+
+fn entriesFor(txid: String, items: List<Int>, index: Int, acc: List<String>) -> List<String>
+    ? "Walk the items, using txid in every entry and again in the tail call."
+    match items
+        [] -> List.reverse(acc)
+        [head, ..tail] -> entriesFor(txid, tail, index + 1, List.prepend(entryFor(txid, index), acc))
+
+verify entriesFor
+    entriesFor("ab", [7, 8], 0, []) => ["ab:0", "ab:1"]
+"#,
+    )
+    .expect("write self-TCO moved-value probe source");
+
+    let verify = Command::new(aver_bin())
+        .current_dir(repo_root())
+        .arg("verify")
+        .arg(&source)
+        .output()
+        .expect("expected `aver verify` to execute");
+    assert!(
+        verify.status.success(),
+        "VM verify failed:\n{}",
+        format_output(&verify)
+    );
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(&source, &project, "self_tco_loop_carried_move", None, &[])?;
+
+        // Load-bearing assertion: before the fix this build failed E0382 on
+        // the second loop iteration. Build before checking source shape so
+        // the test proves the emitted project passes rustc's ownership gate.
+        let _bin = cargo_build(&project, "self_tco_loop_carried_move")?;
+
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("entryFor(txid.clone(), index)") {
+            return Err(format!(
+                "the later owning helper call did not clone loop-carried txid:\n{emitted}"
+            ));
+        }
+        if emitted.contains("let __tco0 = txid.clone()") {
+            return Err(format!(
+                "identity pass-through was cloned instead of the actual owning use:\n{emitted}"
+            ));
+        }
+
+        cargo_test_in(&project, &shared_target_dir())?;
         Ok(())
     })();
 

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -4617,6 +4617,91 @@ verify entriesFor
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// A mutual-TCO invariant is removed from the state enum and passed to the
+/// trampoline as `&T`. Equality must still recognize that Rust representation
+/// and borrow the computed owned operand, just as it does for an ordinary
+/// borrow-by-default parameter.
+#[test]
+fn mutual_tco_aligns_owned_equality_with_borrowed_invariant() {
+    let ws = temp_dir("mutual_tco_borrowed_equality");
+    let source = ws.join("main.av");
+    fs::write(
+        &source,
+        r#"module Repro
+    exposes [without, kept]
+    intent = "Mutual tail recursion compares an owned temporary with a shared invariant."
+    effects []
+
+fn without(items: List<List<Int>>, target: List<Int>, acc: List<List<Int>>) -> List<List<Int>>
+    ? "Walk the outer list, handing each element to the partner."
+    match items
+        [] -> List.reverse(acc)
+        [head, ..tail] -> kept(head, tail, target, acc)
+
+fn kept(item: List<Int>, rest: List<List<Int>>, target: List<Int>, acc: List<List<Int>>) -> List<List<Int>>
+    ? "Compare an owned reversed item with the invariant target."
+    match List.reverse(item) == target
+        true -> without(rest, target, acc)
+        false -> without(rest, target, List.prepend(item, acc))
+
+verify without
+    without([[1], [2]], [1], []) => [[2]]
+
+verify kept
+    kept([1], [], [1], []) => []
+"#,
+    )
+    .expect("write mutual-TCO borrowed-equality probe source");
+
+    let verify = Command::new(aver_bin())
+        .current_dir(repo_root())
+        .arg("verify")
+        .arg(&source)
+        .output()
+        .expect("expected `aver verify` to execute");
+    assert!(
+        verify.status.success(),
+        "VM verify failed:\n{}",
+        format_output(&verify)
+    );
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(&source, &project, "mutual_tco_borrowed_equality", None, &[])?;
+
+        // Load-bearing assertion: before the fix this build failed E0308
+        // because `item.reverse()` was owned while `target` was `&T`.
+        let _bin = cargo_build(&project, "mutual_tco_borrowed_equality")?;
+
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("enum __MutualTco") || !emitted.contains("fn __mutual_tco_trampoline_")
+        {
+            return Err(format!(
+                "probe did not exercise the mutual-TCO trampoline:\n{emitted}"
+            ));
+        }
+        if !emitted.contains("&(item.reverse()) == target") {
+            return Err(format!(
+                "owned comparison operand was not aligned with borrowed invariant target:\n{emitted}"
+            ));
+        }
+
+        cargo_test_in(&project, &shared_target_dir())?;
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 /// Second half of #1037: the same owned-versus-borrowed comparison as the
 /// subject of a boolean `match`, which the Rust backend lowers to an `if`
 /// through its own comparison emitter. That path skipped the borrow


### PR DESCRIPTION
Fixes #1105. Two shapes, two separate causes, both reported against 9d4131de by n1bor/btc-listener, whose sources had not changed since the previous pin.

Regression introduced by cedafe0b (#1098, the resolved-IR migration), found by bisect with an independent rebuild of the good and bad commits rather than by reading the diff.

## Shape 1 — a loop-carried parameter was moved

```aver
fn entriesFor(txid: String, items: List<Int>, index: Int, acc: List<String>) -> List<String>
    match items
        [] -> List.reverse(acc)
        [head, ..tail] -> entriesFor(txid, tail, index + 1, List.prepend(entryFor(txid, index), acc))
```

Resolved pass-through detection elided the identity TCO argument for `txid`, so the last-use analysis let the helper call move it — not seeing the use hidden in the next lap of the loop. `error[E0382]: use of moved value`.

Loop-carried parameters are now tracked per tail call, and the existing ownership policy clones only at genuine owning uses. Identity pass-through, borrows and `Copy` values stay clone-free — a blanket clone here would be a silent performance regression on a hot path.

## Shape 2 — a mutual trampoline compared an owned temporary to a borrowed invariant

```aver
fn kept(item: List<Int>, rest: List<List<Int>>, target: List<Int>, acc: List<List<Int>>) -> …
    match List.reverse(item) == target
```

`error[E0308]: expected AverIntList, found &AverIntList`.

Worth recording, because it is the more interesting half: this is the **same class as #1037, #1060 and #1065, and it bypassed their fix entirely**. Mutual TCO does reach `mir_emit_equality`, but a trampoline's hoisted invariants live only in `rc_wrapped`, while the alignment logic added by those tickets consulted `borrowed_params` alone. Their tests covered ordinary borrowed parameters, never a mutual trampoline, so the gap was invisible.

Mutual trampoline contexts now classify `rc_wrapped` invariants as borrowed references for equality emission. The existing alignment then emits `&(item.reverse()) == target` — no allocation, no clone. Self-TCO's `Arc<T>` representation is untouched.

## Tests

Two regression tests in `tests/rust_codegen_differential.rs`, each red before its fix and green after. Both go further than asserting emitted text: they build the generated project and run its verify cases. The mutual test requires a `__MutualTco` trampoline in the output, because a self-recursive case never reaches that path — which is exactly how the earlier tickets missed this.

`cargo fmt --all -- --check`, `cargo clippy` and `cargo test --test rust_codegen_differential` (56 passed) all pass. Both reproducers from the issue compile and build end to end; verified independently of the implementer's report.