### PR TITLE
Allow capability ADTs to carry local resources

### DIFF
--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -60,19 +60,18 @@ impl TypeChecker {
                 }
             }
         }
+        // Capability resources may be carried by represented types declared
+        // in the same module. Their nominal identities already exist in the
+        // symbol table, but the bare local aliases must be installed before
+        // constructor fields are canonicalized below. Consumer modules did
+        // not expose this ordering bug because they receive the resource
+        // identity while their dependency registry is integrated.
+        self.register_capability_sigs();
         for item in items {
             if let TopLevel::TypeDef(td) = item {
                 self.register_type_def_sigs(td, &module_name);
             }
         }
-        // Capability resources participate in ordinary function signatures:
-        // hostile profiles for a resource-minting operation receive the fresh
-        // resource as an explicit oracle parameter.  Register their nominal
-        // identities before walking FnDefs, otherwise a perfectly valid local
-        // profile such as `fn accept(..., fresh: Token)` is diagnosed as using
-        // an unknown type merely because operation signatures used to be
-        // installed last.
-        self.register_capability_sigs();
         for item in items {
             if let TopLevel::FnDef(f) = item {
                 let mut params = Vec::new();

--- a/tests/capability_grammar_spec.rs
+++ b/tests/capability_grammar_spec.rs
@@ -576,6 +576,37 @@ fn tick() -> Int
 }
 
 #[test]
+fn capability_types_may_carry_their_own_resource() {
+    let dir = temp_dir("local-resource-carriers");
+    fs::write(
+        dir.join("Sock.av"),
+        "\
+module Sock
+    kind = capability
+    semantics = effectful
+    exposes [Slot, Socket, Stored]
+    effects []
+
+resource Slot
+
+type Socket
+    Listening(Slot)
+    Open(Slot)
+
+record Stored
+    slot: Slot
+",
+    )
+    .expect("write Sock.av");
+
+    let (code, text) = run("check", &dir, "Sock.av");
+    assert_eq!(
+        code, 0,
+        "a capability's own sum types and records must be able to carry its resource:\n{text}"
+    );
+}
+
+#[test]
 fn capability_effects_require_operation_granularity() {
     let dir = temp_dir("effect-shorthand");
     fs::write(dir.join("Clock.av"), VALID_EFFECT_CAPABILITY).expect("write Clock.av");


### PR DESCRIPTION
## Summary

- make local capability resources nameable before constructor fields are canonicalized
- allow sum types and records declared inside a capability to carry that capability's own resources
- cover both carrier shapes with a CLI-level regression test

## Why

Consumer modules could already define ADTs carrying a dependency resource such as `Tcp.Connection`, but the capability that declared a resource could not use it in its own ADT. The symbol table already contained the nominal resource identity; the checker installed its bare local alias after processing type definitions.

This is a narrow prerequisite for modeling the pollable TCP state as a capability-owned sum type:

```aver
type Socket
    Listening(Listener)
    Dialing(Dial)
    Open(Connection)
```

Prerequisite for #1125 and #1131.

## Validation

- `cargo test --test capability_grammar_spec` — 30 passed
- `cargo test --test typechecker_spec` — 304 passed
- `cargo fmt --all`
- `git diff --check`
