### PR TITLE
fix(rust): disambiguate let binders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 - **Proof export is substantially harder to make green for the wrong reason.** Fixes cover nested effect evaluation order, refused-claim accounting, defaults introduced by `?`, opaque capability resources, mutual-recursion measures and fuel, method applications in argument position, map-order observations through callbacks/tail calls/interpolation, and symbolic provider calls hidden behind transparent wrappers.
 
-- **Module and type identity no longer depends on load order or bare-name collisions.** Lean, Dafny, generated Rust, wasm-gc constructor patterns, equality/hash derivation, and diagnostics retain the declaration's owning module through resolution and rendering.
+- **Module and type identity no longer depends on load order or bare-name collisions.** Lean, Dafny, generated Rust, wasm-gc constructor patterns, equality/hash derivation, and diagnostics retain the declaration's owning module through resolution and rendering. Generated Rust also keeps local `let` bindings unambiguous when multiple dependencies expose functions with the same name.
 
 - **Cross-backend runtime behaviour is aligned.** wasm-gc maps grow and delete colliding keys correctly; generated Rust preserves borrows, evaluates policy-checked effect arguments once, and agrees on negative `List.take/drop`; `Http.head`, 204, and 304 responses accept an empty body; `Args.get` and browser `Http.*` calls appear in verify traces.
 

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -22,12 +22,13 @@ pub(super) use super::syntax::{has_list_patterns, has_string_literal_patterns};
 
 /// Render an identifier in a Rust pattern as an explicit binding.
 ///
-/// A bare identifier in a pattern is also eligible for item resolution. When
-/// two dependency glob imports expose the same function name, rustc reports
-/// `Ok(name)` as ambiguous instead of treating `name` as the local binder that
-/// Aver declares. `name @ _` is semantically identical and syntactically
-/// unambiguous, while keeping all body references under the original name.
-fn explicit_binding_pattern(name: &str) -> String {
+/// A bare identifier in any pattern is also eligible for item resolution.
+/// When two dependency glob imports expose the same function name, rustc can
+/// report either `Ok(name)` or `let name = value` as ambiguous instead of
+/// treating `name` as the local binder that Aver declares. `name @ _` is
+/// semantically identical and syntactically unambiguous, while keeping all
+/// body references under the original name.
+pub(super) fn explicit_binding_pattern(name: &str) -> String {
     format!("{} @ _", aver_name_to_rust(name))
 }
 

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -66,8 +66,8 @@ use super::emit_ctx::{is_copy_type, should_borrow_param};
 use super::expr::{
     callee_borrow_mask, constructor_boxed_positions, emit_dispatch_table_match, emit_list_match,
     emit_literal, emit_parallel_result_tuple_unwrap, emit_pattern_rebindings,
-    emit_ref_match_rebindings, emit_result_tuple_unwrap, emit_tuple_from_vars, has_list_patterns,
-    has_string_literal_patterns,
+    emit_ref_match_rebindings, emit_result_tuple_unwrap, emit_tuple_from_vars,
+    explicit_binding_pattern, has_list_patterns, has_string_literal_patterns,
 };
 use super::pattern::emit_pattern;
 use super::syntax::aver_name_to_rust;
@@ -1414,7 +1414,7 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
         }
         MirExpr::Let(spanned_let) => {
             // `let binding = value; body` →
-            // Rust block-expression `{ let x = value; body }`.
+            // Rust block-expression `{ let x @ _ = value; body }`.
             // A discarded intermediate (an effectful `Stmt::Expr` at
             // non-tail position, or a `_ = effect()` discard) carries
             // `binding_name.is_empty()` — there's no source ident to
@@ -1442,7 +1442,7 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             if let_node.binding_name.is_empty() {
                 Some(format!("{{ {}; {} }}", value, body))
             } else {
-                let name = aver_name_to_rust(&let_node.binding_name);
+                let name = explicit_binding_pattern(&let_node.binding_name);
                 Some(format!("{{ let {} = {}; {} }}", name, value, body))
             }
         }
@@ -2155,7 +2155,8 @@ pub(super) fn emit_mir_guest_entry_body(
 /// with `mir_expr_compilable`).
 ///
 /// Returns the rendered value strings in statement order on full success
-/// (the caller wraps each in the `let {name} = …;` / bare-expr-discard
+/// (the caller wraps each in the explicit `let {name} @ _ = …;` /
+/// bare-expr-discard
 /// `…;` templating), or `None` if there's no MIR program or ANY
 /// statement falls outside the lowerable / renderable subset — the
 /// signal for the caller to emit a hard codegen diagnostic for the block
@@ -3366,7 +3367,7 @@ fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
 }
 
 /// Emit a top-level `Let` chain as flat Rust statement lines: each
-/// binding becomes `let {name} = {value};`, one per line, 4-space
+/// binding becomes `let {name} @ _ = {value};`, one per line, 4-space
 /// indented and `\n`-joined, terminated by the chain's final expression
 /// on its own line.
 ///
