### PR TITLE
perf(wasm-gc): keep Bytes packed across provider pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,9 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 ### Fixed
 
-- **`Bytes` cross raw wasm-gc host boundaries in bulk.** Generated modules expose linear-memory copy helpers for plain `Bytes` and `Result<Bytes, String>`, replacing one JavaScript-to-wasm call per octet with one copy and one call. The same ABI works whether proof lowering packed the value into a byte array or a custom-provider boundary kept its boxed representation, and the embedded wasm-gc runner selects it automatically.
+- **`Bytes` cross raw wasm-gc host boundaries in bulk.** Generated modules expose linear-memory copy helpers for plain `Bytes` and `Result<Bytes, String>`, replacing one JavaScript-to-wasm call per octet with one copy and one call. Custom capability boundaries now retain proof-packed byte arrays behind representation-independent record factories/projectors; the boxed differential lane uses the same host ABI, and the embedded wasm-gc runner selects it automatically.
+
+- **Byte buffers stay packed while they are combined and sliced on wasm-gc.** `Bytes.empty`, `len`, `concat`, `take`, and `drop` make the preserving operations explicit and total. Their proof-packed lowering uses `array.len` / `array.copy` directly, so a provider-returned byte array no longer becomes millions of boxed `Int` cons cells merely to append it to an inbox or inspect a short header.
 
 - **Raw wasm-gc hosts can drive the complete TCP reactor API.** Generated modules export typed probes for every occupied `Tcp.poll` waitset entry plus token getters for `Tcp.Dial`, `Tcp.Listener`, and `Tcp.Socket`, so JavaScript hosts can implement readiness without guessing GC layouts or hard-coding caller keys.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 ### Fixed
 
+- **`Bytes` cross raw wasm-gc host boundaries in bulk.** Generated modules expose linear-memory copy helpers for plain `Bytes` and `Result<Bytes, String>`, replacing one JavaScript-to-wasm call per octet with one copy and one call. The same ABI works whether proof lowering packed the value into a byte array or a custom-provider boundary kept its boxed representation, and the embedded wasm-gc runner selects it automatically.
+
 - **Raw wasm-gc hosts can drive the complete TCP reactor API.** Generated modules export typed probes for every occupied `Tcp.poll` waitset entry plus token getters for `Tcp.Dial`, `Tcp.Listener`, and `Tcp.Socket`, so JavaScript hosts can implement readiness without guessing GC layouts or hard-coding caller keys.
 
 - **Proof export is substantially harder to make green for the wrong reason.** Fixes cover nested effect evaluation order, refused-claim accounting, defaults introduced by `?`, opaque capability resources, mutual-recursion measures and fuel, method applications in argument position, map-order observations through callbacks/tail calls/interpolation, and symbolic provider calls hidden behind transparent wrappers.

--- a/docs/services.md
+++ b/docs/services.md
@@ -41,6 +41,11 @@ computed element, or a literal outside `0..=255`. See
 |---|---|---|
 | `Bytes.fromList` | `List<Int> -> Result<Bytes, String>` | Validates every octet; `Result.Err` names the offending value and its index. An all-literal in-range list argument discharges to plain `Bytes` — see below |
 | `Bytes.octets` | `Bytes -> List<Int>` | Exposes validated values |
+| `Bytes.empty` | `() -> Bytes` | Empty byte sequence |
+| `Bytes.len` | `Bytes -> Int` | Number of octets |
+| `Bytes.concat` | `(Bytes, Bytes) -> Bytes` | Concatenates without revalidation |
+| `Bytes.take` | `(Bytes, Int) -> Bytes` | Prefix of at most `count` octets |
+| `Bytes.drop` | `(Bytes, Int) -> Bytes` | Octets after `count` positions |
 | `Bytes.fromHex` | `String -> Result<Bytes, String>` | Even length, case-insensitive, no `0x` prefix |
 | `Bytes.toHex` | `Bytes -> String` | Total, lowercase output |
 | `Crypto.Digest32.fromBytes` | `Bytes -> Result<Digest32, String>` | Requires exactly 32 bytes |

--- a/docs/wasm-gc-custom-capabilities.md
+++ b/docs/wasm-gc-custom-capabilities.md
@@ -91,6 +91,15 @@ filled internally, including inside `Option`, `List`, and `Vector`.
 ordinary `Result<Int, String>` on parse. Strings cross JavaScript through the
 existing `memory`, `__rt_string_from_lm`, and `__rt_string_to_lm` bridge.
 
+`Bytes` has the equivalent bulk bridge. A host writes octets at `memory[0..n]`
+and calls `__rt_bytes_from_lm(n)`; `__rt_bytes_to_lm(bytes)` copies the other
+direction and returns the written length. When `Result<Bytes, String>` is
+reachable, `__rt_result_bytes_string_ok_from_lm(n)` combines the inbound copy
+with its `Result.Ok` wrapper. These exports keep the same ABI whether the
+compiler proof-packed `Bytes` into a GC byte array or retained its boxed
+representation at a custom-provider boundary, so hosts never need a helper
+call per octet.
+
 An import function may close over an instance variable assigned immediately
 after `WebAssembly.instantiate`. Calls happen when an exported Aver entry point
 runs, so the provider can then call the instance's factories and return their

--- a/docs/wasm-gc-custom-capabilities.md
+++ b/docs/wasm-gc-custom-capabilities.md
@@ -56,10 +56,13 @@ there is no JSON codec and no narrowing of Aver values:
 | `List` | nullable typed cons reference |
 | `Vector` | typed mutable GC array reference |
 | `Map` | Aver's typed deterministic map reference |
+| proof-packed `List<Int>` refinement | typed GC array reference; record factories/projectors bridge its declared carrier |
 
-Boundary records and sums keep their nominal representation even when an
-internal optimizer could normally erase a one-field wrapper. This pins the ABI
-to the contract rather than to a size optimization selected for one program.
+Boundary records and sums keep their nominal representation when scalar
+wrapper erasure would otherwise change their ABI. A proof-packed structural
+refinement is the deliberate exception: its `make` and field inspector aliases
+point at the generated pack/unpack helpers, so the declared record API stays
+stable while byte-heavy providers keep the array representation end to end.
 
 ## Host bridge exports
 
@@ -96,9 +99,8 @@ and calls `__rt_bytes_from_lm(n)`; `__rt_bytes_to_lm(bytes)` copies the other
 direction and returns the written length. When `Result<Bytes, String>` is
 reachable, `__rt_result_bytes_string_ok_from_lm(n)` combines the inbound copy
 with its `Result.Ok` wrapper. These exports keep the same ABI whether the
-compiler proof-packed `Bytes` into a GC byte array or retained its boxed
-representation at a custom-provider boundary, so hosts never need a helper
-call per octet.
+compiler proof-packed `Bytes` into a GC byte array or packing is disabled in an
+internal differential-test build, so hosts never need a helper call per octet.
 
 An import function may close over an instance variable assigned immediately
 after `WebAssembly.instantiate`. Calls happen when an exported Aver entry point

