### PR TITLE
Keep certificate Result prelude attribute-free

### DIFF
--- a/src/codegen/lean/prelude.rs
+++ b/src/codegen/lean/prelude.rs
@@ -106,11 +106,16 @@ const LEAN_PRELUDE_EXCEPT_DEC_EQ: &str = r#"instance [DecidableEq ε] [Decidable
   | .ok _, .error _ => isFalse (by intro h; cases h)
   | .error _, .ok _ => isFalse (by intro h; cases h)"#;
 
-// Keep `proven_ok` untagged. `AverCommon.lean` is certificate DATA and the
-// verifier correctly rejects elaboration-active attributes (`@[...]`) there.
-// Result-discharge tactics name `Except.proven` explicitly in their simp set,
-// so reducing the successful branch does not rely on a global simp attribute.
-const LEAN_PRELUDE_EXCEPT_NS: &str = r#"namespace Except
+/// The shared Result-discharge model, with one deliberate mode difference.
+/// Standalone proof export needs `proven_ok` in the global simp set for laws
+/// whose Oracle reduction exposes an `Except.proven (Except.ok ...)` only
+/// after simplifying the caller. Certificate model files are untrusted DATA,
+/// so the verifier correctly rejects elaboration-active attributes (`@[...]`)
+/// there; its generated tactics name `Except.proven` explicitly instead.
+fn generate_except_namespace_prelude(cert_model: bool) -> String {
+    let proven_ok_attribute = if cert_model { "" } else { "@[simp] " };
+    format!(
+        r#"namespace Except
 def withDefault (r : Except ε α) (d : α) : α :=
   match r with
   | .ok v => v
@@ -126,9 +131,11 @@ noncomputable def proven [Nonempty α] (r : Except ε α) : α :=
   | .ok v => v
   | .error _ => Classical.choice (inferInstance : Nonempty α)
 
-theorem proven_ok [Nonempty α] (v : α) :
+{proven_ok_attribute}theorem proven_ok [Nonempty α] (v : α) :
     proven (Except.ok v : Except ε α) = v := rfl
-end Except"#;
+end Except"#
+    )
+}
 
 const LEAN_PRELUDE_OPTION_TO_EXCEPT: &str = r#"def Option.toExcept (o : Option α) (e : ε) : Except ε α :=
   match o with
@@ -1225,7 +1232,7 @@ fn generate_prelude_for_body(body: &str, include_all_helpers: bool) -> String {
             ]),
             "ExceptInstances" => parts.extend([
                 LEAN_PRELUDE_EXCEPT_DEC_EQ.to_string(),
-                LEAN_PRELUDE_EXCEPT_NS.to_string(),
+                generate_except_namespace_prelude(false),
                 LEAN_PRELUDE_OPTION_TO_EXCEPT.to_string(),
             ]),
             "StringHadd" => parts.push(generate_string_hadd_prelude(body, include_all_helpers)),
@@ -1460,7 +1467,7 @@ pub(super) fn build_common_lean(union_body: &str, cert_model: bool) -> String {
             ]),
             "ExceptInstances" => parts.extend([
                 LEAN_PRELUDE_EXCEPT_DEC_EQ.to_string(),
-                LEAN_PRELUDE_EXCEPT_NS.to_string(),
+                generate_except_namespace_prelude(cert_model),
                 LEAN_PRELUDE_OPTION_TO_EXCEPT.to_string(),
             ]),
             "StringHadd" => parts.push(generate_string_hadd_prelude(union_body, false)),

--- a/src/codegen/lean/prelude.rs
+++ b/src/codegen/lean/prelude.rs
@@ -106,6 +106,10 @@ const LEAN_PRELUDE_EXCEPT_DEC_EQ: &str = r#"instance [DecidableEq ε] [Decidable
   | .ok _, .error _ => isFalse (by intro h; cases h)
   | .error _, .ok _ => isFalse (by intro h; cases h)"#;
 
+// Keep `proven_ok` untagged. `AverCommon.lean` is certificate DATA and the
+// verifier correctly rejects elaboration-active attributes (`@[...]`) there.
+// Result-discharge tactics name `Except.proven` explicitly in their simp set,
+// so reducing the successful branch does not rely on a global simp attribute.
 const LEAN_PRELUDE_EXCEPT_NS: &str = r#"namespace Except
 def withDefault (r : Except ε α) (d : α) : α :=
   match r with
@@ -122,7 +126,7 @@ noncomputable def proven [Nonempty α] (r : Except ε α) : α :=
   | .ok v => v
   | .error _ => Classical.choice (inferInstance : Nonempty α)
 