@@ -3380,7 +3381,7 @@ fn emit_bare_return_tail(expr: &Spanned<MirExpr>, ctx: &MirEmitCtx<'_>) -> Optio
 /// The chain is the run of directly-nested `Let` nodes: each one emits
 /// its statement line and continues into its body until a body that
 /// isn't a `Let` becomes the final expression. A named binding emits
-/// `let {name} = {value};`; an empty-`binding_name` binding (a
+/// `let {name} @ _ = {value};`; an empty-`binding_name` binding (a
 /// discarded intermediate `Stmt::Expr` or a `_ = effect()` discard)
 /// emits a bare `{value};` statement (the value evaluated for its
 /// effects, result dropped). Returns `None` only when a binding value or
@@ -3402,7 +3403,7 @@ fn emit_mir_let_chain_flat(
             // (`Console.print(…)`) evaluated for its effect.
             lines.push(format!("{};", value));
         } else {
-            let name = aver_name_to_rust(&current.binding_name);
+            let name = explicit_binding_pattern(&current.binding_name);
             lines.push(format!("let {} = {};", name, value));
         }
 
@@ -3678,7 +3679,7 @@ fn bare_return_type(ret_type: &str, bare_facts: Option<&crate::ir::mir::FnBareFa
 
 /// Emit the self-TCO loop body (inside `loop { … }`). Leads with
 /// `cancel_checkpoint();`, then renders the MIR body in tail position. A
-/// top-level `Let` chain (leading bindings) emits flat `let x = v;` lines
+/// top-level `Let` chain (leading bindings) emits flat `let x @ _ = v;` lines
 /// then recurses into the chain's final expression as a tail expr.
 fn emit_mir_tco_body(
     body: &Spanned<MirExpr>,
@@ -3691,7 +3692,7 @@ fn emit_mir_tco_body(
     lines.push("        crate::cancel_checkpoint();".to_string());
 
     // Walk the leading `Let` chain as plain statements, then the final
-    // expression as a tail expr. A named binding emits `let x = v;`; an
+    // expression as a tail expr. A named binding emits `let x @ _ = v;`; an
     // empty-`binding_name` binding (a discarded intermediate `Stmt::Expr`
     // or a `_ = effect()` discard) emits a bare `v;` statement (the value
     // evaluated for its effect, result dropped) — the mirror of HIR's
@@ -3703,7 +3704,7 @@ fn emit_mir_tco_body(
         if let_node.binding_name.is_empty() {
             lines.push(format!("        {};", value));
         } else {
-            let name = aver_name_to_rust(&let_node.binding_name);
+            let name = explicit_binding_pattern(&let_node.binding_name);
             lines.push(format!("        let {} = {};", name, value));
         }
         current = &let_node.body;
@@ -4200,7 +4201,7 @@ fn emit_mir_trampoline_body(
             // — bare statement, result dropped.
             lines.push(format!("                {};", value));
         } else {
-            let name = aver_name_to_rust(&let_node.binding_name);
+            let name = explicit_binding_pattern(&let_node.binding_name);
             lines.push(format!("                let {} = {};", name, value));
         }
         current = &let_node.body;
@@ -6490,7 +6491,7 @@ mod tests {
 
     #[test]
     fn emits_let_as_block_expr() {
-        // `let x = 7; x` → `{ let x = aver_rt::AverInt::from_i64(7); x }`.
+        // `let x = 7; x` → `{ let x @ _ = aver_rt::AverInt::from_i64(7); x }`.
         let value = span(MirExpr::Literal(span(crate::ast::Literal::Int(7))));
         let body_local = MirLocal {
             slot: LocalId(0),
@@ -6506,7 +6507,7 @@ mod tests {
         };
         let expr = span(MirExpr::Let(span(let_node)));
         let emit = emit_mir_expr(&expr, &empty_ctx()).expect("let should emit");
-        assert_eq!(emit, "{ let x = aver_rt::AverInt::from_i64(7); x }");
+        assert_eq!(emit, "{ let x @ _ = aver_rt::AverInt::from_i64(7); x }");
     }
 
     #[test]
@@ -6721,7 +6722,7 @@ mod tests {
         let emit = emit_mir_fn_body(&body, &empty_ctx()).expect("let chain emits");
         assert_eq!(
             emit,
-            "    crate::cancel_checkpoint();\n    let a = aver_rt::AverInt::from_i64(1);\n    let b = aver_rt::AverInt::from_i64(2);\n    a"
+            "    crate::cancel_checkpoint();\n    let a @ _ = aver_rt::AverInt::from_i64(1);\n    let b @ _ = aver_rt::AverInt::from_i64(2);\n    a"
         );
     }
 
@@ -6748,7 +6749,7 @@ mod tests {
         let emit = emit_mir_fn_body(&body, &empty_ctx()).expect("discarded stmt emits");
         assert_eq!(
             emit,
-            "    crate::cancel_checkpoint();\n    let g = aver_rt::AverInt::from_i64(1);\n    aver_rt::AverInt::from_i64(2);\n    g"
+            "    crate::cancel_checkpoint();\n    let g @ _ = aver_rt::AverInt::from_i64(1);\n    aver_rt::AverInt::from_i64(2);\n    g"
         );
     }
 
@@ -6772,7 +6773,7 @@ mod tests {
         let emit = emit_mir_fn_body(&body, &empty_ctx()).expect("leading discard emits");
         assert_eq!(
             emit,
-            "    crate::cancel_checkpoint();\n    aver_rt::AverInt::from_i64(1);\n    let g = aver_rt::AverInt::from_i64(2);\n    g"
+            "    crate::cancel_checkpoint();\n    aver_rt::AverInt::from_i64(1);\n    let g @ _ = aver_rt::AverInt::from_i64(2);\n    g"
         );
     }
 
@@ -6952,7 +6953,7 @@ mod tests {
         );
         assert_eq!(
             emit_mir_fn_body(&body, &ctx).expect("binding chain emits"),
-            "    crate::cancel_checkpoint();\n    let kept = s.clone();\n    let k = s.piece.kind.clone();\n    kept"
+            "    crate::cancel_checkpoint();\n    let kept @ _ = s.clone();\n    let k @ _ = s.piece.kind.clone();\n    kept"
         );
     }
 
@@ -6971,7 +6972,7 @@ mod tests {
         );
         assert_eq!(
             emit_mir_fn_body(&body, &ctx).expect("binding chain emits"),
-            "    crate::cancel_checkpoint();\n    let kept = s;\n    let k = s.piece.kind;\n    s.tag"
+            "    crate::cancel_checkpoint();\n    let kept @ _ = s;\n    let k @ _ = s.piece.kind;\n    s.tag"
         );
     }
 
@@ -7015,7 +7016,7 @@ mod tests {
         };
         let expr = span(MirExpr::Let(span(let_node)));
         let emit = emit_mir_expr(&expr, &empty_ctx()).expect("inline let emits");
-        assert_eq!(emit, "{ let x = aver_rt::AverInt::from_i64(7); x }");
+        assert_eq!(emit, "{ let x @ _ = aver_rt::AverInt::from_i64(7); x }");
     }
 
     #[test]

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -1462,7 +1462,9 @@ fn useTwice(audit: Audit) -> List<Audit>
         // `first` is consumed by `List.concat` so it stays live (an unused
         // binding is correctly dead-code-eliminated); both `[audit]` literals
         // then clone the borrowed `audit` because it is used more than once.
-        assert!(entry.contains("let first = aver_rt::AverList::from_vec(vec![audit.clone()]);"));
+        assert!(
+            entry.contains("let first @ _ = aver_rt::AverList::from_vec(vec![audit.clone()]);")
+        );
         // Borrowed param always needs .clone() when consumed
         assert!(entry.contains("aver_rt::AverList::from_vec(vec![audit.clone()])"));
     }

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -1,5 +1,5 @@
 use super::emit_ctx::{EmitCtx, should_borrow_param};
-use super::expr::{aver_name_to_rust, classify_thin_fn_def_for_rust};
+use super::expr::{aver_name_to_rust, classify_thin_fn_def_for_rust, explicit_binding_pattern};
 use super::types::type_annotation_to_rust_scoped;
 use crate::ast::*;
 use crate::codegen::CodegenContext;
@@ -1438,7 +1438,8 @@ fn emit_main_with_visibility(
     // W6/Stage-3): render every statement VALUE through the MIR walker
     // all-or-nothing (the VM #338 isolation: one cloned program,
     // pre-check every value renders before emitting any), then re-apply
-    // the `let {name} = …;` / bare-expr `…;` templating per statement.
+    // the explicit `let {name} @ _ = …;` / bare-expr `…;` templating per
+    // statement.
     // A `None` is a hard codegen error (the MIR walker could not render
     // a top-level statement) — never a silent drop.
     if !top_stmts.is_empty() {
@@ -1477,7 +1478,7 @@ fn emit_main_with_visibility(
             // named `let`, `Expr` → a discarded statement.
             let rendered = match stmt {
                 Stmt::Binding(name, _, _) => {
-                    format!("let {} = {};", aver_name_to_rust(name), value)
+                    format!("let {} = {};", explicit_binding_pattern(name), value)
                 }
                 Stmt::Expr(_) => format!("{};", value),
             };

--- a/src/self_host/aver_generated/domain/ast/mod.rs
+++ b/src/self_host/aver_generated/domain/ast/mod.rs
@@ -3056,7 +3056,7 @@ pub fn userCtorTagOffsetLoop(
 /// Update the user constructor rolling hash and keep it in a bounded range.
 pub fn userCtorTagStep(acc: aver_rt::AverInt, code: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
-    let next = acc.mul(&aver_rt::AverInt::from_i64(131)).add(&code);
+    let next @ _ = acc.mul(&aver_rt::AverInt::from_i64(131)).add(&code);
     (next)
         .rem_euclid(&(aver_rt::AverInt::from_i64(1000003)))
         .unwrap()
@@ -3294,7 +3294,7 @@ pub fn userCtorTagOffsetLoop__indexed(
     let __str_index = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
-        let accPlusOne = acc.add(&aver_rt::AverInt::from_i64(1));
+        let accPlusOne @ _ = acc.add(&aver_rt::AverInt::from_i64(1));
         if (pos < aver_rt::AverInt::from_i64(name.chars().count() as i64)) {
             match aver_rt::string_index_char_at(&name, &__str_index, &pos) {
                 Some(ch @ _) => {
@@ -3324,7 +3324,7 @@ pub fn userCtorTagOffsetLoop__indexed(
 #[inline(always)]
 pub fn canonicalCtorName__indexed(name: AverStr, __str_index: &aver_rt::StringIndex) -> AverStr {
     crate::cancel_checkpoint();
-    let total = aver_rt::AverInt::from_i64(name.chars().count() as i64);
+    let total @ _ = aver_rt::AverInt::from_i64(name.chars().count() as i64);
     crate::aver_generated::domain::ast::canonicalCtorNameAtLastDot__indexed(
         name.clone(),
         total.clone(),

--- a/src/self_host/aver_generated/domain/builtins/list/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/list/mod.rs
@@ -82,7 +82,7 @@ pub fn builtinListPrepend(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (v, lstV) = pair;
         crate::aver_generated::domain::builtins::list::builtinListPrependInner(&v, &lstV)
@@ -95,7 +95,7 @@ pub fn builtinListPrependInner(
     lstV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         aver_rt::AverList::prepend(v.clone(), &items),
     ))
@@ -106,8 +106,8 @@ pub fn builtinListLen(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValInt(
         aver_rt::AverInt::from_i64(items.len() as i64),
     ))
@@ -118,7 +118,7 @@ pub fn builtinListTake(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, nV) = pair;
         crate::aver_generated::domain::builtins::list::builtinListTakeInner(&lstV, &nV)
@@ -131,8 +131,8 @@ pub fn builtinListTakeInner(
     nV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
-    let count = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
+    let count @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         crate::aver_generated::domain::builtins::list::listTake(&items, count),
     ))
@@ -157,7 +157,7 @@ pub fn builtinListDrop(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, nV) = pair;
         crate::aver_generated::domain::builtins::list::builtinListDropInner(&lstV, &nV)
@@ -170,8 +170,8 @@ pub fn builtinListDropInner(
     nV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
-    let count = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
+    let count @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         crate::aver_generated::domain::builtins::list::listDrop(items, count),
     ))
@@ -204,8 +204,8 @@ pub fn builtinListReverse(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         items.reverse(),
     ))
@@ -216,7 +216,7 @@ pub fn builtinListConcat(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::list::builtinListConcatInner(&aV, &bV)
@@ -229,8 +229,8 @@ pub fn builtinListConcatInner(
     bV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let aItems = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
-    let bItems = crate::aver_generated::domain::builtins::helpers::expectList(bV)?;
+    let aItems @ _ = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
+    let bItems @ _ = crate::aver_generated::domain::builtins::helpers::expectList(bV)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         aver_rt::AverList::concat(&aItems, &bItems),
     ))
@@ -241,7 +241,7 @@ pub fn builtinListContains(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, needle) = pair;
         crate::aver_generated::domain::builtins::list::builtinListContainsInner(&lstV, &needle)
@@ -254,7 +254,7 @@ pub fn builtinListContainsInner(
     needle: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
     Ok(crate::aver_generated::domain::value::Val::ValBool(
         crate::aver_generated::domain::builtins::list::listContainsVal(items, needle.clone()),
     ))
@@ -282,7 +282,7 @@ pub fn builtinListZip(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::list::builtinListZipInner(&aV, &bV)
@@ -295,8 +295,8 @@ pub fn builtinListZipInner(
     bV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let aItems = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
-    let bItems = crate::aver_generated::domain::builtins::helpers::expectList(bV)?;
+    let aItems @ _ = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
+    let bItems @ _ = crate::aver_generated::domain::builtins::helpers::expectList(bV)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         crate::aver_generated::domain::builtins::list::zipLists(&aItems, &bItems),
     ))
@@ -325,7 +325,7 @@ pub fn zipListsAcc(
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
-        let reversed = acc.reverse();
+        let reversed @ _ = acc.reverse();
         aver_list_match!(a, [] => { return reversed; }, [x, xs] => { aver_list_match!(b, [] => { return reversed; }, [y, ys] => { {
             let __tco0 = xs;
             let __tco1 = ys;
@@ -343,8 +343,8 @@ pub fn builtinListHead(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
     aver_list_match!(items, [] => Ok(crate::aver_generated::domain::value::Val::ValNone), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(h))))
 }
 
@@ -353,7 +353,7 @@ pub fn builtinListTail(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
     aver_list_match!(items, [] => Ok(crate::aver_generated::domain::value::Val::ValNone), [h, rest] => Ok(crate::aver_generated::domain::value::Val::ValSome(std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValList(rest)))))
 }

--- a/src/self_host/aver_generated/domain/builtins/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/mod.rs
@@ -244,7 +244,7 @@ pub fn builtinConsolePrint(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     {
         let __provider_arg0: AverStr = crate::aver_generated::domain::value::valRepr(&v);
         crate::cancel_checkpoint();
@@ -273,7 +273,7 @@ pub fn builtinConsoleError(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     {
         let __provider_arg0: AverStr = crate::aver_generated::domain::value::valRepr(&v);
         crate::cancel_checkpoint();
@@ -302,7 +302,7 @@ pub fn builtinConsoleWarn(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     {
         let __provider_arg0: AverStr = crate::aver_generated::domain::value::valRepr(&v);
         crate::cancel_checkpoint();
@@ -357,8 +357,8 @@ pub fn builtinDiskReadText(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
@@ -393,7 +393,7 @@ pub fn builtinArgsGet(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let rawArgs = {
+    let rawArgs @ _ = {
         crate::cancel_checkpoint();
         crate::aver_replay::invoke_capability_effect("Args.get", "recorded", vec![], || {
             crate::provider_support::invoke::<aver_rt::AverList<AverStr>>(
@@ -418,8 +418,8 @@ pub fn builtinEnvGet(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let key = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let key @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = key;
         crate::cancel_checkpoint();
@@ -452,7 +452,7 @@ pub fn builtinEnvSet(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (keyV, valueV) = pair;
         crate::aver_generated::domain::builtins::builtinEnvSetInner(&keyV, &valueV)
@@ -465,8 +465,8 @@ pub fn builtinEnvSetInner(
     valueV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let key = crate::aver_generated::domain::builtins::helpers::expectStr(keyV)?;
-    let value = crate::aver_generated::domain::builtins::helpers::expectStr(valueV)?;
+    let key @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(keyV)?;
+    let value @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(valueV)?;
     match {
         let __provider_arg0: AverStr = key;
         let __provider_arg1: AverStr = value;
@@ -524,7 +524,7 @@ pub fn builtinMapEntries(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValList(
@@ -568,7 +568,7 @@ pub fn builtinMapKeys(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValList(
@@ -593,7 +593,7 @@ pub fn builtinMapValues(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValList({
@@ -611,8 +611,8 @@ pub fn builtinMapFromList(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValMap(
         crate::aver_generated::domain::builtins::tuplesToMap(&items, &HashMap::new()),
     ))
@@ -623,7 +623,7 @@ pub fn builtinMapSize(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValInt(
@@ -639,7 +639,7 @@ pub fn builtinMapRemove(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (mapV, keyV) = pair;
         crate::aver_generated::domain::builtins::builtinMapRemoveInner(&mapV, &keyV)
@@ -680,7 +680,7 @@ pub fn builtinRandomInt(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (minV, maxV) = pair;
         crate::aver_generated::domain::builtins::builtinRandomIntInner(&minV, &maxV)
@@ -693,8 +693,8 @@ pub fn builtinRandomIntInner(
     maxV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let minN = crate::aver_generated::domain::builtins::helpers::expectInt(minV)?;
-    let maxN = crate::aver_generated::domain::builtins::helpers::expectInt(maxV)?;
+    let minN @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(minV)?;
+    let maxN @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(maxV)?;
     match {
         let __provider_arg0: aver_rt::AverInt = minN;
         let __provider_arg1: aver_rt::AverInt = maxN;
@@ -734,8 +734,8 @@ pub fn builtinTimeSleep(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let ms = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let ms @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     match {
         let __provider_arg0: aver_rt::AverInt = ms;
         crate::cancel_checkpoint();
@@ -1066,7 +1066,7 @@ pub fn builtinTerminalPrint(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v.clone() {
         crate::aver_generated::domain::value::Val::ValStr(s) => {
             crate::aver_generated::domain::builtins::termPrintStr(s)
@@ -1114,8 +1114,8 @@ pub fn builtinTerminalSetColor(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = s;
         crate::cancel_checkpoint();
@@ -1150,7 +1150,7 @@ pub fn builtinTerminalMoveTo(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (xV, yV) = pair;
         crate::aver_generated::domain::builtins::builtinTerminalMoveToInner(&xV, &yV)
@@ -1163,8 +1163,8 @@ pub fn builtinTerminalMoveToInner(
     yV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let x = crate::aver_generated::domain::builtins::helpers::expectInt(xV)?;
-    let y = crate::aver_generated::domain::builtins::helpers::expectInt(yV)?;
+    let x @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(xV)?;
+    let y @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(yV)?;
     match {
         let __provider_arg0: aver_rt::AverInt = x;
         let __provider_arg1: aver_rt::AverInt = y;
@@ -1204,7 +1204,7 @@ pub fn builtinDiskWriteText(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (pathV, contentV) = pair;
         crate::aver_generated::domain::builtins::builtinDiskWriteTextInner(&pathV, &contentV)
@@ -1217,8 +1217,8 @@ pub fn builtinDiskWriteTextInner(
     contentV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(pathV)?;
-    let content = crate::aver_generated::domain::builtins::helpers::expectStr(contentV)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(pathV)?;
+    let content @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(contentV)?;
     match {
         let __provider_arg0: AverStr = path;
         let __provider_arg1: AverStr = content;
@@ -1258,7 +1258,7 @@ pub fn builtinDiskAppendText(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (pathV, contentV) = pair;
         crate::aver_generated::domain::builtins::builtinDiskAppendTextInner(&pathV, &contentV)
@@ -1271,8 +1271,8 @@ pub fn builtinDiskAppendTextInner(
     contentV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(pathV)?;
-    let content = crate::aver_generated::domain::builtins::helpers::expectStr(contentV)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(pathV)?;
+    let content @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(contentV)?;
     match {
         let __provider_arg0: AverStr = path;
         let __provider_arg1: AverStr = content;
@@ -1312,8 +1312,8 @@ pub fn builtinDiskDelete(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
@@ -1348,8 +1348,8 @@ pub fn builtinDiskDeleteDir(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
@@ -1384,8 +1384,8 @@ pub fn builtinDiskMakeDir(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
@@ -1420,8 +1420,8 @@ pub fn builtinDiskExists(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValBool({
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
@@ -1449,8 +1449,8 @@ pub fn builtinDiskListDir(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let path = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
@@ -1532,7 +1532,7 @@ pub fn builtinBoolOr(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::builtinBoolOrInner(&aV, &bV)
@@ -1565,7 +1565,7 @@ pub fn builtinBoolAnd(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::builtinBoolAndInner(&aV, &bV)
@@ -1598,7 +1598,7 @@ pub fn builtinBoolNot(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValBool(b) => {
             if b {
@@ -1665,7 +1665,7 @@ pub fn builtinMapGet(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (mapV, keyV) = pair;
         crate::aver_generated::domain::builtins::builtinMapGetInner(&mapV, &keyV)
@@ -1699,7 +1699,7 @@ pub fn builtinMapHas(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (mapV, keyV) = pair;
         crate::aver_generated::domain::builtins::builtinMapHasInner(&mapV, &keyV)
@@ -1741,8 +1741,8 @@ pub fn builtinHttpSimple(
     method: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let url = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let url @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     {
         let __dispatch_subject = method;
         if &*__dispatch_subject == "get" {
@@ -1876,9 +1876,9 @@ pub fn builtinHttpBodyInner(
     method: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let url = crate::aver_generated::domain::builtins::helpers::expectStr(urlV)?;
-    let body = crate::aver_generated::domain::builtins::helpers::expectStr(bodyV)?;
-    let ct = crate::aver_generated::domain::builtins::helpers::expectStr(ctV)?;
+    let url @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(urlV)?;
+    let body @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(bodyV)?;
+    let ct @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(ctV)?;
     {
         let __dispatch_subject = method;
         if &*__dispatch_subject == "post" {
@@ -2130,9 +2130,9 @@ pub fn builtinTcpSendInner(
     msgV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let host = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
-    let port = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
-    let msg = crate::aver_generated::domain::builtins::helpers::expectStr(msgV)?;
+    let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
+    let port @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
+    let msg @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(msgV)?;
     match {
         let __provider_arg0: AverStr = host;
         let __provider_arg1: aver_rt::AverInt = port;
@@ -2175,7 +2175,7 @@ pub fn builtinTcpPing(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hostV, portV) = pair;
         crate::aver_generated::domain::builtins::builtinTcpPingInner(&hostV, &portV)
@@ -2188,8 +2188,8 @@ pub fn builtinTcpPingInner(
     portV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let host = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
-    let port = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
+    let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
+    let port @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
     match {
         let __provider_arg0: AverStr = host;
         let __provider_arg1: aver_rt::AverInt = port;
@@ -2229,7 +2229,7 @@ pub fn builtinTcpConnect(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hostV, portV) = pair;
         crate::aver_generated::domain::builtins::builtinTcpConnectInner(&hostV, &portV)
@@ -2242,8 +2242,8 @@ pub fn builtinTcpConnectInner(
     portV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let host = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
-    let port = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
+    let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
+    let port @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
     match {
         let __provider_arg0: AverStr = host;
         let __provider_arg1: aver_rt::AverInt = port;
@@ -2304,7 +2304,7 @@ pub fn builtinTcpBeginConnect(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hostV, portV) = pair;
         crate::aver_generated::domain::builtins::builtinTcpBeginConnectInner(&hostV, &portV)
@@ -2317,8 +2317,8 @@ pub fn builtinTcpBeginConnectInner(
     portV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let host = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
-    let port = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
+    let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
+    let port @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
     match {
         let __provider_arg0: AverStr = host;
         let __provider_arg1: aver_rt::AverInt = port;
@@ -2369,8 +2369,8 @@ pub fn builtinTcpDialled(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let dial = crate::aver_generated::domain::builtins::valToTcpDial(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let dial @ _ = crate::aver_generated::domain::builtins::valToTcpDial(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Dial = dial;
         crate::cancel_checkpoint();
@@ -2416,7 +2416,7 @@ pub fn builtinTcpListen(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (portV, backlogV) = pair;
         crate::aver_generated::domain::builtins::builtinTcpListenInner(&portV, &backlogV)
@@ -2429,8 +2429,8 @@ pub fn builtinTcpListenInner(
     backlogV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let port = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
-    let backlog = crate::aver_generated::domain::builtins::helpers::expectInt(backlogV)?;
+    let port @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
+    let backlog @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(backlogV)?;
     match {
         let __provider_arg0: aver_rt::AverInt = port;
         let __provider_arg1: aver_rt::AverInt = backlog;
@@ -2485,8 +2485,8 @@ pub fn builtinTcpAccept(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let listener = crate::aver_generated::domain::builtins::valToTcpListener(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let listener @ _ = crate::aver_generated::domain::builtins::valToTcpListener(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Listener = listener;
         crate::cancel_checkpoint();
@@ -2532,8 +2532,8 @@ pub fn builtinTcpPeerAddress(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let connection = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let connection @ _ = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Connection = connection;
         crate::cancel_checkpoint();
@@ -2657,7 +2657,7 @@ pub fn builtinTcpPoll(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (socketsV, timeoutV) = pair;
         match socketsV {
@@ -2677,8 +2677,8 @@ pub fn builtinTcpPollInner(
     timeoutV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let timeoutMs = crate::aver_generated::domain::builtins::helpers::expectInt(timeoutV)?;
-    let typedSockets = crate::aver_generated::domain::builtins::tcpSocketEntriesToMap(
+    let timeoutMs @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(timeoutV)?;
+    let typedSockets @ _ = crate::aver_generated::domain::builtins::tcpSocketEntriesToMap(
         {
             let mut es: Vec<_> = sockets
                 .iter()
@@ -2738,8 +2738,8 @@ pub fn builtinTcpCloseDial(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let dial = crate::aver_generated::domain::builtins::valToTcpDial(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let dial @ _ = crate::aver_generated::domain::builtins::valToTcpDial(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Dial = dial;
         crate::cancel_checkpoint();
@@ -2774,8 +2774,8 @@ pub fn builtinTcpCloseListener(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let listener = crate::aver_generated::domain::builtins::valToTcpListener(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let listener @ _ = crate::aver_generated::domain::builtins::valToTcpListener(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Listener = listener;
         crate::cancel_checkpoint();
@@ -2810,7 +2810,7 @@ pub fn builtinTcpWriteLine(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (connV, lineV) = pair;
         crate::aver_generated::domain::builtins::builtinTcpWriteLineInner(&connV, &lineV)
@@ -2823,8 +2823,8 @@ pub fn builtinTcpWriteLineInner(
     lineV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let tc = crate::aver_generated::domain::builtins::valToTcpConn(connV)?;
-    let line = crate::aver_generated::domain::builtins::helpers::expectStr(lineV)?;
+    let tc @ _ = crate::aver_generated::domain::builtins::valToTcpConn(connV)?;
+    let line @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(lineV)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Connection = tc;
         let __provider_arg1: AverStr = line;
@@ -2864,8 +2864,8 @@ pub fn builtinTcpReadLine(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let tc = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let tc @ _ = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Connection = tc;
         crate::cancel_checkpoint();
@@ -2900,8 +2900,8 @@ pub fn builtinTcpClose(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let tc = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let tc @ _ = crate::aver_generated::domain::builtins::valToTcpConn(&v)?;
     match {
         let __provider_arg0: crate::aver_generated::tcp::Connection = tc;
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
@@ -73,7 +73,7 @@ pub fn builtinIntMax(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinIntMaxInner(&aV, &bV)
@@ -86,8 +86,8 @@ pub fn builtinIntMaxInner(
     bV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
-    let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
+    let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
+    let b @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     if (a > b) {
         Ok(crate::aver_generated::domain::value::Val::ValInt(a))
     } else {
@@ -100,7 +100,7 @@ pub fn builtinIntMin(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinIntMinInner(&aV, &bV)
@@ -113,8 +113,8 @@ pub fn builtinIntMinInner(
     bV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
-    let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
+    let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
+    let b @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     if (a < b) {
         Ok(crate::aver_generated::domain::value::Val::ValInt(a))
     } else {
@@ -224,8 +224,8 @@ pub fn builtinIntToFloat(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValFloat(
         n.to_f64(),
     ))
@@ -236,8 +236,8 @@ pub fn builtinIntToString(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (n.to_string()).into_aver(),
     ))
@@ -248,8 +248,8 @@ pub fn builtinIntAbs(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValInt(n.abs()))
 }
 
@@ -258,7 +258,7 @@ pub fn builtinIntMod(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinIntModInner(&aV, &bV)
@@ -271,8 +271,8 @@ pub fn builtinIntModInner(
     bV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
-    let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
+    let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
+    let b @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     if (b == aver_rt::AverInt::from_i64(0)) {
         Ok(crate::aver_generated::domain::value::Val::ValErr(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(
@@ -298,7 +298,7 @@ pub fn builtinIntDiv(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (aV, bV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinIntDivInner(&aV, &bV)
@@ -311,8 +311,8 @@ pub fn builtinIntDivInner(
     bV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let a = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
-    let b = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
+    let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
+    let b @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(bV)?;
     match (match (a).div_euclid(&(b)) {
         Some(__q) => Ok(__q),
         None => Err("division by zero".to_string()),
@@ -333,8 +333,8 @@ pub fn builtinStringLen(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValInt(
         aver_rt::AverInt::from_i64(s.chars().count() as i64),
     ))
@@ -345,7 +345,7 @@ pub fn builtinStringCharAt(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, idxV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringCharAtInner(&sV, &idxV)
@@ -358,8 +358,8 @@ pub fn builtinStringCharAtInner(
     idxV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let idx = crate::aver_generated::domain::builtins::helpers::expectInt(idxV)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let idx @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(idxV)?;
     match ((idx)
         .to_usize()
         .and_then(|__i| s.chars().nth(__i).map(|c| c.to_string())))
@@ -377,7 +377,7 @@ pub fn builtinStringJoin(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (lstV, sepV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringJoinInner(&lstV, &sepV)
@@ -390,9 +390,9 @@ pub fn builtinStringJoinInner(
     sepV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
-    let sep = crate::aver_generated::domain::builtins::helpers::expectStr(sepV)?;
-    let strs = crate::aver_generated::domain::builtins::primitives::extractStrings__collected(
+    let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
+    let sep @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sepV)?;
+    let strs @ _ = crate::aver_generated::domain::builtins::primitives::extractStrings__collected(
         items,
         aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     )?;
@@ -469,9 +469,9 @@ pub fn builtinStringSliceInner(
     endV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let start = crate::aver_generated::domain::builtins::helpers::expectInt(startV)?;
-    let end = crate::aver_generated::domain::builtins::helpers::expectInt(endV)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let start @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(startV)?;
+    let end @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(endV)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (aver_rt::string_slice(
             &s,
@@ -487,7 +487,7 @@ pub fn builtinStringFromBool(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValBool(b) => Ok(
             crate::aver_generated::domain::value::Val::ValStr((b.to_string()).into_aver()),
@@ -501,8 +501,8 @@ pub fn builtinStringFromInt(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (n.to_string()).into_aver(),
     ))
@@ -513,7 +513,7 @@ pub fn builtinStringFromFloat(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
             crate::aver_generated::domain::value::Val::ValStr((f.to_string()).into_aver()),
@@ -527,7 +527,7 @@ pub fn builtinStringContains(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (hV, nV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringContainsInner(&hV, &nV)
@@ -540,8 +540,8 @@ pub fn builtinStringContainsInner(
     nV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let h = crate::aver_generated::domain::builtins::helpers::expectStr(hV)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectStr(nV)?;
+    let h @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hV)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(nV)?;
     Ok(crate::aver_generated::domain::value::Val::ValBool(
         h.contains(&*n),
     ))
@@ -552,7 +552,7 @@ pub fn builtinStringStartsWith(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, pV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringStartsWithInner(&sV, &pV)
@@ -565,8 +565,8 @@ pub fn builtinStringStartsWithInner(
     pV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let p = crate::aver_generated::domain::builtins::helpers::expectStr(pV)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let p @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(pV)?;
     Ok(crate::aver_generated::domain::value::Val::ValBool(
         s.starts_with(&*p),
     ))
@@ -577,8 +577,8 @@ pub fn builtinStringToLower(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (s.to_lowercase()).into_aver(),
     ))
@@ -589,8 +589,8 @@ pub fn builtinStringFromCodePoint(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     match ((n).to_u32().and_then(char::from_u32).map(|c| c.to_string())).into_aver() {
         Some(c @ _) => Ok(crate::aver_generated::domain::value::Val::ValSome(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValStr(c)),
@@ -604,8 +604,8 @@ pub fn builtinStringFirstCodePoint(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match (s)
         .chars()
         .next()
@@ -623,8 +623,8 @@ pub fn builtinIntFromString(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match ({
         let __s = &(s);
         __s.parse::<aver_rt::AverInt>()
@@ -646,8 +646,8 @@ pub fn builtinStringChars(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(
         crate::aver_generated::domain::builtins::primitives::stringToCharList(
             s.clone(),
@@ -769,8 +769,8 @@ pub fn builtinFloatFromString(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     match ({
         let __s = &(s);
         __s.parse::<f64>()
@@ -792,8 +792,8 @@ pub fn builtinFloatFromInt(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValFloat(
         n.to_f64(),
     ))
@@ -804,7 +804,7 @@ pub fn builtinFloatRound(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => {
             Ok(crate::aver_generated::domain::value::Val::ValInt(
@@ -820,7 +820,7 @@ pub fn builtinFloatToString(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
             crate::aver_generated::domain::value::Val::ValStr((f.to_string()).into_aver()),
@@ -834,7 +834,7 @@ pub fn builtinFloatAbs(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => {
             Ok(crate::aver_generated::domain::value::Val::ValFloat(f.abs()))
@@ -848,7 +848,7 @@ pub fn builtinFloatFloor(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => {
             Ok(crate::aver_generated::domain::value::Val::ValInt(
@@ -864,7 +864,7 @@ pub fn builtinFloatCeil(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => {
             Ok(crate::aver_generated::domain::value::Val::ValInt(
@@ -880,7 +880,7 @@ pub fn builtinFloatMin(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
         (
             crate::aver_generated::domain::value::Val::ValFloat(a),
@@ -897,7 +897,7 @@ pub fn builtinFloatMax(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
         (
             crate::aver_generated::domain::value::Val::ValFloat(a),
@@ -914,7 +914,7 @@ pub fn builtinFloatSin(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => {
             Ok(crate::aver_generated::domain::value::Val::ValFloat(f.sin()))
@@ -928,7 +928,7 @@ pub fn builtinFloatCos(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => {
             Ok(crate::aver_generated::domain::value::Val::ValFloat(f.cos()))
@@ -942,7 +942,7 @@ pub fn builtinFloatSqrt(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValFloat(f) => Ok(
             crate::aver_generated::domain::value::Val::ValFloat(f.sqrt()),
@@ -956,7 +956,7 @@ pub fn builtinFloatPow(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
         (
             crate::aver_generated::domain::value::Val::ValFloat(a),
@@ -973,7 +973,7 @@ pub fn builtinFloatAtan2(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
         (
             crate::aver_generated::domain::value::Val::ValFloat(a),
@@ -1007,8 +1007,8 @@ pub fn builtinStringToUpper(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (s.to_uppercase()).into_aver(),
     ))
@@ -1019,8 +1019,8 @@ pub fn builtinStringTrim(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(&v)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (s.trim().to_string()).into_aver(),
     ))
@@ -1031,7 +1031,7 @@ pub fn builtinStringEndsWith(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, pV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringEndsWithInner(&sV, &pV)
@@ -1044,8 +1044,8 @@ pub fn builtinStringEndsWithInner(
     pV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let p = crate::aver_generated::domain::builtins::helpers::expectStr(pV)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let p @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(pV)?;
     Ok(crate::aver_generated::domain::value::Val::ValBool(
         s.ends_with(&*p),
     ))
@@ -1056,7 +1056,7 @@ pub fn builtinStringSplit(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, sepV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringSplitInner(&sV, &sepV)
@@ -1069,9 +1069,9 @@ pub fn builtinStringSplitInner(
     sepV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let sep = crate::aver_generated::domain::builtins::helpers::expectStr(sepV)?;
-    let parts =
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let sep @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sepV)?;
+    let parts @ _ =
         (aver_rt::AverList::from_vec(s.split(&*sep).map(|s| s.to_string()).collect::<Vec<_>>()))
             .into_aver();
     Ok(crate::aver_generated::domain::value::Val::ValList(
@@ -1105,7 +1105,7 @@ pub fn builtinStringRepeat(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (sV, nV) = pair;
         crate::aver_generated::domain::builtins::primitives::builtinStringRepeatInner(&sV, &nV)
@@ -1118,8 +1118,8 @@ pub fn builtinStringRepeatInner(
     nV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let n = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let n @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(nV)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         crate::aver_generated::domain::builtins::primitives::repeatStr(s, n, AverStr::from("")),
     ))
@@ -1173,9 +1173,9 @@ pub fn builtinStringReplaceAllDo(
     toV: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let s = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
-    let from = crate::aver_generated::domain::builtins::helpers::expectStr(fromV)?;
-    let to = crate::aver_generated::domain::builtins::helpers::expectStr(toV)?;
+    let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
+    let from @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(fromV)?;
+    let to @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(toV)?;
     Ok(crate::aver_generated::domain::value::Val::ValStr(
         (s.replace(&*from, &*to)).into_aver(),
     ))
@@ -1193,7 +1193,7 @@ pub fn stringToCharList__indexed(
     let __str_index = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
-        let reversed = acc.reverse();
+        let reversed @ _ = acc.reverse();
         if (pos < total) {
             match aver_rt::string_index_char_at(&s, &__str_index, &pos) {
                 Some(c @ _) => {

--- a/src/self_host/aver_generated/domain/builtins/vector/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/vector/mod.rs
@@ -65,7 +65,7 @@ pub fn builtinVectorNew(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
         (crate::aver_generated::domain::value::Val::ValInt(size), defaultVal) => {
             Ok(crate::aver_generated::domain::value::Val::ValVector(
@@ -84,7 +84,7 @@ pub fn builtinVectorGet(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     match pair {
         (
             crate::aver_generated::domain::value::Val::ValVector(vec),
@@ -183,7 +183,7 @@ pub fn builtinVectorLen(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValVector(vec) => {
             Ok(crate::aver_generated::domain::value::Val::ValInt(
@@ -199,7 +199,7 @@ pub fn builtinVectorFromList(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValList(items) => {
             Ok(crate::aver_generated::domain::value::Val::ValVector(
@@ -215,7 +215,7 @@ pub fn builtinVectorToList(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     match v {
         crate::aver_generated::domain::value::Val::ValVector(vec) => Ok(
             crate::aver_generated::domain::value::Val::ValList(vec.to_list()),

--- a/src/self_host/aver_generated/domain/builtins/wrappers/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/wrappers/mod.rs
@@ -57,7 +57,7 @@ pub fn builtinResultOk(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     Ok(crate::aver_generated::domain::value::Val::ValOk(
         std::sync::Arc::new(v),
     ))
@@ -68,7 +68,7 @@ pub fn builtinResultErr(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     Ok(crate::aver_generated::domain::value::Val::ValErr(
         std::sync::Arc::new(v),
     ))
@@ -79,7 +79,7 @@ pub fn builtinResultWithDefault(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (resV, defV) = pair;
         match resV {
@@ -98,7 +98,7 @@ pub fn builtinOptionSome(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
+    let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
     Ok(crate::aver_generated::domain::value::Val::ValSome(
         std::sync::Arc::new(v),
     ))
@@ -109,7 +109,7 @@ pub fn builtinOptionWithDefault(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (optV, defV) = pair;
         match optV {
@@ -128,7 +128,7 @@ pub fn callResultFromOption(
     args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let pair = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
+    let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
     {
         let (optV, errV) = pair;
         match optV {

--- a/src/self_host/aver_generated/domain/eval/common/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/common/mod.rs
@@ -70,7 +70,7 @@ pub fn wrapPropagatedError(msg: AverStr) -> AverStr {
 #[inline(always)]
 pub fn unwrapPropagatedError(err: AverStr) -> Option<AverStr> {
     crate::cancel_checkpoint();
-    let prefix = AverStr::from("__aver_prop__:");
+    let prefix @ _ = AverStr::from("__aver_prop__:");
     if err.starts_with(&*prefix) {
         Some(
             (aver_rt::string_slice(

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -508,7 +508,7 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::EvalBoolBranch(mut cond, mut thenExpr, mut elseExpr, mut env) => {
                 crate::cancel_checkpoint();
-                let condV =
+                let condV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&cond, &env, &*fns)?;
                 match condV.clone() {
                     crate::aver_generated::domain::value::Val::ValBool(flag) => {
@@ -691,11 +691,11 @@ fn __mutual_tco_trampoline_1(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV =
+                let vecV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&vecExpr, &env, &*fns)?;
-                let idxV =
+                let idxV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&idxExpr, &env, &*fns)?;
-                let valueV =
+                let valueV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&valueExpr, &env, &*fns)?;
                 __MutualTco1::EvalVectorSetWithDefaultExprResult(
                     vecV,
@@ -777,9 +777,9 @@ fn __mutual_tco_trampoline_1(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV =
+                let vecV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&vecExpr, &env, &*fns)?;
-                let idxV =
+                let idxV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&idxExpr, &env, &*fns)?;
                 __MutualTco1::EvalVectorGetWithDefaultExprResult(vecV, idxV, defaultExpr, env)
             }
@@ -1152,7 +1152,7 @@ fn __mutual_tco_trampoline_2(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let condV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let condV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &cond, &env, &*slotMap, &*fns,
                 )?;
                 match condV.clone() {
@@ -1178,7 +1178,7 @@ fn __mutual_tco_trampoline_2(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &scrutinee, &env, &*slotMap, &*fns,
                 )?;
                 __MutualTco2::EvalTailMatchSlot(selfId, v, arms, slotCount, env)
@@ -1655,7 +1655,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::EvalBoolBranchSlot(mut cond, mut thenExpr, mut elseExpr, mut env) => {
                 crate::cancel_checkpoint();
-                let condV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let condV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &cond, &env, &*slotMap, &*fns,
                 )?;
                 match condV.clone() {
@@ -1824,13 +1824,13 @@ fn __mutual_tco_trampoline_3(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let vecV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &vecExpr, &env, &*slotMap, &*fns,
                 )?;
-                let idxV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let idxV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &idxExpr, &env, &*slotMap, &*fns,
                 )?;
-                let valueV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let valueV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &valueExpr, &env, &*slotMap, &*fns,
                 )?;
                 __MutualTco3::EvalVectorSetWithDefaultExprSlotResult(
@@ -1907,10 +1907,10 @@ fn __mutual_tco_trampoline_3(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let vecV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let vecV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &vecExpr, &env, &*slotMap, &*fns,
                 )?;
-                let idxV = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let idxV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &idxExpr, &env, &*slotMap, &*fns,
                 )?;
                 __MutualTco3::EvalVectorGetWithDefaultExprSlotResult(vecV, idxV, defaultExpr, env)
@@ -1934,7 +1934,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::EvalMatchExprSlot(mut scrutinee, mut arms, mut env) => {
                 crate::cancel_checkpoint();
-                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &scrutinee, &env, &*slotMap, &*fns,
                 )?;
                 __MutualTco3::EvalMatchSlot(v, arms, env)
@@ -2500,10 +2500,11 @@ fn __mutual_tco_trampoline_7(
         __state = match __state {
             __MutualTco7::EvalStmtBindSlotNext(mut slot, mut e, mut rest, mut env) => {
                 crate::cancel_checkpoint();
-                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
                 )?;
-                let nextEnv = crate::aver_generated::domain::eval::slots::setSlot(&env, slot, &v);
+                let nextEnv @ _ =
+                    crate::aver_generated::domain::eval::slots::setSlot(&env, slot, &v);
                 {
                     let __list_subject = rest.clone();
                     if __list_subject.is_empty() {
@@ -2515,7 +2516,7 @@ fn __mutual_tco_trampoline_7(
             }
             __MutualTco7::EvalStmtExprSlotNext(mut e, mut rest, mut env) => {
                 crate::cancel_checkpoint();
-                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
                 )?;
                 {
@@ -2529,7 +2530,7 @@ fn __mutual_tco_trampoline_7(
             }
             __MutualTco7::EvalStmtBindFallbackSlotNext(mut name, mut e, mut rest, mut env) => {
                 crate::cancel_checkpoint();
-                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
                 )?;
                 {
@@ -2692,7 +2693,7 @@ fn __mutual_tco_trampoline_8(
                 mut env,
             ) => {
                 crate::cancel_checkpoint();
-                let v = crate::aver_generated::domain::eval::core::evalExprSlot(
+                let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
                 )?;
                 __MutualTco8::EvalStmtsSlotTail(
@@ -2942,8 +2943,8 @@ pub fn evalVectorGetOrIntExpr(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let vecV = crate::aver_generated::domain::eval::core::evalExpr(vecExpr, env, fns)?;
-    let idxV = crate::aver_generated::domain::eval::core::evalExpr(idxExpr, env, fns)?;
+    let vecV @ _ = crate::aver_generated::domain::eval::core::evalExpr(vecExpr, env, fns)?;
+    let idxV @ _ = crate::aver_generated::domain::eval::core::evalExpr(idxExpr, env, fns)?;
     crate::aver_generated::domain::eval::ops::evalVectorGetOrIntVals(&vecV, &idxV, defaultValue)
 }
 
@@ -2956,8 +2957,8 @@ pub fn evalIntModOrIntExpr(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let aV = crate::aver_generated::domain::eval::core::evalExpr(a, env, fns)?;
-    let bV = crate::aver_generated::domain::eval::core::evalExpr(b, env, fns)?;
+    let aV @ _ = crate::aver_generated::domain::eval::core::evalExpr(a, env, fns)?;
+    let bV @ _ = crate::aver_generated::domain::eval::core::evalExpr(b, env, fns)?;
     crate::aver_generated::domain::eval::ops::evalIntModOrIntVals(&aV, &bV, defaultValue)
 }
 
@@ -2968,7 +2969,7 @@ pub fn evalPropagate(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExpr(inner, env, fns)?;
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExpr(inner, env, fns)?;
     match v {
         crate::aver_generated::domain::value::Val::ValOk(x) => {
             let x = (*x).clone();
@@ -2999,7 +3000,8 @@ pub fn evalIndependentProduct(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::eval::core::evalIndependentItems(exprs, env, fns)?;
+    let items @ _ =
+        crate::aver_generated::domain::eval::core::evalIndependentItems(exprs, env, fns)?;
     if unwrap {
         crate::aver_generated::domain::eval::core::unwrapProductResults__collected(
             items,
@@ -3260,7 +3262,7 @@ pub fn evalTupleExpr(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::eval::core::evalListItems(exprs, env, fns)?;
+    let items @ _ = crate::aver_generated::domain::eval::core::evalListItems(exprs, env, fns)?;
     Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
 }
 
@@ -3272,7 +3274,8 @@ pub fn evalRecordExpr(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let fields = crate::aver_generated::domain::eval::core::evalRecordFields(fieldExprs, env, fns)?;
+    let fields @ _ =
+        crate::aver_generated::domain::eval::core::evalRecordFields(fieldExprs, env, fns)?;
     Ok(crate::aver_generated::domain::value::Val::ValRecord(
         name, fields,
     ))
@@ -3297,8 +3300,9 @@ pub fn evalRecordFieldOne(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExpr(expr, env, fns)?;
-    let restFields = crate::aver_generated::domain::eval::core::evalRecordFields(rest, env, fns)?;
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExpr(expr, env, fns)?;
+    let restFields @ _ =
+        crate::aver_generated::domain::eval::core::evalRecordFields(rest, env, fns)?;
     Ok(aver_rt::AverList::prepend((fname, v), &restFields))
 }
 
@@ -3310,7 +3314,7 @@ pub fn evalFieldAccess(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExpr(obj, env, fns)?;
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExpr(obj, env, fns)?;
     match v {
         crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
             crate::aver_generated::domain::eval::common::lookupField(fields, field)
@@ -3438,7 +3442,7 @@ pub fn callResolved(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let fnId = crate::aver_generated::domain::eval::store::lookupFnId(fns, fd.name.clone())?;
+    let fnId @ _ = crate::aver_generated::domain::eval::store::lookupFnId(fns, fd.name.clone())?;
     crate::aver_generated::domain::eval::core::callResolvedById(fnId, fd, args, fns)
 }
 
@@ -3501,7 +3505,7 @@ pub fn evalResolvedSlotLoop(
     let fns = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
-        let step = crate::aver_generated::domain::eval::core::evalResolvedSlotStep(
+        let step @ _ = crate::aver_generated::domain::eval::core::evalResolvedSlotStep(
             fnId.clone(),
             &*fd,
             &calleeEnv,
@@ -3527,7 +3531,7 @@ pub fn evalResolvedSlotDirect(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let result = match fd.fastPath.clone() {
+    let result @ _ = match fd.fastPath.clone() {
         crate::aver_generated::domain::ast::FnFastPath::FastLeaf(leaf) => {
             crate::aver_generated::domain::eval::fast::runFastLeafSlot(&leaf, calleeEnv)
         }
@@ -3728,7 +3732,7 @@ pub fn evalResolvedNamedFn(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let result = match fd.fastPath.clone() {
+    let result @ _ = match fd.fastPath.clone() {
         crate::aver_generated::domain::ast::FnFastPath::FastLeaf(leaf) => {
             crate::aver_generated::domain::eval::core::runFastLeafNamed(
                 &leaf, &fd.body, calleeEnv, fns,
@@ -3957,12 +3961,12 @@ pub fn fastForwardCall(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let args = crate::aver_generated::domain::eval::core::collectFastForwardArgs__collected(
+    let args @ _ = crate::aver_generated::domain::eval::core::collectFastForwardArgs__collected(
         slotArgs.clone(),
         calleeEnv.clone(),
         aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     )?;
-    let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
+    let fd @ _ = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
     crate::aver_generated::domain::eval::core::callResolvedById(fnId, &fd, &args, fns)
 }
 
@@ -4008,7 +4012,7 @@ pub fn evalCallDirect(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
+    let fd @ _ = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
     if (fd.slotCount > aver_rt::AverInt::from_i64(0)) {
         crate::aver_generated::domain::eval::core::evalCallDirectMapToSlot(
             fnId, &fd, argExprs, env, fns,
@@ -4027,7 +4031,7 @@ pub fn evalCallDirectMapToSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsMapToSlotEnv(
+    let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsMapToSlotEnv(
         argExprs.clone(),
         env.clone(),
         fns.clone(),
@@ -4051,7 +4055,7 @@ pub fn evalCallDirectMapToNamed(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsMapToNamedEnv(
+    let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsMapToNamedEnv(
         argExprs,
         &fd.params,
         env,
@@ -4192,8 +4196,8 @@ pub fn evalProgram(
     prog: &crate::aver_generated::domain::ast::Program,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let fnsStore = crate::aver_generated::domain::eval::store::fnsToStore(&prog.fns);
-    let top = crate::aver_generated::domain::eval::core::evalTopLevelStmts(
+    let fnsStore @ _ = crate::aver_generated::domain::eval::store::fnsToStore(&prog.fns);
+    let top @ _ = crate::aver_generated::domain::eval::core::evalTopLevelStmts(
         prog.stmts.clone(),
         HashMap::new(),
         crate::aver_generated::domain::value::Val::ValUnit,
@@ -4214,10 +4218,10 @@ pub fn evalProgramWithFns(
     extraFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let allFns = crate::aver_generated::domain::eval::store::fnsToStore(
+    let allFns @ _ = crate::aver_generated::domain::eval::store::fnsToStore(
         &aver_rt::AverList::concat(&extraFns.clone(), &prog.fns.clone()),
     );
-    let top = crate::aver_generated::domain::eval::core::evalTopLevelStmts(
+    let top @ _ = crate::aver_generated::domain::eval::core::evalTopLevelStmts(
         prog.stmts.clone(),
         HashMap::new(),
         crate::aver_generated::domain::value::Val::ValUnit,
@@ -4303,7 +4307,7 @@ pub fn evalBinopSlotInt(
     env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let left = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
+    let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
     crate::aver_generated::domain::eval::ops::evalBinopVals(
         &left,
         &crate::aver_generated::domain::value::Val::ValInt(rhs),
@@ -4319,8 +4323,8 @@ pub fn evalBinopSlots(
     env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let left = crate::aver_generated::domain::eval::slots::lookupSlot(env, lhs)?;
-    let right = crate::aver_generated::domain::eval::slots::lookupSlot(env, rhs)?;
+    let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, lhs)?;
+    let right @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, rhs)?;
     crate::aver_generated::domain::eval::ops::evalBinopVals(&left, &right, op)
 }
 
@@ -4332,7 +4336,7 @@ pub fn evalCmpSlotInt(
     env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let left = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
+    let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
     crate::aver_generated::domain::eval::ops::evalCmpVals(
         &left,
         &crate::aver_generated::domain::value::Val::ValInt(rhs),
@@ -4348,8 +4352,8 @@ pub fn evalCmpSlots(
     env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let left = crate::aver_generated::domain::eval::slots::lookupSlot(env, lhs)?;
-    let right = crate::aver_generated::domain::eval::slots::lookupSlot(env, rhs)?;
+    let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, lhs)?;
+    let right @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, rhs)?;
     crate::aver_generated::domain::eval::ops::evalCmpVals(&left, &right, op)
 }
 
@@ -4363,8 +4367,10 @@ pub fn evalVectorGetOrIntExprSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let vecV = crate::aver_generated::domain::eval::core::evalExprSlot(vecExpr, env, slotMap, fns)?;
-    let idxV = crate::aver_generated::domain::eval::core::evalExprSlot(idxExpr, env, slotMap, fns)?;
+    let vecV @ _ =
+        crate::aver_generated::domain::eval::core::evalExprSlot(vecExpr, env, slotMap, fns)?;
+    let idxV @ _ =
+        crate::aver_generated::domain::eval::core::evalExprSlot(idxExpr, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalVectorGetOrIntVals(&vecV, &idxV, defaultValue)
 }
 
@@ -4378,8 +4384,8 @@ pub fn evalIntModOrIntExprSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let aV = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
-    let bV = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
+    let aV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
+    let bV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalIntModOrIntVals(&aV, &bV, defaultValue)
 }
 
@@ -4393,8 +4399,8 @@ pub fn evalBinopSlot(
     op: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let va = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
-    let vb = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
+    let va @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
+    let vb @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalBinopVals(&va, &vb, op)
 }
 
@@ -4406,7 +4412,7 @@ pub fn evalNegSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalNegVals(&v)
 }
 
@@ -4420,8 +4426,8 @@ pub fn evalCmpSlot(
     op: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let va = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
-    let vb = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
+    let va @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
+    let vb @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(b, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::ops::evalCmpVals(&va, &vb, op)
 }
 
@@ -4473,7 +4479,7 @@ pub fn evalTupleSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items =
+    let items @ _ =
         crate::aver_generated::domain::eval::core::evalListItemsSlot(exprs, env, slotMap, fns)?;
     Ok(crate::aver_generated::domain::value::Val::ValTuple(items))
 }
@@ -4486,7 +4492,7 @@ pub fn evalListSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items =
+    let items @ _ =
         crate::aver_generated::domain::eval::core::evalListItemsSlot(exprs, env, slotMap, fns)?;
     Ok(crate::aver_generated::domain::value::Val::ValList(items))
 }
@@ -4540,7 +4546,7 @@ pub fn evalRecordSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let fields = crate::aver_generated::domain::eval::core::evalRecordFieldsSlot(
+    let fields @ _ = crate::aver_generated::domain::eval::core::evalRecordFieldsSlot(
         fieldExprs, env, slotMap, fns,
     )?;
     Ok(crate::aver_generated::domain::value::Val::ValRecord(
@@ -4569,8 +4575,8 @@ pub fn evalRecordFieldOneSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExprSlot(expr, env, slotMap, fns)?;
-    let restFields =
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(expr, env, slotMap, fns)?;
+    let restFields @ _ =
         crate::aver_generated::domain::eval::core::evalRecordFieldsSlot(rest, env, slotMap, fns)?;
     Ok(aver_rt::AverList::prepend((fname, v), &restFields))
 }
@@ -4584,7 +4590,7 @@ pub fn evalFieldAccessSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExprSlot(obj, env, slotMap, fns)?;
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(obj, env, slotMap, fns)?;
     match v {
         crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
             crate::aver_generated::domain::eval::common::lookupField(fields, field)
@@ -4602,7 +4608,7 @@ pub fn evalCallSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let args =
+    let args @ _ =
         crate::aver_generated::domain::eval::core::evalArgsSlot(argExprs, env, slotMap, fns)?;
     crate::aver_generated::domain::eval::core::callWithArgs(&args, name, fns)
 }
@@ -4616,7 +4622,7 @@ pub fn evalCallDirectSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let fd = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
+    let fd @ _ = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
     if (fd.slotCount > aver_rt::AverInt::from_i64(0)) {
         crate::aver_generated::domain::eval::core::evalCallDirectSlotToSlot(
             fnId, &fd, argExprs, env, slotMap, fns,
@@ -4638,7 +4644,7 @@ pub fn evalCallDirectSlotToSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(
+    let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(
         argExprs.clone(),
         env.clone(),
         slotMap.clone(),
@@ -4664,7 +4670,7 @@ pub fn evalCallDirectSlotToNamed(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let calleeEnv = crate::aver_generated::domain::eval::core::evalArgsSlotToNamedEnv(
+    let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsSlotToNamedEnv(
         argExprs,
         &fd.params,
         env,
@@ -4684,7 +4690,7 @@ pub fn evalCallBuiltinSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let args =
+    let args @ _ =
         crate::aver_generated::domain::eval::core::evalArgsSlot(argExprs, env, slotMap, fns)?;
     crate::aver_generated::domain::builtins::callBuiltin(name, &args)
 }
@@ -4708,7 +4714,7 @@ pub fn evalArgsSlot1(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
-    let v0 = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
+    let v0 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
     Ok(aver_rt::AverList::from_vec(vec![v0]))
 }
 
@@ -4721,8 +4727,8 @@ pub fn evalArgsSlot2(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
-    let v0 = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
-    let v1 = crate::aver_generated::domain::eval::core::evalExprSlot(e1, env, slotMap, fns)?;
+    let v0 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
+    let v1 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e1, env, slotMap, fns)?;
     Ok(aver_rt::AverList::from_vec(vec![v0, v1]))
 }
 
@@ -4736,9 +4742,9 @@ pub fn evalArgsSlot3(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
-    let v0 = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
-    let v1 = crate::aver_generated::domain::eval::core::evalExprSlot(e1, env, slotMap, fns)?;
-    let v2 = crate::aver_generated::domain::eval::core::evalExprSlot(e2, env, slotMap, fns)?;
+    let v0 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
+    let v1 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e1, env, slotMap, fns)?;
+    let v2 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e2, env, slotMap, fns)?;
     Ok(aver_rt::AverList::from_vec(vec![v0, v1, v2]))
 }
 
@@ -4823,7 +4829,7 @@ pub fn evalPropagateSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let v = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
+    let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
     match v {
         crate::aver_generated::domain::value::Val::ValOk(x) => {
             let x = (*x).clone();
@@ -4855,7 +4861,7 @@ pub fn evalIndependentProductSlot(
     fns: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let items = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(
+    let items @ _ = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(
         exprs, env, slotMap, fns,
     )?;
     if unwrap {

--- a/src/self_host/aver_generated/domain/eval/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/fast/mod.rs
@@ -85,7 +85,7 @@ pub fn fastBoolSlotBranch(
     elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let slotV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
+    let slotV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match slotV {
         crate::aver_generated::domain::value::Val::ValBool(cond) => {
             crate::aver_generated::domain::eval::fast::selectFastLeaf(
@@ -105,7 +105,7 @@ pub fn fastEqIntBranch(
     elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let slotV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
+    let slotV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match slotV {
         crate::aver_generated::domain::value::Val::ValInt(actual) => {
             crate::aver_generated::domain::eval::fast::selectFastLeaf(
@@ -128,7 +128,7 @@ pub fn fastEqStringBranch(
     elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let slotV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
+    let slotV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match slotV {
         crate::aver_generated::domain::value::Val::ValStr(actual) => {
             crate::aver_generated::domain::eval::fast::selectFastLeaf(
@@ -151,8 +151,8 @@ pub fn fastLtIntSlotsBranch(
     elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let lhsV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, lhsSlot)?;
-    let rhsV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, rhsSlot)?;
+    let lhsV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, lhsSlot)?;
+    let rhsV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, rhsSlot)?;
     match lhsV {
         crate::aver_generated::domain::value::Val::ValInt(lhs) => match rhsV {
             crate::aver_generated::domain::value::Val::ValInt(rhs) => {
@@ -195,7 +195,7 @@ pub fn fastListSlotBranch(
     consLeaf: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let listV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
+    let listV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match listV {
         crate::aver_generated::domain::value::Val::ValList(items) => {
             crate::aver_generated::domain::eval::fast::fastListSlotBranchItems(
@@ -227,7 +227,7 @@ pub fn fastFieldAccessSlot(
     field: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let recordV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
+    let recordV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
     match recordV {
         crate::aver_generated::domain::value::Val::ValRecord(_, fields) => {
             crate::aver_generated::domain::eval::common::lookupField(fields, field)
@@ -243,8 +243,8 @@ pub fn fastMapGetSlot(
     keySlot: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
-    let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
+    let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
+    let keyV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
     crate::aver_generated::domain::eval::fast::fastMapGetSlotInner(&mapV, &keyV)
 }
 
@@ -278,9 +278,9 @@ pub fn fastMapSetSlot(
     valueSlot: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
-    let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
-    let valueV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, valueSlot)?;
+    let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
+    let keyV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
+    let valueV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, valueSlot)?;
     crate::aver_generated::domain::eval::fast::fastMapSetSlotInner(&mapV, &keyV, &valueV)
 }
 
@@ -309,7 +309,7 @@ pub fn fastVectorNewSlot(
     fill: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let sizeV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, sizeSlot)?;
+    let sizeV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, sizeSlot)?;
     crate::aver_generated::domain::eval::fast::fastVectorNewSlotInner(&sizeV, fill)
 }
 
@@ -343,8 +343,8 @@ pub fn fastVectorGetOrIntSlot(
     defaultValue: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let vecV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
-    let idxV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, idxSlot)?;
+    let vecV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
+    let idxV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, idxSlot)?;
     crate::aver_generated::domain::eval::fast::fastVectorGetOrIntSlotInner(
         &vecV,
         &idxV,
@@ -382,8 +382,8 @@ pub fn fastMapHasSlot(
     keySlot: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
-    let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
+    let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
+    let keyV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
     match mapV {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValBool(
@@ -401,8 +401,8 @@ pub fn fastMapRemoveSlot(
     keySlot: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let mapV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
-    let keyV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
+    let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
+    let keyV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, keySlot)?;
     match mapV {
         crate::aver_generated::domain::value::Val::ValMap(m) => {
             Ok(crate::aver_generated::domain::value::Val::ValMap(
@@ -419,7 +419,7 @@ pub fn fastVectorLenSlot(
     vecSlot: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let vecV = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
+    let vecV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
     match vecV {
         crate::aver_generated::domain::value::Val::ValVector(vec) => {
             Ok(crate::aver_generated::domain::value::Val::ValInt(
@@ -438,8 +438,8 @@ pub fn fastBinopSlots(
     slotB: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let va = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotA)?;
-    let vb = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotB)?;
+    let va @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotA)?;
+    let vb @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotB)?;
     crate::aver_generated::domain::eval::ops::evalBinopVals(&va, &vb, op)
 }
 
@@ -451,7 +451,7 @@ pub fn fastCmpSlots(
     slotB: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let va = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotA)?;
-    let vb = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotB)?;
+    let va @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotA)?;
+    let vb @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotB)?;
     crate::aver_generated::domain::eval::ops::evalCmpVals(&va, &vb, op)
 }

--- a/src/self_host/aver_generated/domain/eval/records/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/records/mod.rs
@@ -214,7 +214,7 @@ pub fn removeOverrideAcc(
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     loop {
         crate::cancel_checkpoint();
-        let reversed = acc.reverse();
+        let reversed @ _ = acc.reverse();
         aver_list_match!(overrides, [] => { return reversed; }, [pair, rest] => { { let (ok, ov) = pair; if (ok == k) { return aver_rt::AverList::concat(&reversed, &rest); } else { {
             let __tco1 = rest;
             let __tco2 = aver_rt::AverList::prepend((ok, ov), &acc);

--- a/src/self_host/aver_generated/domain/eval/store/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/store/mod.rs
@@ -239,7 +239,7 @@ pub fn mergeBindings(
 /// Build a function store with a name->id index and id->FnDef table.
 pub fn fnsToStore(fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>) -> FnStore {
     crate::cancel_checkpoint();
-    let nameToId = crate::aver_generated::domain::eval::store::fnsToIdMap(
+    let nameToId @ _ = crate::aver_generated::domain::eval::store::fnsToIdMap(
         fns.clone(),
         HashMap::new(),
         aver_rt::AverInt::from_i64(0),

--- a/src/self_host/aver_generated/domain/lexer/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/mod.rs
@@ -43,7 +43,7 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::TokenizeBraceOrSkip__indexed(mut c, mut src, mut pos) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 if (c == crate::aver_generated::domain::lexer::openBrace()) {
                     return aver_rt::AverList::prepend(
                         crate::aver_generated::domain::token::Token::TkLBrace,
@@ -70,7 +70,7 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::TokenizeChar__indexed(mut c, mut src, mut pos) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
                     let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
                     if __dispatch_subject == aver_rt::AverInt::from_i64(32) {
@@ -299,7 +299,7 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::TokenizeStringEscape__indexed(mut src, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                     Some(c @ _) => {
                         let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
@@ -409,7 +409,7 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::TokenizeStringMaybeEscapedBrace__indexed(mut src, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
                     Some(next @ _) => {
                         if (next == crate::aver_generated::domain::lexer::openBrace()) {
@@ -439,8 +439,8 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::TokenizeStringMaybeEscapedClose__indexed(mut src, mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
-                let accBrace = (acc + &crate::aver_generated::domain::lexer::closeBrace());
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
+                let accBrace @ _ = (acc + &crate::aver_generated::domain::lexer::closeBrace());
                 match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
                     Some(next @ _) => {
                         if (next == crate::aver_generated::domain::lexer::closeBrace()) {
@@ -631,7 +631,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::TokenizeInterpPunct__indexed(mut src, mut pos, mut c) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
                     let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
                     if __dispatch_subject == aver_rt::AverInt::from_i64(32) {
@@ -833,7 +833,7 @@ fn __mutual_tco_trampoline_4(
             }
             __MutualTco4::CountIndentChar__indexed(mut src, mut pos, mut spaces) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
                     let __int_match_subject =
                         aver_rt::string_index_code_at(&src, &__str_index, &pos);
@@ -1745,7 +1745,7 @@ pub fn emitIndentChange(
     stack: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let currentIndent = crate::aver_generated::domain::lexer::stackTop(stack);
+    let currentIndent @ _ = crate::aver_generated::domain::lexer::stackTop(stack);
     if (indent > currentIndent) {
         aver_rt::AverList::prepend(
             crate::aver_generated::domain::token::Token::TkNewline,
@@ -1795,7 +1795,7 @@ pub fn emitDedentsAcc(
     let rest = std::sync::Arc::new(rest);
     loop {
         crate::cancel_checkpoint();
-        let reversed = acc.reverse();
+        let reversed @ _ = acc.reverse();
         aver_list_match!(stack.clone(), [] => { return aver_rt::AverList::concat(&reversed, &crate::aver_generated::domain::lexer::processIndentation(&*rest, &aver_rt::AverIntList::from_vec(vec![aver_rt::AverInt::from_i64(0)]))); }, [top, below] => { if (top > targetIndent) { {
             let __tco2 = below;
             let __tco3 = aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkDedent, &acc);
@@ -1826,7 +1826,7 @@ pub fn emitFinalDedentsAcc(
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     loop {
         crate::cancel_checkpoint();
-        let reversed = acc.reverse();
+        let reversed @ _ = acc.reverse();
         aver_list_match!(stack, [] => { return reversed; }, [top, rest] => { if (top > aver_rt::AverInt::from_i64(0)) { {
             let __tco0 = rest;
             let __tco1 = aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkDedent, &acc);
@@ -1902,7 +1902,7 @@ pub fn tokenizeAfterIntDot__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(d @ _) => {
             if crate::aver_generated::domain::lexer::chars::isDigit(d) {
@@ -1961,7 +1961,7 @@ pub fn buildFloat__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let f = (intPart.to_f64()
+    let f @ _ = (intPart.to_f64()
         + (decPart.to_f64() / crate::aver_generated::domain::lexer::pow10(decDigits)));
     aver_rt::AverList::prepend(
         crate::aver_generated::domain::token::Token::TkFloat(f),
@@ -2020,7 +2020,7 @@ pub fn tokenizeMinus__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(c @ _) => {
             if crate::aver_generated::domain::lexer::isGreaterThan(c) {
@@ -2083,7 +2083,7 @@ pub fn tokenizeInterpString__indexed(
     let __str_index = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
             match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                 Some(c @ _) => {
@@ -2201,7 +2201,7 @@ pub fn tokenizeInterpAfterIntDot__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(d @ _) => {
             if crate::aver_generated::domain::lexer::chars::isDigit(d) {
@@ -2268,7 +2268,7 @@ pub fn tokenizeInterpBuildFloat__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let f = (intPart.to_f64()
+    let f @ _ = (intPart.to_f64()
         + (decPart.to_f64() / crate::aver_generated::domain::lexer::pow10(decDigits)));
     aver_rt::AverList::prepend(
         crate::aver_generated::domain::token::Token::TkFloat(f),
@@ -2284,7 +2284,7 @@ pub fn tokenizeSlashOrComment__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(c @ _) => {
             if (&*c == "/") {
@@ -2321,7 +2321,7 @@ pub fn skipLineComment__indexed(
     let __str_index = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
             match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                 Some(c @ _) => {
@@ -2361,7 +2361,7 @@ pub fn tokenizeDot__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(c @ _) => {
             if (&*c == ".") {
@@ -2399,7 +2399,7 @@ pub fn tokenizeLt__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(c @ _) => {
             if (&*c == "=") {
@@ -2437,7 +2437,7 @@ pub fn tokenizeGt__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(c @ _) => {
             if (&*c == "=") {
@@ -2475,7 +2475,7 @@ pub fn tokenizeBang__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
         Some(c @ _) => {
             if (&*c == "=") {
@@ -2512,8 +2512,8 @@ pub fn tokenizeEq__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
-    let pos2 = pos.add(&aver_rt::AverInt::from_i64(2));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
+    let pos2 @ _ = pos.add(&aver_rt::AverInt::from_i64(2));
     {
         let __int_match_subject = aver_rt::string_index_code_at(&src, &__str_index, &nextPos);
         if __int_match_subject == -1i64 {
@@ -2567,7 +2567,7 @@ pub fn tokenizeNewline__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::lexer::countIndent__indexed(
+    let r @ _ = crate::aver_generated::domain::lexer::countIndent__indexed(
         src.clone(),
         pos,
         aver_rt::AverInt::from_i64(0),
@@ -2595,12 +2595,12 @@ pub fn lex__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
-    let raw = crate::aver_generated::domain::lexer::tokenize__indexed(
+    let raw @ _ = crate::aver_generated::domain::lexer::tokenize__indexed(
         src,
         aver_rt::AverInt::from_i64(0),
         __str_index,
     );
-    let processed = crate::aver_generated::domain::lexer::processIndentation(
+    let processed @ _ = crate::aver_generated::domain::lexer::processIndentation(
         &raw,
         &aver_rt::AverIntList::from_vec(vec![aver_rt::AverInt::from_i64(0)]),
     );

--- a/src/self_host/aver_generated/domain/match_mod/mod.rs
+++ b/src/self_host/aver_generated/domain/match_mod/mod.rs
@@ -38,7 +38,8 @@ fn __mutual_tco_trampoline_1(
                 mut acc,
             ) => {
                 crate::cancel_checkpoint();
-                let bindings = crate::aver_generated::domain::match_mod::matchPattern(&pat, &item)?;
+                let bindings @ _ =
+                    crate::aver_generated::domain::match_mod::matchPattern(&pat, &item)?;
                 __MutualTco1::MatchPatTupleItemsAcc(
                     restPats,
                     restItems,
@@ -544,7 +545,7 @@ pub fn zipBindingsAcc(
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     loop {
         crate::cancel_checkpoint();
-        let reversed = acc.reverse();
+        let reversed @ _ = acc.reverse();
         aver_list_match!(names, [] => { return reversed; }, [n, ns] => { aver_list_match!(vals, [] => { return reversed; }, [v, vs] => { {
             let __tco0 = ns;
             let __tco1 = vs;

--- a/src/self_host/aver_generated/domain/parser/expr/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/expr/mod.rs
@@ -25,8 +25,9 @@ fn __mutual_tco_trampoline_1(
         __state = match __state {
             __MutualTco1::ParseAddExprTail(mut pos, mut left) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
-                let t = crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone());
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
+                let t @ _ =
+                    crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone());
                 match t {
                     crate::aver_generated::domain::token::Token::TkPlus => {
                         __MutualTco1::ParseAddExprRight(
@@ -47,7 +48,8 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::ParseAddExprRight(mut pos, mut left, mut op) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::expr::parseMulExpr(&*tokens, pos)?;
+                let r @ _ =
+                    crate::aver_generated::domain::parser::expr::parseMulExpr(&*tokens, pos)?;
                 {
                     let (right, pos2) = r;
                     if (op == aver_rt::AverInt::from_i64(0)) {
@@ -113,7 +115,7 @@ fn __mutual_tco_trampoline_2(
         __state = match __state {
             __MutualTco2::ParseMulExprTail(mut pos, mut left) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkStar => {
                         __MutualTco2::ParseMulExprRight(
@@ -134,7 +136,7 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::ParseMulExprRight(mut pos, mut left, mut op) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::expr::parseAtom(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseAtom(&*tokens, pos)?;
                 {
                     let (right, pos2) = r;
                     if (op == aver_rt::AverInt::from_i64(0)) {
@@ -207,7 +209,7 @@ fn __mutual_tco_trampoline_3(
         __state = match __state {
             __MutualTco3::ParseMapEntries(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let kr = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
+                let kr @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
                     let (keyExpr, pos2) = kr;
                     __MutualTco3::ParseMapAfterKey(pos2, acc, keyExpr)
@@ -215,12 +217,13 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseMapAfterKey(mut pos, mut acc, mut keyExpr) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::expect(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
                     pos,
                     &crate::aver_generated::domain::token::Token::TkFatArrow,
                 )?;
-                let vr = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
+                let vr @ _ =
+                    crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
                 {
                     let (valExpr, pos3) = vr;
                     __MutualTco3::ParseMapEntryTail(
@@ -236,7 +239,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseMapEntryTail(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pos2 =
+                let pos2 @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos);
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos2.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -327,7 +330,7 @@ fn __mutual_tco_trampoline_4(
         __state = match __state {
             __MutualTco4::ParseInterpParts(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
                     let (expr, pos2) = r;
                     __MutualTco4::ParseInterpAfterExpr(pos2, aver_rt::AverList::prepend(expr, &acc))
@@ -347,7 +350,7 @@ fn __mutual_tco_trampoline_4(
             }
             __MutualTco4::ParseInterpContinue(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkStr(s) => {
                         __MutualTco4::ParseInterpAfterStr(
@@ -450,7 +453,7 @@ fn __mutual_tco_trampoline_5(
         __state = match __state {
             __MutualTco5::ParseListItems(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
                     let (expr, pos2) = r;
                     __MutualTco5::ParseListItemsTail(pos2, aver_rt::AverList::prepend(expr, &acc))
@@ -458,7 +461,7 @@ fn __mutual_tco_trampoline_5(
             }
             __MutualTco5::ParseListItemsTail(mut pos0, mut items) => {
                 crate::cancel_checkpoint();
-                let pos =
+                let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -552,7 +555,7 @@ fn __mutual_tco_trampoline_6(
         __state = match __state {
             __MutualTco6::ParseTupleRest(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
                     let (expr, pos2) = r;
                     __MutualTco6::ParseTupleRestTail(pos2, aver_rt::AverList::prepend(expr, &acc))
@@ -560,7 +563,7 @@ fn __mutual_tco_trampoline_6(
             }
             __MutualTco6::ParseTupleRestTail(mut pos0, mut items) => {
                 crate::cancel_checkpoint();
-                let pos =
+                let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -743,12 +746,12 @@ fn __mutual_tco_trampoline_8(
             }
             __MutualTco8::ParseRecordField(mut pos, mut name, mut acc, mut field) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::expect(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
                     pos,
                     &crate::aver_generated::domain::token::Token::TkEq,
                 )?;
-                let r = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
                 {
                     let (expr, pos3) = r;
                     __MutualTco8::ParseRecordFieldsTail(
@@ -760,7 +763,7 @@ fn __mutual_tco_trampoline_8(
             }
             __MutualTco8::ParseRecordFieldsTail(mut pos, mut name, mut fields) => {
                 crate::cancel_checkpoint();
-                let pos2 =
+                let pos2 @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos);
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos2.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -887,7 +890,7 @@ fn __mutual_tco_trampoline_9(
         __state = match __state {
             __MutualTco9::ParseCallArgsList(mut pos, mut name, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
                     let (expr, pos2) = r;
                     __MutualTco9::ParseCallArgsListTail(
@@ -899,7 +902,7 @@ fn __mutual_tco_trampoline_9(
             }
             __MutualTco9::ParseCallArgsListTail(mut pos0, mut name, mut args) => {
                 crate::cancel_checkpoint();
-                let pos =
+                let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -1081,12 +1084,12 @@ fn __mutual_tco_trampoline_10(
             }
             __MutualTco10::ParseNamedArgField(mut pos, mut name, mut namedAcc, mut field) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::expect(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
                     pos,
                     &crate::aver_generated::domain::token::Token::TkEq,
                 )?;
-                let r = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
+                let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
                 {
                     let (expr, pos3) = r;
                     __MutualTco10::ParseNamedArgsTail(
@@ -1098,7 +1101,7 @@ fn __mutual_tco_trampoline_10(
             }
             __MutualTco10::ParseNamedArgsTail(mut pos0, mut name, mut namedAcc) => {
                 crate::cancel_checkpoint();
-                let pos =
+                let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -1207,7 +1210,7 @@ fn __mutual_tco_trampoline_11(
         __state = match __state {
             __MutualTco11::ParseMatchArms(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::skipNewlines(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(
                     (*tokens).clone(),
                     pos,
                 );
@@ -1245,7 +1248,8 @@ fn __mutual_tco_trampoline_11(
             }
             __MutualTco11::ParseOneArm(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pr = crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
+                let pr @ _ =
+                    crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
                 {
                     let (pat, pos2) = pr;
                     __MutualTco11::ParseOneArmBody(pos2, acc, pat)
@@ -1253,12 +1257,13 @@ fn __mutual_tco_trampoline_11(
             }
             __MutualTco11::ParseOneArmBody(mut pos, mut acc, mut pat) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::expect(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
                     pos,
                     &crate::aver_generated::domain::token::Token::TkArrow,
                 )?;
-                let er = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
+                let er @ _ =
+                    crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
                 {
                     let (body, pos3) = er;
                     __MutualTco11::ParseMatchArms(
@@ -1371,7 +1376,8 @@ fn __mutual_tco_trampoline_12(
             }
             __MutualTco12::ParseOneArmFlat(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pr = crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
+                let pr @ _ =
+                    crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
                 {
                     let (pat, pos2) = pr;
                     __MutualTco12::ParseOneArmFlatBody(pos2, acc, pat)
@@ -1379,12 +1385,13 @@ fn __mutual_tco_trampoline_12(
             }
             __MutualTco12::ParseOneArmFlatBody(mut pos, mut acc, mut pat) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::expect(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
                     pos,
                     &crate::aver_generated::domain::token::Token::TkArrow,
                 )?;
-                let er = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
+                let er @ _ =
+                    crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos2)?;
                 {
                     let (body, pos3) = er;
                     __MutualTco12::ParseMatchArmsFlat(
@@ -1456,7 +1463,7 @@ pub fn parseExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseCmpExpr(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseCmpExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
         Ok(crate::aver_generated::domain::parser::expr::parsePostfixQuestion(tokens, pos2, &expr))
@@ -1487,7 +1494,7 @@ pub fn parseCmpExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
     {
         let (left, pos2) = r;
         crate::aver_generated::domain::parser::expr::parseCmpExprTail(tokens, pos2, &left)
@@ -1501,7 +1508,7 @@ pub fn parseCmpExprTail(
     left: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
         crate::aver_generated::domain::token::Token::TkEqEq => {
             crate::aver_generated::domain::parser::expr::parseCmpExprRight(
@@ -1563,7 +1570,7 @@ pub fn parseCmpExprRight(
     op: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
     {
         let (right, pos2) = r;
         crate::aver_generated::domain::parser::expr::buildCmpExpr(left, &right, pos2, op)
@@ -1651,7 +1658,7 @@ pub fn parseAddExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseMulExpr(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseMulExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
         crate::aver_generated::domain::parser::expr::parseAddExprTail(tokens, pos2, &expr)
@@ -1664,7 +1671,7 @@ pub fn parseMulExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
     {
         let (expr, pos2) = r;
         crate::aver_generated::domain::parser::expr::parseMulExprTail(tokens, pos2, &expr)
@@ -1677,8 +1684,8 @@ pub fn parseAtom(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t.clone() {
         crate::aver_generated::domain::token::Token::TkMinus => {
             crate::aver_generated::domain::parser::expr::parseNegAtom(tokens, nextPos)
@@ -1739,7 +1746,7 @@ pub fn parseMapLiteral(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
+    let pos2 @ _ = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
         crate::aver_generated::domain::token::Token::TkRBrace => Ok((
             crate::aver_generated::domain::ast::Expr::ExprCall(
@@ -1764,7 +1771,7 @@ pub fn parseNegAtom(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
     {
         let (expr, pos2) = r;
         Ok((
@@ -1804,7 +1811,7 @@ pub fn parseListExpr(
     pos0: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
+    let pos @ _ = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
         crate::aver_generated::domain::token::Token::TkRBracket => Ok((
             crate::aver_generated::domain::ast::Expr::ExprList(aver_rt::AverList::empty()),
@@ -1824,7 +1831,7 @@ pub fn parseParenExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
     {
         let (expr, pos2) = r;
         match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
@@ -1901,7 +1908,7 @@ pub fn parseIdentOrCall(
     name: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
         crate::aver_generated::domain::token::Token::TkLParen => {
             crate::aver_generated::domain::parser::expr::chainFieldAccess(tokens, nextPos, name)
@@ -1924,7 +1931,7 @@ pub fn chainFieldAccess(
     name: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseCallOrRecord(tokens, pos, name)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseCallOrRecord(tokens, pos, name)?;
     {
         let (expr, pos2) = r;
         crate::aver_generated::domain::parser::expr::parseFieldAccessTail(tokens, pos2, &expr)
@@ -1939,7 +1946,7 @@ pub fn skipNl(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkNewline => {
                 let __tco1 = nextPos;
@@ -1970,7 +1977,7 @@ pub fn parseCallOrRecord(
     name: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
+    let pos2 @ _ = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
         crate::aver_generated::domain::token::Token::TkRParen => Ok((
             crate::aver_generated::domain::ast::Expr::ExprCall(name, aver_rt::AverList::empty()),
@@ -2025,7 +2032,7 @@ pub fn parseMatchExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
     {
         let (subject, pos2) = r;
         crate::aver_generated::domain::parser::expr::parseMatchAfterSubject(tokens, pos2, &subject)
@@ -2039,7 +2046,7 @@ pub fn parseMatchAfterSubject(
     subject: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
+    let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
         crate::aver_generated::domain::token::Token::TkIndent => {
             crate::aver_generated::domain::parser::expr::parseMatchArms(

--- a/src/self_host/aver_generated/domain/parser/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/mod.rs
@@ -37,7 +37,7 @@ fn __mutual_tco_trampoline_1(
         __state = match __state {
             __MutualTco1::ParseFnBodyStmtsIndented(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::skipNewlines(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(
                     (*tokens).clone(),
                     pos,
                 );
@@ -51,7 +51,7 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::ParseFnBodyOneStmtIndented(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
                 {
                     let (stmt, pos2) = r;
                     __MutualTco1::ParseFnBodyStmtsIndented(
@@ -139,7 +139,7 @@ fn __mutual_tco_trampoline_2(
             }
             __MutualTco2::ParseFnBodyOneStmtFlat(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
                 {
                     let (stmt, pos2) = r;
                     __MutualTco2::ParseFnBodyAfterStmtFlat(
@@ -260,7 +260,7 @@ fn __mutual_tco_trampoline_3(
         __state = match __state {
             __MutualTco3::ParseProgram(mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
-                let pos2 = crate::aver_generated::domain::parser_match::skipNewlinesAndDedents(
+                let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlinesAndDedents(
                     (*tokens).clone(),
                     pos,
                 );
@@ -288,7 +288,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseProgramKeyword(mut pos, mut deps, mut fns, mut stmts, mut kw) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
                     let __dispatch_subject = kw;
                     if &*__dispatch_subject == "module" {
@@ -344,7 +344,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseProgramModuleHeader(mut pos, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
-                let r =
+                let r @ _ =
                     crate::aver_generated::domain::parser_match::parseModuleHeader(&*tokens, pos);
                 {
                     let (depList, endPos) = r;
@@ -353,7 +353,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseProgramFn(mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::parseFnDef(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::parseFnDef(&*tokens, pos)?;
                 {
                     let (fd, pos2) = r;
                     __MutualTco3::ParseProgram(
@@ -369,7 +369,7 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseProgramStmt(mut pos, mut deps, mut fns, mut stmts) => {
                 crate::cancel_checkpoint();
-                let r = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
+                let r @ _ = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
                 {
                     let (st, pos2) = r;
                     __MutualTco3::ParseProgram(
@@ -463,7 +463,7 @@ pub fn parseStmt(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
     match t {
         crate::aver_generated::domain::token::Token::TkIdent(name) => {
             crate::aver_generated::domain::parser::parseStmtAfterIdent(
@@ -508,7 +508,7 @@ pub fn skipTypeAnnotationAndEq(
     pos: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::skipTypeAnnotation(tokens, pos);
+    let pos2 @ _ = crate::aver_generated::domain::parser_match::skipTypeAnnotation(tokens, pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
         crate::aver_generated::domain::token::Token::TkEq => {
             pos2.add(&aver_rt::AverInt::from_i64(1))
@@ -524,7 +524,7 @@ pub fn parseBinding(
     name: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos.clone())?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos.clone())?;
     {
         let (expr, pos2) = r;
         Ok((
@@ -568,7 +568,7 @@ pub fn countIndentsInRange(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (pos < endPos) {
             match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos) {
                 crate::aver_generated::domain::token::Token::TkIndent => {
@@ -607,7 +607,7 @@ pub fn skipNDedents(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (n > aver_rt::AverInt::from_i64(0)) {
             match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                 crate::aver_generated::domain::token::Token::TkNewline => {
@@ -638,7 +638,7 @@ pub fn parseStmtExpr(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let r = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos.clone())?;
+    let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos.clone())?;
     {
         let (expr, pos2) = r;
         Ok((
@@ -655,7 +655,7 @@ pub fn parseStmtExprFrom(
     name: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let ir = crate::aver_generated::domain::parser::expr::parseIdentOrCall(tokens, pos, name)?;
+    let ir @ _ = crate::aver_generated::domain::parser::expr::parseIdentOrCall(tokens, pos, name)?;
     {
         let (expr, pos2) = ir;
         crate::aver_generated::domain::parser::parseStmtExprFromMul(tokens, pos2, &expr)
@@ -669,7 +669,7 @@ pub fn parseStmtExprFromMul(
     expr: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let mr = crate::aver_generated::domain::parser::expr::parseMulExprTail(tokens, pos, expr)?;
+    let mr @ _ = crate::aver_generated::domain::parser::expr::parseMulExprTail(tokens, pos, expr)?;
     {
         let (expr2, pos2) = mr;
         crate::aver_generated::domain::parser::parseStmtExprFromAdd(tokens, pos2, &expr2)
@@ -683,7 +683,7 @@ pub fn parseStmtExprFromAdd(
     expr: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let ar = crate::aver_generated::domain::parser::expr::parseAddExprTail(tokens, pos, expr)?;
+    let ar @ _ = crate::aver_generated::domain::parser::expr::parseAddExprTail(tokens, pos, expr)?;
     {
         let (expr2, pos2) = ar;
         crate::aver_generated::domain::parser::parseStmtExprFromCmp(tokens, pos2, &expr2)
@@ -697,7 +697,7 @@ pub fn parseStmtExprFromCmp(
     expr: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let cr = crate::aver_generated::domain::parser::expr::parseCmpExprTail(tokens, pos, expr)?;
+    let cr @ _ = crate::aver_generated::domain::parser::expr::parseCmpExprTail(tokens, pos, expr)?;
     {
         let (expr2, pos2) = cr;
         Ok(crate::aver_generated::domain::parser::parseStmtExprFromQ(
@@ -713,7 +713,8 @@ pub fn parseStmtExprFromQ(
     expr: &crate::aver_generated::domain::ast::Expr,
 ) -> (crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
-    let qr = crate::aver_generated::domain::parser::expr::parsePostfixQuestion(tokens, pos, expr);
+    let qr @ _ =
+        crate::aver_generated::domain::parser::expr::parsePostfixQuestion(tokens, pos, expr);
     {
         let (expr2, pos2) = qr;
         (
@@ -729,7 +730,7 @@ pub fn parseFnDef(
     pos: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
     match t {
         crate::aver_generated::domain::token::Token::TkIdent(name) => {
             crate::aver_generated::domain::parser::parseFnDefParams(
@@ -749,12 +750,12 @@ pub fn parseFnDefParams(
     name: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::expect(
+    let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
         tokens,
         pos,
         &crate::aver_generated::domain::token::Token::TkLParen,
     )?;
-    let pr = crate::aver_generated::domain::parser_match::parseParamList(
+    let pr @ _ = crate::aver_generated::domain::parser_match::parseParamList(
         tokens,
         pos2,
         &aver_rt::AverList::empty(),
@@ -773,8 +774,8 @@ pub fn parseFnDefBody(
     params: &aver_rt::AverList<AverStr>,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::skipReturnType(tokens, pos);
-    let pos3 = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos2);
+    let pos2 @ _ = crate::aver_generated::domain::parser_match::skipReturnType(tokens, pos);
+    let pos3 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos2);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos3.clone()) {
         crate::aver_generated::domain::token::Token::TkIndent => {
             crate::aver_generated::domain::parser::parseFnDefBodyIndented(
@@ -796,8 +797,9 @@ pub fn parseFnDefBodyIndented(
     params: &aver_rt::AverList<AverStr>,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::skipDescAndEffects(tokens.clone(), pos);
-    let sr = crate::aver_generated::domain::parser::parseFnBodyStmtsIndented(
+    let pos2 @ _ =
+        crate::aver_generated::domain::parser_match::skipDescAndEffects(tokens.clone(), pos);
+    let sr @ _ = crate::aver_generated::domain::parser::parseFnBodyStmtsIndented(
         tokens,
         pos2,
         &aver_rt::AverList::empty(),
@@ -827,8 +829,9 @@ pub fn parseFnDefBodyFlat(
     params: &aver_rt::AverList<AverStr>,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::skipDescAndEffects(tokens.clone(), pos);
-    let sr = crate::aver_generated::domain::parser::parseFnBodyStmtsFlat(
+    let pos2 @ _ =
+        crate::aver_generated::domain::parser_match::skipDescAndEffects(tokens.clone(), pos);
+    let sr @ _ = crate::aver_generated::domain::parser::parseFnBodyStmtsFlat(
         tokens,
         pos2,
         &aver_rt::AverList::empty(),

--- a/src/self_host/aver_generated/domain/parser_match/mod.rs
+++ b/src/self_host/aver_generated/domain/parser_match/mod.rs
@@ -25,7 +25,7 @@ fn __mutual_tco_trampoline_1(
         __state = match __state {
             __MutualTco1::ParseIdentPatternMaybeConstructor(mut pos, mut name) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
         crate::aver_generated::domain::token::Token::TkDot => {
             __MutualTco1::ParseIdentPatternDotted(nextPos, name)
@@ -237,7 +237,8 @@ fn __mutual_tco_trampoline_3(
             }
             __MutualTco3::ParseTuplePatternElement(mut pos, mut acc) => {
                 crate::cancel_checkpoint();
-                let pr = crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
+                let pr @ _ =
+                    crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
                 {
                     let (pat, pos2) = pr;
                     __MutualTco3::ParseTuplePatternElementTail(
@@ -336,7 +337,7 @@ fn __mutual_tco_trampoline_4(
         __state = match __state {
             __MutualTco4::SkipBlockFlat(mut pos) => {
                 crate::cancel_checkpoint();
-                let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+                let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkEof => return pos,
                     crate::aver_generated::domain::token::Token::TkNewline => {
@@ -513,7 +514,7 @@ pub fn expect(
     expected: &crate::aver_generated::domain::token::Token,
 ) -> Result<aver_rt::AverInt, AverStr> {
     crate::cancel_checkpoint();
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
     if crate::aver_generated::domain::parser_match::isToken(&t, expected) {
         Ok(pos.add(&aver_rt::AverInt::from_i64(1)))
     } else {
@@ -572,7 +573,7 @@ pub fn skipNewlinesAndDedents(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkNewline => {
                 let __tco1 = nextPos;
@@ -603,8 +604,8 @@ pub fn parsePattern(
     AverStr,
 > {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t.clone() {
         crate::aver_generated::domain::token::Token::TkInt(n) => Ok((
             crate::aver_generated::domain::ast::Pattern::PatInt(n),
@@ -734,17 +735,17 @@ pub fn parseConsPattern(
     AverStr,
 > {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::expect(
+    let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
         tokens,
         pos,
         &crate::aver_generated::domain::token::Token::TkComma,
     )?;
-    let pos3 = crate::aver_generated::domain::parser_match::expect(
+    let pos3 @ _ = crate::aver_generated::domain::parser_match::expect(
         tokens,
         pos2,
         &crate::aver_generated::domain::token::Token::TkDotDot,
     )?;
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos3.clone());
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos3.clone());
     match t {
         crate::aver_generated::domain::token::Token::TkIdent(tail) => Ok((
             crate::aver_generated::domain::ast::Pattern::PatCons(head, tail),
@@ -781,7 +782,7 @@ pub fn skipTypeExpr(
     pos: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
-    let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+    let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
         crate::aver_generated::domain::token::Token::TkIdent(_) => {
             crate::aver_generated::domain::parser_match::skipTypeExprTail(tokens.clone(), nextPos)
@@ -805,7 +806,7 @@ pub fn skipTypeExprTail(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkLt => {
                 return crate::aver_generated::domain::parser_match::skipUntilGt(
@@ -843,7 +844,7 @@ pub fn skipUntilGt(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (depth == aver_rt::AverInt::from_i64(0)) {
             return pos;
         } else {
@@ -885,7 +886,7 @@ pub fn skipUntilClose(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (depth == aver_rt::AverInt::from_i64(0)) {
             return pos;
         } else {
@@ -942,7 +943,7 @@ pub fn skipDescAndEffects(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkQuestion => {
                 let __tco1 = crate::aver_generated::domain::parser_match::skipToNextLine(
@@ -991,7 +992,7 @@ pub fn skipUntilRBracket(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkEof => {
                 return pos;
@@ -1019,7 +1020,7 @@ pub fn skipToNextLine(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkEof => {
                 return pos;
@@ -1042,7 +1043,7 @@ pub fn skipBlock(
     pos: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
-    let pos2 = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
+    let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos2.clone()) {
         crate::aver_generated::domain::token::Token::TkIndent => {
             crate::aver_generated::domain::parser_match::skipIndentBlock(
@@ -1065,7 +1066,7 @@ pub fn skipIndentBlock(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
             crate::aver_generated::domain::token::Token::TkEof => {
                 return pos;
@@ -1105,8 +1106,8 @@ pub fn parseModuleHeader(
     pos: aver_rt::AverInt,
 ) -> (aver_rt::AverList<AverStr>, aver_rt::AverInt) {
     crate::cancel_checkpoint();
-    let endPos = crate::aver_generated::domain::parser_match::skipBlock(tokens, pos.clone());
-    let depList = crate::aver_generated::domain::parser_match::findDependsInRange(
+    let endPos @ _ = crate::aver_generated::domain::parser_match::skipBlock(tokens, pos.clone());
+    let depList @ _ = crate::aver_generated::domain::parser_match::findDependsInRange(
         tokens.clone(),
         pos,
         endPos.clone(),
@@ -1124,7 +1125,7 @@ pub fn findDependsInRange(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (pos < endPos) {
             match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos) {
                 crate::aver_generated::domain::token::Token::TkIdent(kw) => {
@@ -1183,7 +1184,7 @@ pub fn collectDependsNames(
     let tokens = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (pos < endPos) {
             match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos) {
                 crate::aver_generated::domain::token::Token::TkRBracket => {
@@ -1214,7 +1215,7 @@ pub fn isBodyEndFlat(
     pos: aver_rt::AverInt,
 ) -> bool {
     crate::cancel_checkpoint();
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t {
         crate::aver_generated::domain::token::Token::TkEof => true,
         crate::aver_generated::domain::token::Token::TkFn => true,
@@ -1230,7 +1231,7 @@ pub fn isArmStart(
     pos: aver_rt::AverInt,
 ) -> bool {
     crate::cancel_checkpoint();
-    let t = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
+    let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
     match t {
         crate::aver_generated::domain::token::Token::TkInt(_) => true,
         crate::aver_generated::domain::token::Token::TkFloat(_) => true,

--- a/src/self_host/aver_generated/domain/resolver/calls/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/calls/mod.rs
@@ -481,7 +481,7 @@ pub fn resolveOneCall(
     fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
-    let resolvedArgs =
+    let resolvedArgs @ _ =
         crate::aver_generated::domain::resolver::calls::resolveCallsInExprs__collected(
             args.clone(),
             fnMap.clone(),

--- a/src/self_host/aver_generated/domain/resolver/core/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/core/mod.rs
@@ -280,7 +280,7 @@ pub fn resolveFn(
     fd: &crate::aver_generated::domain::ast::FnDef,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
-    let paramResult = crate::aver_generated::domain::resolver::core::buildParamSlots(
+    let paramResult @ _ = crate::aver_generated::domain::resolver::core::buildParamSlots(
         fd.params.clone(),
         HashMap::new(),
         aver_rt::AverInt::from_i64(0),
@@ -322,7 +322,7 @@ pub fn resolveBody(
     nextSlot: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
-    let resolved = crate::aver_generated::domain::resolver::core::resolveStmts__collected(
+    let resolved @ _ = crate::aver_generated::domain::resolver::core::resolveStmts__collected(
         fd.body.clone(),
         slots.clone(),
         nextSlot,
@@ -347,7 +347,7 @@ pub fn computeSlotCount(
     slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
-    let maxFromBody = crate::aver_generated::domain::resolver::core::maxSlotInStmts(
+    let maxFromBody @ _ = crate::aver_generated::domain::resolver::core::maxSlotInStmts(
         body.clone(),
         baseSlot.sub(&aver_rt::AverInt::from_i64(1)),
     );
@@ -621,7 +621,7 @@ pub fn resolveStmtBindFinish(
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
     crate::cancel_checkpoint();
-    let newSlots = slots.clone().insert_owned(name, next.clone());
+    let newSlots @ _ = slots.clone().insert_owned(name, next.clone());
     crate::aver_generated::domain::resolver::core::resolveStmts(
         rest.clone(),
         newSlots,
@@ -967,8 +967,8 @@ pub fn resolveBinExpr(
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
     crate::cancel_checkpoint();
-    let ra = crate::aver_generated::domain::resolver::core::resolveExprSimple(a, slots);
-    let rb = crate::aver_generated::domain::resolver::core::resolveExprSimple(b, slots);
+    let ra @ _ = crate::aver_generated::domain::resolver::core::resolveExprSimple(a, slots);
+    let rb @ _ = crate::aver_generated::domain::resolver::core::resolveExprSimple(b, slots);
     {
         let __dispatch_subject = op;
         if &*__dispatch_subject == "add" {
@@ -1114,8 +1114,8 @@ pub fn resolveMatchExpr(
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
     crate::cancel_checkpoint();
-    let rs = crate::aver_generated::domain::resolver::core::resolveExprSimple(subj, slots);
-    let armsResult = crate::aver_generated::domain::resolver::core::resolveArms__collected(
+    let rs @ _ = crate::aver_generated::domain::resolver::core::resolveExprSimple(subj, slots);
+    let armsResult @ _ = crate::aver_generated::domain::resolver::core::resolveArms__collected(
         arms.clone(),
         slots.clone(),
         aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
@@ -1386,7 +1386,7 @@ pub fn resolveArm(
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
     crate::cancel_checkpoint();
-    let armSlotResult =
+    let armSlotResult @ _ =
         crate::aver_generated::domain::resolver::core::addPatternSlots(&arm.pattern, slots);
     {
         let (newSlots, _) = armSlotResult;
@@ -1431,7 +1431,7 @@ pub fn patternBindingSlots(
     slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> aver_rt::AverMap<AverStr, aver_rt::AverInt> {
     crate::cancel_checkpoint();
-    let nextSlot = crate::aver_generated::domain::resolver::core::mapMaxVal(slots)
+    let nextSlot @ _ = crate::aver_generated::domain::resolver::core::mapMaxVal(slots)
         .add(&aver_rt::AverInt::from_i64(1));
     {
         let (bindingSlots, _) =
@@ -1503,7 +1503,7 @@ pub fn patternBindingSlotsCons(
     aver_rt::AverInt,
 ) {
     crate::cancel_checkpoint();
-    let bindingSlots2 = bindingSlots.clone().insert_owned(h, next.clone());
+    let bindingSlots2 @ _ = bindingSlots.clone().insert_owned(h, next.clone());
     (
         bindingSlots2.insert_owned(t, next.add(&aver_rt::AverInt::from_i64(1))),
         next.add(&aver_rt::AverInt::from_i64(2)),
@@ -1567,7 +1567,7 @@ pub fn addPatternSlots(
     aver_rt::AverInt,
 ) {
     crate::cancel_checkpoint();
-    let nextSlot = crate::aver_generated::domain::resolver::core::mapMaxVal(slots)
+    let nextSlot @ _ = crate::aver_generated::domain::resolver::core::mapMaxVal(slots)
         .add(&aver_rt::AverInt::from_i64(1));
     crate::aver_generated::domain::resolver::core::addPatternSlotsInner(pat, slots, nextSlot)
 }
@@ -1576,7 +1576,7 @@ pub fn addPatternSlots(
 #[inline(always)]
 pub fn mapMaxVal(m: &aver_rt::AverMap<AverStr, aver_rt::AverInt>) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
-    let vals = {
+    let vals @ _ = {
         let mut es: Vec<_> = m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
         es.sort_by(|a, b| a.0.cmp(&b.0));
         aver_rt::AverIntList::from_vec(es.into_iter().map(|(_, v)| v).collect::<Vec<_>>())
@@ -1657,7 +1657,7 @@ pub fn addConsSlots(
     aver_rt::AverInt,
 ) {
     crate::cancel_checkpoint();
-    let slots2 = slots.clone().insert_owned(h, next.clone());
+    let slots2 @ _ = slots.clone().insert_owned(h, next.clone());
     (
         slots2.insert_owned(t, next.add(&aver_rt::AverInt::from_i64(1))),
         next.add(&aver_rt::AverInt::from_i64(2)),

--- a/src/self_host/aver_generated/domain/resolver/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/fast/mod.rs
@@ -29,7 +29,7 @@ pub fn annotateFastFn(
     fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
-    let selfId = fnMap
+    let selfId @ _ = fnMap
         .get(&fd.name)
         .cloned()
         .unwrap_or(aver_rt::AverInt::from_i64(-1));
@@ -825,8 +825,8 @@ pub fn classifyFastListArmPair(
     arm2: &crate::aver_generated::domain::ast::MatchArm,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
-    let leaf1 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
-    let leaf2 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm2.body);
+    let leaf1 @ _ = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
+    let leaf2 @ _ = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm2.body);
     match leaf1 {
         Some(v1 @ _) => match leaf2 {
             Some(v2 @ _) => {
@@ -1044,8 +1044,8 @@ pub fn classifyBoolArmPair(
     crate::aver_generated::domain::ast::FastLeaf,
 )> {
     crate::cancel_checkpoint();
-    let leaf1 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
-    let leaf2 = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm2.body);
+    let leaf1 @ _ = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
+    let leaf2 @ _ = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm2.body);
     match leaf1 {
         Some(v1 @ _) => match leaf2 {
             Some(v2 @ _) => crate::aver_generated::domain::resolver::fast::classifyBoolArmPatterns(

--- a/src/self_host/aver_generated/domain/resolver/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/mod.rs
@@ -16,21 +16,21 @@ pub fn resolveProgram(
     prog: &crate::aver_generated::domain::ast::Program,
 ) -> crate::aver_generated::domain::ast::Program {
     crate::cancel_checkpoint();
-    let resolvedFns = crate::aver_generated::domain::resolver::core::resolveFns(
+    let resolvedFns @ _ = crate::aver_generated::domain::resolver::core::resolveFns(
         prog.fns.clone(),
         aver_rt::AverList::empty(),
     );
-    let fnMap = crate::aver_generated::domain::resolver::calls::buildFnMap(
+    let fnMap @ _ = crate::aver_generated::domain::resolver::calls::buildFnMap(
         resolvedFns.clone(),
         HashMap::new(),
         aver_rt::AverInt::from_i64(0),
     );
-    let calledFns = crate::aver_generated::domain::resolver::calls::resolveCallsInFns(
+    let calledFns @ _ = crate::aver_generated::domain::resolver::calls::resolveCallsInFns(
         resolvedFns,
         fnMap.clone(),
         aver_rt::AverList::empty(),
     );
-    let annotatedFns = crate::aver_generated::domain::resolver::fast::annotateFastFns(
+    let annotatedFns @ _ = crate::aver_generated::domain::resolver::fast::annotateFastFns(
         calledFns,
         fnMap,
         aver_rt::AverList::empty(),

--- a/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
@@ -475,8 +475,8 @@ pub fn rewritePatConstructor(
     bindings: &aver_rt::AverList<AverStr>,
 ) -> crate::aver_generated::domain::ast::Pattern {
     crate::cancel_checkpoint();
-    let canonical = crate::aver_generated::domain::ast::canonicalCtorName(name);
-    let tag = crate::aver_generated::domain::ast::ctorNameToTag(canonical.clone());
+    let canonical @ _ = crate::aver_generated::domain::ast::canonicalCtorName(name);
+    let tag @ _ = crate::aver_generated::domain::ast::ctorNameToTag(canonical.clone());
     crate::aver_generated::domain::ast::Pattern::PatConstructorId(tag, canonical, bindings.clone())
 }
 

--- a/src/self_host/aver_generated/entry/mod.rs
+++ b/src/self_host/aver_generated/entry/mod.rs
@@ -48,7 +48,7 @@ fn __mutual_tco_trampoline_1(
             }
             __MutualTco1::QualifyFnsOne__indexed(mut f, mut rest, mut prefix, mut acc) => {
                 crate::cancel_checkpoint();
-                let qualified = crate::aver_generated::domain::ast::FnDef {
+                let qualified @ _ = crate::aver_generated::domain::ast::FnDef {
                     name: ((prefix.clone() + &AverStr::from(".")) + &f.name),
                     params: f.params.clone(),
                     body: f.body.clone(),
@@ -97,9 +97,9 @@ pub fn qualifyFnsOne__indexed(
 /// Lex, parse, resolve, and evaluate an Aver source string (no module loading).
 pub fn run(source: AverStr) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let tokens = crate::aver_generated::domain::lexer::lex(source);
-    let prog = crate::aver_generated::domain::parser::parse(&tokens)?;
-    let resolved = crate::aver_generated::domain::resolver::resolveProgram(&prog);
+    let tokens @ _ = crate::aver_generated::domain::lexer::lex(source);
+    let prog @ _ = crate::aver_generated::domain::parser::parse(&tokens)?;
+    let resolved @ _ = crate::aver_generated::domain::resolver::resolveProgram(&prog);
     runGuestProgram(
         &resolved,
         &aver_rt::AverList::empty(),
@@ -113,7 +113,7 @@ pub fn runWithModules(
     moduleRoot: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let prepared = prepareProgramWithModules(source, moduleRoot)?;
+    let prepared @ _ = prepareProgramWithModules(source, moduleRoot)?;
     {
         let (prog, moduleFns) = prepared;
         runGuestProgram(&prog, &moduleFns, &aver_rt::AverList::empty())
@@ -132,10 +132,10 @@ pub fn prepareProgramWithModules(
     AverStr,
 > {
     crate::cancel_checkpoint();
-    let tokens = crate::aver_generated::domain::lexer::lex(source);
-    let prog = crate::aver_generated::domain::parser::parse(&tokens)?;
-    let resolved = crate::aver_generated::domain::resolver::resolveProgram(&prog);
-    let r = loadModules(
+    let tokens @ _ = crate::aver_generated::domain::lexer::lex(source);
+    let prog @ _ = crate::aver_generated::domain::parser::parse(&tokens)?;
+    let resolved @ _ = crate::aver_generated::domain::resolver::resolveProgram(&prog);
+    let r @ _ = loadModules(
         resolved.deps.clone(),
         moduleRoot,
         aver_rt::AverList::empty(),
@@ -815,7 +815,7 @@ pub fn loadProgramFromFile(
     AverStr,
 > {
     crate::cancel_checkpoint();
-    let source = {
+    let source @ _ = {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
         crate::aver_replay::invoke_capability_effect(
@@ -854,7 +854,7 @@ pub fn runCliFile(
     guestArgs: &aver_rt::AverList<AverStr>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
-    let prepared = loadProgramFromFile(path, moduleRoot)?;
+    let prepared @ _ = loadProgramFromFile(path, moduleRoot)?;
     {
         let (prog, moduleFns) = prepared;
         runGuestCliProgram(&prog, &moduleFns, &prog.fns, guestArgs)
@@ -954,9 +954,9 @@ pub fn printIfNotUnit(s: AverStr) -> () {
 /// Show built-in demo programs.
 pub fn runDemo() -> Result<(), AverStr> {
     crate::cancel_checkpoint();
-    let demoArithmetic = runRepr(AverStr::from("x = 3 + 4\nx * 2"));
-    let demoDouble = runRepr(AverStr::from("fn double(n)\n    n + n\n\ndouble(21)"));
-    let demoFib = runRepr(AverStr::from(
+    let demoArithmetic @ _ = runRepr(AverStr::from("x = 3 + 4\nx * 2"));
+    let demoDouble @ _ = runRepr(AverStr::from("fn double(n)\n    n + n\n\ndouble(21)"));
+    let demoFib @ _ = runRepr(AverStr::from(
         "fn fib(n)\n    match n\n        0 -> 0\n        1 -> 1\n        _ -> fib(n - 1) + fib(n - 2)\n\nfib(10)",
     ));
     {
@@ -1174,13 +1174,13 @@ pub fn loadOneModule__indexed(
     AverStr,
 > {
     crate::cancel_checkpoint();
-    let path = findModulePath__indexed(
+    let path @ _ = findModulePath__indexed(
         dep.clone(),
         moduleRoot.clone(),
         aver_rt::AverInt::from_i64(0),
         __str_index.clone(),
     );
-    let source = {
+    let source @ _ = {
         let __provider_arg0: AverStr = path;
         crate::cancel_checkpoint();
         crate::aver_replay::invoke_capability_effect(
@@ -1200,11 +1200,11 @@ pub fn loadOneModule__indexed(
             },
         )
     }?;
-    let tokens = crate::aver_generated::domain::lexer::lex(source);
-    let prog = crate::aver_generated::domain::parser::parse(&tokens)?;
-    let moduleFns = resolveQualifiedModuleFns__indexed(&prog, dep.clone(), __str_index);
-    let loaded2 = loaded.clone().insert_owned(dep, true);
-    let innerResult = loadModules(prog.deps.clone(), moduleRoot.clone(), acc.clone(), loaded2)?;
+    let tokens @ _ = crate::aver_generated::domain::lexer::lex(source);
+    let prog @ _ = crate::aver_generated::domain::parser::parse(&tokens)?;
+    let moduleFns @ _ = resolveQualifiedModuleFns__indexed(&prog, dep.clone(), __str_index);
+    let loaded2 @ _ = loaded.clone().insert_owned(dep, true);
+    let innerResult @ _ = loadModules(prog.deps.clone(), moduleRoot.clone(), acc.clone(), loaded2)?;
     {
         let (accWithInner, loaded3) = innerResult;
         loadModules(
@@ -1235,7 +1235,7 @@ pub fn findModulePath__indexed(
     let __str_index = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
-        let path = modulePathFromName__indexed(dep.clone(), root.clone(), &*__str_index);
+        let path @ _ = modulePathFromName__indexed(dep.clone(), root.clone(), &*__str_index);
         if {
             let __provider_arg0: AverStr = path.clone();
             crate::cancel_checkpoint();
@@ -1303,7 +1303,7 @@ pub fn dotToSlash__indexed(
     let __str_index = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
-        let nextPos = pos.add(&aver_rt::AverInt::from_i64(1));
+        let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
         if (pos < total) {
             match aver_rt::string_index_char_at(&name, &__str_index, &pos) {
                 Some(c @ _) => {
@@ -1342,7 +1342,7 @@ pub fn resolveQualifiedModuleFns__indexed(
     __str_index: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     crate::cancel_checkpoint();
-    let qualifiedProg = crate::aver_generated::domain::ast::Program {
+    let qualifiedProg @ _ = crate::aver_generated::domain::ast::Program {
         deps: prog.deps.clone(),
         fns: qualifyFns__indexed(&prog.fns, dep, &aver_rt::AverList::empty(), __str_index),
         stmts: prog.stmts.clone(),
@@ -1447,7 +1447,7 @@ pub fn shiftFnIdsInArms__collected(
 
 pub fn main() -> Result<(), AverStr> {
     crate::cancel_checkpoint();
-    let args = {
+    let args @ _ = {
         crate::cancel_checkpoint();
         crate::aver_replay::invoke_capability_effect("Args.get", "recorded", vec![], || {
             crate::provider_support::invoke::<aver_rt::AverList<AverStr>>(

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -5237,6 +5237,106 @@ fn main() -> Unit
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Regression for #1151: the same Rust item-resolution ambiguity applies to
+/// an ordinary `let` pattern. The source only calls qualified dependency
+/// functions, so the local `opened` binding must remain unambiguously local.
+#[test]
+fn colliding_dependency_function_names_do_not_conflict_with_let_binders() {
+    let ws = temp_dir("dependency_function_let_binder_collision");
+    for (module, value) in [("Alpha", 1), ("Beta", 2)] {
+        fs::write(
+            ws.join(format!("{module}.av")),
+            format!(
+                r#"module {module}
+    exposes [opened]
+    intent = "Expose one of two colliding short function names."
+    effects []
+
+fn opened() -> Int
+    ? "Return this module's value."
+    {value}
+"#
+            ),
+        )
+        .expect("write dependency module");
+    }
+
+    let entry = ws.join("main.av");
+    fs::write(
+        &entry,
+        r#"module Main
+    depends [Alpha, Beta]
+    intent = "Keep a local let binder distinct from colliding dependency functions."
+    effects [Console]
+
+fn total() -> Int
+    ? "Bind a qualified call under the dependencies' shared short name."
+    opened = Alpha.opened()
+    higher(opened, Beta.opened())
+
+fn higher(a: Int, b: Int) -> Int
+    ? "Return the larger dependency value."
+    match a >= b
+        true -> a
+        false -> b
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("total={total()}")
+"#,
+    )
+    .expect("write entry module");
+
+    let vm_stdout = run_vm(&entry, Some(&ws)).expect("VM run");
+    assert_eq!(vm_stdout, "total=2", "VM contract changed");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(
+            &entry,
+            &project,
+            "dependency_function_let_binder_collision",
+            Some(&ws),
+            &[],
+        )?;
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("let opened @ _ =") {
+            return Err(format!(
+                "local let binder was not made explicit:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, "dependency_function_let_binder_collision")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "dependency-function-let-binder generated binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "dependency-function-let-binder stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 // ─── Mode (h): Int.fromString / Float.fromString Err-message bytes ────────
 //
 // `Int.fromString` / `Float.fromString` return a `Result<_, String>`.


### PR DESCRIPTION
Closes #1151.

Generated Rust now emits source-level let binders as explicit patterns (`name @ _`), matching the existing #1043 fix for match binders. This prevents Rust item resolution from treating a local binder as ambiguous when multiple dependency glob imports expose functions with the same short name.

The change covers inline MIR lets, flat function bodies, self-TCO bodies, mutual-TCO trampolines, and top-level bindings. The checked-in self-host output is regenerated, hence the mechanical generated diff.

Validation:
- full rust_codegen_differential: 60 passed, 10 ignored
- rust_codegen_regression: 4 passed
- from_mir unit suite: 64 passed
- exact CI clippy gate: clean
- self-host freshness: clean
- cargo fmt and git diff --check: clean