### PR TITLE
fix(wasm-gc): preserve named types across module graphs

### DIFF
--- a/src/codegen/wasm_gc/flatten.rs
+++ b/src/codegen/wasm_gc/flatten.rs
@@ -51,6 +51,8 @@ use std::collections::{HashMap, HashSet};
 use crate::ast::{Expr, FnBody, Pattern, Spanned, Stmt, TopLevel, TypeDef};
 use crate::codegen::ModuleInfo;
 use crate::codegen::common::type_def_name;
+use crate::ir::identity::{TypeId, TypeKey};
+use crate::visibility::{ModuleTypeExports, ModuleTypeSurface};
 
 /// Which capability function closure belongs in the flattened module.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -177,6 +179,50 @@ pub fn flatten_multimodule(
         .map(|(bare, _)| bare.clone())
         .collect();
 
+    // Resolve a bare colliding type in the scope where it was written, not
+    // against every declaration that happens to land in the final artifact.
+    // `Worker depends [Left]` gives bare `State` one meaning inside Worker
+    // even when an unrelated entry branch also loads `Right.State`. The
+    // typechecker already made this decision through module visibility; the
+    // flattener must preserve it when both declarations receive qualified
+    // registry keys.
+    let type_surfaces: Vec<ModuleTypeSurface<'_>> = dep_modules
+        .iter()
+        .map(|dep| ModuleTypeSurface {
+            name: &dep.prefix,
+            depends: &dep.depends,
+            exposes: crate::visibility::declared_exposes(&dep.exposes),
+            exposes_opaque: &dep.exposes_opaque,
+            declared_types: dep.type_defs.iter().map(type_def_name).collect(),
+        })
+        .collect();
+    let module_type_exports = crate::visibility::collect_type_exports(&type_surfaces);
+
+    // Expression stamps already carry the declaration identity selected by
+    // typechecking. Preserve that decision across the flatten boundary:
+    // `Left.build() : Result<Built, String>` still denotes Left.Built even in
+    // an entry that also imports Right.Built. The flattened symbol table uses
+    // fresh entry-scope IDs, so rewrite the spelling from the old stable ID
+    // and clear the ID for the post-link resolver to re-home.
+    let mut flattened_name_by_type_id: HashMap<TypeId, String> = HashMap::new();
+    for bare in &entry_bare_names {
+        flattened_name_by_type_id.insert(TypeId::for_key(&TypeKey::entry(bare)), bare.clone());
+    }
+    for dep in dep_modules {
+        for td in &dep.type_defs {
+            let bare = type_def_name(td);
+            let flattened = if colliding_bare_names.contains(bare) {
+                format!("{}.{}", dep.prefix, bare)
+            } else {
+                bare.to_string()
+            };
+            flattened_name_by_type_id.insert(
+                TypeId::for_key(&TypeKey::in_module(&dep.prefix, bare)),
+                flattened,
+            );
+        }
+    }
+
     let mut type_aliases: HashMap<String, String> = HashMap::new();
     for (bare, owners) in &bare_owners {
         if owners.len() == 1 && !entry_bare_names.contains(bare.as_str()) {
@@ -196,8 +242,17 @@ pub fn flatten_multimodule(
         })
         .collect();
 
-    let empty_owner: HashMap<String, String> = HashMap::new();
     let empty_set: HashSet<String> = HashSet::new();
+
+    let entry_decl = crate::visibility::module_decl(items);
+    let entry_depends = entry_decl.map(|m| m.depends.as_slice()).unwrap_or(&[]);
+    let entry_colliding_owner = colliding_owners_in_scope(
+        &entry_bare_names,
+        None,
+        entry_depends,
+        &module_type_exports,
+        &colliding_bare_names,
+    );
 
     let entry_ctx = RewriteCtx {
         type_prefixes: &type_prefixes,
@@ -205,22 +260,25 @@ pub fn flatten_multimodule(
         qualified_type_names: &qualified_type_names,
         same_module_prefix: None,
         same_module_fns: &empty_set,
-        // The entry keeps the bare spelling of every name it declares, so
-        // nothing in its own body needs canonicalising.
-        colliding_owner: &empty_owner,
-        dep_prefix: "",
+        // The entry keeps the bare spelling of every name it declares, while
+        // an imported colliding name is canonicalised to the one declaration
+        // visible through the entry's own `depends` surface.
+        colliding_owner: &entry_colliding_owner,
+        flattened_name_by_type_id: &flattened_name_by_type_id,
         colliding_bare_names: &colliding_bare_names,
     };
     for item in items.iter_mut() {
         match item {
             TopLevel::FnDef(fd) => {
                 rewrite_fn_signature(fd, &qualified_type_names, &colliding_bare_names);
+                canonicalise_fn_signature_for_own_colliding(fd, &entry_colliding_owner);
                 let body_arc = std::sync::Arc::make_mut(&mut fd.body);
                 let FnBody::Block(stmts) = body_arc;
                 rewrite_stmts(stmts, &entry_ctx);
             }
             TopLevel::TypeDef(td) => {
                 rewrite_type_def(td, &qualified_type_names, &colliding_bare_names);
+                canonicalise_type_def_for_colliding(td, &entry_colliding_owner);
             }
             _ => {}
         }
@@ -240,7 +298,11 @@ pub fn flatten_multimodule(
             .filter(|fd| !verification_only.contains(&fd.name))
             .map(|fd| fd.name.clone())
             .collect();
-        let own_types: HashSet<&str> = dep.type_defs.iter().map(type_def_name).collect();
+        let own_types: HashSet<String> = dep
+            .type_defs
+            .iter()
+            .map(|td| type_def_name(td).to_string())
+            .collect();
         // What each ambiguous bare name means INSIDE this module — the
         // canonicalisation passes rewrite its references to `Owner.Name`
         // (only ambiguous ones; a name only one module declares keeps
@@ -254,18 +316,13 @@ pub fn flatten_multimodule(
         // and letting the entry claim the name here is what made a
         // dependency's constructor resolve to a record it had never heard
         // of and lower to a trap stub.
-        let colliding_owner: HashMap<String, String> = colliding_bare_names
-            .iter()
-            .filter_map(|bare| {
-                if own_types.contains(bare.as_str()) {
-                    return Some((bare.clone(), dep.prefix.clone()));
-                }
-                match bare_owners.get(bare).map(Vec::as_slice) {
-                    Some([only]) => Some((bare.clone(), only.clone())),
-                    _ => None,
-                }
-            })
-            .collect();
+        let colliding_owner = colliding_owners_in_scope(
+            &own_types,
+            Some(&dep.prefix),
+            &dep.depends,
+            &module_type_exports,
+            &colliding_bare_names,
+        );
         let dep_ctx = RewriteCtx {
             type_prefixes: &type_prefixes,
             capability_operations: &capability_operations,
@@ -273,13 +330,14 @@ pub fn flatten_multimodule(
             same_module_prefix: Some(&dep.prefix),
             same_module_fns: &same_module_fns,
             colliding_owner: &colliding_owner,
-            dep_prefix: &dep.prefix,
+            flattened_name_by_type_id: &flattened_name_by_type_id,
             colliding_bare_names: &colliding_bare_names,
         };
 
         for td in &dep.type_defs {
             let mut new_td = td.clone();
             rewrite_type_def(&mut new_td, &qualified_type_names, &colliding_bare_names);
+            canonicalise_type_def_for_colliding(&mut new_td, &colliding_owner);
             // Rename the typedef itself to `Prefix.Name` if it collides
             // with another dep's bare name.
             rename_typedef_if_colliding(&mut new_td, &dep.prefix, &colliding_bare_names);
@@ -373,6 +431,76 @@ fn canonicalise_fn_signature_for_own_colliding(
         *ty = canonicalise_own_colliding(ty, colliding_owner);
     }
     fd.return_type = canonicalise_own_colliding(&fd.return_type, colliding_owner);
+}
+
+fn canonicalise_type_def_for_colliding(
+    td: &mut TypeDef,
+    colliding_owner: &HashMap<String, String>,
+) {
+    if colliding_owner.is_empty() {
+        return;
+    }
+    match td {
+        TypeDef::Sum { variants, .. } => {
+            for variant in variants {
+                for ty in &mut variant.fields {
+                    *ty = canonicalise_own_colliding(ty, colliding_owner);
+                }
+            }
+        }
+        TypeDef::Product { fields, .. } => {
+            for (_, ty) in fields {
+                *ty = canonicalise_own_colliding(ty, colliding_owner);
+            }
+        }
+    }
+}
+
+/// Map each ambiguous bare type to the declaration owner visible in one
+/// module. Local declarations win. Otherwise visibility is resolved through
+/// this module's direct dependencies, retaining the original owner across an
+/// explicit re-export.
+fn colliding_owners_in_scope(
+    own_types: &HashSet<String>,
+    own_prefix: Option<&str>,
+    depends: &[String],
+    type_exports: &ModuleTypeExports,
+    colliding_bare_names: &HashSet<String>,
+) -> HashMap<String, String> {
+    let mut resolved = HashMap::new();
+    for bare in colliding_bare_names {
+        if own_types.contains(bare) {
+            // Dependency typedefs are renamed to `Prefix.Name`. Entry-local
+            // typedefs keep the bare spelling, so they need no rewrite.
+            if let Some(prefix) = own_prefix {
+                resolved.insert(bare.clone(), prefix.to_string());
+            }
+            continue;
+        }
+
+        let mut owner: Option<&str> = None;
+        let mut ambiguous = false;
+        for dependency in depends {
+            let Some(target) = type_exports
+                .get(dependency)
+                .and_then(|exports| exports.get(bare))
+            else {
+                continue;
+            };
+            match owner {
+                None => owner = Some(&target.module),
+                Some(existing) if existing == target.module => {}
+                Some(_) => {
+                    ambiguous = true;
+                    break;
+                }
+            }
+        }
+        if !ambiguous && let Some(owner) = owner {
+            resolved.insert(bare.clone(), owner.to_string());
+        }
+    }
+    resolved
 }
 
 /// Strip module prefixes from qualified type references in `type_str`,
@@ -481,9 +609,10 @@ fn attr_chain_to_dotted(expr: &Expr) -> Option<String> {
     }
 }
 
-/// Invariants for one body-rewriting traversal. `dep_prefix` is empty and
-/// `colliding_owner` is empty while the entry module's own items are
-/// walked, so the canonicalisation passes keyed on them are inert there.
+/// Invariants for one body-rewriting traversal. `colliding_owner` contains
+/// only the ambiguous bare names that have one meaning in this module's own
+/// scope; entry-local declarations are deliberately absent because they keep
+/// their bare post-flatten spelling.
 struct RewriteCtx<'a> {
     /// Every dependency module that may own a represented boundary type.
     /// Unlike `prefixes`, this includes capability modules: their operations
@@ -505,8 +634,10 @@ struct RewriteCtx<'a> {
     /// elsewhere among the dependencies. The entry's declaration is never a
     /// candidate — a dependency does not import the entry.
     colliding_owner: &'a HashMap<String, String>,
-    /// The owning dep's path, or `""` for the entry module.
-    dep_prefix: &'a str,
+    /// Pre-flatten stable declaration identity → post-flatten type spelling.
+    /// This wins over source-scope name resolution for expression stamps,
+    /// because a value returned by another module already carries its owner.
+    flattened_name_by_type_id: &'a HashMap<TypeId, String>,
     /// Every ambiguous bare type name in the program — a reference to one
     /// of these through another module's path keeps the qualified spelling.
     colliding_bare_names: &'a HashSet<String>,
@@ -528,10 +659,13 @@ fn rewrite_stamped_type(ty: &mut crate::ast::Type, ctx: &RewriteCtx<'_>) {
     use crate::ast::Type;
     match ty {
         Type::Named { id, name } => {
-            *name = rewrite_type_spelling(name, ctx);
-            // TypeIds are table-local. `flatten_multimodule` changes the
-            // table, so carrying the old numeric id would misidentify a
-            // different declaration (or index past the new table).
+            *name = (*id)
+                .and_then(|incoming| ctx.flattened_name_by_type_id.get(&incoming))
+                .cloned()
+                .unwrap_or_else(|| rewrite_type_spelling(name, ctx));
+            // Flattened typedefs live in a fresh entry scope, so even stable
+            // declaration-derived IDs must be re-homed from the rewritten
+            // spelling by the post-link resolver.
             *id = None;
         }
         Type::List(inner) | Type::Vector(inner) | Type::Option(inner) => {
@@ -562,11 +696,7 @@ fn rewrite_type_spelling(type_name: &str, ctx: &RewriteCtx<'_>) -> String {
         ctx.qualified_type_names,
         ctx.colliding_bare_names,
     );
-    if ctx.dep_prefix.is_empty() {
-        stripped
-    } else {
-        canonicalise_own_colliding(&stripped, ctx.colliding_owner)
-    }
+    canonicalise_own_colliding(&stripped, ctx.colliding_owner)
 }
 
 fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
@@ -639,9 +769,7 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
                 *expr = new_node;
                 return;
             }
-            if !ctx.dep_prefix.is_empty() {
-                canonicalise_attr_head_for_own_colliding(expr, ctx.colliding_owner);
-            }
+            canonicalise_attr_head_for_own_colliding(expr, ctx.colliding_owner);
             if let Expr::Attr(obj, _) = expr {
                 rewrite_spanned_expr(obj, ctx);
             }
@@ -653,9 +781,7 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
             }
         }
         Expr::RecordCreate { type_name, fields } => {
-            if !ctx.dep_prefix.is_empty() {
-                canonicalise_bare_type_name(type_name, ctx.colliding_owner);
-            }
+            canonicalise_bare_type_name(type_name, ctx.colliding_owner);
             for (_, expr) in fields.iter_mut() {
                 rewrite_spanned_expr(expr, ctx);
             }
@@ -665,9 +791,7 @@ fn rewrite_expr(expr: &mut Expr, ctx: &RewriteCtx<'_>) {
             base,
             updates,
         } => {
-            if !ctx.dep_prefix.is_empty() {
-                canonicalise_bare_type_name(type_name, ctx.colliding_owner);
-            }
+            canonicalise_bare_type_name(type_name, ctx.colliding_owner);
             rewrite_spanned_expr(base, ctx);
             for (_, expr) in updates.iter_mut() {
                 rewrite_spanned_expr(expr, ctx);
@@ -772,9 +896,7 @@ fn rewrite_constructor_name(name: &mut String, ctx: &RewriteCtx<'_>) {
         *name = flattened;
         return;
     }
-    if !ctx.dep_prefix.is_empty() {
-        canonicalise_constructor_name(name, ctx.colliding_owner);
-    }
+    canonicalise_constructor_name(name, ctx.colliding_owner);
 }
 
 /// The post-flatten spelling of a constructor written with the module path

--- a/src/types/checker/check.rs
+++ b/src/types/checker/check.rs
@@ -189,6 +189,7 @@ impl TypeChecker {
         modules: &[crate::source::LoadedModule],
         visible_modules: &[String],
     ) {
+        self.integrate_loaded_record_schemas(modules);
         self.visible_module_names
             .extend(visible_modules.iter().cloned());
         let pairs: Vec<_> = modules
@@ -205,6 +206,43 @@ impl TypeChecker {
         }
         self.canonicalize_source_typed_builtin_sigs();
         self.register_capability_sigs();
+    }
+
+    /// Register the public structural shape of every record in the loaded
+    /// graph without making its source name visible to the current module.
+    ///
+    /// A visible API may return `Rules`, whose public field is a `Policy`, to
+    /// a consumer that never directly imports `Policy`'s module. The value's
+    /// `TypeId` preserves that declaration identity, so chained projection
+    /// (`rules.policy.witnessPubKeyType`) must be able to consult Policy's
+    /// public fields. This is representation closure, not import closure:
+    /// constructors, functions, and bare type aliases remain gated by the
+    /// consumer's explicit `depends` surface.
+    fn integrate_loaded_record_schemas(&mut self, modules: &[crate::source::LoadedModule]) {
+        for module in modules {
+            for item in &module.items {
+                let TopLevel::TypeDef(TypeDef::Product { name, fields, .. }) = item else {
+                    continue;
+                };
+                let publicly_structural = self
+                    .module_type_exports
+                    .get(&module.dep_name)
+                    .and_then(|exports| exports.get(name))
+                    .is_some_and(|target| target.module == module.dep_name && !target.is_opaque);
+                if !publicly_structural {
+                    continue;
+                }
+                let canonical_type = crate::visibility::qualified_name(&module.dep_name, name);
+                for (field_name, field_type) in fields {
+                    let ty = self.canonicalize_named_in_module(
+                        parse_type_str_strict(field_type).unwrap_or(Type::Invalid),
+                        &module.dep_name,
+                    );
+                    self.record_field_types
+                        .insert(RecordFieldKey::new(&canonical_type, field_name), ty);
+                }
+            }
+        }
     }
 
     /// Re-stamp builtin signatures whose nominal types are owned by embedded

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -1596,32 +1596,29 @@ impl TypeChecker {
                     }
                 }
                 match obj_ty {
-                    Type::Named {
-                        name: ref type_name,
-                        ..
-                    } => {
+                    Type::Named { id, ref name } => {
                         // Phase B: `opaque_types` keys are canonical
                         // "Module.Type"; resolve the bare reference
                         // through the symbol table before checking.
-                        let canon = self.canonical_type_name(type_name);
+                        let canon = self.canonical_type_name_from_stamp(id, name);
                         if !self.self_host_mode && self.opaque_types.contains(&canon) {
-                            if self.is_capability_resource_type(type_name) {
+                            if self.is_capability_resource_type_named(id, name) {
                                 self.error(format!(
                                     "Cannot access field '{}' of capability resource '{}'",
-                                    field, type_name
+                                    field, name
                                 ));
                             } else {
                                 self.error(format!(
                                     "Cannot access field '{}' of opaque type '{}'",
-                                    field, type_name
+                                    field, name
                                 ));
                             }
                             return Type::Invalid;
                         }
-                        if let Some(field_ty) = self.find_record_field_type(type_name, field) {
+                        if let Some(field_ty) = self.find_record_field_type_named(id, name, field) {
                             field_ty.clone()
-                        } else if self.has_record_schema(type_name) {
-                            self.error(format!("Record '{}' has no field '{}'", type_name, field));
+                        } else if self.has_record_schema_named(id, name) {
+                            self.error(format!("Record '{}' has no field '{}'", name, field));
                             Type::Invalid
                         } else {
                             Type::Invalid

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -1414,6 +1414,13 @@ impl TypeChecker {
             .any(|resource| resource == &canonical)
     }
 
+    fn is_capability_resource_type_named(&self, type_id: Option<TypeId>, name: &str) -> bool {
+        let canonical = self.canonical_type_name_from_stamp(type_id, name);
+        self.capabilities
+            .resource_types()
+            .any(|resource| resource == &canonical)
+    }
+
     /// Render the two types of a "expected X, got Y" diagnostic.
     ///
     /// Aver lets a module declare a type whose bare name a dependency
@@ -1533,6 +1540,25 @@ impl TypeChecker {
         None
     }
 
+    /// Field lookup for a type carried by an already-typed value. The value's
+    /// `TypeId` records the declaration that produced it even when the current
+    /// module never wrote or directly imported that type name — for example a
+    /// public `Rules.policy: Policy` field projected by a consumer that only
+    /// depends on `Rules`. Re-resolving bare `Policy` in the consumer's source
+    /// scope loses that identity and used to stamp the next projection
+    /// `Type::Invalid` without reporting an error.
+    fn find_record_field_type_named(
+        &self,
+        type_id: Option<TypeId>,
+        type_name: &str,
+        field_name: &str,
+    ) -> Option<&Type> {
+        let canonical = self.canonical_type_name_from_stamp(type_id, type_name);
+        self.record_field_types
+            .get(&RecordFieldKey::new(canonical, field_name))
+            .or_else(|| self.find_record_field_type(type_name, field_name))
+    }
+
     fn fields_for_type(&self, type_name: &str) -> Vec<(String, Type)> {
         let canonical = self.canonical_type_name(type_name);
         let canonical_ref: &str = canonical.as_str();
@@ -1549,6 +1575,27 @@ impl TypeChecker {
         self.record_field_types
             .keys()
             .any(|k| k.type_name == canonical_ref || k.type_name == type_name)
+    }
+
+    fn has_record_schema_named(&self, type_id: Option<TypeId>, type_name: &str) -> bool {
+        let canonical = self.canonical_type_name_from_stamp(type_id, type_name);
+        self.record_field_types
+            .keys()
+            .any(|key| key.type_name == canonical)
+            || self.has_record_schema(type_name)
+    }
+
+    fn canonical_type_name_from_stamp(&self, type_id: Option<TypeId>, name: &str) -> String {
+        let Some(entry) = type_id.and_then(|id| self.symbol_table.type_entry_if_present(id)) else {
+            return self.canonical_type_name(name);
+        };
+        if entry.module.is_entry()
+            && let Some(prefix) = self.current_module_prefix.as_deref()
+        {
+            crate::visibility::qualified_name(prefix, &entry.key.name)
+        } else {
+            entry.key.canonical()
+        }
     }
 
     /// Look up the variant list for a named sum type. Resolves

--- a/tests/wasm_gc_spec.rs
+++ b/tests/wasm_gc_spec.rs
@@ -687,6 +687,184 @@ record Box
     );
 }
 
+#[test]
+fn dependency_bare_type_resolves_with_unrelated_same_named_type_in_graph() {
+    // `Worker` imports only `Left`, so bare `State` inside Worker has one
+    // unambiguous meaning. The whole linked graph also contains Right.State,
+    // however, which forces both declarations to keep qualified wasm-gc
+    // registry keys. Flattening must resolve Worker's bare spelling through
+    // its own dependency scope rather than through the set of every owner in
+    // the final artifact. btc-listener has this exact shape: modules using
+    // Domain.ScriptState.State share a final graph with Domain.SipHash.State.
+    let entry_src = r#"
+module Entry
+    intent = "loads two State owners through separate dependency branches"
+    depends [Worker, Right]
+
+fn main() -> Int
+    Worker.answer() + Right.answer()
+"#;
+    let left_src = r#"
+module Left
+    intent = "the State visible to Worker"
+    exposes [State]
+    depends []
+
+record State
+    value: Int
+"#;
+    let worker_src = r#"
+module Worker
+    intent = "uses its sole imported State through the bare spelling"
+    exposes [answer]
+    depends [Left]
+
+fn valueOf(state: State) -> Int
+    state.value
+
+fn answer() -> Int
+    valueOf(State(value = 40))
+"#;
+    let right_src = r#"
+module Right
+    intent = "an unrelated State owner elsewhere in the final graph"
+    exposes [State, answer]
+    depends []
+
+record State
+    code: Int
+
+fn answer() -> Int
+    State(code = 2).code
+"#;
+    let result = run_int_multi(
+        entry_src,
+        &[
+            ("Left", left_src),
+            ("Worker", worker_src),
+            ("Right", right_src),
+        ],
+    );
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn nested_public_record_projection_keeps_indirect_type_identity() {
+    // Worker never names or directly imports Policy. It receives that nominal
+    // type by projecting a public field from Rules, then projects Policy's
+    // Bool field. The first projection's TypeId is the authority for the
+    // second lookup; resolving bare `Policy` again in Worker's source scope
+    // used to produce a silent Type::Invalid stamp and fail wasm-gc lowering.
+    let entry_src = r#"
+module Entry
+    intent = "runs the indirect record projection"
+    depends [Worker]
+
+fn main() -> Int
+    Worker.answer()
+"#;
+    let policy_src = r#"
+module Policy
+    intent = "owns the nested record"
+    exposes [Policy, enabled]
+    depends []
+
+record Policy
+    enabled: Bool
+
+fn enabled() -> Policy
+    Policy(enabled = true)
+"#;
+    let rules_src = r#"
+module Rules
+    intent = "carries a Policy without re-exporting its type name"
+    exposes [Rules, latest]
+    depends [Policy]
+
+record Rules
+    policy: Policy
+
+fn latest() -> Rules
+    Rules(policy = Policy.enabled())
+"#;
+    let context_src = r#"
+module Context
+    intent = "hands Rules through one more public function"
+    exposes [rulesOf]
+    depends [Rules]
+
+fn rulesOf() -> Rules
+    Rules.latest()
+"#;
+    let worker_src = r#"
+module Worker
+    intent = "projects a field whose type arrived through another record"
+    exposes [answer]
+    depends [Context]
+
+fn answer() -> Int
+    match Context.rulesOf().policy.enabled
+        true -> 42
+        false -> 0
+"#;
+    let result = run_int_multi(
+        entry_src,
+        &[
+            ("Policy", policy_src),
+            ("Rules", rules_src),
+            ("Context", context_src),
+            ("Worker", worker_src),
+        ],
+    );
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn qualified_calls_keep_colliding_result_payload_identity_through_try() {
+    // The entry imports two `Built` declarations and therefore cannot resolve
+    // the bare name in its own source scope. Each qualified call's typed
+    // result already carries the correct declaration ID; flattening must use
+    // it when registering/emitting `Result<Built, String>` for `?`.
+    let entry_src = r#"
+module Entry
+    intent = "unwraps two qualified calls returning same-named records"
+    depends [Left, Right]
+
+fn main() -> Result<Int, String>
+    left = Left.build()?
+    right = Right.build()?
+    Result.Ok(left.value + right.code)
+"#;
+    let left_src = r#"
+module Left
+    intent = "owns one Built result"
+    exposes [Built, build]
+    depends []
+
+record Built
+    value: Int
+
+fn build() -> Result<Built, String>
+    Result.Ok(Built(value = 40))
+"#;
+    let right_src = r#"
+module Right
+    intent = "owns the other Built result"
+    exposes [Built, build]
+    depends []
+
+record Built
+    code: Int
+
+fn build() -> Result<Built, String>
+    Result.Ok(Built(code = 2))
+"#;
+    let bytes = compile_multi_module_bytes(entry_src, &[("Left", left_src), ("Right", right_src)]);
+    wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::all())
+        .validate_all(&bytes)
+        .expect("qualified colliding Result payloads must validate");
+}
+
 // Cross-module same-bare-name `==`/`!=` dispatch — exercises the
 // canonical-key routing through `named_type_registry_key` at the three
 // eq-helper sites (`register_nominal_in_type`, the `BinOp Eq/Neq` arm of


### PR DESCRIPTION
## What

Preserve nominal type identity while flattening large multi-module programs for wasm-gc.

- resolve colliding bare type names in the dependency scope where they were written
- rewrite expression stamps from their stable TypeId, so qualified calls keep the correct same-named Result payload
- load the public structural closure of record fields without making transitive type names visible imports

## Why

A real btc-listener compile exposed three forms of the same lost-identity problem: unrelated ScriptState.State and SipHash.State declarations, chained Rules.policy.witnessPubKeyType projection, and several modules returning Result<Built, String>. The first failed as an unlowerable State, the second leaked a silent Type::Invalid stamp, and the third registered the wrong Result instantiation.

## Evidence

- cargo test --features wasm --test wasm_gc_spec --test cross_module_type_keys --test typechecker_spec: 402 passed
- full btc-listener main.av now compiles to a validated 517188-byte wasm-gc module with all standard and both custom capabilities in its import manifest
- cargo fmt and git diff --check pass

Clippy with Rust 1.95 still reports the repository existing warning backlog under -D warnings; none point at this diff.