-@[simp] theorem proven_ok [Nonempty α] (v : α) :
+theorem proven_ok [Nonempty α] (v : α) :
     proven (Except.ok v : Except ε α) = v := rfl
 end Except"#;
 

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     VerifyEmitMode, generate_prelude, proof_mode_issues, recurrence, transpile,
-    transpile_for_proof_mode, transpile_with_verify_mode,
+    transpile_for_cert_model, transpile_for_proof_mode, transpile_with_verify_mode,
 };
 use crate::ast::{
     BinOp, Expr, FnBody, FnDef, Literal, MatchArm, Pattern, Spanned, Stmt, TailCallData, TopLevel,
@@ -208,6 +208,32 @@ fn nestedArg(n: Int, d: Int) -> Result<Int, String>
         lean.contains("| .ok q =>")
             && lean.contains("| .error __qm_err_0 => Except.error __qm_err_0"),
         "statement-level `?` lowering must retain its short-circuiting match:\n{lean}"
+    );
+}
+
+#[test]
+fn cert_result_discharge_prelude_has_no_elaboration_active_attribute() {
+    let mut ctx = ctx_from_source(
+        r#"
+module CertDischarge
+    effects []
+
+fn checkedHalf(n: Int) -> Result<Int, String>
+    Result.Ok(Int.div(n, 2))
+"#,
+        "CertDischarge",
+    );
+    let out = transpile_for_cert_model(&mut ctx);
+    let common = out
+        .files
+        .iter()
+        .find_map(|(name, content)| (name == "AverCommon.lean").then_some(content))
+        .expect("certificate model should emit AverCommon.lean");
+
+    assert!(common.contains("theorem proven_ok"), "{common}");
+    assert!(
+        !common.contains("@["),
+        "certificate DATA must stay free of elaboration-active attributes:\n{common}"
     );
 }
 

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -212,17 +212,27 @@ fn nestedArg(n: Int, d: Int) -> Result<Int, String>
 }
 
 #[test]
-fn cert_result_discharge_prelude_has_no_elaboration_active_attribute() {
-    let mut ctx = ctx_from_source(
-        r#"
+fn result_discharge_prelude_keeps_proof_simp_but_cert_data_attribute_free() {
+    let source = r#"
 module CertDischarge
     effects []
 
 fn checkedHalf(n: Int) -> Result<Int, String>
     Result.Ok(Int.div(n, 2))
-"#,
-        "CertDischarge",
+"#;
+    let mut proof_ctx = ctx_from_source(source, "CertDischarge");
+    let proof_out = transpile_for_proof_mode(&mut proof_ctx, VerifyEmitMode::NativeDecide);
+    let proof_common = proof_out
+        .files
+        .iter()
+        .find_map(|(name, content)| (name == "AverCommon.lean").then_some(content))
+        .expect("proof export should emit AverCommon.lean");
+    assert!(
+        proof_common.contains("@[simp] theorem proven_ok"),
+        "standalone proof reduction needs the simp attribute:\n{proof_common}"
     );
+
+    let mut ctx = ctx_from_source(source, "CertDischarge");
     let out = transpile_for_cert_model(&mut ctx);
     let common = out
         .files


### PR DESCRIPTION
## Summary

- keep the fail-closed Except.proven model and its proven_ok theorem
- retain @[simp] for standalone proof export, where caller reduction can expose the proven Ok branch only after simplification
- omit that elaboration-active attribute only from certificate DATA
- pin both modes with a regression test

## Why

PR #1109 added @[simp] to the shared Result-discharge prelude. Certificate models reuse that prelude, while the verifier correctly rejects elaboration-active attributes in untrusted Lean DATA. The scheduled cert_verify_spec rest-7/8 lane therefore declined AverCommon.lean before checking the artifact.

Removing the attribute globally was also wrong: it left rollOnce.usesOracle open in ordinary Proof Export. The prelude generator now makes the distinction explicit: proof mode keeps the simp theorem, while cert mode emits the same theorem untagged and continues to use explicit discharge tactics.

## Verification

- cargo test -p aver-lang --test proof_spec proof_export_builds_oracle_trace_when_lake_is_available -- --nocapture
- cargo test -p aver-lang --features wasm --test cert_verify_spec cert_verify_accepts_refined_argument_sum_carrying_model -- --nocapture
- cargo test -p aver-lang --test proof_spec discharged -- --nocapture
- cargo test -p aver-lang --lib result_discharge_prelude_keeps_proof_simp_but_cert_data_attribute_free
- cargo fmt -- --check
- git diff --check