### PR TITLE
perf(rust): reuse packed byte refinements in O(1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 - **Maps have one deterministic order on every backend.** Iteration is sorted by key, `keys[i]` pairs with `values[i]`, and equality uses the same canonical form in execution and proof. Map keys must have a modelled total order; `Float` keys are rejected instead of giving NaN or proof-model divergences.
 
-- **The VM and generated Rust avoid several formerly quadratic paths.** List traversal and `List.drop`, string/codepoint scans, list/string/byte builders, map construction and folding, immutable collection relocation, large append-only stores, and generated-Rust accumulator returns now preserve sharing or ownership instead of repeatedly rebuilding live data. The embedded wasm engine separately moves to wasmtime 46's copying collector.
+- **The VM and generated Rust avoid several formerly quadratic paths.** List traversal and `List.drop`, string/codepoint scans, list/string/byte builders, map construction and folding, immutable collection relocation, large append-only stores, generated-Rust accumulator returns, and already-packed byte refinements now preserve sharing or ownership instead of repeatedly rebuilding or revalidating live data. The embedded wasm engine separately moves to wasmtime 46's copying collector.
 
 - **Generated projects pin the compiler's actual source provenance.** Path builds emit path dependencies, git builds pin the repository and revision, and registry builds emit exact registry versions for both `aver-lang` and `aver-rt`.
 

--- a/aver-rt/src/int_list.rs
+++ b/aver-rt/src/int_list.rs
@@ -62,6 +62,21 @@ impl AverIntList {
         Self::Packed(values)
     }
 
+    /// Borrow the compact carrier when this list already has one.
+    ///
+    /// A `Packed` value proves every element is in `0..=255` by
+    /// construction. Rust smart constructors can therefore clone the
+    /// immutable carrier in O(1) instead of walking it to establish the same
+    /// fact again. `Wide` deliberately returns `None`: its elements still
+    /// require ordinary validation.
+    #[inline]
+    pub fn as_packed(&self) -> Option<&AverPackedU8> {
+        match self {
+            Self::Packed(values) => Some(values),
+            Self::Wide(_) => None,
+        }
+    }
+
     pub fn len(&self) -> usize {
         match self {
             Self::Packed(values) => values.len(),
@@ -302,6 +317,21 @@ mod tests {
             values.drop_first(1).take_first(2).aver_display(),
             "[1, 127]"
         );
+    }
+
+    #[test]
+    fn packed_access_reuses_the_backing_storage() {
+        let values = AverIntList::from_vec(
+            [0, 1, 127, 255]
+                .into_iter()
+                .map(AverInt::from_i64)
+                .collect(),
+        );
+        let packed = values.as_packed().expect("byte values should be packed");
+        let reused = packed.clone();
+
+        assert_eq!(packed.as_slice().as_ptr(), reused.as_slice().as_ptr());
+        assert_eq!(packed.as_slice(), reused.as_slice());
     }
 
     #[test]

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -3454,6 +3454,7 @@ pub(super) fn emit_mir_fn_body_routed(
     resolved: &crate::ir::hir::ResolvedFnDef,
     scope: Option<&str>,
     borrow_by_default: bool,
+    post_checkpoint_prologue: Option<&str>,
     ctx: &CodegenContext,
 ) -> Option<String> {
     let mut policy = MirFnEmitPolicy::from_resolved(resolved, scope, borrow_by_default);
@@ -3469,7 +3470,17 @@ pub(super) fn emit_mir_fn_body_routed(
     // return are bare.
     policy.apply_bare_i64(mir_fn.fn_id, ctx);
     let emit_ctx = MirEmitCtx::for_fn(ctx, &policy);
-    emit_mir_fn_body(&mir_fn.body, &emit_ctx)
+    let body = emit_mir_fn_body(&mir_fn.body, &emit_ctx)?;
+    let Some(prologue) = post_checkpoint_prologue else {
+        return Some(body);
+    };
+
+    // `emit_mir_fn_body` owns this prefix as part of its documented output
+    // contract. Keep backend-specific representation fast paths after the
+    // cooperative cancellation point but before any source-level work.
+    const CHECKPOINT: &str = "    crate::cancel_checkpoint();\n";
+    let tail = body.strip_prefix(CHECKPOINT)?;
+    Some(format!("{CHECKPOINT}{prologue}\n{tail}"))
 }
 
 /// Is the type stamp a primitive numeric?

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -865,6 +865,8 @@ fn emit_fn_def_with_visibility(
             "{}fn {}({}) -> {} {{",
             visibility, fn_name, params, ret_type
         ));
+        let packed_refinement_prologue =
+            packed_refinement_constructor_prologue(resolved_fd, ctx, scope);
         let body = mir_fn
             .and_then(|mir_fn| {
                 super::from_mir::emit_mir_fn_body_routed(
@@ -872,6 +874,7 @@ fn emit_fn_def_with_visibility(
                     resolved_fd,
                     scope,
                     /* borrow_by_default */ true,
+                    packed_refinement_prologue.as_deref(),
                     ctx,
                 )
             })
@@ -891,6 +894,64 @@ fn emit_fn_def_with_visibility(
     }
 
     lines.join("\n")
+}
+
+/// Emit the Rust-only O(1) arm of a full-octet refinement constructor.
+///
+/// `AverIntList::Packed` is a backend representation fact, not an Aver or MIR
+/// fact, so this optimization belongs here. A packed list proves exactly the
+/// interval `0..=255`: narrower U8 refinements must still validate. The
+/// `Wide` arm falls through to the unchanged MIR body and therefore keeps the
+/// smart constructor's exact first-offender diagnostics.
+fn packed_refinement_constructor_prologue(
+    resolved_fd: &crate::ir::hir::ResolvedFnDef,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> Option<String> {
+    // backend-link-stage: `scope` is the linked owner paired with the typed
+    // `FnId`, so this selects only that module's candidate records.
+    let type_defs = if let Some(prefix) = scope {
+        &ctx.modules
+            .iter()
+            .find(|module| module.prefix == prefix)?
+            .type_defs
+    } else {
+        &ctx.type_defs
+    };
+    let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
+    let full_octet_interval = crate::ir::interval::Interval::between(0, 255);
+
+    for type_def in type_defs {
+        let type_name = crate::codegen::common::type_def_name(type_def);
+        let Some(layout) = ctx.packed_sequence_layouts.get(type_name) else {
+            continue;
+        };
+        if layout.element != crate::codegen::proof_lower::PackedIntElement::U8
+            || layout.element_interval != full_octet_interval
+        {
+            continue;
+        }
+        let Some(info) =
+            crate::codegen::common::refinement_info_for_in_scope(type_name, &inputs, scope)
+        else {
+            continue;
+        };
+        let constructor_key = match scope {
+            Some(prefix) => crate::ir::FnKey::in_module(prefix.to_string(), info.constructor_fn),
+            None => crate::ir::FnKey::entry(info.constructor_fn),
+        };
+        if ctx.symbol_table.fn_id_of(&constructor_key) != Some(resolved_fd.fn_id) {
+            continue;
+        }
+
+        let parameter = aver_name_to_rust(info.param_name);
+        let record = aver_name_to_rust(type_name);
+        let field = aver_name_to_rust(info.carrier_field);
+        return Some(format!(
+            "    if let Some(__packed) = {parameter}.as_packed() {{\n        return Ok({record} {{ {field}: __packed.clone() }});\n    }}"
+        ));
+    }
+    None
 }
 
 /// Emit the non-TCO param signature, graduating `own_param`-proven

--- a/src/self_host/aver_generated/bytes/mod.rs
+++ b/src/self_host/aver_generated/bytes/mod.rs
@@ -139,6 +139,11 @@ pub fn firstOutOfRangeIndex(xs: &aver_rt::AverIntList) -> aver_rt::AverInt {
 #[inline(always)]
 pub fn fromList(xs: &aver_rt::AverIntList) -> Result<Bytes, AverStr> {
     crate::cancel_checkpoint();
+    if let Some(__packed) = xs.as_packed() {
+        return Ok(Bytes {
+            values: __packed.clone(),
+        });
+    }
     if crate::aver_generated::bytes::allInRange(xs.clone()) {
         Ok(crate::aver_generated::bytes::Bytes {
             values: aver_rt::into_packed_u8(xs.clone())

--- a/tests/fixtures/rust_packed_octets.av
+++ b/tests/fixtures/rust_packed_octets.av
@@ -20,12 +20,31 @@ fn fromList(xs: List<Int>) -> Result<Octets, String>
 fn toList(value: Octets) -> List<Int>
     value.values
 
+record SevenBit
+    values: List<Int>
+
+fn allSevenBit(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 127)
+            true -> allSevenBit(tail)
+            false -> false
+
+fn fromSevenBit(xs: List<Int>) -> Result<SevenBit, String>
+    match allSevenBit(xs)
+        true -> Result.Ok(SevenBit(values = xs))
+        false -> Result.Err("outside seven-bit range")
+
 fn wideListRoundTrip(values: List<Int>) -> List<Int>
     List.concat(List.drop(List.prepend(-1, values), 1), [256])
 
 verify fromList
     fromList([0, 127, 255]) => Octets(values = [0, 127, 255])
     fromList([256]) => Result.Err("oob")
+
+verify fromSevenBit
+    fromSevenBit([0, 127]) => SevenBit(values = [0, 127])
+    fromSevenBit([255]) => Result.Err("outside seven-bit range")
 
 verify wideListRoundTrip
     wideListRoundTrip([1, 2]) => [1, 2, 256]

--- a/tests/fixtures/stdlib_bytes_app.av
+++ b/tests/fixtures/stdlib_bytes_app.av
@@ -67,7 +67,9 @@ fn checkedChecksum(values: List<Int>) -> Result<Int, String>
 
 verify roundTrip
     roundTrip([0, 127, 255]) => Result.Ok([0, 127, 255])
+    roundTrip(List.drop(List.prepend(-1, [0, 127, 255]), 1)) => Result.Ok([0, 127, 255])
     roundTrip([0, 256]) => Result.Err("byte 256 at index 1 is outside 0..=255")
+    roundTrip([0, 300, 256]) => Result.Err("byte 300 at index 1 is outside 0..=255")
 
 verify hexRoundTrip
     hexRoundTrip("00aF") => Result.Ok("00af")

--- a/tests/rust_codegen_regression.rs
+++ b/tests/rust_codegen_regression.rs
@@ -203,6 +203,16 @@ fn rust_codegen_builds_embedded_bytes_crypto_fixture() {
         bytes_module.contains("pub values: aver_rt::AverPackedU8"),
         "stdlib Bytes should earn proof-derived U8 storage"
     );
+    let packed_fast_path = bytes_module
+        .find("if let Some(__packed) = xs.as_packed()")
+        .expect("Bytes.fromList should recognize an already-packed Rust carrier");
+    let range_walk = bytes_module
+        .find("allInRange(xs.clone())")
+        .expect("Bytes.fromList should retain validation for a Wide carrier");
+    assert!(
+        packed_fast_path < range_walk,
+        "the O(1) packed return must precede the source-level validation walk"
+    );
     let entry_module = fs::read_to_string(project_dir.join("src/aver_generated/entry/mod.rs"))
         .expect("read generated crypto entry module");
     assert!(
@@ -270,6 +280,11 @@ fn rust_codegen_uses_proof_derived_u8_storage_for_generic_refinement() {
     assert!(
         generated.contains(".to_int_list()"),
         "the semantic List<Int> projection should remain a zero-copy hybrid view"
+    );
+    assert_eq!(
+        generated.matches(".as_packed()").count(),
+        1,
+        "the full 0..=255 refinement should reuse Packed, while the narrower seven-bit refinement must still validate:\n{generated}"
     );
 
     let tests = Command::new("cargo")


### PR DESCRIPTION
## Outcome

Generated Rust now returns an already-packed full-octet refinement in O(1). `Bytes.fromList` no longer walks an `AverIntList::Packed` value to prove a fact guaranteed by its `u8` carrier.

The optimization is proof-derived rather than hard-coded to `Bytes`: it applies only to recognized smart constructors whose packed layout proves the exact interval `0..=255`. Narrower U8-backed refinements such as `0..=127` still run their own predicate because the carrier alone does not prove that narrower bound.

`Wide` values fall through to the unchanged MIR body, preserving successful packing and the exact first-invalid-byte/index diagnostic.

## Measurement

Same reproduction as #1148: Apple M-series, release + LTO, 20 Blocks of 1,507,304 bytes, two full-payload `Bytes.fromList` calls per Block.

| emission | median | s / GB |
|---|---:|---:|
| old full path | 487 ms | 16.2 |
| new full path | 84 ms | 2.8 |
| manually lean path | 84 ms | 2.8 |

The new full path and the manually stripped control are indistinguishable at this resolution.

## Backend and refinement audit

- Rust has the relevant runtime theorem: `AverIntList::Packed` contains only `u8` and cloning its Arc-backed carrier is O(1).
- VM uses an ordinary value list and has no Packed/Wide carrier fact at the constructor boundary.
- wasm-gc stores nominal byte refinements in packed arrays, but `Bytes.octets` currently materializes an ordinary `List<Int>` cons chain before a later constructor sees it. Preserving that provenance through `concat` / `take` / `drop` is tracked separately in #1149; an unconditional MIR rewrite would be unsound for arbitrary `List<Int>`.
- `Digest32.fromBytes` must still check length 32; the byte carrier does not prove length.
- Other exact full-octet refinements get this fast path generically. A regression fixture proves that narrower U8 refinements do not.

## Verification

- `cargo test -p aver-lang --test rust_codegen_regression --features runtime`
- `cargo test -p aver-lang --test identity_guardrails --features runtime`
- `cargo test -p aver-lang --test stdlib_spec --features runtime`
- `cargo test -p aver-rt`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1148