### PR TITLE
Deploy edge releases to the production domain

### DIFF
--- a/tools/edge/dist/wrangler.toml
+++ b/tools/edge/dist/wrangler.toml
@@ -1,13 +1,16 @@
-# tools/edge-gc — Cloudflare Workers config for the wasm-gc PoC.
+# tools/edge — production Cloudflare Workers config for the wasm-gc demo.
 # `worker.js` ESM-imports `./handler.wasm`; the wasm module exports
 # `handle(query: String) -> String` plus the `__rt_string_*` /
 # `__rt_memory_*` LM bridge described in worker.js. Wasm-gc + tail
 # calls are stable on workerd's V8 build, so no compat flags are
 # needed beyond the recent compatibility_date.
 
-name = "aver-edge-gc-demo"
+name = "aver-edge-demo"
 main = "worker.js"
 compatibility_date = "2025-01-01"
+workers_dev = false
+preview_urls = false
+routes = [{ pattern = "edge.averlang.dev", custom_domain = true }]
 
 [observability]
 [observability.logs]

--- a/tools/release.py
+++ b/tools/release.py
@@ -1815,11 +1815,9 @@ def deploy_edge(dry_run: bool) -> None:
         check=True,
     )
 
-    # Smoke. Endpoint URL comes from wrangler's deploy output, but for the
-    # canonical demo it's the production hostname workers.dev assigns.
-    # Hard-coded here matches what the worker.js / wrangler.toml shipped
-    # in `tools/edge/dist/` declare.
-    base = "https://aver-edge-gc-demo.jasisz.workers.dev"
+    # Smoke the public production domain declared by the shipped Wrangler
+    # configuration. The workers.dev and preview routes stay disabled.
+    base = "https://edge.averlang.dev"
     for path in ("/", "/api", "/fractal"):
         url = base + path
         with urllib.request.urlopen(url, timeout=10) as resp:


### PR DESCRIPTION
Summary:
- target the aver-edge-demo production Worker
- bind only edge.averlang.dev and disable workers.dev/preview URLs
- smoke the production domain from the release helper

Validation:
- Wrangler 4.126 dry-run passed
- production deploy version 383a26fe-5e43-473b-accf-620de05df0ef
- /, /api, and /fractal returned HTTP 200
- aver-edge-demo.jasisz.workers.dev returned HTTP 404
- tools/release.py passed py_compile