--- a/src/analysis/literal_refinement.rs
+++ b/src/analysis/literal_refinement.rs
@@ -380,7 +380,10 @@ fn runtime_provenance_is_closed(
     entry_items: &[TopLevel],
     dep_modules: &[ModuleInfo],
 ) -> bool {
-    let scan_expr = |scope: Option<&str>, inside_gate: bool, expr: &Spanned<Expr>| {
+    let scan_expr = |scope: Option<&str>,
+                     inside_gate: bool,
+                     nominal_params: &HashSet<String>,
+                     expr: &Spanned<Expr>| {
         let mut closed = true;
         crate::codegen::proof_lower::carrier_walk_expr_with_byte_payloads(
             expr,
@@ -409,6 +412,10 @@ fn runtime_provenance_is_closed(
                         fields,
                         ctor.element_interval,
                         byte_payloads,
+                    ) || crate::codegen::proof_lower::construct_arg_preserves_list_refinement(
+                        fields,
+                        &ctor.carrier_field,
+                        nominal_params,
                     ));
                 if !independently_safe {
                     closed = false;
@@ -420,11 +427,21 @@ fn runtime_provenance_is_closed(
 
     let scan_fn = |scope: Option<&str>, fd: &FnDef| {
         let inside_gate = scope == ctor.scope.as_deref() && fd.name == ctor.constructor_fn;
+        let nominal_params: HashSet<String> = fd
+            .params
+            .iter()
+            .filter(|(_, ty)| {
+                crate::types::parse_type_str(ty)
+                    .named_name()
+                    .is_some_and(|name| name.rsplit('.').next() == Some(ctor.type_name.as_str()))
+            })
+            .map(|(name, _)| name.clone())
+            .collect();
         fd.body.stmts().iter().all(|stmt| {
             let expr = match stmt {
                 crate::ast::Stmt::Binding(_, _, value) | crate::ast::Stmt::Expr(value) => value,
             };
-            scan_expr(scope, inside_gate, expr)
+            scan_expr(scope, inside_gate, &nominal_params, expr)
         })
     };
 
@@ -432,7 +449,9 @@ fn runtime_provenance_is_closed(
         let closed = match item {
             TopLevel::FnDef(fd) => scan_fn(None, fd),
             TopLevel::Stmt(crate::ast::Stmt::Binding(_, _, value))
-            | TopLevel::Stmt(crate::ast::Stmt::Expr(value)) => scan_expr(None, false, value),
+            | TopLevel::Stmt(crate::ast::Stmt::Expr(value)) => {
+                scan_expr(None, false, &HashSet::new(), value)
+            }
             _ => true,
         };
         if !closed {

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -251,10 +251,13 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
             // `X(value := carrier)` collapses to the carrier expression.
             // Dafny narrowing (via `if pred then ... else ...`) is
             // what closes the refinement obligation at the call site.
-            if crate::codegen::common::find_refined_type(ctx, type_name).is_some()
+            if let Some(decl) = crate::codegen::common::find_refined_type(ctx, type_name)
                 && fields.len() == 1
             {
                 let (_, value_expr) = &fields[0];
+                if let Some(value) = packed_refinement_value(value_expr, decl, ctx) {
+                    return value;
+                }
                 return emit_expr(value_expr, ctx);
             }
             let field_strs: Vec<String> = fields
@@ -306,6 +309,55 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
             format!("{}({})", aver_name_to_dafny(name), arg_strs.join(", "))
         }
+    }
+}
+
+pub(super) fn packed_refinement_helper_stem(type_name: &str) -> String {
+    format!("AverPacked{}", aver_name_to_dafny(type_name))
+}
+
+/// Re-express structural carrier operations through subtype-preserving Dafny
+/// functions. The accepted grammar deliberately matches the fail-closed
+/// packed-layout scan: same-nominal carrier projections composed only by
+/// concat/take/drop, none of which can introduce a new element.
+fn packed_refinement_value(
+    expr: &Spanned<ResolvedExpr>,
+    decl: &crate::ir::RefinedTypeDecl,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    if !ctx.packed_sequence_layouts.contains_key(&decl.name) {
+        return None;
+    }
+    if let ResolvedExpr::Attr(base, field) = &expr.node
+        && field == &decl.carrier_field
+        && base
+            .ty()
+            .and_then(|ty| crate::codegen::common::find_refined_type_for_named(ctx, ty))
+            .is_some_and(|base_decl| std::ptr::eq(base_decl, decl))
+    {
+        return Some(emit_expr(base, ctx));
+    }
+    let ResolvedExpr::Call(ResolvedCallee::Builtin(name), args) = &expr.node else {
+        return None;
+    };
+    let stem = packed_refinement_helper_stem(&decl.name);
+    match (name.as_str(), args.as_slice()) {
+        ("List.concat", [left, right]) => Some(format!(
+            "{stem}Append({}, {})",
+            packed_refinement_value(left, decl, ctx)?,
+            packed_refinement_value(right, decl, ctx)?
+        )),
+        ("List.take", [source, count]) => Some(format!(
+            "{stem}Take({}, {})",
+            packed_refinement_value(source, decl, ctx)?,
+            emit_expr(count, ctx)
+        )),
+        ("List.drop", [source, count]) => Some(format!(
+            "{stem}Drop({}, {})",
+            packed_refinement_value(source, decl, ctx)?,
+            emit_expr(count, ctx)
+        )),
+        _ => None,
     }
 }
 

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -216,9 +216,12 @@ pub fn emit_type_def_in_scope(
                 let bind = aver_name_to_dafny(&decl.predicate_param);
                 let carrier = emit_type_in_scope(&decl.carrier_type, scope);
                 let witness = decl.witness.clone().unwrap_or_else(|| "*".to_string());
-                return Some(format!(
-                    "type {name} = {bind}: {carrier} | {predicate} witness {witness}\n"
-                ));
+                let definition =
+                    format!("type {name} = {bind}: {carrier} | {predicate} witness {witness}\n");
+                let Some(support) = emit_packed_refinement_support(name, ctx) else {
+                    return Some(definition);
+                };
+                return Some(format!("{definition}\n{support}"));
             }
             let field_strs: Vec<String> = fields
                 .iter()
@@ -238,6 +241,38 @@ pub fn emit_type_def_in_scope(
             ))
         }
     }
+}
+
+/// The proof backend models packed `List<Int>` refinements as Dafny subset
+/// types. Recursive structural helpers preserve that subset by construction,
+/// so concat/take/drop need neither an axiom nor an impossible default value.
+fn emit_packed_refinement_support(name: &str, ctx: &CodegenContext) -> Option<String> {
+    if !ctx.packed_sequence_layouts.contains_key(name) {
+        return None;
+    }
+    let stem = super::expr::packed_refinement_helper_stem(name);
+    Some(format!(
+        r#"function {stem}Append(a: {name}, b: {name}): {name}
+  decreases |a|
+{{
+  if |a| == 0 then b else [a[0]] + {stem}Append(a[1..], b)
+}}
+
+function {stem}Take(a: {name}, n: int): {name}
+  decreases |a|
+{{
+  if |a| == 0 || n <= 0 then []
+  else [a[0]] + {stem}Take(a[1..], n - 1)
+}}
+
+function {stem}Drop(a: {name}, n: int): {name}
+  decreases |a|
+{{
+  if |a| == 0 || n <= 0 then a
+  else {stem}Drop(a[1..], n - 1)
+}}
+"#
+    ))
 }
 
 /// Emit a recursive fn whose shape is outside the proof subset

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -284,6 +284,9 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
                 && fields.len() == 1
             {
                 let (_, value_expr) = &fields[0];
+                if let Some((value, evidence)) = packed_refinement_evidence(value_expr, decl, ctx) {
+                    return format!("⟨{value}, by exact {evidence}⟩");
+                }
                 let value_str = emit_expr(value_expr, ctx);
                 let mut ladder =
                     "first | omega | decide | (simp_all; omega) | assumption".to_string();
@@ -431,7 +434,10 @@ fn escape_lean_string(s: &str) -> String {
 /// well-founded recursion. A non-call invariant (a bare comparison such
 /// as `n >= 0`) has no name to unfold and returns `None`; those goals
 /// are already closed by `omega` / `decide`.
-fn invariant_head_name(invariant: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> Option<String> {
+pub(super) fn invariant_head_name(
+    invariant: &Spanned<ResolvedExpr>,
+    ctx: &CodegenContext,
+) -> Option<String> {
     // Only a USER function has equation lemmas worth unfolding; a builtin
     // head (`Bool.and`, a comparison) is already in `simp`'s reach and
     // rendering one here would need its arguments anyway.
@@ -446,6 +452,68 @@ fn invariant_head_name(invariant: &Spanned<ResolvedExpr>, ctx: &CodegenContext) 
         }
         _ => bare,
     })
+}
+
+pub(super) fn packed_refinement_lemma_stem(type_name: &str) -> String {
+    format!("__averPacked{}", aver_name_to_lean(type_name))
+}
+
+/// Return the emitted carrier and a proof that it still satisfies the
+/// structural refinement. This is deliberately the same narrow grammar as
+/// the fail-closed layout scan: same-nominal carrier projections composed by
+/// `List.concat`, `List.take`, and `List.drop`. No element-producing operation
+/// can enter this path.
+fn packed_refinement_evidence(
+    expr: &Spanned<ResolvedExpr>,
+    decl: &crate::ir::RefinedTypeDecl,
+    ctx: &CodegenContext,
+) -> Option<(String, String)> {
+    if !ctx.packed_sequence_layouts.contains_key(&decl.name) {
+        return None;
+    }
+    if let ResolvedExpr::Attr(base, field) = &expr.node
+        && field == &decl.carrier_field
+        && base
+            .ty()
+            .and_then(|ty| crate::codegen::common::find_refined_type_for_named(ctx, ty))
+            .is_some_and(|base_decl| std::ptr::eq(base_decl, decl))
+    {
+        let base = emit_expr(base, ctx);
+        return Some((emit_expr(expr, ctx), format!("({base}).property")));
+    }
+    let ResolvedExpr::Call(ResolvedCallee::Builtin(name), args) = &expr.node else {
+        return None;
+    };
+    let stem = packed_refinement_lemma_stem(&decl.name);
+    match (name.as_str(), args.as_slice()) {
+        ("List.concat", [left, right]) => {
+            let (left_value, left_evidence) = packed_refinement_evidence(left, decl, ctx)?;
+            let (right_value, right_evidence) = packed_refinement_evidence(right, decl, ctx)?;
+            Some((
+                emit_expr(expr, ctx),
+                format!(
+                    "{stem}Append ({left_value}) ({right_value}) ({left_evidence}) ({right_evidence})"
+                ),
+            ))
+        }
+        ("List.take", [source, count]) => {
+            let (source_value, source_evidence) = packed_refinement_evidence(source, decl, ctx)?;
+            let count = emit_expr(count, ctx);
+            Some((
+                emit_expr(expr, ctx),
+                format!("{stem}Take ({source_value}) (Int.toNat ({count})) ({source_evidence})"),
+            ))
+        }
+        ("List.drop", [source, count]) => {
+            let (source_value, source_evidence) = packed_refinement_evidence(source, decl, ctx)?;
+            let count = emit_expr(count, ctx);
+            Some((
+                emit_expr(expr, ctx),
+                format!("{stem}Drop ({source_value}) (Int.toNat ({count})) ({source_evidence})"),
+            ))
+        }
+        _ => None,
+    }
 }
 
 fn emit_fn_call(

--- a/src/codegen/lean/toplevel/type_def.rs
+++ b/src/codegen/lean/toplevel/type_def.rs
@@ -423,10 +423,14 @@ fn emit_product_type(
         let carrier_ty = type_annotation_to_lean(&decl.carrier_type);
         let param = aver_name_to_lean(&decl.predicate_param);
         let predicate = super::expr::emit_expr(&decl.invariant.expr, ctx);
-        return format!(
+        let definition = format!(
             "abbrev {} := {{ {param} : {carrier_ty} // {predicate} }}",
             aver_name_to_lean(name)
         );
+        let Some(support) = emit_packed_refinement_support(name, decl, ctx) else {
+            return definition;
+        };
+        return format!("{definition}\n\n{support}");
     }
 
     let mut lines = Vec::new();
@@ -446,6 +450,56 @@ fn emit_product_type(
         .all(|(_, field)| field_is_inhabitable(field, ctx, scope, &mut Vec::new()));
     lines.push(derives_line(inhabited, !is_recursive));
     lines.join("\n")
+}
+
+/// Proof-packed `List<Int>` refinements admit exactly three structural
+/// operations that cannot introduce a new element. Their runtime lowering is
+/// array-native; these lemmas establish the corresponding subtype obligations
+/// in Lean from the operands' existing `.property` proofs.
+fn emit_packed_refinement_support(
+    name: &str,
+    decl: &crate::ir::RefinedTypeDecl,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    if !ctx.packed_sequence_layouts.contains_key(name) {
+        return None;
+    }
+    let predicate = super::expr::invariant_head_name(&decl.invariant.expr, ctx)?;
+    let stem = super::expr::packed_refinement_lemma_stem(name);
+    Some(format!(
+        r#"private theorem {stem}Append (a b : List Int)
+    (ha : {predicate} a = true) (hb : {predicate} b = true) :
+    {predicate} (a ++ b) = true := by
+  induction a with
+  | nil => simpa [{predicate}] using hb
+  | cons head tail ih =>
+      simp [{predicate}] at ha ⊢
+      exact ⟨ha.1, ih ha.2⟩
+
+private theorem {stem}Take (a : List Int) (n : Nat)
+    (ha : {predicate} a = true) : {predicate} (a.take n) = true := by
+  induction a generalizing n with
+  | nil => simp [{predicate}]
+  | cons head tail ih =>
+      cases n with
+      | zero => simp [{predicate}]
+      | succ n =>
+          simp [{predicate}] at ha ⊢
+          exact ⟨ha.1, ih n ha.2⟩
+
+private theorem {stem}Drop (a : List Int) (n : Nat)
+    (ha : {predicate} a = true) : {predicate} (a.drop n) = true := by
+  induction a generalizing n with
+  | nil => simp [{predicate}]
+  | cons head tail ih =>
+      cases n with
+      | zero => simpa using ha
+      | succ n =>
+          simp only [List.drop_succ_cons]
+          apply ih n
+          simp [{predicate}] at ha
+          exact ha.2"#
+    ))
 }
 
 fn measure_fn_name(type_name: &str) -> String {

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -1445,10 +1445,12 @@ pub fn carrier_ungated_construction_demotions(
     }
 
     let mut ctor_fn_of: HashMap<String, String> = HashMap::new();
+    let mut carrier_field_of: HashMap<String, String> = HashMap::new();
     for name in candidates {
         if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(name, inputs, None)
         {
             ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
+            carrier_field_of.insert(name.clone(), info.carrier_field.to_string());
         } else {
             for m in inputs.dep_modules {
                 if let Some(info) = crate::codegen::common::refinement_info_for_in_scope(
@@ -1457,6 +1459,7 @@ pub fn carrier_ungated_construction_demotions(
                     Some(m.prefix.as_str()),
                 ) {
                     ctor_fn_of.insert(name.clone(), info.constructor_fn.to_string());
+                    carrier_field_of.insert(name.clone(), info.carrier_field.to_string());
                     break;
                 }
             }
@@ -1500,7 +1503,20 @@ pub fn carrier_ungated_construction_demotions(
                         if construct_arg_is_in_interval(fields, *iv)
                             || construct_arg_is_finalized_bytes(fields, *iv, byte_payloads)
                 );
-                if !safe_literal {
+                let nominal_params: HashSet<String> = fd
+                    .params
+                    .iter()
+                    .filter(|(_, ty)| {
+                        crate::types::parse_type_str(ty)
+                            .named_name()
+                            .is_some_and(|name| canonical_spelling(name, type_aliases) == type_name)
+                    })
+                    .map(|(name, _)| name.clone())
+                    .collect();
+                let safe_preserving = carrier_field_of.get(type_name).is_some_and(|field| {
+                    construct_arg_preserves_list_refinement(fields, field, &nominal_params)
+                });
+                if !safe_literal && !safe_preserving {
                     demoted.insert(type_name.to_string());
                 }
             });
@@ -1662,6 +1678,61 @@ pub(crate) fn construct_arg_is_finalized_bytes(
         &value.node,
         Expr::Ident(name) | Expr::Resolved { name, .. } if byte_payloads.contains(name)
     )
+}
+
+/// A direct structural-refinement construction is independently safe when
+/// its `List<Int>` carrier contains no newly introduced element: either the
+/// empty list, a projection from a parameter of the same nominal type, or a
+/// tree of `List.concat` / `List.take` / `List.drop` over such projections.
+///
+/// This is the source-level twin of MIR runtime provenance. It lets a module
+/// expose total preserving operations (`Bytes.concat`, `Bytes.take`, …)
+/// without the fail-closed wasm layout scan mistaking them for invariant
+/// bypasses. `prepend`, literals, arbitrary locals and calls all decline.
+pub(crate) fn construct_arg_preserves_list_refinement(
+    fields: &[(String, Spanned<Expr>)],
+    carrier_field: &str,
+    nominal_params: &HashSet<String>,
+) -> bool {
+    let [(field, value)] = fields else {
+        return false;
+    };
+    field == carrier_field
+        && list_expr_preserves_refinement(&value.node, carrier_field, nominal_params)
+}
+
+fn list_expr_preserves_refinement(
+    expr: &Expr,
+    carrier_field: &str,
+    nominal_params: &HashSet<String>,
+) -> bool {
+    match expr {
+        Expr::List(items) => items.is_empty(),
+        Expr::Attr(base, field) if field == carrier_field => matches!(
+            &base.node,
+            Expr::Ident(name) | Expr::Resolved { name, .. } if nominal_params.contains(name)
+        ),
+        Expr::FnCall(callee, args) => {
+            let Some(dotted) = crate::codegen::common::expr_to_dotted_name(&callee.node) else {
+                return false;
+            };
+            match (dotted.as_str(), args.as_slice()) {
+                ("List.concat", [left, right]) => {
+                    list_expr_preserves_refinement(&left.node, carrier_field, nominal_params)
+                        && list_expr_preserves_refinement(
+                            &right.node,
+                            carrier_field,
+                            nominal_params,
+                        )
+                }
+                ("List.take" | "List.drop", [source, _]) => {
+                    list_expr_preserves_refinement(&source.node, carrier_field, nominal_params)
+                }
+                _ => false,
+            }
+        }
+        _ => false,
+    }
 }
 
 /// Carrier visitor that tracks values proven to be byte lists by the

--- a/src/codegen/wasm_gc/body/from_mir/builtins.rs
+++ b/src/codegen/wasm_gc/body/from_mir/builtins.rs
@@ -58,7 +58,7 @@ pub(crate) fn lift_i64_result_to_aint(
 /// receiving helper clamps out-of-range counts/indices (`List.take` /
 /// `List.drop` counts, `String.charAt` / `String.slice` indices). A no-op
 /// passthrough when `bignum` is off (the arg is already i64).
-fn emit_aint_arg_as_i64_sat(
+pub(crate) fn emit_aint_arg_as_i64_sat(
     func: &mut Function,
     arg: &Spanned<MirExpr>,
     slots: &SlotTable,
@@ -2138,6 +2138,22 @@ pub(crate) fn emit_mir_list_builtin(
             };
             if !arity_ok {
                 return Ok(MirBuiltinEmit::NotHandled);
+            }
+            // A carrier projection immediately consumed by `List.len` does
+            // not need to become a linked `List<Int>` first. The nominal is
+            // already an array, so read its length in O(1). This is generic
+            // over every proof-packed structural refinement; `Bytes` merely
+            // happens to be the first standard-library consumer.
+            if matches!(dotted, "List.len" | "List.length")
+                && let Some((base, _)) = mir_packed_carrier_projection(&args[0], ctx)
+            {
+                if emit_mir_expr(func, base, slots, ctx)?.is_none() {
+                    return Ok(MirBuiltinEmit::Fallback);
+                }
+                func.instruction(&Instruction::ArrayLen);
+                func.instruction(&Instruction::I64ExtendI32U);
+                lift_i64_result_to_aint(func, ctx)?;
+                return Ok(MirBuiltinEmit::Produced(true));
             }
             let list_aver = aver_type_str_of(&args[0]);
             let canonical = normalize_compound(&list_aver);

--- a/src/codegen/wasm_gc/body/from_mir/records.rs
+++ b/src/codegen/wasm_gc/body/from_mir/records.rs
@@ -3,6 +3,120 @@
 
 use super::*;
 
+/// Recognise the source-level carrier projection of a proof-packed nominal.
+/// The returned base already has the packed array representation at runtime;
+/// emitting the ordinary projection would call `unpack` and allocate one cons
+/// cell per element.
+pub(crate) fn mir_packed_carrier_projection<'a>(
+    expr: &'a Spanned<MirExpr>,
+    ctx: &EmitCtx<'_>,
+) -> Option<(&'a Spanned<MirExpr>, String)> {
+    let MirExpr::Project(project) = &expr.node else {
+        return None;
+    };
+    let raw_name = aver_type_str_of(&project.node.base);
+    let type_name = ctx.registry.canonical_type_name(&raw_name);
+    ctx.registry.packed_sequence(type_name)?;
+    let carrier_field = ctx
+        .registry
+        .record_fields
+        .get(type_name)?
+        .first()
+        .map(|(name, _)| name)?;
+    (project.node.field == *carrier_field)
+        .then(|| (project.node.base.as_ref(), type_name.to_string()))
+}
+
+fn is_mir_packed_carrier_expr(expr: &Spanned<MirExpr>, type_name: &str, ctx: &EmitCtx<'_>) -> bool {
+    if let Some((_, projected_name)) = mir_packed_carrier_projection(expr, ctx) {
+        return projected_name == type_name;
+    }
+    let MirExpr::Call(call) = &expr.node else {
+        return false;
+    };
+    let MirCallee::Builtin(id) = call.node.callee else {
+        return false;
+    };
+    let Some(dotted) = ctx.mir_builtins.and_then(|names| names.get(id.0 as usize)) else {
+        return false;
+    };
+    match (dotted.as_str(), call.node.args.as_slice()) {
+        ("List.concat", [left, right]) => {
+            is_mir_packed_carrier_expr(left, type_name, ctx)
+                && is_mir_packed_carrier_expr(right, type_name, ctx)
+        }
+        ("List.take" | "List.drop", [source, _]) => {
+            is_mir_packed_carrier_expr(source, type_name, ctx)
+        }
+        _ => false,
+    }
+}
+
+fn emit_mir_packed_carrier_expr(
+    func: &mut Function,
+    expr: &Spanned<MirExpr>,
+    type_name: &str,
+    slots: &SlotTable,
+    ctx: &EmitCtx<'_>,
+) -> Result<(), WasmGcError> {
+    if let Some((base, projected_name)) = mir_packed_carrier_projection(expr, ctx) {
+        debug_assert_eq!(projected_name, type_name);
+        emit_mir_expr(func, base, slots, ctx)?.ok_or_else(|| {
+            WasmGcError::Validation(format!(
+                "packed carrier `{type_name}` base could not be emitted"
+            ))
+        })?;
+        return Ok(());
+    }
+    let MirExpr::Call(call) = &expr.node else {
+        return Err(WasmGcError::Validation(format!(
+            "packed carrier `{type_name}` expression lost its recognised shape"
+        )));
+    };
+    let MirCallee::Builtin(id) = call.node.callee else {
+        unreachable!("packed carrier recogniser only accepts builtin calls");
+    };
+    let dotted = ctx
+        .mir_builtins
+        .and_then(|names| names.get(id.0 as usize))
+        .expect("packed carrier recogniser pinned the builtin identity");
+    let ops = ctx
+        .fn_map
+        .packed_sequence_ops_lookup(type_name)
+        .ok_or_else(|| {
+            WasmGcError::Validation(format!(
+                "packed record `{type_name}` has no preserving operation bridge"
+            ))
+        })?;
+    match (dotted.as_str(), call.node.args.as_slice()) {
+        ("List.concat", [left, right]) => {
+            emit_mir_packed_carrier_expr(func, left, type_name, slots, ctx)?;
+            emit_mir_packed_carrier_expr(func, right, type_name, slots, ctx)?;
+            func.instruction(&Instruction::Call(ops.concat));
+        }
+        ("List.take", [source, count]) => {
+            emit_mir_packed_carrier_expr(func, source, type_name, slots, ctx)?;
+            if !emit_aint_arg_as_i64_sat(func, count, slots, ctx)? {
+                return Err(WasmGcError::Validation(
+                    "packed take count could not be emitted".into(),
+                ));
+            }
+            func.instruction(&Instruction::Call(ops.take));
+        }
+        ("List.drop", [source, count]) => {
+            emit_mir_packed_carrier_expr(func, source, type_name, slots, ctx)?;
+            if !emit_aint_arg_as_i64_sat(func, count, slots, ctx)? {
+                return Err(WasmGcError::Validation(
+                    "packed drop count could not be emitted".into(),
+                ));
+            }
+            func.instruction(&Instruction::Call(ops.drop));
+        }
+        _ => unreachable!("packed carrier recogniser and emitter diverged"),
+    }
+    Ok(())
+}
+
 /// Emit a record field / update value, mirroring `emit_record_create`'s
 /// per-field special-cases: an `Option.None` value emits through the
 /// constructor with the field's declared `T` (the bare-literal value's
@@ -66,6 +180,10 @@ pub(crate) fn emit_mir_record_create(
         let field = fields.first().ok_or(WasmGcError::Validation(format!(
             "packed record `{type_name}` requires one List<Int> field"
         )))?;
+        if is_mir_packed_carrier_expr(&field.value, type_name, ctx) {
+            emit_mir_packed_carrier_expr(func, &field.value, type_name, slots, ctx)?;
+            return Ok(Some(()));
+        }
         let produced = emit_mir_record_field_value(func, &field.value, "List<Int>", slots, ctx)?;
         if produced.is_some() {
             let ops = ctx

--- a/src/codegen/wasm_gc/bytes_bridge.rs
+++ b/src/codegen/wasm_gc/bytes_bridge.rs
@@ -1,0 +1,473 @@
+//! Bulk linear-memory transport for `Bytes` values.
+//!
+//! WebAssembly GC arrays are opaque to JavaScript. Without this bridge a raw
+//! host has to construct or inspect `Bytes` through one exported call per
+//! octet, first materialising a linked `List<Int>` and then asking the guest
+//! to repack it. The bridge uses the same LM[0..len] scratch buffer as String.
+//! Proof-packed Bytes need one guest array allocation; the boxed fallback
+//! still builds its list inside wasm, avoiding a JS↔wasm call per octet.
+
+use wasm_encoder::{
+    BlockType, CodeSection, ExportKind, ExportSection, Function, FunctionSection, HeapType,
+    Instruction, MemArg, RefType, TypeSection, ValType,
+};
+
+use super::types::{RESULT_OK_TAG, TypeRegistry};
+use super::{WasmGcError, wat_helper};
+use crate::codegen::proof_lower::PackedIntElement;
+
+#[derive(Debug, Clone, Copy)]
+struct OptionalSlot {
+    type_idx: u32,
+    fn_idx: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BytesRepresentation {
+    Packed {
+        type_idx: u32,
+    },
+    Boxed {
+        bytes_idx: u32,
+        list_idx: u32,
+        from_i64: Option<u32>,
+        to_i64: Option<u32>,
+    },
+}
+
+impl BytesRepresentation {
+    fn type_idx(self) -> u32 {
+        match self {
+            Self::Packed { type_idx } => type_idx,
+            Self::Boxed { bytes_idx, .. } => bytes_idx,
+        }
+    }
+}
+
+/// Slots for the raw-host exports. The Result helper is present only when the
+/// compiled graph actually carries `Result<Bytes, String>`.
+pub(super) struct BytesBridge {
+    representation: BytesRepresentation,
+    from_lm_type: u32,
+    to_lm_type: u32,
+    from_lm_fn: u32,
+    to_lm_fn: u32,
+    result_ok_from_lm: Option<OptionalSlot>,
+}
+
+impl BytesBridge {
+    pub(super) fn allocate(
+        types: &mut TypeSection,
+        next_type_idx: &mut u32,
+        next_fn_idx: &mut u32,
+        registry: &TypeRegistry,
+    ) -> Result<Option<Self>, WasmGcError> {
+        let representation = if let Some(bytes) = registry.packed_sequence("Bytes") {
+            if !matches!(bytes.layout.element, PackedIntElement::U8) {
+                return Err(WasmGcError::Validation(
+                    "raw-host Bytes bridge requires the proof-packed U8 layout".into(),
+                ));
+            }
+            BytesRepresentation::Packed {
+                type_idx: bytes.type_idx,
+            }
+        } else if let Some(bytes_idx) = registry.record_type_idx("Bytes") {
+            let canonical = registry.canonical_type_name("Bytes");
+            let fields = registry
+                .record_fields
+                .get(canonical)
+                .or_else(|| registry.record_fields.get("Bytes"));
+            if !matches!(fields, Some(fields) if fields.len() == 1 && fields[0].1.replace(' ', "") == "List<Int>")
+            {
+                return Err(WasmGcError::Validation(
+                    "raw-host Bytes bridge requires one List<Int> carrier field".into(),
+                ));
+            }
+            let list_idx = registry.list_type_idx("List<Int>").ok_or_else(|| {
+                WasmGcError::Validation("raw-host boxed Bytes bridge requires List<Int>".into())
+            })?;
+            let (from_i64, to_i64) = if registry.bignum {
+                (
+                    Some(registry.aint_from_i64_fn_idx.ok_or_else(|| {
+                        WasmGcError::Validation(
+                            "raw-host boxed Bytes bridge requires __aint_from_i64".into(),
+                        )
+                    })?),
+                    Some(registry.aint_to_i64_checked_fn_idx.ok_or_else(|| {
+                        WasmGcError::Validation(
+                            "raw-host boxed Bytes bridge requires __aint_to_i64_checked".into(),
+                        )
+                    })?),
+                )
+            } else {
+                (None, None)
+            };
+            BytesRepresentation::Boxed {
+                bytes_idx,
+                list_idx,
+                from_i64,
+                to_i64,
+            }
+        } else {
+            return Ok(None);
+        };
+        let bytes_ref = ValType::Ref(RefType {
+            nullable: true,
+            heap_type: HeapType::Concrete(representation.type_idx()),
+        });
+
+        types.ty().function([ValType::I32], [bytes_ref]);
+        let from_lm_type = *next_type_idx;
+        *next_type_idx += 1;
+        let from_lm_fn = *next_fn_idx;
+        *next_fn_idx += 1;
+
+        types.ty().function([bytes_ref], [ValType::I32]);
+        let to_lm_type = *next_type_idx;
+        *next_type_idx += 1;
+        let to_lm_fn = *next_fn_idx;
+        *next_fn_idx += 1;
+
+        let result_ok_from_lm =
+            registry
+                .result_type_idx("Result<Bytes,String>")
+                .map(|result_idx| {
+                    let result_ref = ValType::Ref(RefType {
+                        nullable: true,
+                        heap_type: HeapType::Concrete(result_idx),
+                    });
+                    types.ty().function([ValType::I32], [result_ref]);
+                    let slot = OptionalSlot {
+                        type_idx: *next_type_idx,
+                        fn_idx: *next_fn_idx,
+                    };
+                    *next_type_idx += 1;
+                    *next_fn_idx += 1;
+                    slot
+                });
+
+        Ok(Some(Self {
+            representation,
+            from_lm_type,
+            to_lm_type,
+            from_lm_fn,
+            to_lm_fn,
+            result_ok_from_lm,
+        }))
+    }
+
+    pub(super) fn emit_function_entries(&self, functions: &mut FunctionSection) {
+        functions.function(self.from_lm_type);
+        functions.function(self.to_lm_type);
+        if let Some(slot) = self.result_ok_from_lm {
+            functions.function(slot.type_idx);
+        }
+    }
+
+    pub(super) fn emit_exports(&self, exports: &mut ExportSection) {
+        exports.export("__rt_bytes_from_lm", ExportKind::Func, self.from_lm_fn);
+        exports.export("__rt_bytes_to_lm", ExportKind::Func, self.to_lm_fn);
+        if let Some(slot) = self.result_ok_from_lm {
+            exports.export(
+                "__rt_result_bytes_string_ok_from_lm",
+                ExportKind::Func,
+                slot.fn_idx,
+            );
+        }
+    }
+
+    pub(super) fn emit_bodies(
+        &self,
+        codes: &mut CodeSection,
+        registry: &TypeRegistry,
+    ) -> Result<(), WasmGcError> {
+        match self.representation {
+            BytesRepresentation::Packed { type_idx } => {
+                codes.function(&emit_from_lm_packed(type_idx)?);
+                codes.function(&emit_to_lm_packed(type_idx)?);
+            }
+            BytesRepresentation::Boxed {
+                bytes_idx,
+                list_idx,
+                from_i64,
+                to_i64,
+            } => {
+                codes.function(&emit_from_lm_boxed(bytes_idx, list_idx, from_i64));
+                codes.function(&emit_to_lm_boxed(bytes_idx, list_idx, to_i64));
+            }
+        }
+        if self.result_ok_from_lm.is_some() {
+            codes.function(&emit_result_ok_from_lm(registry, self.from_lm_fn)?);
+        }
+        Ok(())
+    }
+}
+
+fn emit_from_lm_packed(bytes_idx: u32) -> Result<Function, WasmGcError> {
+    let padding = wat_helper::padding_types(bytes_idx);
+    let wat = format!(
+        r#"
+        (module
+          {padding}
+          (type $bytes (array (mut i8)))
+          (memory 1)
+          (func (export "helper") (param $len i32) (result (ref null $bytes))
+            (local $bytes (ref null $bytes))
+            (local $i i32)
+            local.get $len
+            array.new_default $bytes
+            local.set $bytes
+            i32.const 0
+            local.set $i
+            (block $break
+              (loop $next
+                local.get $i
+                local.get $len
+                i32.ge_u
+                br_if $break
+
+                local.get $bytes
+                local.get $i
+                local.get $i
+                i32.load8_u
+                array.set $bytes
+
+                local.get $i
+                i32.const 1
+                i32.add
+                local.set $i
+                br $next))
+            local.get $bytes)
+        )
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+fn emit_to_lm_packed(bytes_idx: u32) -> Result<Function, WasmGcError> {
+    let padding = wat_helper::padding_types(bytes_idx);
+    let wat = format!(
+        r#"
+        (module
+          {padding}
+          (type $bytes (array (mut i8)))
+          (memory 1)
+          (func (export "helper") (param $bytes (ref null $bytes)) (result i32)
+            (local $len i32)
+            (local $i i32)
+            (local $needed i32)
+            (local $current i32)
+            local.get $bytes
+            array.len
+            local.set $len
+
+            local.get $len
+            i32.const 65535
+            i32.add
+            i32.const 16
+            i32.shr_u
+            local.set $needed
+
+            memory.size
+            local.set $current
+            local.get $needed
+            local.get $current
+            i32.gt_u
+            (if
+              (then
+                local.get $needed
+                local.get $current
+                i32.sub
+                memory.grow
+                drop))
+
+            i32.const 0
+            local.set $i
+            (block $break
+              (loop $next
+                local.get $i
+                local.get $len
+                i32.ge_u
+                br_if $break
+
+                local.get $i
+                local.get $bytes
+                local.get $i
+                array.get_u $bytes
+                i32.store8
+
+                local.get $i
+                i32.const 1
+                i32.add
+                local.set $i
+                br $next))
+            local.get $len)
+        )
+    "#
+    );
+    wat_helper::compile_wat_helper(&wat)
+}
+
+fn emit_from_lm_boxed(bytes_idx: u32, list_idx: u32, from_i64: Option<u32>) -> Function {
+    let list_ref = ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(list_idx),
+    });
+    let mut function = Function::new([(1, list_ref), (1, ValType::I32)]);
+    function.instruction(&Instruction::RefNull(HeapType::Concrete(list_idx)));
+    function.instruction(&Instruction::LocalSet(1));
+    function.instruction(&Instruction::LocalGet(0));
+    function.instruction(&Instruction::LocalSet(2));
+    function.instruction(&Instruction::Block(BlockType::Empty));
+    function.instruction(&Instruction::Loop(BlockType::Empty));
+    function.instruction(&Instruction::LocalGet(2));
+    function.instruction(&Instruction::I32Eqz);
+    function.instruction(&Instruction::BrIf(1));
+    function.instruction(&Instruction::LocalGet(2));
+    function.instruction(&Instruction::I32Const(RESULT_OK_TAG));
+    function.instruction(&Instruction::I32Sub);
+    function.instruction(&Instruction::LocalTee(2));
+    function.instruction(&Instruction::I32Load8U(byte_memarg()));
+    function.instruction(&Instruction::I64ExtendI32U);
+    if let Some(from_i64) = from_i64 {
+        function.instruction(&Instruction::Call(from_i64));
+    }
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::StructNew(list_idx));
+    function.instruction(&Instruction::LocalSet(1));
+    function.instruction(&Instruction::Br(0));
+    function.instruction(&Instruction::End);
+    function.instruction(&Instruction::End);
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::StructNew(bytes_idx));
+    function.instruction(&Instruction::End);
+    function
+}
+
+fn emit_to_lm_boxed(bytes_idx: u32, list_idx: u32, to_i64: Option<u32>) -> Function {
+    let list_ref = ValType::Ref(RefType {
+        nullable: true,
+        heap_type: HeapType::Concrete(list_idx),
+    });
+    let mut function = Function::new([(1, list_ref), (2, ValType::I32)]);
+
+    // First pass: find the length so the helper can grow LM once.
+    function.instruction(&Instruction::LocalGet(0));
+    function.instruction(&Instruction::StructGet {
+        struct_type_index: bytes_idx,
+        field_index: 0,
+    });
+    function.instruction(&Instruction::LocalSet(1));
+    function.instruction(&Instruction::I32Const(0));
+    function.instruction(&Instruction::LocalSet(2));
+    function.instruction(&Instruction::Block(BlockType::Empty));
+    function.instruction(&Instruction::Loop(BlockType::Empty));
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::RefIsNull);
+    function.instruction(&Instruction::BrIf(1));
+    function.instruction(&Instruction::LocalGet(2));
+    function.instruction(&Instruction::I32Const(1));
+    function.instruction(&Instruction::I32Add);
+    function.instruction(&Instruction::LocalSet(2));
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 1,
+    });
+    function.instruction(&Instruction::LocalSet(1));
+    function.instruction(&Instruction::Br(0));
+    function.instruction(&Instruction::End);
+    function.instruction(&Instruction::End);
+
+    // Ensure LM[0..len] exists before the copy pass.
+    function.instruction(&Instruction::LocalGet(2));
+    function.instruction(&Instruction::I32Const(65_535));
+    function.instruction(&Instruction::I32Add);
+    function.instruction(&Instruction::I32Const(16));
+    function.instruction(&Instruction::I32ShrU);
+    function.instruction(&Instruction::MemorySize(0));
+    function.instruction(&Instruction::I32GtU);
+    function.instruction(&Instruction::If(BlockType::Empty));
+    function.instruction(&Instruction::LocalGet(2));
+    function.instruction(&Instruction::I32Const(65_535));
+    function.instruction(&Instruction::I32Add);
+    function.instruction(&Instruction::I32Const(16));
+    function.instruction(&Instruction::I32ShrU);
+    function.instruction(&Instruction::MemorySize(0));
+    function.instruction(&Instruction::I32Sub);
+    function.instruction(&Instruction::MemoryGrow(0));
+    function.instruction(&Instruction::Drop);
+    function.instruction(&Instruction::End);
+
+    // Second pass: checked-unbox each proven octet and store it in LM.
+    function.instruction(&Instruction::LocalGet(0));
+    function.instruction(&Instruction::StructGet {
+        struct_type_index: bytes_idx,
+        field_index: 0,
+    });
+    function.instruction(&Instruction::LocalSet(1));
+    function.instruction(&Instruction::I32Const(0));
+    function.instruction(&Instruction::LocalSet(3));
+    function.instruction(&Instruction::Block(BlockType::Empty));
+    function.instruction(&Instruction::Loop(BlockType::Empty));
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::RefIsNull);
+    function.instruction(&Instruction::BrIf(1));
+    function.instruction(&Instruction::LocalGet(3));
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 0,
+    });
+    if let Some(to_i64) = to_i64 {
+        function.instruction(&Instruction::Call(to_i64));
+    }
+    function.instruction(&Instruction::I32WrapI64);
+    function.instruction(&Instruction::I32Store8(byte_memarg()));
+    function.instruction(&Instruction::LocalGet(3));
+    function.instruction(&Instruction::I32Const(1));
+    function.instruction(&Instruction::I32Add);
+    function.instruction(&Instruction::LocalSet(3));
+    function.instruction(&Instruction::LocalGet(1));
+    function.instruction(&Instruction::StructGet {
+        struct_type_index: list_idx,
+        field_index: 1,
+    });
+    function.instruction(&Instruction::LocalSet(1));
+    function.instruction(&Instruction::Br(0));
+    function.instruction(&Instruction::End);
+    function.instruction(&Instruction::End);
+    function.instruction(&Instruction::LocalGet(2));
+    function.instruction(&Instruction::End);
+    function
+}
+
+fn byte_memarg() -> MemArg {
+    MemArg {
+        offset: 0,
+        align: 0,
+        memory_index: 0,
+    }
+}
+
+fn emit_result_ok_from_lm(
+    registry: &TypeRegistry,
+    from_lm_fn: u32,
+) -> Result<Function, WasmGcError> {
+    let result_idx = registry
+        .result_type_idx("Result<Bytes,String>")
+        .expect("checked at allocation");
+    let string_idx = registry
+        .string_array_type_idx
+        .ok_or(WasmGcError::Validation(
+            "Result<Bytes, String> bridge requires String".into(),
+        ))?;
+    let mut function = Function::new([]);
+    function.instruction(&Instruction::I32Const(1));
+    function.instruction(&Instruction::LocalGet(0));
+    function.instruction(&Instruction::Call(from_lm_fn));
+    function.instruction(&Instruction::RefNull(HeapType::Concrete(string_idx)));
+    function.instruction(&Instruction::StructNew(result_idx));
+    function.instruction(&Instruction::End);
+    Ok(function)
+}

--- a/src/codegen/wasm_gc/capability_abi.rs
+++ b/src/codegen/wasm_gc/capability_abi.rs
@@ -17,6 +17,7 @@ use crate::ast::Type;
 use super::CapabilityWasmGcPlan;
 use super::WasmGcError;
 use super::maps::MapKVHelpers;
+use super::packed_sequences::PackedSequenceOps;
 use super::types::{TypeRegistry, aver_to_wasm};
 
 #[derive(Debug, Clone)]
@@ -101,12 +102,17 @@ pub(super) struct IntAbiHelpers {
     pub(super) to_decimal: u32,
 }
 
+pub(super) struct CollectionAbiHelpers<'a> {
+    pub(super) maps: &'a dyn Fn(&str) -> Option<MapKVHelpers>,
+    pub(super) packed_sequences: &'a dyn Fn(&str) -> Option<PackedSequenceOps>,
+}
+
 impl CapabilityAbi {
     pub(super) fn allocate(
         plan: Option<&CapabilityWasmGcPlan>,
         registry: &TypeRegistry,
         int_helpers: Option<IntAbiHelpers>,
-        map_helpers: &impl Fn(&str) -> Option<MapKVHelpers>,
+        collection_helpers: &CollectionAbiHelpers<'_>,
         types: &mut TypeSection,
         next_type_idx: &mut u32,
         next_fn_idx: &mut u32,
@@ -135,7 +141,7 @@ impl CapabilityAbi {
                 ty,
                 registry,
                 int_helpers,
-                map_helpers,
+                collection_helpers,
                 types,
                 next_type_idx,
                 next_fn_idx,
@@ -150,7 +156,7 @@ impl CapabilityAbi {
         ty: &Type,
         registry: &TypeRegistry,
         int_helpers: Option<IntAbiHelpers>,
-        map_helpers: &impl Fn(&str) -> Option<MapKVHelpers>,
+        collection_helpers: &CollectionAbiHelpers<'_>,
         types: &mut TypeSection,
         next_type_idx: &mut u32,
         next_fn_idx: &mut u32,
@@ -399,7 +405,7 @@ impl CapabilityAbi {
                 // wasm-gc map monomorphisation registry uses its compact
                 // canonical spelling. Both denote the same boundary type.
                 let compact = canonical.replace(' ', "");
-                let helpers = map_helpers(&compact).ok_or_else(|| {
+                let helpers = (collection_helpers.maps)(&compact).ok_or_else(|| {
                     WasmGcError::Validation(format!("capability ABI lacks `{canonical}` helpers"))
                 })?;
                 for (suffix, fn_idx) in [
@@ -417,7 +423,43 @@ impl CapabilityAbi {
                 if registry.is_capability_resource(name) {
                     return Ok(());
                 }
-                if let Some(type_idx) = registry.record_type_idx(name) {
+                if registry.packed_sequence(name).is_some() {
+                    let helpers = (collection_helpers.packed_sequences)(name).ok_or_else(|| {
+                        WasmGcError::Validation(format!(
+                            "capability ABI lacks packed `{name}` helpers"
+                        ))
+                    })?;
+                    let fields = registry
+                        .record_fields
+                        .get(registry.canonical_type_name(name))
+                        .or_else(|| {
+                            name.rsplit_once('.')
+                                .and_then(|(_, bare)| registry.record_fields.get(bare))
+                        })
+                        .ok_or_else(|| {
+                            WasmGcError::Validation(format!(
+                                "capability ABI lacks packed `{name}` fields"
+                            ))
+                        })?;
+                    let [(field_name, field_type)] = fields.as_slice() else {
+                        return Err(WasmGcError::Validation(format!(
+                            "capability ABI packed `{name}` must have one carrier field"
+                        )));
+                    };
+                    if field_type.replace(' ', "") != "List<Int>" {
+                        return Err(WasmGcError::Validation(format!(
+                            "capability ABI packed `{name}` carrier must be List<Int>"
+                        )));
+                    }
+                    self.aliases.push((format!("{stem}_make"), helpers.pack));
+                    self.aliases.push((
+                        format!(
+                            "{stem}_field_{}",
+                            crate::codegen::wasip2::plan::encode_interface_identifier(field_name)
+                        ),
+                        helpers.unpack,
+                    ));
+                } else if let Some(type_idx) = registry.record_type_idx(name) {
                     let fields = registry
                         .record_fields
                         .get(name)

--- a/src/codegen/wasm_gc/mod.rs
+++ b/src/codegen/wasm_gc/mod.rs
@@ -59,6 +59,7 @@ use crate::ir::AnalysisResult;
 
 mod body;
 mod builtins;
+mod bytes_bridge;
 mod capability_abi;
 mod capability_imports;
 mod capability_plan;

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -451,13 +451,17 @@ pub(super) fn emit_module_with(
             &intervals,
             type_aliases,
         );
-        let mut layouts: std::collections::HashMap<_, _> = layouts
+        let layouts: std::collections::HashMap<_, _> = layouts
             .into_iter()
             .filter(|(name, _)| !demoted.contains(name))
             .collect();
-        if let Some(plan) = capability_wasm_gc_plan {
-            layouts.retain(|name, _| !plan.named_boundary_types().contains(name));
-        }
+        // Unlike scalar/multi-field carrier erasure, proof-packed sequence
+        // refinements keep a representation-independent custom-capability
+        // ABI: the exported named-type make/field helpers alias the same
+        // pack/unpack functions. A JavaScript host therefore observes the
+        // declared List<Int> carrier API whether the guest stores the nominal
+        // as a struct or an array. Keeping the packed layout here is both
+        // contract-stable and essential for byte-heavy providers.
         layouts
     } else {
         std::collections::HashMap::new()
@@ -2490,7 +2494,10 @@ pub(super) fn emit_module_with(
         capability_wasm_gc_plan,
         &registry,
         capability_int_abi,
-        &|canonical| map_helpers.kv_helpers(canonical),
+        &super::capability_abi::CollectionAbiHelpers {
+            maps: &|canonical| map_helpers.kv_helpers(canonical),
+            packed_sequences: &|name| packed_sequence_helpers.ops_for(name),
+        },
         &mut types,
         &mut next_type_idx,
         &mut next_builtin_fn_idx,

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -1506,6 +1506,21 @@ pub(super) fn emit_module_with(
         None
     };
 
+    // 8a) `Bytes` transport for raw wasm-gc hosts. JavaScript cannot inspect
+    //     GC arrays or structs directly, so expose one LM bridge call instead
+    //     of forcing one exported helper call per octet. This also covers the
+    //     boxed representation retained at custom-provider boundaries.
+    let bytes_bridge = if matches!(target, super::TargetMode::AverBridge) {
+        super::bytes_bridge::BytesBridge::allocate(
+            &mut types,
+            &mut next_type_idx,
+            &mut next_builtin_fn_idx,
+            &registry,
+        )?
+    } else {
+        None
+    };
+
     // 8b) `cabi_realloc` — Phase 1.3.1. The Component Model
     //     canonical ABI requires a guest export named exactly
     //     `cabi_realloc(old_ptr i32, old_size i32, align i32,
@@ -2594,6 +2609,9 @@ pub(super) fn emit_module_with(
         funcs.function(b.pages_type);
         funcs.function(b.grow_type);
     }
+    if let Some(b) = &bytes_bridge {
+        b.emit_function_entries(&mut funcs);
+    }
     if let Some(c) = &cabi_realloc {
         funcs.function(c.fn_type);
     }
@@ -2716,7 +2734,7 @@ pub(super) fn emit_module_with(
     //   internal wasm-side glue at effect call sites.
     let need_memory_for_wasip2 =
         matches!(target, super::TargetMode::Wasip2) && wasip2_import_count > 0;
-    if bridge.is_some() || need_memory_for_wasip2 {
+    if bridge.is_some() || bytes_bridge.is_some() || need_memory_for_wasip2 {
         let mut memories = wasm_encoder::MemorySection::new();
         memories.memory(wasm_encoder::MemoryType {
             minimum: 1,
@@ -3431,6 +3449,9 @@ pub(super) fn emit_module_with(
             }
         }
         exports.export("memory", ExportKind::Memory, 0);
+    } else if let Some(b) = &bytes_bridge {
+        b.emit_exports(&mut exports);
+        exports.export("memory", ExportKind::Memory, 0);
     } else if cabi_realloc.is_some() {
         // wasip2 path with no bridge (theoretical — cabi_realloc
         // gates on `wasip2_imports.import_count() > 0` which only
@@ -3438,6 +3459,12 @@ pub(super) fn emit_module_with(
         // every such effect today implies a String). Defensive
         // export so the host can find memory regardless.
         exports.export("memory", ExportKind::Memory, 0);
+    }
+    if bridge.is_some()
+        && matches!(target, super::TargetMode::AverBridge)
+        && let Some(b) = &bytes_bridge
+    {
+        b.emit_exports(&mut exports);
     }
     if let Some(c) = &cabi_realloc {
         // Required by Component Model canonical ABI as the guest's
@@ -3981,6 +4008,9 @@ pub(super) fn emit_module_with(
 
     if bridge.is_some() {
         emit_bridge_bodies(&mut codes, &registry)?;
+    }
+    if let Some(b) = &bytes_bridge {
+        b.emit_bodies(&mut codes, &registry)?;
     }
 
     if cabi_realloc.is_some() {

--- a/src/codegen/wasm_gc/packed_sequences.rs
+++ b/src/codegen/wasm_gc/packed_sequences.rs
@@ -2,8 +2,9 @@
 //!
 //! A packed nominal value is an array in wasm, while Aver code inside the
 //! defining module still constructs and projects its declared `List<Int>`
-//! carrier. Two small per-type helpers make that boundary explicit. They are
-//! generic over the proof-selected integer width and never key on `Bytes`.
+//! carrier. Per-type helpers make that boundary explicit and keep preserving
+//! `concat` / `take` / `drop` pipelines packed. They are generic over the
+//! proof-selected integer width and never key on `Bytes`.
 
 use std::collections::HashMap;
 
@@ -20,12 +21,15 @@ use crate::codegen::proof_lower::PackedIntElement;
 pub(super) struct PackedSequenceOps {
     pub(super) pack: u32,
     pub(super) unpack: u32,
+    pub(super) concat: u32,
+    pub(super) take: u32,
+    pub(super) drop: u32,
 }
 
 #[derive(Default)]
 pub(super) struct PackedSequenceHelperRegistry {
     ops: HashMap<String, PackedSequenceOps>,
-    type_indices: HashMap<String, (u32, u32)>,
+    type_indices: HashMap<String, (u32, u32, u32, u32)>,
     order: Vec<String>,
 }
 
@@ -41,14 +45,34 @@ impl PackedSequenceHelperRegistry {
             *next_type_idx += 1;
             let unpack_type = *next_type_idx;
             *next_type_idx += 1;
+            let concat_type = *next_type_idx;
+            *next_type_idx += 1;
+            let slice_type = *next_type_idx;
+            *next_type_idx += 1;
             let pack = *next_fn_idx;
             *next_fn_idx += 1;
             let unpack = *next_fn_idx;
             *next_fn_idx += 1;
-            self.ops
-                .insert(name.clone(), PackedSequenceOps { pack, unpack });
-            self.type_indices
-                .insert(name.clone(), (pack_type, unpack_type));
+            let concat = *next_fn_idx;
+            *next_fn_idx += 1;
+            let take = *next_fn_idx;
+            *next_fn_idx += 1;
+            let drop = *next_fn_idx;
+            *next_fn_idx += 1;
+            self.ops.insert(
+                name.clone(),
+                PackedSequenceOps {
+                    pack,
+                    unpack,
+                    concat,
+                    take,
+                    drop,
+                },
+            );
+            self.type_indices.insert(
+                name.clone(),
+                (pack_type, unpack_type, concat_type, slice_type),
+            );
             self.order.push(name.clone());
         }
         // Register the flatten-derived qualified aliases as extra lookup
@@ -98,15 +122,22 @@ impl PackedSequenceHelperRegistry {
             let packed_ref = ref_ty(packed.type_idx);
             types.ty().function([list_ref], [packed_ref]);
             types.ty().function([packed_ref], [list_ref]);
+            types.ty().function([packed_ref, packed_ref], [packed_ref]);
+            types
+                .ty()
+                .function([packed_ref, ValType::I64], [packed_ref]);
         }
         Ok(())
     }
 
     pub(super) fn emit_function_section(&self, funcs: &mut FunctionSection) {
         for name in &self.order {
-            let (pack, unpack) = self.type_indices[name];
+            let (pack, unpack, concat, slice) = self.type_indices[name];
             funcs.function(pack);
             funcs.function(unpack);
+            funcs.function(concat);
+            funcs.function(slice);
+            funcs.function(slice);
         }
     }
 
@@ -118,9 +149,147 @@ impl PackedSequenceHelperRegistry {
         for name in &self.order {
             codes.function(&emit_pack(name, registry)?);
             codes.function(&emit_unpack(name, registry)?);
+            codes.function(&emit_concat(name, registry)?);
+            codes.function(&emit_take(name, registry)?);
+            codes.function(&emit_drop(name, registry)?);
         }
         Ok(())
     }
+}
+
+fn emit_concat(name: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let packed = registry
+        .packed_sequence(name)
+        .ok_or_else(|| WasmGcError::Validation(format!("packed type `{name}` missing")))?;
+    let packed_ref = ref_ty(packed.type_idx);
+    // params: 0=left, 1=right. locals: 2=left_len, 3=right_len, 4=out.
+    let mut f = Function::new([(2, ValType::I32), (1, packed_ref)]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::I32Add);
+    f.instruction(&Instruction::ArrayNewDefault(packed.type_idx));
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::ArrayCopy {
+        array_type_index_dst: packed.type_idx,
+        array_type_index_src: packed.type_idx,
+    });
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::ArrayCopy {
+        array_type_index_dst: packed.type_idx,
+        array_type_index_src: packed.type_idx,
+    });
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::End);
+    Ok(f)
+}
+
+fn emit_take(name: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let packed = registry
+        .packed_sequence(name)
+        .ok_or_else(|| WasmGcError::Validation(format!("packed type `{name}` missing")))?;
+    let packed_ref = ref_ty(packed.type_idx);
+    // params: 0=input, 1=count. locals: 2=len, 3=out_len, 4=out.
+    let mut f = Function::new([(2, ValType::I32), (1, packed_ref)]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I64Const(0));
+    f.instruction(&Instruction::I64GtS);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I64ExtendI32U);
+    f.instruction(&Instruction::I64LtU);
+    f.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32WrapI64);
+    f.instruction(&Instruction::Else);
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::ArrayNewDefault(packed.type_idx));
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::ArrayCopy {
+        array_type_index_dst: packed.type_idx,
+        array_type_index_src: packed.type_idx,
+    });
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::End);
+    Ok(f)
+}
+
+fn emit_drop(name: &str, registry: &TypeRegistry) -> Result<Function, WasmGcError> {
+    let packed = registry
+        .packed_sequence(name)
+        .ok_or_else(|| WasmGcError::Validation(format!("packed type `{name}` missing")))?;
+    let packed_ref = ref_ty(packed.type_idx);
+    // params: 0=input, 1=count. locals: 2=len, 3=offset, 4=out_len, 5=out.
+    let mut f = Function::new([(3, ValType::I32), (1, packed_ref)]);
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::ArrayLen);
+    f.instruction(&Instruction::LocalSet(2));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I64Const(0));
+    f.instruction(&Instruction::I64GtS);
+    f.instruction(&Instruction::If(BlockType::Empty));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::I64ExtendI32U);
+    f.instruction(&Instruction::I64LtU);
+    f.instruction(&Instruction::If(BlockType::Result(ValType::I32)));
+    f.instruction(&Instruction::LocalGet(1));
+    f.instruction(&Instruction::I32WrapI64);
+    f.instruction(&Instruction::Else);
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalSet(3));
+    f.instruction(&Instruction::End);
+    f.instruction(&Instruction::LocalGet(2));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::I32Sub);
+    f.instruction(&Instruction::LocalSet(4));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::ArrayNewDefault(packed.type_idx));
+    f.instruction(&Instruction::LocalSet(5));
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::I32Const(0));
+    f.instruction(&Instruction::LocalGet(0));
+    f.instruction(&Instruction::LocalGet(3));
+    f.instruction(&Instruction::LocalGet(4));
+    f.instruction(&Instruction::ArrayCopy {
+        array_type_index_dst: packed.type_idx,
+        array_type_index_src: packed.type_idx,
+    });
+    f.instruction(&Instruction::LocalGet(5));
+    f.instruction(&Instruction::End);
+    Ok(f)
 }
 
 fn ref_ty(type_idx: u32) -> ValType {

--- a/src/runtime/wasm_gc/imports/factories.rs
+++ b/src/runtime/wasm_gc/imports/factories.rs
@@ -6,7 +6,7 @@
 //! or from a recording.
 
 use super::super::RunWasmGcHost;
-use super::lm::{lm_string_from_host, lm_string_to_host};
+use super::lm::{lm_result_bytes_from_host, lm_string_from_host, lm_string_to_host};
 
 pub(crate) fn host_option_string_some(
     caller: &mut wasmtime::Caller<'_, RunWasmGcHost>,
@@ -645,14 +645,28 @@ pub(crate) fn host_result_err_list_int(
     })
 }
 
-/// Build a `Result<Bytes, String>::Ok(bytes)` ref. Each response byte
-/// is lifted through the module's canonical `$AverInt` constructor;
-/// the exported factory wraps the completed private list in `Bytes`.
+/// Build a `Result<Bytes, String>::Ok(bytes)` ref. Packed and boxed modules
+/// copy the whole payload through linear memory in one boundary crossing. The
+/// element-wise path is retained as a defensive fallback for older modules.
 pub(crate) fn host_result_ok_bytes(
     caller: &mut wasmtime::Caller<'_, RunWasmGcHost>,
     items: &[i64],
 ) -> Result<Option<wasmtime::Rooted<wasmtime::AnyRef>>, wasmtime::Error> {
     use wasmtime::Val;
+    let bytes = items
+        .iter()
+        .map(|item| {
+            u8::try_from(*item).map_err(|_| {
+                wasmtime::Error::msg(format!(
+                    "Bytes provider returned an octet outside 0..255: {item}"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if let Some(result) = lm_result_bytes_from_host(caller, &bytes)? {
+        return Ok(Some(result));
+    }
+
     let nil = caller
         .get_export("__rt_list_int_nil")
         .and_then(|e| e.into_func());

--- a/src/runtime/wasm_gc/imports/lm.rs
+++ b/src/runtime/wasm_gc/imports/lm.rs
@@ -157,3 +157,38 @@ pub(crate) fn lm_string_from_host<T: 'static>(
     };
     Ok(r)
 }
+
+/// Build `Result<Bytes, String>::Ok` through the Bytes linear-memory bridge.
+/// Returns `None` defensively for a module produced without that export; both
+/// packed and boxed Bytes representations normally provide it.
+pub(crate) fn lm_result_bytes_from_host<T: 'static>(
+    caller: &mut wasmtime::Caller<'_, T>,
+    bytes: &[u8],
+) -> Result<Option<wasmtime::Rooted<wasmtime::AnyRef>>, wasmtime::Error> {
+    use wasmtime::Val;
+
+    let factory = caller
+        .get_export("__rt_result_bytes_string_ok_from_lm")
+        .and_then(|export| export.into_func());
+    let memory = caller
+        .get_export("memory")
+        .and_then(|export| export.into_memory());
+    let (Some(factory), Some(memory)) = (factory, memory) else {
+        return Ok(None);
+    };
+    let len = i32::try_from(bytes.len())
+        .map_err(|_| wasmtime::Error::msg("Bytes payload exceeds wasm32 linear memory"))?;
+    let needed_pages = ((bytes.len() as u64) + 65_535) >> 16;
+    let current_pages = memory.size(&*caller);
+    if needed_pages > current_pages {
+        memory.grow(&mut *caller, needed_pages - current_pages)?;
+    }
+    memory.write(&mut *caller, 0, bytes)?;
+
+    let mut result = [Val::AnyRef(None)];
+    factory.call(&mut *caller, &[Val::I32(len)], &mut result)?;
+    Ok(match &result[0] {
+        Val::AnyRef(value) => *value,
+        _ => None,
+    })
+}

--- a/src/self_host/aver_generated/bytes/mod.rs
+++ b/src/self_host/aver_generated/bytes/mod.rs
@@ -187,6 +187,58 @@ pub fn octets(bytes: &Bytes) -> aver_rt::AverIntList {
     (bytes.values).to_int_list().clone()
 }
 
+/// The empty byte sequence.
+pub fn empty() -> Bytes {
+    crate::cancel_checkpoint();
+    crate::aver_generated::bytes::Bytes {
+        values: aver_rt::into_packed_u8(aver_rt::AverIntList::empty())
+            .expect("proof-packed U8 construction escaped its refinement gate"),
+    }
+}
+
+/// The number of octets in a byte sequence.
+#[inline(always)]
+pub fn len(bytes: &Bytes) -> aver_rt::AverInt {
+    crate::cancel_checkpoint();
+    aver_rt::AverInt::from_i64((bytes.values).to_int_list().len() as i64)
+}
+
+/// The octets of left followed by the octets of right.
+pub fn concat(left: &Bytes, right: &Bytes) -> Bytes {
+    crate::cancel_checkpoint();
+    crate::aver_generated::bytes::Bytes {
+        values: aver_rt::into_packed_u8(aver_rt::AverIntList::concat(
+            &(left.values).to_int_list().clone(),
+            &(right.values).to_int_list().clone(),
+        ))
+        .expect("proof-packed U8 construction escaped its refinement gate"),
+    }
+}
+
+/// At most count octets from the front; non-positive counts give empty bytes.
+pub fn take(bytes: &Bytes, count: aver_rt::AverInt) -> Bytes {
+    crate::cancel_checkpoint();
+    crate::aver_generated::bytes::Bytes {
+        values: aver_rt::into_packed_u8({
+            let __n = aver_rt::clamp_list_count(&(count));
+            ((bytes.values).to_int_list()).take_first(__n)
+        })
+        .expect("proof-packed U8 construction escaped its refinement gate"),
+    }
+}
+
+/// The octets after count positions; non-positive counts preserve all bytes.
+pub fn drop(bytes: &Bytes, count: aver_rt::AverInt) -> Bytes {
+    crate::cancel_checkpoint();
+    crate::aver_generated::bytes::Bytes {
+        values: aver_rt::into_packed_u8({
+            let __n = aver_rt::clamp_list_count(&(count));
+            ((bytes.values).to_int_list()).drop_first(__n)
+        })
+        .expect("proof-packed U8 construction escaped its refinement gate"),
+    }
+}
+
 /// Parse hexadecimal pairs into octets from left to right.
 #[inline(always)]
 pub fn parseHexChars(

--- a/stdlib/bytes.av
+++ b/stdlib/bytes.av
@@ -1,7 +1,7 @@
 module Bytes
     intent =
         "Defines validated byte sequences as an ordinary Aver refinement."
-    exposes [fromList, octets, fromHex, toHex]
+    exposes [fromList, octets, empty, len, concat, take, drop, fromHex, toHex]
     exposes opaque [Bytes]
     effects []
 
@@ -41,6 +41,26 @@ fn fromList(xs: List<Int>) -> Result<Bytes, String>
 fn octets(bytes: Bytes) -> List<Int>
     ? "Expose the validated octets for ordinary List operations."
     bytes.values
+
+fn empty() -> Bytes
+    ? "The empty byte sequence."
+    Bytes(values = [])
+
+fn len(bytes: Bytes) -> Int
+    ? "The number of octets in a byte sequence."
+    List.len(bytes.values)
+
+fn concat(left: Bytes, right: Bytes) -> Bytes
+    ? "The octets of left followed by the octets of right."
+    Bytes(values = List.concat(left.values, right.values))
+
+fn take(bytes: Bytes, count: Int) -> Bytes
+    ? "At most count octets from the front; non-positive counts give empty bytes."
+    Bytes(values = List.take(bytes.values, count))
+
+fn drop(bytes: Bytes, count: Int) -> Bytes
+    ? "The octets after count positions; non-positive counts preserve all bytes."
+    Bytes(values = List.drop(bytes.values, count))
 
 fn parseHexChars(chars: List<String>, acc: List<Int>) -> Result<List<Int>, String>
     ? "Parse hexadecimal pairs into octets from left to right."
@@ -144,6 +164,26 @@ verify fromList
     fromList(List.concat([0, 127], [255])) => Result.Ok(Bytes(values = [0, 127, 255]))
     fromList([256]) => Result.Err("byte 256 at index 0 is outside 0..=255")
     fromList([0, 256]) => Result.Err("byte 256 at index 1 is outside 0..=255")
+
+verify empty
+    octets(empty()) => []
+
+verify len
+    len(fromList([])) => 0
+    len(fromList([0, 127, 255])) => 3
+
+verify concat
+    octets(concat(fromList([0, 127]), fromList([255]))) => [0, 127, 255]
+
+verify take
+    octets(take(fromList([0, 127, 255]), -1)) => []
+    octets(take(fromList([0, 127, 255]), 2)) => [0, 127]
+    octets(take(fromList([0, 127, 255]), 9)) => [0, 127, 255]
+
+verify drop
+    octets(drop(fromList([0, 127, 255]), -1)) => [0, 127, 255]
+    octets(drop(fromList([0, 127, 255]), 2)) => [255]
+    octets(drop(fromList([0, 127, 255]), 9)) => []
 
 verify parseHexChars
     parseHexChars([], []) => Result.Ok([])

--- a/tests/proof_spec/export_structure.rs
+++ b/tests/proof_spec/export_structure.rs
@@ -635,6 +635,17 @@ fn embedded_bytes_and_crypto_digest_preserve_refinements_in_both_proof_backends(
         "embedded standard refinements degraded in Lean:\n{bytes_lean}\n{digest_lean}"
     );
     assert!(
+        bytes_lean.contains("private theorem __averPackedBytesAppend")
+            && bytes_lean.contains("private theorem __averPackedBytesTake")
+            && bytes_lean.contains("private theorem __averPackedBytesDrop")
+            && bytes_lean.contains("by exact __averPackedBytesAppend")
+            && bytes_lean.contains("by exact __averPackedBytesTake")
+            && bytes_lean.contains("by exact __averPackedBytesDrop"),
+        "Lean must prove Bytes.concat/take/drop preserve the packed refinement \
+         from their operands instead of leaving the generated subtype obligation \
+         to a generic tactic ladder:\n{bytes_lean}"
+    );
+    assert!(
         crypto_lean.contains("def sha256 (bytes : Bytes.Bytes)")
             && crypto_lean.contains("def compress")
             && !crypto_lean.contains("axiom ")
@@ -682,6 +693,16 @@ fn embedded_bytes_and_crypto_digest_preserve_refinements_in_both_proof_backends(
             && digest_dafny
                 .contains("type Digest32 = payload: Bytes | hasLength32(payload) witness *"),
         "embedded standard refinements degraded in Dafny:\n{bytes_dafny}\n{digest_dafny}"
+    );
+    assert!(
+        bytes_dafny.contains("function AverPackedBytesAppend")
+            && bytes_dafny.contains("function AverPackedBytesTake")
+            && bytes_dafny.contains("function AverPackedBytesDrop")
+            && bytes_dafny.contains("AverPackedBytesAppend(left, right)")
+            && bytes_dafny.contains("AverPackedBytesTake(bytes, count)")
+            && bytes_dafny.contains("AverPackedBytesDrop(bytes, count)"),
+        "Dafny must route Bytes.concat/take/drop through structural functions \
+         whose result type carries the refinement:\n{bytes_dafny}"
     );
     assert!(
         crypto_dafny.contains("function sha256(bytes: Bytes): Digest32")

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -143,12 +143,21 @@ fn compile_flattened(
     items: &[TopLevel],
     type_aliases: &std::collections::HashMap<String, String>,
 ) -> Result<Vec<u8>, aver::codegen::wasm_gc::WasmGcError> {
-    aver::codegen::wasm_gc::compile_to_wasm_gc_flattened(
+    compile_flattened_with_packing(items, type_aliases, true)
+}
+
+fn compile_flattened_with_packing(
+    items: &[TopLevel],
+    type_aliases: &std::collections::HashMap<String, String>,
+    packed_sequences_enabled: bool,
+) -> Result<Vec<u8>, aver::codegen::wasm_gc::WasmGcError> {
+    aver::codegen::wasm_gc::compile_to_wasm_gc_flattened_with_options(
         items,
         None,
         None,
         aver::codegen::wasm_gc::TargetMode::AverBridge,
         type_aliases,
+        packed_sequences_enabled,
     )
     .map(|out| out.bytes)
 }
@@ -305,6 +314,7 @@ fn chunk(conn: Tcp.Connection, maxBytes: Int) -> Result<Bytes, String>
     let mut poll_found = false;
     let mut read_some_found = false;
     let mut poll_bridge = std::collections::BTreeSet::new();
+    let mut bytes_bridge = std::collections::BTreeSet::new();
     for payload in WasmParser::new(0).parse_all(&bytes) {
         match payload.expect("generated module must parse") {
             Payload::ImportSection(reader) => {
@@ -332,6 +342,16 @@ fn chunk(conn: Tcp.Connection, maxBytes: Int) -> Result<Bytes, String>
                     {
                         poll_bridge.insert(export.name.to_string());
                     }
+                    if matches!(export.kind, wasmparser::ExternalKind::Func)
+                        && matches!(
+                            export.name,
+                            "__rt_bytes_from_lm"
+                                | "__rt_bytes_to_lm"
+                                | "__rt_result_bytes_string_ok_from_lm"
+                        )
+                    {
+                        bytes_bridge.insert(export.name.to_string());
+                    }
                 }
             }
             _ => {}
@@ -357,6 +377,144 @@ fn chunk(conn: Tcp.Connection, maxBytes: Int) -> Result<Bytes, String>
         .collect(),
         "raw JavaScript hosts must be able to inspect every Tcp.poll map entry"
     );
+    assert_eq!(
+        bytes_bridge,
+        [
+            "__rt_bytes_from_lm",
+            "__rt_bytes_to_lm",
+            "__rt_result_bytes_string_ok_from_lm",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+        "packed Bytes must cross a raw JavaScript host boundary in one bulk copy"
+    );
+}
+
+#[test]
+fn bytes_bulk_bridge_round_trips_more_than_one_page_in_both_representations() {
+    use wasmtime::Val;
+
+    let source = r#"module Probe
+    intent = "Keep packed Bytes live for the raw-host transport bridge."
+    depends [Bytes]
+    exposes [identity]
+
+fn identity(value: Bytes) -> Bytes
+    value
+"#;
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    for packed_sequences_enabled in [true, false] {
+        let bytes = compile_flattened_with_packing(&items, &type_aliases, packed_sequences_enabled)
+            .unwrap_or_else(|e| panic!("wasm-gc compile: {e}\n--- source ---\n{source}"));
+
+        let mut config = wasmtime::Config::new();
+        config.wasm_gc(true);
+        config.wasm_tail_call(true);
+        config.wasm_function_references(true);
+        config.wasm_reference_types(true);
+        config.wasm_bulk_memory(true);
+        let engine = wasmtime::Engine::new(&config).expect("wasmtime engine");
+        let module = wasmtime::Module::new(&engine, bytes).expect("wasmtime accepts module");
+        assert_eq!(
+            module.imports().count(),
+            0,
+            "pure Bytes probe has no host imports"
+        );
+        let mut store = wasmtime::Store::new(&engine, ());
+        let instance =
+            wasmtime::Instance::new(&mut store, &module, &[]).expect("instantiate probe");
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .expect("bulk bridge exports memory");
+        let payload = (0..130_000)
+            .map(|index| ((index * 37 + 11) & 0xff) as u8)
+            .collect::<Vec<_>>();
+        let needed_pages = ((payload.len() as u64) + 65_535) >> 16;
+        let current_pages = memory.size(&store);
+        if needed_pages > current_pages {
+            memory
+                .grow(&mut store, needed_pages - current_pages)
+                .expect("grow bridge scratch memory");
+        }
+        memory
+            .write(&mut store, 0, &payload)
+            .expect("write host payload");
+
+        let from_lm = instance
+            .get_func(&mut store, "__rt_bytes_from_lm")
+            .expect("Bytes from-LM bridge");
+        let mut bytes_ref = [Val::AnyRef(None)];
+        from_lm
+            .call(
+                &mut store,
+                &[Val::I32(payload.len() as i32)],
+                &mut bytes_ref,
+            )
+            .expect("build Bytes payload");
+        memory
+            .write(&mut store, 0, &vec![0; payload.len()])
+            .expect("erase scratch memory before unpacking");
+
+        let to_lm = instance
+            .get_func(&mut store, "__rt_bytes_to_lm")
+            .expect("Bytes to-LM bridge");
+        let mut length = [Val::I32(0)];
+        to_lm
+            .call(&mut store, &bytes_ref, &mut length)
+            .expect("unpack payload");
+        assert_eq!(length[0].i32(), Some(payload.len() as i32));
+        let mut round_trip = vec![0; payload.len()];
+        memory
+            .read(&store, 0, &mut round_trip)
+            .expect("read unpacked payload");
+        assert_eq!(
+            round_trip, payload,
+            "bulk bridge must preserve both packed and boxed Bytes"
+        );
+
+        memory
+            .write(&mut store, 0, &payload)
+            .expect("rewrite payload for Result factory");
+        let result_ok = instance
+            .get_func(&mut store, "__rt_result_bytes_string_ok_from_lm")
+            .expect("Result<Bytes, String> bulk factory");
+        let mut result_value = [Val::AnyRef(None)];
+        result_ok
+            .call(
+                &mut store,
+                &[Val::I32(payload.len() as i32)],
+                &mut result_value,
+            )
+            .expect("build Result.Ok(Bytes)");
+        let result_ref = match result_value[0] {
+            Val::AnyRef(Some(value)) => value,
+            ref other => panic!("Result factory returned {other:?}"),
+        };
+        let result_struct = result_ref
+            .as_struct(&mut store)
+            .expect("inspect Result ref")
+            .expect("Result is a struct");
+        assert!(matches!(
+            result_struct.field(&mut store, 0).expect("Result tag"),
+            Val::I32(1)
+        ));
+        let ok_bytes = result_struct
+            .field(&mut store, 1)
+            .expect("Result Ok payload");
+        let mut ok_length = [Val::I32(0)];
+        to_lm
+            .call(&mut store, &[ok_bytes], &mut ok_length)
+            .expect("unpack Result Ok payload");
+        assert_eq!(ok_length[0].i32(), Some(payload.len() as i32));
+        let mut ok_round_trip = vec![0; payload.len()];
+        memory
+            .read(&store, 0, &mut ok_round_trip)
+            .expect("read Result Ok payload");
+        assert_eq!(ok_round_trip, payload);
+    }
 }
 
 #[test]

--- a/tests/wasm_gc_packed_sequence.rs
+++ b/tests/wasm_gc_packed_sequence.rs
@@ -564,9 +564,11 @@ fn scenario() -> Result<String, String>
     direct = Bytes.fromList(Bytes.octets(left))?
     combined = Bytes.fromList(List.concat(Bytes.octets(direct), Bytes.octets(right)))?
     sliced = Bytes.fromList(List.drop(List.take(Bytes.octets(combined), 4), 1))?
+    packedCombined = Bytes.concat(direct, right)
+    packedSliced = Bytes.drop(Bytes.take(packedCombined, 4), 1)
     match Bytes.fromList(List.prepend(999, Bytes.octets(sliced)))
         Result.Ok(_) -> Result.Err("prepend unexpectedly retained provenance")
-        Result.Err(error) -> Result.Ok("{Bytes.toHex(direct)}/{Bytes.toHex(combined)}/{Bytes.toHex(sliced)}/{error}")
+        Result.Err(error) -> Result.Ok("{Bytes.toHex(direct)}/{Bytes.toHex(combined)}/{Bytes.toHex(sliced)}/{Bytes.len(Bytes.empty())}/{Bytes.toHex(packedCombined)}/{Bytes.toHex(packedSliced)}/{error}")
 
 fn main() -> Unit
     ! [Console.print]
@@ -585,10 +587,18 @@ fn byte_list_provenance_matches_vm_packed_and_boxed_wasm() {
     assert!(boxed_ok, "boxed wasm failed: {boxed}");
     assert_eq!(
         vm,
-        "000102/000102aabb/0102aa/byte 999 at index 0 is outside 0..=255"
+        "000102/000102aabb/0102aa/0/000102aabb/0102aa/byte 999 at index 0 is outside 0..=255"
     );
     assert_eq!(packed, vm, "packed wasm-gc diverged from the VM");
     assert_eq!(boxed, vm, "boxed wasm-gc diverged from the VM");
+
+    let packed_wasm = compile(BYTES_PROVENANCE, true);
+    let boxed_wasm = compile(BYTES_PROVENANCE, false);
+    assert_eq!(
+        i8_array_count(&packed_wasm),
+        i8_array_count(&boxed_wasm) + 1,
+        "total preserving Bytes operations must not demote the proof-packed layout"
+    );
 }
 
 // ─── Literal smart-constructor discharge ────────────────────────────────


### PR DESCRIPTION
## Summary

- add bulk linear-memory bridges for `Bytes` and `Result<Bytes, String>` on raw wasm-gc hosts
- keep proof-packed structural refinements packed across custom capability boundaries while preserving the existing named-record host ABI
- add total `Bytes.empty`, `len`, `concat`, `take`, and `drop` operations and lower their preserving pipelines to GC-array operations
- keep the optimisation fail-closed: only empty carriers and same-nominal projections composed through `List.concat` / `take` / `drop` retain provenance; arbitrary constructors still demote
- use the bulk bridge in the embedded wasm-gc runner, with the old element-wise path retained as a compatibility fallback

## Why

The first bulk bridge removed JavaScript↔wasm calls per octet, but a real TCP consumer still crossed `Bytes.octets : Bytes -> List<Int>` and performed inbox operations on linked cons cells. On a synthetic 3.5 MB peer frame, GC dominated the complete btc-listener path.

The new nominal `Bytes` operations let the source say that no octet is introduced, while wasm-gc can implement the same semantics with `array.len` and `array.copy`. The host sees the declared record factory/projector ABI in both packed and boxed differential builds.

## End-to-end measurement

Local macOS, Node v26, complete btc-listener wasm-gc node host, synthetic 3,500,171-byte corrupt `ping` frame:

- original element-wise host bridge: about **10.1 s**
- bulk bridge alone, with boxed inbox operations: about **9.5 s**
- bulk bridge plus packed `Bytes` inbox pipeline: about **0.2 s**

This is a deliberately adversarial regression workload, not a general throughput claim. It exercises TCP poll/read, framing, header parsing, hashing, checksum rejection, and peer teardown through the real program.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --features wasm`
- `cargo clippy --features wasm,wasip2 --lib -- -D clippy::too-many-arguments`
- `cargo test --features wasm --test wasm_gc_packed_sequence -- --nocapture`
- `cargo test --features wasm --test wasm_gc_codegen_regression`
- `cargo test derives_the_element_interval_for_the_real_standard_library_bytes_module`
- `cargo test an_ungated_record_constructor_disables_runtime_provenance_only`
- `aver verify stdlib/bytes.av` (51/51)
- compiled and ran the complete btc-listener wasm-gc artifact under Node for both the ordinary handshake fixture and the 3.5 MB regression fixture

Follow-up to the raw-host TCP bridge in #1155. Related to the wider wasm-gc traversal work in #943, but does not close it.
