### PR TITLE
perf(mir): preserve byte list provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 - **Maps have one deterministic order on every backend.** Iteration is sorted by key, `keys[i]` pairs with `values[i]`, and equality uses the same canonical form in execution and proof. Map keys must have a modelled total order; `Float` keys are rejected instead of giving NaN or proof-model divergences.
 
-- **The VM and generated Rust avoid several formerly quadratic paths.** List traversal and `List.drop`, string/codepoint scans, list/string/byte builders, map construction and folding, immutable collection relocation, large append-only stores, generated-Rust accumulator returns, and already-packed byte refinements now preserve sharing or ownership instead of repeatedly rebuilding or revalidating live data. The embedded wasm engine separately moves to wasmtime 46's copying collector.
+- **The VM and generated Rust avoid several formerly quadratic paths.** List traversal and `List.drop`, string/codepoint scans, list/string/byte builders, map construction and folding, immutable collection relocation, large append-only stores, generated-Rust accumulator returns, and byte refinements now preserve sharing, ownership, or their proven range instead of repeatedly rebuilding or revalidating live data. VM and wasm-gc carry that range through byte projection, concatenation, and slicing; the embedded wasm engine separately moves to wasmtime 46's copying collector.
 
 - **Generated projects pin the compiler's actual source provenance.** Path builds emit path dependencies, git builds pin the repository and revision, and registry builds emit exact registry versions for both `aver-lang` and `aver-rt`.
 

--- a/src/analysis/literal_refinement.rs
+++ b/src/analysis/literal_refinement.rs
@@ -82,7 +82,7 @@ use crate::ast::{Expr, FnDef, Spanned, TopLevel};
 use crate::codegen::ModuleInfo;
 use crate::ir::SymbolTable;
 use crate::ir::hir::{ResolveCtx, ResolvedCallee};
-use crate::ir::identity::{FnId, FnKey};
+use crate::ir::identity::{FnId, FnKey, TypeId, TypeKey};
 use crate::ir::interval::Interval;
 
 /// One recognized smart constructor over a `List<Int>` carrier whose
@@ -92,6 +92,9 @@ pub struct ListRefinementCtor {
     /// Resolved identity of the smart constructor — the ONLY key a call
     /// site is matched against. See the module-level invariant.
     pub fn_id: FnId,
+    /// Resolved identity of the refined nominal record. Runtime provenance
+    /// is compared by this identity, never by the source spelling.
+    pub type_id: TypeId,
     /// Dependency-module prefix that owns the refinement (`"Bytes"`), or
     /// `None` when the refinement is declared in the entry file.
     pub scope: Option<String>,
@@ -102,8 +105,15 @@ pub struct ListRefinementCtor {
     /// Bare source name of the smart constructor (`"fromList"`). Carried
     /// for diagnostics only; it is never a lookup key.
     pub constructor_fn: String,
+    /// Exact carrier-projector functions in the refinement's owning module.
+    /// Each has the structural body `fn p(x: T) -> List<Int> = x.<field>`.
+    pub projector_fns: Vec<FnId>,
     /// Interval proven for EVERY element of the carrier list.
     pub element_interval: Interval,
+    /// Whether every executable construction of this nominal is gated by the
+    /// smart constructor (or is independently proven safe). Only closed
+    /// refinements may seed runtime list provenance.
+    pub runtime_provenance: bool,
 }
 
 /// Every literal-dischargeable smart constructor in one compilation,
@@ -139,13 +149,12 @@ impl LiteralRefinementTable {
             return Self::default();
         }
 
-        let entry_fns: Vec<&FnDef> = entry_items
+        let entry_all_fns: Vec<&FnDef> = entry_items
             .iter()
             .filter_map(|item| match item {
                 TopLevel::FnDef(fd) => Some(fd),
                 _ => None,
             })
-            .filter(|fd| crate::codegen::common::is_pure_fn(fd))
             .collect();
 
         // A bare record name declared in more than one scope would make the
@@ -169,15 +178,19 @@ impl LiteralRefinementTable {
             if !is_int_list(&carrier_type) {
                 continue;
             }
-            let scope_fns: Vec<&FnDef> = match scope.as_deref() {
-                None => entry_fns.clone(),
+            let scope_all_fns: Vec<&FnDef> = match scope.as_deref() {
+                None => entry_all_fns.clone(),
                 Some(prefix) => dep_modules
                     .iter()
                     .filter(|m| m.prefix == prefix)
                     .flat_map(|m| m.fn_defs.iter())
-                    .filter(|fd| crate::codegen::common::is_pure_fn(fd))
                     .collect(),
             };
+            let scope_fns: Vec<&FnDef> = scope_all_fns
+                .iter()
+                .copied()
+                .filter(|fd| crate::codegen::common::is_pure_fn(fd))
+                .collect();
             let resolve = |expr: &Spanned<Expr>| {
                 let mut rctx = crate::ir::hir::ResolveCtx::new(symbols);
                 rctx.current_module = scope.clone();
@@ -200,6 +213,21 @@ impl LiteralRefinementTable {
             if !seen.insert((scope.clone(), type_name.clone())) {
                 continue;
             }
+            // `FnKey` is name-based within one scope. If another definition
+            // shares the smart constructor's name, its call sites collapse to
+            // the same identity and neither literal nor runtime discharge is
+            // sound. Requiring the sole definition to be pure also prevents a
+            // discharge from erasing declared effects.
+            let constructor_defs = scope_all_fns
+                .iter()
+                .filter(|fd| fd.name == constructor_fn)
+                .copied()
+                .collect::<Vec<_>>();
+            if constructor_defs.len() != 1
+                || !crate::codegen::common::is_pure_fn(constructor_defs[0])
+            {
+                continue;
+            }
             // The one key a call site is ever matched against. A
             // constructor the symbol table doesn't index cannot be named
             // by any resolved callee, so it is dropped rather than kept
@@ -211,13 +239,43 @@ impl LiteralRefinementTable {
             let Some(fn_id) = symbols.fn_id_of(&key) else {
                 continue;
             };
+            let type_key = match scope.as_deref() {
+                Some(prefix) => TypeKey::in_module(prefix, &type_name),
+                None => TypeKey::entry(&type_name),
+            };
+            let Some(type_id) = symbols.type_id_of(&type_key) else {
+                continue;
+            };
+            let projector_fns = scope_fns
+                .iter()
+                .filter(|fd| is_exact_carrier_projector(fd, &type_name, &carrier_field))
+                // Duplicate names collapse to one `FnId`; even a structurally
+                // exact sibling cannot prove which body a call will execute.
+                .filter(|fd| {
+                    scope_all_fns
+                        .iter()
+                        .filter(|candidate| candidate.name == fd.name)
+                        .count()
+                        == 1
+                })
+                .filter_map(|fd| {
+                    let key = match scope.as_deref() {
+                        Some(prefix) => FnKey::in_module(prefix, &fd.name),
+                        None => FnKey::entry(&fd.name),
+                    };
+                    symbols.fn_id_of(&key)
+                })
+                .collect();
             ctors.push(ListRefinementCtor {
                 fn_id,
+                type_id,
                 scope,
                 type_name,
                 carrier_field,
                 constructor_fn,
+                projector_fns,
                 element_interval,
+                runtime_provenance: false,
             });
         }
 
@@ -231,6 +289,15 @@ impl LiteralRefinementTable {
         }
         ctors.retain(|ctor| per_identity[&ctor.fn_id] == 1);
 
+        // A projected carrier proves its element interval only when every
+        // inhabitant of the nominal passed an equivalent gate. Keep literal
+        // discharge independent: an in-range literal remains dischargeable
+        // even when the surrounding module also constructs the record
+        // unsafely, but runtime provenance must fail closed in that case.
+        for ctor in &mut ctors {
+            ctor.runtime_provenance = runtime_provenance_is_closed(ctor, entry_items, dep_modules);
+        }
+
         Self { ctors }
     }
 
@@ -238,6 +305,12 @@ impl LiteralRefinementTable {
     /// skip the per-call-site work entirely.
     pub fn is_empty(&self) -> bool {
         self.ctors.is_empty()
+    }
+
+    /// Recognized constructors, including the identity-pinned runtime
+    /// provenance metadata consumed by the MIR optimization pass.
+    pub fn iter(&self) -> impl Iterator<Item = &ListRefinementCtor> {
+        self.ctors.iter()
     }
 
     /// Decide the discharge for one call site.
@@ -259,6 +332,134 @@ impl LiteralRefinementTable {
             .iter()
             .all(|k| ctor.element_interval.contains_point(*k))
             .then_some(ctor)
+    }
+}
+
+/// Recognize the representation-independent carrier projection that can seed
+/// a runtime provenance fact. The function must live in the same scope as the
+/// refinement (the caller supplies that pool), accept the nominal itself, and
+/// return its sole `List<Int>` field without any computation.
+fn is_exact_carrier_projector(fd: &FnDef, type_name: &str, carrier_field: &str) -> bool {
+    if !crate::codegen::common::is_pure_fn(fd) || fd.params.len() != 1 {
+        return false;
+    }
+    let (param_name, param_ty) = &fd.params[0];
+    let param_matches = matches!(
+        crate::types::parse_type_str(param_ty),
+        crate::types::Type::Named { name, .. }
+            if name.rsplit('.').next() == Some(type_name)
+    );
+    if !param_matches
+        || !matches!(
+            crate::types::parse_type_str(&fd.return_type),
+            crate::types::Type::List(inner) if *inner == crate::types::Type::Int
+        )
+    {
+        return false;
+    }
+    let [crate::ast::Stmt::Expr(body)] = fd.body.stmts() else {
+        return false;
+    };
+    matches!(
+        &body.node,
+        Expr::Attr(base, field)
+            if field == carrier_field
+                && matches!(
+                    &base.node,
+                    Expr::Ident(name) | Expr::Resolved { name, .. } if name == param_name
+                )
+    )
+}
+
+/// Prove that a nominal's carrier invariant is closed over every source-level
+/// construction site. Opaque access prevents callers from constructing the
+/// record, but its own module may still bypass the smart constructor. One such
+/// site invalidates runtime provenance for the whole nominal.
+fn runtime_provenance_is_closed(
+    ctor: &ListRefinementCtor,
+    entry_items: &[TopLevel],
+    dep_modules: &[ModuleInfo],
+) -> bool {
+    let scan_expr = |scope: Option<&str>, inside_gate: bool, expr: &Spanned<Expr>| {
+        let mut closed = true;
+        crate::codegen::proof_lower::carrier_walk_expr_with_byte_payloads(
+            expr,
+            &HashSet::new(),
+            &mut |node, byte_payloads| {
+                if !closed {
+                    return;
+                }
+                let (spelling, fields, is_update) = match node {
+                    Expr::RecordCreate { type_name, fields } => {
+                        (type_name.as_str(), fields.as_slice(), false)
+                    }
+                    Expr::RecordUpdate {
+                        type_name, updates, ..
+                    } => (type_name.as_str(), updates.as_slice(), true),
+                    _ => return,
+                };
+                if !record_spelling_denotes_ctor(ctor, scope, spelling) || inside_gate {
+                    return;
+                }
+                let independently_safe = !is_update
+                    && (crate::codegen::proof_lower::construct_arg_is_in_interval(
+                        fields,
+                        ctor.element_interval,
+                    ) || crate::codegen::proof_lower::construct_arg_is_finalized_bytes(
+                        fields,
+                        ctor.element_interval,
+                        byte_payloads,
+                    ));
+                if !independently_safe {
+                    closed = false;
+                }
+            },
+        );
+        closed
+    };
+
+    let scan_fn = |scope: Option<&str>, fd: &FnDef| {
+        let inside_gate = scope == ctor.scope.as_deref() && fd.name == ctor.constructor_fn;
+        fd.body.stmts().iter().all(|stmt| {
+            let expr = match stmt {
+                crate::ast::Stmt::Binding(_, _, value) | crate::ast::Stmt::Expr(value) => value,
+            };
+            scan_expr(scope, inside_gate, expr)
+        })
+    };
+
+    for item in entry_items {
+        let closed = match item {
+            TopLevel::FnDef(fd) => scan_fn(None, fd),
+            TopLevel::Stmt(crate::ast::Stmt::Binding(_, _, value))
+            | TopLevel::Stmt(crate::ast::Stmt::Expr(value)) => scan_expr(None, false, value),
+            _ => true,
+        };
+        if !closed {
+            return false;
+        }
+    }
+    for module in dep_modules {
+        for fd in &module.fn_defs {
+            if !scan_fn(Some(module.prefix.as_str()), fd) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn record_spelling_denotes_ctor(
+    ctor: &ListRefinementCtor,
+    current_scope: Option<&str>,
+    spelling: &str,
+) -> bool {
+    if current_scope == ctor.scope.as_deref() && spelling == ctor.type_name {
+        return true;
+    }
+    match ctor.scope.as_deref() {
+        Some(prefix) => spelling == format!("{prefix}.{}", ctor.type_name),
+        None => false,
     }
 }
 
@@ -529,15 +730,21 @@ fn go() -> Int
         let fn_id = symbols
             .fn_id_of(&FnKey::in_module("Octets", "fromList"))
             .expect("Octets.fromList must be indexed");
+        let type_id = symbols
+            .type_id_of(&TypeKey::in_module("Octets", "Octets"))
+            .expect("Octets type must be indexed");
         assert_eq!(
             symbols.literal_refinements().ctors,
             vec![ListRefinementCtor {
                 fn_id,
+                type_id,
                 scope: Some("Octets".to_string()),
                 type_name: "Octets".to_string(),
                 carrier_field: "values".to_string(),
                 constructor_fn: "fromList".to_string(),
+                projector_fns: Vec::new(),
                 element_interval: Interval::between(0, 255),
+                runtime_provenance: true,
             }]
         );
     }
@@ -548,15 +755,68 @@ fn go() -> Int
             CONSUMER,
             &[("Bytes", include_str!("../../stdlib/bytes.av"))],
         );
+        let bytes = symbols
+            .literal_refinements()
+            .ctors
+            .iter()
+            .find(|c| c.type_name == "Bytes")
+            .expect("Bytes refinement");
+        assert_eq!(bytes.element_interval, Interval::between(0, 255));
+        assert!(bytes.runtime_provenance);
         assert_eq!(
-            symbols
-                .literal_refinements()
-                .ctors
-                .iter()
-                .find(|c| c.type_name == "Bytes")
-                .map(|c| c.element_interval),
-            Some(Interval::between(0, 255))
+            bytes.projector_fns,
+            vec![
+                symbols
+                    .fn_id_of(&FnKey::in_module("Bytes", "octets"))
+                    .expect("Bytes.octets identity")
+            ]
         );
+    }
+
+    #[test]
+    fn an_ungated_record_constructor_disables_runtime_provenance_only() {
+        let unsafe_octets = format!(
+            "{OCTETS}\n\nfn octets(value: Octets) -> List<Int>\n    value.values\n\nfn bypass(xs: List<Int>) -> Octets\n    Octets(values = xs)\n"
+        );
+        let symbols = symbols_for(CONSUMER, &[("Octets", &unsafe_octets)]);
+        let ctor = symbols
+            .literal_refinements()
+            .ctors
+            .iter()
+            .find(|ctor| ctor.type_name == "Octets")
+            .expect("literal refinement still exists");
+        assert!(!ctor.runtime_provenance);
+        assert_eq!(ctor.projector_fns.len(), 1);
+        assert!(discharges_from(&symbols, None, "Octets.fromList([1, 2])"));
+    }
+
+    #[test]
+    fn a_duplicate_projector_name_cannot_seed_runtime_provenance() {
+        let ambiguous_octets = format!(
+            "{OCTETS}\n\nfn octets(value: Octets) -> List<Int>\n    value.values\n\nfn octets(value: Octets) -> List<Int>\n    List.prepend(999, value.values)\n"
+        );
+        let symbols = symbols_for(CONSUMER, &[("Octets", &ambiguous_octets)]);
+        let ctor = symbols
+            .literal_refinements()
+            .ctors
+            .iter()
+            .find(|ctor| ctor.type_name == "Octets")
+            .expect("literal refinement still exists");
+        assert!(ctor.runtime_provenance);
+        assert!(ctor.projector_fns.is_empty());
+    }
+
+    #[test]
+    fn an_ungated_top_level_constructor_disables_runtime_provenance() {
+        let unsafe_octets = format!("{OCTETS}\n\nunsafe = Octets(values = [256])\n");
+        let symbols = symbols_for(&unsafe_octets, &[]);
+        let ctor = symbols
+            .literal_refinements()
+            .ctors
+            .iter()
+            .find(|ctor| ctor.type_name == "Octets")
+            .expect("literal refinement still exists");
+        assert!(!ctor.runtime_provenance);
     }
 
     #[test]

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -1622,7 +1622,7 @@ pub fn carrier_eligibility_demotions(
 /// `IntRange(value = -5)` (parsed as `Expr::Neg(Literal(Int))`). Any other
 /// shape (a parameter, a call, an arithmetic expression) is NOT a provable
 /// constant ⇒ returns `false` ⇒ the construct is treated as ungated.
-fn construct_arg_is_in_interval(
+pub(crate) fn construct_arg_is_in_interval(
     fields: &[(String, Spanned<Expr>)],
     iv: crate::ir::interval::Interval,
 ) -> bool {
@@ -1647,7 +1647,7 @@ fn construct_arg_is_in_interval(
 /// so wrapping that payload is another refinement gate rather than an escape.
 /// Keep this structural and interval-exact: a byte builder cannot establish a
 /// narrower refinement such as 0..=127.
-fn construct_arg_is_finalized_bytes(
+pub(crate) fn construct_arg_is_finalized_bytes(
     fields: &[(String, Spanned<Expr>)],
     iv: crate::ir::interval::Interval,
     byte_payloads: &HashSet<String>,
@@ -1668,7 +1668,7 @@ fn construct_arg_is_finalized_bytes(
 /// compiler-internal `__byt_finalize : ByteBuilder -> Result<List<Int>,
 /// String>` boundary. Facts are scoped to the matching `Result.Ok` arm and
 /// therefore cannot leak across an unrelated constructor site.
-fn carrier_walk_expr_with_byte_payloads(
+pub(crate) fn carrier_walk_expr_with_byte_payloads(
     expr: &Spanned<Expr>,
     byte_payloads: &HashSet<String>,
     visit: &mut impl FnMut(&Expr, &HashSet<String>),

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -263,7 +263,10 @@ pub(super) fn emit_module_with(
             .cloned()
             .map(crate::ir::hir::ResolvedTopLevel::FnDef)
             .collect();
-        crate::ir::mir::optimize(crate::ir::mir::lower_program(&mir_items))
+        crate::ir::mir::optimize::optimize_with_list_refinements(
+            crate::ir::mir::lower_program(&mir_items),
+            symbol_table.literal_refinements(),
+        )
     };
 
     let eligible_carriers: std::collections::HashSet<String> =

--- a/src/ir/mir/optimize/list_refinement.rs
+++ b/src/ir/mir/optimize/list_refinement.rs
@@ -1,0 +1,377 @@
+//! Runtime provenance for closed `List<Int>` refinements.
+//!
+//! A carrier projector from a closed refinement proves that every element of
+//! the resulting list satisfies that refinement's derived interval. The proof
+//! survives only operations that cannot introduce an element (`concat` of two
+//! equally-proven lists, `take`, and `drop`). Feeding the fact back to the same
+//! smart constructor makes its validation branch unreachable, so this pass
+//! replaces the call with the constructor's `Result.Ok(record)` answer.
+//!
+//! Identity is the soundness boundary: constructor, projector, and nominal are
+//! matched by `FnId` / `TypeId`. No source spelling such as `Bytes` is special.
+
+use std::collections::HashMap;
+
+use crate::analysis::literal_refinement::LiteralRefinementTable;
+use crate::ast::{Spanned, Type};
+use crate::ir::{BuiltinId, FnId, TypeId};
+
+use super::super::expr::{
+    MirConstruct, MirCtor, MirExpr, MirRecordCreate, MirRecordField, walk_children_mut,
+};
+use super::super::program::{LocalId, MirProgram};
+use crate::ir::hir::BuiltinCtor;
+
+#[derive(Debug, Clone)]
+struct RefinementPlan {
+    type_id: TypeId,
+    type_name: String,
+    carrier_field: String,
+}
+
+#[derive(Debug, Clone)]
+struct ListFact {
+    type_id: TypeId,
+    /// Present only for an immediately nested exact carrier projection. It is
+    /// safe to replace `from(project(value))` with `Ok(value)` because this
+    /// removes the projection without duplicating evaluation. Facts stored in
+    /// locals deliberately drop this field.
+    direct_nominal: Option<Spanned<MirExpr>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PreservingListOp {
+    Concat,
+    TakeOrDrop,
+}
+
+/// Discharge smart-constructor validation when the input list carries a
+/// closed, identity-matching refinement provenance fact.
+pub fn discharge_proven_lists(
+    mut program: MirProgram,
+    refinements: &LiteralRefinementTable,
+) -> MirProgram {
+    let mut constructors: HashMap<FnId, RefinementPlan> = HashMap::new();
+    let mut projectors: HashMap<FnId, TypeId> = HashMap::new();
+    let mut by_type: HashMap<TypeId, RefinementPlan> = HashMap::new();
+    for ctor in refinements.iter().filter(|ctor| ctor.runtime_provenance) {
+        let plan = RefinementPlan {
+            type_id: ctor.type_id,
+            type_name: ctor.type_name.clone(),
+            carrier_field: ctor.carrier_field.clone(),
+        };
+        constructors.insert(ctor.fn_id, plan.clone());
+        by_type.insert(ctor.type_id, plan);
+        for projector in &ctor.projector_fns {
+            projectors.insert(*projector, ctor.type_id);
+        }
+    }
+    if constructors.is_empty() {
+        return program;
+    }
+
+    let preserving_builtins: HashMap<BuiltinId, PreservingListOp> = program
+        .builtins
+        .iter()
+        .enumerate()
+        .filter_map(|(index, name)| {
+            let op = match name.as_str() {
+                "List.concat" => PreservingListOp::Concat,
+                "List.take" | "List.drop" => PreservingListOp::TakeOrDrop,
+                _ => return None,
+            };
+            Some((BuiltinId(index as u32), op))
+        })
+        .collect();
+
+    for mir_fn in program.fns.values_mut() {
+        let mut locals = HashMap::new();
+        rewrite_expr(
+            &mut mir_fn.body,
+            &mut locals,
+            &constructors,
+            &projectors,
+            &by_type,
+            &preserving_builtins,
+        );
+    }
+    program
+}
+
+fn rewrite_expr(
+    expr: &mut Spanned<MirExpr>,
+    locals: &mut HashMap<LocalId, ListFact>,
+    constructors: &HashMap<FnId, RefinementPlan>,
+    projectors: &HashMap<FnId, TypeId>,
+    by_type: &HashMap<TypeId, RefinementPlan>,
+    preserving_builtins: &HashMap<BuiltinId, PreservingListOp>,
+) -> Option<ListFact> {
+    match &mut expr.node {
+        MirExpr::Local(local) => locals.get(&local.node.slot).cloned().map(|mut fact| {
+            fact.direct_nominal = None;
+            fact
+        }),
+        MirExpr::Let(let_node) => {
+            let value_fact = rewrite_expr(
+                &mut let_node.node.value,
+                locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            let binding = let_node.node.binding;
+            let previous = match value_fact {
+                Some(mut fact) => {
+                    fact.direct_nominal = None;
+                    locals.insert(binding, fact)
+                }
+                None => locals.remove(&binding),
+            };
+            let body_fact = rewrite_expr(
+                &mut let_node.node.body,
+                locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            match previous {
+                Some(fact) => {
+                    locals.insert(binding, fact);
+                }
+                None => {
+                    locals.remove(&binding);
+                }
+            }
+            body_fact
+        }
+        MirExpr::Call(call_node) => {
+            let arg_facts = call_node
+                .node
+                .args
+                .iter_mut()
+                .map(|arg| {
+                    rewrite_expr(
+                        arg,
+                        locals,
+                        constructors,
+                        projectors,
+                        by_type,
+                        preserving_builtins,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            if let super::super::expr::MirCallee::Fn(fn_id) = call_node.node.callee {
+                if let Some(plan) = constructors.get(&fn_id)
+                    && let [Some(fact)] = arg_facts.as_slice()
+                    && fact.type_id == plan.type_id
+                {
+                    let direct = fact.direct_nominal.clone();
+                    let carrier = call_node.node.args.remove(0);
+                    replace_with_success(expr, plan, direct, carrier);
+                    return None;
+                }
+                if let Some(type_id) = projectors.get(&fn_id).copied()
+                    && call_node.node.args.len() == 1
+                    && call_node.node.args[0].ty().and_then(Type::named_id) == Some(type_id)
+                {
+                    return Some(ListFact {
+                        type_id,
+                        direct_nominal: Some(call_node.node.args[0].clone()),
+                    });
+                }
+            }
+
+            if let super::super::expr::MirCallee::Builtin(builtin) = call_node.node.callee {
+                match preserving_builtins.get(&builtin) {
+                    Some(PreservingListOp::Concat) => {
+                        if let [Some(left), Some(right)] = arg_facts.as_slice()
+                            && left.type_id == right.type_id
+                        {
+                            return Some(ListFact {
+                                type_id: left.type_id,
+                                direct_nominal: None,
+                            });
+                        }
+                    }
+                    Some(PreservingListOp::TakeOrDrop) => {
+                        if let Some(Some(source)) = arg_facts.first() {
+                            return Some(ListFact {
+                                type_id: source.type_id,
+                                direct_nominal: None,
+                            });
+                        }
+                    }
+                    None => {}
+                }
+            }
+            None
+        }
+        MirExpr::Project(project) => {
+            rewrite_expr(
+                &mut project.node.base,
+                locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            let type_id = project.node.base.ty().and_then(Type::named_id)?;
+            let plan = by_type.get(&type_id)?;
+            (project.node.field == plan.carrier_field).then(|| ListFact {
+                type_id,
+                direct_nominal: Some((*project.node.base).clone()),
+            })
+        }
+        MirExpr::IfThenElse(branches) => {
+            rewrite_expr(
+                &mut branches.node.cond,
+                locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            let mut then_locals = locals.clone();
+            let then_fact = rewrite_expr(
+                &mut branches.node.then_branch,
+                &mut then_locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            let mut else_locals = locals.clone();
+            let else_fact = rewrite_expr(
+                &mut branches.node.else_branch,
+                &mut else_locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            same_fact(then_fact, else_fact)
+        }
+        MirExpr::Match(match_node) => {
+            rewrite_expr(
+                &mut match_node.node.subject,
+                locals,
+                constructors,
+                projectors,
+                by_type,
+                preserving_builtins,
+            );
+            let mut facts = Vec::with_capacity(match_node.node.arms.len());
+            for arm in &mut match_node.node.arms {
+                let mut arm_locals = locals.clone();
+                facts.push(rewrite_expr(
+                    &mut arm.body,
+                    &mut arm_locals,
+                    constructors,
+                    projectors,
+                    by_type,
+                    preserving_builtins,
+                ));
+            }
+            common_fact(facts)
+        }
+        MirExpr::Return(inner) => rewrite_expr(
+            inner,
+            locals,
+            constructors,
+            projectors,
+            by_type,
+            preserving_builtins,
+        ),
+        _ => {
+            walk_children_mut(&mut expr.node, &mut |child| {
+                let _ = rewrite_expr(
+                    child,
+                    locals,
+                    constructors,
+                    projectors,
+                    by_type,
+                    preserving_builtins,
+                );
+            });
+            None
+        }
+    }
+}
+
+fn same_fact(left: Option<ListFact>, right: Option<ListFact>) -> Option<ListFact> {
+    match (left, right) {
+        (Some(left), Some(right)) if left.type_id == right.type_id => Some(ListFact {
+            type_id: left.type_id,
+            direct_nominal: None,
+        }),
+        _ => None,
+    }
+}
+
+fn common_fact(facts: Vec<Option<ListFact>>) -> Option<ListFact> {
+    let mut facts = facts.into_iter();
+    let first = facts.next()??;
+    facts
+        .all(|fact| fact.is_some_and(|fact| fact.type_id == first.type_id))
+        .then(|| ListFact {
+            type_id: first.type_id,
+            direct_nominal: None,
+        })
+}
+
+fn replace_with_success(
+    expr: &mut Spanned<MirExpr>,
+    plan: &RefinementPlan,
+    direct_nominal: Option<Spanned<MirExpr>>,
+    carrier: Spanned<MirExpr>,
+) {
+    let line = expr.line;
+    let result_ty = expr.ty().cloned();
+    let nominal_ty = Type::named_resolved(plan.type_id, plan.type_name.clone());
+    let nominal = direct_nominal.unwrap_or_else(|| {
+        let record = typed_span(
+            MirRecordCreate {
+                type_id: Some(plan.type_id),
+                type_name: plan.type_name.clone(),
+                fields: vec![MirRecordField {
+                    name: plan.carrier_field.clone(),
+                    value: carrier,
+                }],
+            },
+            line,
+            Some(nominal_ty.clone()),
+        );
+        typed_span(
+            MirExpr::RecordCreate(record),
+            line,
+            Some(nominal_ty.clone()),
+        )
+    });
+    let construct = typed_span(
+        MirConstruct {
+            ctor: MirCtor::Builtin(BuiltinCtor::ResultOk),
+            args: vec![nominal],
+        },
+        line,
+        result_ty,
+    );
+    expr.node = MirExpr::Construct(construct);
+}
+
+fn typed_span<T>(node: T, line: crate::ast::SourceLine, ty: Option<Type>) -> Spanned<T> {
+    let cell = std::sync::OnceLock::new();
+    if let Some(ty) = ty {
+        let _ = cell.set(ty);
+    }
+    Spanned {
+        node,
+        line,
+        ty: cell,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/ir/mir/optimize/list_refinement/tests.rs
+++ b/src/ir/mir/optimize/list_refinement/tests.rs
@@ -1,0 +1,127 @@
+use super::*;
+use crate::ir::mir::{MirCallee, lower_program};
+use crate::source::parse_source;
+
+const PROGRAM: &str = r#"
+module Octets
+    intent = "exercise identity-pinned list refinement provenance"
+    effects []
+
+record Octets
+    values: List<Int>
+
+fn allInRange(xs: List<Int>) -> Bool
+    match xs
+        [] -> true
+        [head, ..tail] -> match Bool.and(head >= 0, head <= 255)
+            true -> allInRange(tail)
+            false -> false
+
+fn fromList(xs: List<Int>) -> Result<Octets, String>
+    match allInRange(xs)
+        true -> Result.Ok(Octets(values = xs))
+        false -> Result.Err("oob")
+
+fn octets(value: Octets) -> List<Int>
+    value.values
+
+fn direct(value: Octets) -> Result<Octets, String>
+    fromList(octets(value))
+
+fn combined(left: Octets, right: Octets) -> Result<Octets, String>
+    fromList(List.concat(octets(left), octets(right)))
+
+fn sliced(value: Octets) -> Result<Octets, String>
+    kept = List.take(octets(value), 4)
+    fromList(List.drop(kept, 1))
+
+fn widened(value: Octets, arbitrary: Int) -> Result<Octets, String>
+    fromList(List.prepend(arbitrary, octets(value)))
+"#;
+
+fn optimized() -> (MirProgram, crate::ir::SymbolTable) {
+    let mut items = parse_source(PROGRAM).expect("parse");
+    let result = crate::ir::pipeline::run(
+        &mut items,
+        crate::ir::pipeline::PipelineConfig {
+            typecheck: Some(crate::ir::pipeline::TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+    assert!(
+        result
+            .typecheck
+            .as_ref()
+            .is_none_or(|tc| tc.errors.is_empty()),
+        "type errors: {:?}",
+        result.typecheck.as_ref().map(|tc| &tc.errors)
+    );
+    let program = super::super::optimize_with_list_refinements(
+        lower_program(&result.resolved_items),
+        result.symbol_table.literal_refinements(),
+    );
+    (program, result.symbol_table)
+}
+
+fn calls_fn(expr: &MirExpr, target: FnId) -> bool {
+    if matches!(
+        expr,
+        MirExpr::Call(call) if call.node.callee == MirCallee::Fn(target)
+    ) {
+        return true;
+    }
+    let mut found = false;
+    super::super::super::expr::walk_children(expr, &mut |child| {
+        found |= calls_fn(child, target);
+    });
+    found
+}
+
+#[test]
+fn discharges_direct_concat_take_and_drop_but_not_prepend() {
+    let (program, symbols) = optimized();
+    let constructor = symbols
+        .fn_id_of(&crate::ir::FnKey::entry("fromList"))
+        .expect("constructor identity");
+    for name in ["direct", "combined", "sliced"] {
+        let id = symbols
+            .fn_id_of(&crate::ir::FnKey::entry(name))
+            .unwrap_or_else(|| panic!("{name} identity"));
+        assert!(
+            !calls_fn(
+                &program.fn_by_id(id).expect("MIR fn").body.node,
+                constructor
+            ),
+            "{name} retained the unreachable validation call"
+        );
+    }
+    let widened = symbols
+        .fn_id_of(&crate::ir::FnKey::entry("widened"))
+        .expect("widened identity");
+    assert!(
+        calls_fn(
+            &program.fn_by_id(widened).expect("MIR fn").body.node,
+            constructor
+        ),
+        "List.prepend must invalidate provenance"
+    );
+}
+
+#[test]
+fn a_direct_round_trip_reuses_the_nominal_without_projecting_it() {
+    let (program, symbols) = optimized();
+    let direct = symbols
+        .fn_id_of(&crate::ir::FnKey::entry("direct"))
+        .expect("direct identity");
+    let MirExpr::Construct(ok) = &program.fn_by_id(direct).expect("MIR fn").body.node else {
+        panic!("direct round-trip should be a Result.Ok construct");
+    };
+    assert_eq!(ok.node.ctor, MirCtor::Builtin(BuiltinCtor::ResultOk));
+    assert!(matches!(
+        ok.node.args.as_slice(),
+        [Spanned {
+            node: MirExpr::Local(_),
+            ..
+        }]
+    ));
+}

--- a/src/ir/mir/optimize/mod.rs
+++ b/src/ir/mir/optimize/mod.rs
@@ -53,6 +53,7 @@ pub mod branch_collapse;
 pub mod const_fold;
 pub mod dead_code;
 pub mod inline;
+pub mod list_refinement;
 pub mod own_param;
 
 #[cfg(test)]
@@ -65,6 +66,7 @@ pub use branch_collapse::branch_collapse;
 pub use const_fold::const_fold;
 pub use dead_code::dead_code;
 pub use inline::inline_nullary_literals;
+pub use list_refinement::discharge_proven_lists;
 pub use own_param::{own_param_refine, own_param_refine_for_rust};
 
 /// The canonical Core-MIR optimization pipeline: the passes applied
@@ -84,4 +86,20 @@ pub fn optimize(program: crate::ir::mir::MirProgram) -> crate::ir::mir::MirProgr
     own_param_refine(dead_code(branch_collapse(bool_match_to_if(
         algebraic_simplify(const_fold(inline_nullary_literals(program))),
     ))))
+}
+
+/// Runtime-backend pipeline with the identity-pinned `List<Int>` refinement
+/// discharge inserted before ownership refinement. Proof exporters keep the
+/// ordinary [`optimize`] shape; VM and wasm-gc opt into this semantics-
+/// preserving removal of an unreachable validation walk.
+pub fn optimize_with_list_refinements(
+    program: crate::ir::mir::MirProgram,
+    refinements: &crate::analysis::literal_refinement::LiteralRefinementTable,
+) -> crate::ir::mir::MirProgram {
+    own_param_refine(discharge_proven_lists(
+        dead_code(branch_collapse(bool_match_to_if(algebraic_simplify(
+            const_fold(inline_nullary_literals(program)),
+        )))),
+        refinements,
+    ))
 }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4580,11 +4580,15 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
     }
 
     // `--emit-ir-after=mir` — lower the resolved HIR to MIR and run the
-    // optimize pipeline (the exact lowering the VM backend consumes),
-    // then print the textual `MirProgram` dump.
+    // optimize pipeline including identity-pinned list-refinement
+    // provenance (the exact lowering the VM backend consumes), then print
+    // the textual `MirProgram` dump.
     if want_mir {
         use aver::ir::mir;
-        let program = mir::optimize(mir::lower_program(&pipeline_result.resolved_items));
+        let program = mir::optimize::optimize_with_list_refinements(
+            mir::lower_program(&pipeline_result.resolved_items),
+            pipeline_result.symbol_table.literal_refinements(),
+        );
         print!("{program}");
         return;
     }

--- a/src/vm/compiler/mod.rs
+++ b/src/vm/compiler/mod.rs
@@ -135,11 +135,14 @@ fn did_not_lower_message(rfd: &ResolvedFnDef, file: &str) -> String {
 /// (3) algebraic-simplify rewrites Int identities, (4) bool-match-to-if
 /// rewrites two-arm `Bool` matches into `IfThenElse`, (5) branch-collapse
 /// drops the dead branch of a folded `IfThenElse`, (6) DCE drops unread
-/// `let _ = <pure>` chains. Shared by the entry compile and per-dep-module
-/// MIR builds so both backends see identical lowered+optimized shapes.
+/// `let _ = <pure>` chains, (7) closed list-refinement provenance removes
+/// unreachable validation walks, and (8) ownership refinement runs on the
+/// final local graph. Shared by the entry compile and per-dep-module MIR
+/// builds so both paths see identical lowered+optimized shapes.
 fn build_optimized_mir(
     items: &[ResolvedTopLevel],
     external_callers_possible: bool,
+    refinements: &crate::analysis::literal_refinement::LiteralRefinementTable,
 ) -> crate::ir::mir::MirProgram {
     let mut lowered = crate::ir::mir::lower_program(items);
     // Mark dependency-module fragments so `own_param_refine` bails: the
@@ -148,7 +151,7 @@ fn build_optimized_mir(
     // param. The entry compile (and the flattened wasm-gc / Rust builds)
     // see all callers, so graduation stays enabled there.
     lowered.external_callers_possible = external_callers_possible;
-    crate::ir::mir::optimize(lowered)
+    crate::ir::mir::optimize::optimize_with_list_refinements(lowered, refinements)
 }
 
 /// Run the four fabricating traversal passes — buffer-build deforestation,
@@ -261,7 +264,7 @@ fn compile_program_inner(
     // Dep-module fns build their own MIR in `integrate_module` (same
     // `build_optimized_mir` pipeline); the per-fn loop there dispatches
     // through the MIR walker with the dep's module scope.
-    let mir_built = build_optimized_mir(items, false);
+    let mir_built = build_optimized_mir(items, false, symbols.literal_refinements());
     let mir_program = &mir_built;
 
     let mut compiler = ProgramCompiler::new();
@@ -700,7 +703,7 @@ impl ProgramCompiler {
         // bytecode with the dep's module scope — the same path the entry
         // module takes. MIR is the only VM codegen path; a rejection
         // surfaces as a hard CompileError (no HIR fallback).
-        let dep_mir = build_optimized_mir(&dep_resolved, true);
+        let dep_mir = build_optimized_mir(&dep_resolved, true, entry_symbols.literal_refinements());
         let mut fn_idx = 0;
         for item in &dep_resolved {
             if let ResolvedTopLevel::FnDef(rfd) = item {

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -321,12 +321,20 @@ fn fromList(xs: List<Int>) -> Result<Octets, String>
 fn bypass(xs: List<Int>) -> Octets
     Octets(values = xs)
 
+fn toList(value: Octets) -> List<Int>
+    value.values
+
+fn roundTrip(value: Octets) -> Result<Octets, String>
+    fromList(toList(value))
+
 fn main() -> Unit
     ! [Console.print]
     value = bypass([256])
-    match value.values
-        [head, .._] -> Console.print("{head}")
-        [] -> Console.print("empty")
+    match roundTrip(value)
+        Result.Ok(_) -> Console.print("unexpected")
+        Result.Err(error) -> match value.values
+            [head, .._] -> Console.print("{head}:{error}")
+            [] -> Console.print("empty:{error}")
 "#;
 
 #[test]
@@ -537,7 +545,50 @@ fn ungated_constructor_demotes_instead_of_truncating() {
     assert!(vm_ok, "VM failed: {vm}");
     assert!(wasm_ok, "wasm failed: {wasm}");
     assert_eq!(wasm, vm);
-    assert_eq!(vm, "256");
+    assert_eq!(vm, "256:oob");
+}
+
+// The real standard-library Bytes refinement through every provenance-
+// preserving operation. The first construction is deliberately dynamic, so
+// it still executes the ordinary gate; only lists projected from the resulting
+// nominal may discharge. `prepend(999, ...)` is the invalidation trip-wire and
+// must retain Bytes.fromList's exact first-offender diagnostic.
+const BYTES_PROVENANCE: &str = r#"module M
+    intent = "exercise runtime byte-list provenance across VM and wasm-gc"
+    depends [Bytes]
+    effects [Console]
+
+fn scenario() -> Result<String, String>
+    left = Bytes.fromList(List.concat([0, 1], [2]))?
+    right = Bytes.fromList(List.concat([170], [187]))?
+    direct = Bytes.fromList(Bytes.octets(left))?
+    combined = Bytes.fromList(List.concat(Bytes.octets(direct), Bytes.octets(right)))?
+    sliced = Bytes.fromList(List.drop(List.take(Bytes.octets(combined), 4), 1))?
+    match Bytes.fromList(List.prepend(999, Bytes.octets(sliced)))
+        Result.Ok(_) -> Result.Err("prepend unexpectedly retained provenance")
+        Result.Err(error) -> Result.Ok("{Bytes.toHex(direct)}/{Bytes.toHex(combined)}/{Bytes.toHex(sliced)}/{error}")
+
+fn main() -> Unit
+    ! [Console.print]
+    match scenario()
+        Result.Ok(text) -> Console.print(text)
+        Result.Err(error) -> Console.print("failed:{error}")
+"#;
+
+#[test]
+fn byte_list_provenance_matches_vm_packed_and_boxed_wasm() {
+    let (vm_ok, vm) = run(BYTES_PROVENANCE, false, true);
+    let (packed_ok, packed) = run(BYTES_PROVENANCE, true, true);
+    let (boxed_ok, boxed) = run(BYTES_PROVENANCE, true, false);
+    assert!(vm_ok, "VM failed: {vm}");
+    assert!(packed_ok, "packed wasm failed: {packed}");
+    assert!(boxed_ok, "boxed wasm failed: {boxed}");
+    assert_eq!(
+        vm,
+        "000102/000102aabb/0102aa/byte 999 at index 0 is outside 0..=255"
+    );
+    assert_eq!(packed, vm, "packed wasm-gc diverged from the VM");
+    assert_eq!(boxed, vm, "boxed wasm-gc diverged from the VM");
 }
 
 // ─── Literal smart-constructor discharge ────────────────────────────────


### PR DESCRIPTION
Closes #1149.

## What changes

- derive closed `List<Int>` refinement provenance from recognized smart constructors and exact carrier projectors, keyed by `FnId` / `TypeId`
- preserve that fact through `List.concat`, `List.take`, and `List.drop`; invalidate it across widening operations such as `List.prepend`
- discharge the matching constructor in common MIR for VM and wasm-gc, including an O(1) direct `from(project(value)) -> Ok(value)` fold
- keep literal discharge independent and fail closed when the nominal can be constructed outside its gate, a projector identity is ambiguous, or the nominal identity does not match
- make `--emit-ir-after=mir` show the same runtime optimization pipeline

## Validation

- `cargo test -p aver-lang --lib analysis::literal_refinement` (12 passed)
- `cargo test -p aver-lang --lib ir::mir::optimize` (116 passed)
- `cargo test -p aver-lang --features wasm --test wasm_gc_packed_sequence` (12 passed)
- `cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings`
- `cargo test -p aver-lang --test rust_self_host_regen`
- `cargo fmt --all -- --check`

The differential test covers VM, packed wasm-gc, and boxed wasm-gc for direct round-trip, concat, take/drop, and exact first-offender diagnostics after `prepend(999, ...)` invalidates provenance.