### PR TITLE
Prepare module graphs once and cache Wasmtime JIT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,14 @@ jobs:
           cargo check -p aver-lang --lib --no-default-features --features playground
           cargo check -p aver-lang --features certify
 
+      - name: Prefetch provider-host feature graph
+        # Some integration tests intentionally build generated provider hosts
+        # with Cargo offline. Those hosts enable wasm even though this job's
+        # root test build uses the default feature set, so a fresh runner must
+        # fetch every package pinned in Cargo.lock before entering that offline
+        # boundary. Never rely on a previous workflow's registry cache.
+        run: cargo fetch --locked
+
       - name: Test
         # Iron — Stage 4: CI exercises proptest sweeps at 2 000 cases
         # per property instead of the 256-case default. The matcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 - **Maps have one deterministic order on every backend.** Iteration is sorted by key, `keys[i]` pairs with `values[i]`, and equality uses the same canonical form in execution and proof. Map keys must have a modelled total order; `Float` keys are rejected instead of giving NaN or proof-model divergences.
 
-- **The VM and generated Rust avoid several formerly quadratic paths.** List traversal and `List.drop`, string/codepoint scans, list/string/byte builders, map construction and folding, immutable collection relocation, large append-only stores, generated-Rust accumulator returns, and byte refinements now preserve sharing, ownership, or their proven range instead of repeatedly rebuilding or revalidating live data. VM and wasm-gc carry that range through byte projection, concatenation, and slicing; the embedded wasm engine separately moves to wasmtime 46's copying collector.
+- **Execution and compilation avoid several formerly quadratic paths.** Collection, string, byte, map, and generated-Rust hot paths preserve sharing, ownership, or proven ranges instead of rebuilding live data. Commands prepare each module graph once rather than recursively rechecking dependency cones. Embedded Wasmtime 48 uses its copying collector and caches reproducibly emitted wasm as native code across runs.
 
 - **Generated projects pin the compiler's actual source provenance.** Path builds emit path dependencies, git builds pin the repository and revision, and registry builds emit exact registry versions for both `aver-lang` and `aver-rt`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,15 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -172,7 +163,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 1.0.69",
- "toml",
+ "toml 0.8.23",
  "url",
  "wasm-bindgen",
  "wasm-encoder 0.248.0",
@@ -182,7 +173,7 @@ dependencies = [
  "wasmtime-wasi",
  "wasmtime-wasi-http",
  "wat",
- "wit-component",
+ "wit-component 0.248.0",
  "wit-encoder",
  "wit-parser 0.248.0",
 ]
@@ -293,70 +284,44 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-net-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "rustix 1.1.4",
- "smallvec",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "ipnet",
  "maybe-owned",
  "rustix 1.1.4",
  "rustix-linux-procfs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
 [[package]]
 name = "cap-std"
-version = "3.4.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "rustix 1.1.4",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.1.4",
- "winx",
 ]
 
 [[package]]
@@ -372,6 +337,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -511,16 +478,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -545,27 +506,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
+checksum = "9903e767cc0a95a59950de099a6b1d61e1476f774be1cdfa06d7ccdc9bfae56f"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
+checksum = "e777252ea3ec9daffa71408fbfe0793ab0a7b7bc3b2cf0f417dd0fa33964b8ef"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
+checksum = "7828208a36e6627481cea61bd24c6234e31411d5c58b48e80ca094a1d593b944"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -573,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
+checksum = "a58c8447cc59ef98c49096679f81392ad0acec2224cea2bef52011f5169f9d02"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
+checksum = "ce520e899df1de583e7b564eafd66760fbc147d72894d2278ddac57a1489fcc0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -615,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
+checksum = "8d8ab23e63d78ea6bbda18ae1ed9c958bc1cb88d90fb5e95f5ba62e9c019474b"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -628,24 +589,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
+checksum = "24319a996b1ef40ebf8af69b39c868c790b35a42cfe38edacfd8c9deb75ea712"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
+checksum = "cf9856d68cc2cefb83229cb2c55b620dd38427555c2fe87d73f8a4421616f628"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
+checksum = "e0ec225d6b79c5d61358cb5ea081a1384ec541dbf8c1a8c618d187875af326ad"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -655,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
+checksum = "7d3a96a09bd9bd3cf6df2de2ea15d7418f493e946a8eaa1acfe39297a67ed3f3"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.0",
@@ -668,15 +629,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
+checksum = "bd28f593c36afbdc9aa17305c0bb66c39ce0530e1caffcf389fbec053950083e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
+checksum = "2987ca47affc261aa31ac643fb80dd7f8274cebf878003ba9f50cd6ff2c1055f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -685,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.2"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
+checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
 
 [[package]]
 name = "crc32fast"
@@ -842,6 +803,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,7 +955,7 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.4",
  "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
@@ -1246,30 +1228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,11 +1361,11 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.18.4"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 3.0.1",
  "windows-sys 0.59.0",
 ]
 
@@ -1416,6 +1374,12 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -1465,6 +1429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1477,15 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1727,6 +1710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,9 +1827,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
+checksum = "f755d75e0809a4738a3e4880eeeb852fadbe1de5a437505b84f09c381657012a"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1850,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
+checksum = "c7e69fa1c4a555946f82e7894a7df88b0e9ee03b4266829b4811467c616ce51d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1971,6 +1960,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -2224,6 +2224,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2514,9 +2523,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -2529,6 +2553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,10 +2569,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2547,6 +2589,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -2823,12 +2871,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.251.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.251.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -2841,6 +2889,18 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.248.0",
  "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01df5f3b4ca7881e843f3bc0fb8a3905d79c68692250dcb8e33e698705ccdb6"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -2869,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.251.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
 dependencies = [
  "bitflags",
  "hashbrown 0.17.0",
@@ -2893,27 +2953,26 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.251.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
+checksum = "64e3ba11e024f504698f87b629b2b66c22a1231758de7607754963f7d198be39"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.251.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
+checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
 dependencies = [
  "addr2line",
  "async-trait",
  "bitflags",
  "bumpalo",
  "cc",
- "cfg-if",
  "encoding_rs",
  "futures",
  "libc",
@@ -2930,8 +2989,9 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.251.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
+ "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -2946,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
+checksum = "00c1070d95484d048994ec109cd42c4932ac07e6ee3cc1886fb90c7a18ec29da"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2968,18 +3028,38 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
- "wasmprinter 0.251.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
+ "wasmprinter 0.254.0",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
-name = "wasmtime-internal-component-macro"
-version = "46.0.2"
+name = "wasmtime-internal-cache"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
+checksum = "9d447fd40f3e149cda8c0cd808660a1d1de438f3ff28627abb9bcda90dfb4895"
+dependencies = [
+ "base64",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "48.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d2b2f9f89a65bb2277d82fbdd49263d27d8233bc717d750c4b13a23d57721c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -2987,20 +3067,20 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.251.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
+checksum = "2c0fe8292115fda08875f29064ae9f7f0b2c1ffbb323146eae538ae34b8a613f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
+checksum = "821385794cf44baf2967fd2515368429ed2bff9b9b256f62d09a0f1301474fd8"
 dependencies = [
  "hashbrown 0.17.0",
  "libm",
@@ -3009,11 +3089,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
+checksum = "0238b4a52773457ad1b8a1a26be90486e0ca0108cf46b9be16cc1d8d8cabdfa1"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -3027,7 +3106,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.251.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -3036,12 +3115,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
+checksum = "596f1d85e06cbf9c9add9c78ea135171c5753264ffe94a83dcc082a1ff49fc9b"
 dependencies = [
  "cc",
- "cfg-if",
  "libc",
  "rustix 1.1.4",
  "wasmtime-environ",
@@ -3051,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
+checksum = "365faed74827bb0116785bab5872372df1baaec9ec0003c83bc99ccdc595f689"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -3061,11 +3139,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
+checksum = "3cce25afd9e7ac4957292a5c6a219951dd0f140b8417e7378a97f50b67c3b96f"
 dependencies = [
- "cfg-if",
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
@@ -3073,11 +3150,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
+checksum = "a1fdea09d51e39c774984ca68a7d7486767e5b2935f5e686fa654aabcfc3c42d"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "log",
  "object",
@@ -3086,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
+checksum = "97e48a5f514c38c2f74249724cb3501e45548d3311ca9e3881694859fd6ba116"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3097,34 +3173,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
+checksum = "07429ab53576255be2d298e04b2e1f381e39645465adbaebd69314b5430165c0"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.251.0",
+ "wit-component 0.254.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88f243a21e600902fd03bd970df7e4671d760d724c9fad202166fd98c842548"
+checksum = "85dd81ee95792682ea5b279c9ed352f6b8a2cba084c2f8abdb225e6933323fed"
 dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
- "cap-net-ext",
- "cap-std",
- "cap-time-ext",
- "cfg-if",
+ "cap-primitives",
  "futures",
- "io-extras",
- "io-lifetimes",
  "rand 0.10.2",
  "rustix 1.1.4",
  "thiserror 2.0.18",
@@ -3139,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de164752f46761e792a4b7b502af772a82791d4b7c040a6b1f5431f64908aa31"
+checksum = "1d75e17f0c94810a34a51dccee9a5e9733eb423dff5176aaeb9152a7a03b2812"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3150,6 +3222,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "pin-project-lite",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -3157,14 +3230,14 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-io",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0373c9dc92c9373aa9cee05963ea438bc318bf07bb284bede77a9ce24b39f682"
+checksum = "6a557bc8a7232cd079f6b423a9bb385f3ff9148824f3c26c07a028b499fab2bf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3220,23 +3293,23 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "wiggle"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9914a7e8ac8cb37be90753103e2aa96959e9e5d2f549a2d081bcfeb8fa97e08d"
+checksum = "b871ea219ad85c1e59ee7d013563814e86d2e6aa094d3bc66b7675ec4ca58bb7"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -3248,9 +3321,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789b4c6d82c1ae0f5003eb6c5b9d3c9fb80112c4be50ad2690eb7347f0edd852"
+checksum = "ed981675756e748a4725286a4059c9be006749a8db4120d54e2021d0f167bac3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3262,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.2"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
+checksum = "7f3927729af874585c58b85710128e40d459a7064bb9aea9b0b420fb5eafd555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3304,63 +3377,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"
@@ -3463,6 +3483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "winx"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,9 +3518,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.248.0",
- "wasm-metadata",
+ "wasm-metadata 0.248.0",
  "wasmparser 0.248.0",
  "wit-parser 0.248.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.254.0",
+ "wasm-metadata 0.254.0",
+ "wasmparser 0.254.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
@@ -3531,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.251.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -3544,8 +3589,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.251.0",
+ "unicode-ident",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -3680,3 +3725,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,14 +86,14 @@ wasm-encoder = { version = "0.248", optional = true }
 wasmparser = { version = "0.248", optional = true }
 wasmprinter = { version = "0.248", optional = true }
 sha2 = "0.10"
-# `gc-copying` (not `gc-drc`): wasmtime 46 made the copying collector
-# the default and it is what the standalone wasmtime CLI runs. On the
-# 1 MiB hex-decode benchmark the DRC collector under 46 is ~13x slower
+# `gc-copying` (not `gc-drc`): Wasmtime's copying collector is the
+# default and it is what the standalone wasmtime CLI runs. On the
+# 1 MiB hex-decode benchmark the DRC collector is ~13x slower
 # than copying (~5.5s vs ~0.42s), so the collector choice is
 # load-bearing for `aver run --wasm-gc` / `--wasip2` throughput.
-wasmtime = { version = "46", optional = true, default-features = false, features = ["cranelift", "runtime", "gc", "gc-copying", "component-model", "component-model-async"] }
-wasmtime-wasi = { version = "46", optional = true }
-wasmtime-wasi-http = { version = "46", optional = true }
+wasmtime = { version = "48.0.1", optional = true, default-features = false, features = ["cache", "cranelift", "runtime", "gc", "gc-copying", "component-model", "component-model-async"] }
+wasmtime-wasi = { version = "48.0.1", optional = true }
+wasmtime-wasi-http = { version = "48.0.1", optional = true }
 wat = { version = "1", optional = true }
 # wasip2 feature deps — versions paired by upstream wasm-tools 1.248
 # release train. `wasi-preview1-component-adapter-provider` is NOT

--- a/src/bench/runner.rs
+++ b/src/bench/runner.rs
@@ -76,16 +76,15 @@ fn run_vm(manifest: &Manifest) -> Result<BenchReport, RunError> {
     // compile` already do — without it the resolver classifies
     // `Module.fn(...)` callsites as `Passthrough` and the VM compiler
     // later errors out with "missing VM symbol for exposed function".
-    let dep_modules = crate::source::load_compile_deps(&items, &module_root)
+    let prepared_deps = crate::source::load_compile_deps(&items, &module_root)
         .map_err(|e| RunError::Setup(format!("load deps: {}", e)))?;
+    let dep_modules = prepared_deps.modules;
 
     let passes_applied = std::cell::RefCell::new(Vec::<String>::new());
     let pipeline_result = crate::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             dep_modules: &dep_modules,
             on_after_pass: Some(Box::new(|stage: PipelineStage, _| {
                 passes_applied.borrow_mut().push(stage.name().to_string());

--- a/src/codegen/wasm_gc/body/eq_helpers.rs
+++ b/src/codegen/wasm_gc/body/eq_helpers.rs
@@ -290,6 +290,13 @@ impl EqHelperRegistry {
     }
 
     pub(crate) fn assign_slots(&mut self, next_fn_idx: &mut u32, next_type_idx: &mut u32) {
+        // Discovery can reach otherwise independent nominal types through a
+        // HashMap-backed registry walk. Their relative order has no semantic
+        // meaning, but letting it choose function/type indices makes identical
+        // source emit different wasm bytes and defeats Wasmtime's content
+        // cache. Canonical names are the stable ordering key used by the rest
+        // of the wasm-gc registries.
+        self.order.sort_unstable();
         for name in &self.order {
             self.slots
                 .insert(name.clone(), (*next_fn_idx, *next_type_idx));
@@ -443,6 +450,31 @@ impl EqHelperRegistry {
             }
         }
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EqHelperRegistry, EqKind};
+
+    #[test]
+    fn slot_assignment_is_independent_of_discovery_order() {
+        let mut left = EqHelperRegistry::new();
+        left.register("Zulu", EqKind::Record);
+        left.register("Alpha", EqKind::Record);
+        let mut right = EqHelperRegistry::new();
+        right.register("Alpha", EqKind::Record);
+        right.register("Zulu", EqKind::Record);
+
+        left.assign_slots(&mut 10, &mut 20);
+        right.assign_slots(&mut 10, &mut 20);
+        assert_eq!(left.lookup_fn_idx("Alpha"), right.lookup_fn_idx("Alpha"));
+        assert_eq!(left.lookup_fn_idx("Zulu"), right.lookup_fn_idx("Zulu"));
+        assert_eq!(
+            left.lookup_type_idx("Alpha"),
+            right.lookup_type_idx("Alpha")
+        );
+        assert_eq!(left.lookup_type_idx("Zulu"), right.lookup_type_idx("Zulu"));
     }
 }
 

--- a/src/codegen/wasm_gc/body/hash_helpers.rs
+++ b/src/codegen/wasm_gc/body/hash_helpers.rs
@@ -253,6 +253,10 @@ impl HashHelperRegistry {
     }
 
     pub(crate) fn assign_slots(&mut self, next_fn_idx: &mut u32, next_type_idx: &mut u32) {
+        // Registration order may inherit a HashMap traversal from nominal
+        // discovery. Stable slots are required for reproducible artifacts and
+        // for Wasmtime to reuse the native-code cache across processes.
+        self.order.sort_unstable();
         for name in &self.order {
             self.slots
                 .insert(name.clone(), (*next_fn_idx, *next_type_idx));
@@ -333,6 +337,31 @@ impl HashHelperRegistry {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HashHelperRegistry, HashKind};
+
+    #[test]
+    fn slot_assignment_is_independent_of_discovery_order() {
+        let mut left = HashHelperRegistry::new();
+        left.register("Zulu", HashKind::Record);
+        left.register("Alpha", HashKind::Record);
+        let mut right = HashHelperRegistry::new();
+        right.register("Alpha", HashKind::Record);
+        right.register("Zulu", HashKind::Record);
+
+        left.assign_slots(&mut 10, &mut 20);
+        right.assign_slots(&mut 10, &mut 20);
+        assert_eq!(left.lookup_fn_idx("Alpha"), right.lookup_fn_idx("Alpha"));
+        assert_eq!(left.lookup_fn_idx("Zulu"), right.lookup_fn_idx("Zulu"));
+        assert_eq!(
+            left.lookup_type_idx("Alpha"),
+            right.lookup_type_idx("Alpha")
+        );
+        assert_eq!(left.lookup_type_idx("Zulu"), right.lookup_type_idx("Zulu"));
     }
 }
 

--- a/src/codegen/wasm_gc/maps.rs
+++ b/src/codegen/wasm_gc/maps.rs
@@ -476,6 +476,13 @@ impl MapHelperRegistry {
             }
         }
 
+        // `variants` is HashMap-backed, so the transitive field walk above can
+        // discover otherwise independent pseudo-keys in a process-random
+        // order. Their relative order is not semantic. Canonicalise it before
+        // assigning function/type slots so identical source produces identical
+        // wasm bytes and can reuse Wasmtime's content-addressed code cache.
+        k_names.sort_unstable();
+
         // First pass: assign K-keyed helpers (hash, eq) per unique K.
         for k_aver in &k_names {
             if !self.key.contains_key(k_aver) {

--- a/src/diagnostics/shape.rs
+++ b/src/diagnostics/shape.rs
@@ -736,14 +736,13 @@ pub fn analyze_source_with(
         .map_err(|e| format!("parse: {}", e))?;
     let module_root = module_root.to_string();
 
-    let dep_modules = crate::source::load_compile_deps(&items, &module_root)
+    let prepared_deps = crate::source::load_compile_deps(&items, &module_root)
         .map_err(|e| format!("deps: {}", e))?;
+    let dep_modules = prepared_deps.modules;
     let pipeline_result = crate::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             dep_modules: &dep_modules,
             ..Default::default()
         },

--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -873,10 +873,10 @@ fn run_verify_for_items_vm_impl(
     // verify fails — exactly the bug #213 surfaced on the 0.22 release.
     // Mirrors what `aver run` / `aver compile` / `bench/runner` /
     // `wasm_gc_verify` all do.
-    let dep_modules = if let Some(root) = base_dir {
-        crate::source::load_compile_deps(&items, root)?
+    let prepared_deps = if let Some(root) = base_dir {
+        Some(crate::source::load_compile_deps(&items, root)?)
     } else {
-        Vec::new()
+        None
     };
 
     // `pipeline::typecheck_gate`, not the bare `pipeline::typecheck`:
@@ -888,14 +888,18 @@ fn run_verify_for_items_vm_impl(
     // the #951 program, whose three executors disagreed about a call
     // through a binder spelling a module fn's name, was still EXECUTED
     // by `aver verify` while `run` and `compile` refused it.
-    let tc_result = crate::ir::pipeline::typecheck_gate(
-        &items,
-        &crate::ir::TypecheckMode::Full { base_dir },
-        &items[..user_program_len],
-    );
+    let typecheck_mode = match prepared_deps.as_ref() {
+        Some(prepared) => crate::ir::TypecheckMode::WithCheckedLoaded(&prepared.loaded),
+        None => crate::ir::TypecheckMode::Full { base_dir },
+    };
+    let tc_result =
+        crate::ir::pipeline::typecheck_gate(&items, &typecheck_mode, &items[..user_program_len]);
     if !tc_result.errors.is_empty() {
         return Err(format_type_errors(&tc_result.errors));
     }
+    let dep_modules = prepared_deps
+        .map(|prepared| prepared.modules)
+        .unwrap_or_default();
 
     let mut verify_blocks = merge_verify_blocks(&items);
     if verify_blocks.is_empty() {

--- a/src/diagnostics/wasm_gc_verify.rs
+++ b/src/diagnostics/wasm_gc_verify.rs
@@ -153,6 +153,12 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
 
     let plans = build_verify_wasm_gc_plans(&mut items, &blocks);
 
+    let prepared_deps = if let Some(root) = base_dir {
+        Some(crate::source::load_compile_deps(&items, root)?)
+    } else {
+        None
+    };
+
     // After helper synthesis, run the full wasm-gc-compatible pipeline:
     // typecheck stamps `ty` on the freshly synthesized `BinOp(Eq, ...)`
     // and `Result.Ok(...)` Spanneds (wasm-gc codegen panics on un-typed
@@ -163,7 +169,10 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
     let result = crate::ir::pipeline::run(
         &mut items,
         crate::ir::PipelineConfig {
-            typecheck: Some(crate::ir::TypecheckMode::Full { base_dir }),
+            typecheck: Some(match prepared_deps.as_ref() {
+                Some(prepared) => crate::ir::TypecheckMode::WithCheckedLoaded(&prepared.loaded),
+                None => crate::ir::TypecheckMode::Full { base_dir },
+            }),
             alloc_policy: Some(&neutral_policy),
             run_interp_lower: false,
             run_buffer_build: false,
@@ -184,11 +193,9 @@ pub fn run_verify_for_items_wasm_gc_with_mode(
     // flatten into the entry items so `compile_to_wasm_gc` sees one
     // self-contained AST. Mirrors the `try_run_wasm_gc` setup in
     // `src/main/run_wasm_gc.rs`.
-    let dep_modules = if let Some(root) = base_dir {
-        crate::source::load_compile_deps(&items, root)?
-    } else {
-        Vec::new()
-    };
+    let dep_modules = prepared_deps
+        .map(|prepared| prepared.modules)
+        .unwrap_or_default();
     let mut type_aliases = std::collections::HashMap::new();
     if !dep_modules.is_empty() {
         type_aliases = crate::codegen::wasm_gc::flatten_multimodule(

--- a/src/ir/pipeline.rs
+++ b/src/ir/pipeline.rs
@@ -44,8 +44,8 @@ use crate::ir::{AllocPolicy, AnalysisResult, CallLowerCtx};
 use crate::source::LoadedModule;
 use crate::types::checker::{
     TypeCheckResult, run_type_check_full, run_type_check_full_self_host,
-    run_type_check_with_checked_loaded, run_type_check_with_loaded,
-    run_type_check_with_loaded_self_host,
+    run_type_check_with_checked_loaded, run_type_check_with_checked_loaded_self_host,
+    run_type_check_with_loaded, run_type_check_with_loaded_self_host,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -172,6 +172,9 @@ pub enum TypecheckMode<'a> {
     FullSelfHost { base_dir: Option<&'a str> },
     /// Self-host variant of [`WithLoaded`].
     WithLoadedSelfHost(&'a [LoadedModule]),
+    /// Self-host variant of [`WithCheckedLoaded`]. Dependency bodies were
+    /// already checked leaves-first with the opaque-type bypass enabled.
+    WithCheckedLoadedSelfHost(&'a [LoadedModule]),
 }
 
 pub struct PipelineConfig<'a> {
@@ -705,6 +708,9 @@ pub fn typecheck(items: &[TopLevel], mode: &TypecheckMode<'_>) -> TypeCheckResul
         TypecheckMode::FullSelfHost { base_dir } => run_type_check_full_self_host(items, *base_dir),
         TypecheckMode::WithLoadedSelfHost(loaded) => {
             run_type_check_with_loaded_self_host(items, loaded)
+        }
+        TypecheckMode::WithCheckedLoadedSelfHost(loaded) => {
+            run_type_check_with_checked_loaded_self_host(items, loaded)
         }
     }
 }

--- a/src/main/capabilities_cmd.rs
+++ b/src/main/capabilities_cmd.rs
@@ -1,7 +1,7 @@
 use aver::source::require_module_declaration;
 use colored::Colorize;
 
-use super::commands::{DepLowering, load_compile_deps};
+use super::commands::{DepLowering, load_compile_deps_prepared};
 use super::shared::{format_type_errors, parse_file, read_file, resolve_module_root};
 
 fn load_capability_target_manifest(
@@ -12,13 +12,14 @@ fn load_capability_target_manifest(
     let source = read_file(file)?;
     let mut items = parse_file(&source, &module_root, file)?;
     require_module_declaration(&items, file)?;
-    let modules = load_compile_deps(&items, &module_root, DepLowering::PRISTINE);
+    let prepared_deps = load_compile_deps_prepared(&items, &module_root, DepLowering::PRISTINE);
+    let modules = prepared_deps.modules;
     let result = aver::ir::pipeline::run(
         &mut items,
         aver::ir::PipelineConfig {
-            typecheck: Some(aver::ir::TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(aver::ir::TypecheckMode::WithCheckedLoaded(
+                &prepared_deps.loaded,
+            )),
             dep_modules: &modules,
             run_interp_lower: false,
             run_buffer_build: false,

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
@@ -13,7 +13,9 @@ use aver::codegen::ModuleInfo;
 use aver::codegen::lean as lean_codegen;
 use aver::codegen::rust as rust_codegen;
 use aver::nan_value::{Arena, NanValueConvert};
-use aver::source::{LoadError, LoadMode, require_module_declaration, resolve_module_source};
+use aver::source::{
+    LoadError, LoadMode, LoadedModule, require_module_declaration, resolve_module_source,
+};
 use aver::types::{Type, parse_type_str};
 use aver::verify_law::{
     collect_contextual_helper_law_hints, collect_missing_helper_law_hints,
@@ -1129,14 +1131,15 @@ pub(super) fn cmd_run_vm(
     //
     // `run_interp_lower` stays off here: it is a separate stage with its
     // own history and no reported inconsistency.
-    let dep_modules =
-        load_compile_deps(&items, &module_root, DepLowering::deforesting(true, false));
+    let prepared_deps =
+        load_compile_deps_prepared(&items, &module_root, DepLowering::deforesting(true, false));
+    let dep_modules = prepared_deps.modules;
     let pipeline_result = aver::ir::pipeline::run(
         &mut items,
         aver::ir::PipelineConfig {
-            typecheck: Some(aver::ir::TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(aver::ir::TypecheckMode::WithCheckedLoaded(
+                &prepared_deps.loaded,
+            )),
             dep_modules: &dep_modules,
             ..Default::default()
         },
@@ -3795,15 +3798,6 @@ fn build_codegen_context(
     // future opaque host type) through the replay `Val` shape. User
     // code outside the self-host always goes through the regular
     // `Full` variant.
-    let typecheck_mode = if with_self_host_support {
-        aver::ir::TypecheckMode::FullSelfHost {
-            base_dir: Some(&module_root),
-        }
-    } else {
-        aver::ir::TypecheckMode::Full {
-            base_dir: Some(&module_root),
-        }
-    };
     // A context that carries ProofIR is one the proof exporters read,
     // so its dep modules keep the fabricating passes off whatever the
     // caller asked for at `apply_traversal_lowering`. The entry
@@ -3824,11 +3818,17 @@ fn build_codegen_context(
     // module-spanning call graphs). load_compile_deps only reads
     // `TopLevel::Module(m).depends`, which TCO never touches, so it's
     // safe to run pre-pipeline.
-    let modules = load_compile_deps(
+    let prepared_deps = load_compile_deps_prepared(
         &items,
         &module_root,
         DepLowering::fully_lowered(dep_lowering, with_self_host_support),
     );
+    let modules = prepared_deps.modules;
+    let typecheck_mode = if with_self_host_support {
+        aver::ir::TypecheckMode::WithCheckedLoadedSelfHost(&prepared_deps.loaded)
+    } else {
+        aver::ir::TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)
+    };
 
     let mut pipeline_result = aver::ir::pipeline::run(
         &mut items,
@@ -4548,13 +4548,12 @@ pub(super) fn cmd_emit_ir_after(file: &str, module_root_override: Option<&str>, 
     // `--emit-ir-after=name_resolve` show stale `<unresolved:…>`
     // markers that the production run path never emits.
     let _ = proof_target; // kept for future per-target diagnostic shape switches
-    let dep_modules = load_compile_deps(&items, &module_root, DepLowering::PRISTINE);
+    let prepared_deps = load_compile_deps_prepared(&items, &module_root, DepLowering::PRISTINE);
+    let dep_modules = prepared_deps.modules;
     let pipeline_result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             // `--emit-ir` is a diagnostic, so attach the neutral policy
             // — the dump's `[no_alloc]` annotation matches the shared
             // VM/WASM baseline. Codegen pipelines should pass their
@@ -4892,14 +4891,13 @@ pub(super) fn cmd_explain_passes(file: &str, module_root_override: Option<&str>,
     // including stages a runtime backend would skip (proof_lower).
     // Pre-load dep modules so proof_lower has the data to walk; without
     // them the stage would only see entry-file refinement records.
-    let dep_modules = load_compile_deps(&items, &module_root, DepLowering::PRISTINE);
+    let prepared_deps = load_compile_deps_prepared(&items, &module_root, DepLowering::PRISTINE);
+    let dep_modules = prepared_deps.modules;
     let dep_fusion = dep_fusion_reports(&items, &module_root);
     let mut result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             alloc_policy: Some(&neutral_policy),
             dep_modules: &dep_modules,
             run_refinement_lower: true,
@@ -5243,13 +5241,12 @@ pub(super) fn cmd_explain_mir_coverage(
         }
     };
 
-    let dep_modules = load_compile_deps(&items, &module_root, DepLowering::PRISTINE);
+    let prepared_deps = load_compile_deps_prepared(&items, &module_root, DepLowering::PRISTINE);
+    let dep_modules = prepared_deps.modules;
     let result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             // Rust coverage needs the symbol table to resolve `FnId` /
             // `TypeId` / `CtorId` through `MirEmitCtx`. Cheap to build;
             // the VM/wasm-gc paths read it too once a ctx is assembled.
@@ -6436,15 +6433,15 @@ fn cmd_compile_wasm_gc(
     // calls remain implicitly visible. Preload them before symbol/MIR building
     // so the target sees a real capability callee rather than an unresolved
     // call that lowers to a trap.
-    let dep_modules = load_compile_deps(&items, &module_root, DepLowering::STRING_INDEX_ONLY);
+    let prepared_deps =
+        load_compile_deps_prepared(&items, &module_root, DepLowering::STRING_INDEX_ONLY);
+    let dep_modules = prepared_deps.modules;
     use aver::ir::{PipelineConfig, TypecheckMode};
     let neutral_policy = aver::ir::NeutralAllocPolicy;
     let result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             alloc_policy: Some(&neutral_policy),
             dep_modules: &dep_modules,
             // wasm-gc backend lowers `Expr::InterpolatedStr` natively
@@ -6743,15 +6740,15 @@ fn cmd_compile_wasip2(
             }
         };
 
-        let dep_modules = load_compile_deps(&items, &module_root, DepLowering::STRING_INDEX_ONLY);
+        let prepared_deps =
+            load_compile_deps_prepared(&items, &module_root, DepLowering::STRING_INDEX_ONLY);
+        let dep_modules = prepared_deps.modules;
         use aver::ir::{PipelineConfig, TypecheckMode};
         let neutral_policy = aver::ir::NeutralAllocPolicy;
         let result = aver::ir::pipeline::run(
             &mut items,
             PipelineConfig {
-                typecheck: Some(TypecheckMode::Full {
-                    base_dir: Some(&module_root),
-                }),
+                typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
                 alloc_policy: Some(&neutral_policy),
                 dep_modules: &dep_modules,
                 run_interp_lower: false,
@@ -11507,6 +11504,17 @@ pub(super) struct DepLowering {
     pub self_host: bool,
 }
 
+/// A dependency graph prepared once for an entry pipeline.
+///
+/// `modules` carries the target-lowered codegen view. `loaded` carries the
+/// pristine source view used by [`aver::ir::TypecheckMode::WithCheckedLoaded`]
+/// (or its self-host variant) to rebuild importer-visible surfaces without
+/// recursively checking dependency bodies again.
+pub(super) struct PreparedCompileDeps {
+    pub(super) modules: Vec<ModuleInfo>,
+    pub(super) loaded: Vec<LoadedModule>,
+}
+
 impl DepLowering {
     /// Source-level dependencies: nothing that invents code.
     pub(super) const PRISTINE: Self = Self {
@@ -11550,11 +11558,20 @@ impl DepLowering {
 /// Load dependent modules for codegen: every module of the program behind
 /// `items`, typechecked and lowered with the target's matrix. Any problem is
 /// fatal here — printed in red, exit 1 — exactly as it always was.
-pub(super) fn load_compile_deps(
+/// Load, type-check, and target-lower the dependency graph exactly once.
+///
+/// The source loader stores modules leaves-first. That makes the same
+/// whole-program preparation used by `verify` available to every runtime and
+/// codegen front door: check a dependency body once, then let its importers
+/// rebuild only signatures, capabilities, and visibility from the already
+/// checked source closure. The previous parent-first loop selected `Full` for
+/// every module, so each importer rediscovered and rechecked its entire
+/// transitive cone before the entry did the same work yet again.
+pub(super) fn load_compile_deps_prepared(
     items: &[TopLevel],
     module_root: &str,
     lowering: DepLowering,
-) -> Vec<ModuleInfo> {
+) -> PreparedCompileDeps {
     fn fail(message: String) -> ! {
         eprintln!("{}", message.red());
         process::exit(1);
@@ -11572,28 +11589,29 @@ pub(super) fn load_compile_deps(
         )),
         Err(error) => fail(error.to_string()),
     };
-    let mut lowered = BTreeMap::new();
-
-    // Parent before child, the order the walk met the modules in: the first
-    // fault on the way down is the one reported. The returned list stays
-    // leaves-first.
+    // Keep loader faults in discovery order: the first broken edge a user
+    // wrote remains the first diagnostic even though successful body checks
+    // below run leaves-first.
     for module in program.dependencies_in_discovery_order() {
         match &module.fault {
             Some(LoadError::Parse { error, .. }) => fail(error.clone()),
             Some(fault) => fail(fault.to_string()),
             None => {}
         }
+    }
+
+    let mut modules = Vec::with_capacity(program.dependencies().len());
+    for module in program.dependencies() {
+        let loaded = program
+            .loaded_dependencies_for(module)
+            .unwrap_or_else(|error| fail(error.to_string()));
         let mut module_items = module.items.clone();
 
         let neutral_policy = aver::ir::NeutralAllocPolicy;
         let dep_typecheck_mode = if lowering.self_host {
-            aver::ir::TypecheckMode::FullSelfHost {
-                base_dir: Some(module_root),
-            }
+            aver::ir::TypecheckMode::WithCheckedLoadedSelfHost(&loaded)
         } else {
-            aver::ir::TypecheckMode::Full {
-                base_dir: Some(module_root),
-            }
+            aver::ir::TypecheckMode::WithCheckedLoaded(&loaded)
         };
         let pipeline_result = aver::ir::pipeline::run(
             &mut module_items,
@@ -11626,21 +11644,17 @@ pub(super) fn load_compile_deps(
             );
             process::exit(1);
         }
-        lowered.insert(
-            module.discovery_index,
-            ModuleInfo::from_items(
-                module.dep_name.clone(),
-                &module_items,
-                pipeline_result.analysis,
-            ),
-        );
+        modules.push(ModuleInfo::from_items(
+            module.dep_name.clone(),
+            &module_items,
+            pipeline_result.analysis,
+        ));
     }
 
-    program
-        .dependencies()
-        .iter()
-        .filter_map(|module| lowered.remove(&module.discovery_index))
-        .collect()
+    let loaded = program
+        .loaded_dependencies_for(program.entry())
+        .unwrap_or_else(|error| fail(error.to_string()));
+    PreparedCompileDeps { modules, loaded }
 }
 
 #[cfg(test)]

--- a/src/main/run_wasip2.rs
+++ b/src/main/run_wasip2.rs
@@ -105,19 +105,18 @@ fn build_component(
     let source = super::shared::read_file(file).map_err(|e| e.to_string())?;
     let mut items =
         super::shared::parse_file(&source, &module_root, file).map_err(|e| e.to_string())?;
-    let dep_modules = super::commands::load_compile_deps(
+    let prepared_deps = super::commands::load_compile_deps_prepared(
         &items,
         &module_root,
         super::commands::DepLowering::STRING_INDEX_ONLY,
     );
+    let dep_modules = prepared_deps.modules;
 
     let neutral_policy = NeutralAllocPolicy;
     let result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             alloc_policy: Some(&neutral_policy),
             dep_modules: &dep_modules,
             // Both traversal-lowering stages stay OFF for wasip2, and
@@ -236,11 +235,10 @@ fn run_component(
     providers: &aver::provider::ProviderRegistry,
 ) -> wasmtime::Result<()> {
     use wasmtime::component::{Component, Linker, ResourceTable};
-    use wasmtime::{Config, Engine, Store};
+    use wasmtime::{Cache, Config, Engine, Store};
     use wasmtime_wasi::p2::bindings::sync::Command;
-    use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
-    use wasmtime_wasi_http::WasiHttpCtx;
-    use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
+    use wasmtime_wasi::{FsPerms, WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
+    use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpCtxView, WasiHttpView};
 
     // Engine config: GC + function-references + Component Model are
     // all needed for the wasm-gc-derived component to validate and
@@ -251,6 +249,13 @@ fn run_component(
     config.wasm_component_model(true);
     config.wasm_gc(true);
     config.wasm_function_references(true);
+    // Match the embedded wasm-gc runner: the component bytes and engine
+    // settings form Wasmtime's cache key, so repeat source runs skip Cranelift
+    // while changed programs and configurations miss safely.
+    // Cache availability is an optimisation, not part of WASI semantics.
+    if let Ok(cache) = Cache::from_file(None) {
+        config.cache(Some(cache));
+    }
     let engine = Engine::new(&config)?;
 
     let component = Component::from_binary(&engine, component_bytes)?;
@@ -284,12 +289,7 @@ fn run_component(
     // Surface the host error up front instead of letting it look
     // like a guest bug.
     ctx_builder
-        .preopened_dir(
-            ".",
-            ".",
-            wasmtime_wasi::DirPerms::all(),
-            wasmtime_wasi::FilePerms::all(),
-        )
+        .preopened_dir(".", ".", FsPerms::ReadWrite)
         .map_err(|e| wasmtime::Error::msg(format!("preopen `.`: {e}")))?;
     // Phase 4 (0.20) — wasi-sockets capabilities for `Tcp.*`.
     // `inherit_network` grants the guest access to the host's

--- a/src/main/run_wasm_gc.rs
+++ b/src/main/run_wasm_gc.rs
@@ -18,7 +18,7 @@ use super::shared;
 use super::shared::{parse_file, read_file, resolve_module_root};
 
 #[cfg(feature = "wasm")]
-use super::commands::{flatten_multimodule, load_compile_deps};
+use super::commands::flatten_multimodule;
 
 #[cfg(feature = "wasm")]
 pub(super) use rt::EffectMode;
@@ -157,18 +157,17 @@ pub(super) fn try_run_wasm_gc(
             });
     let source = read_file(file)?;
     let mut items = parse_file(&source, &module_root, file)?;
-    let dep_modules = load_compile_deps(
+    let prepared_deps = super::commands::load_compile_deps_prepared(
         &items,
         &module_root,
         super::commands::DepLowering::STRING_INDEX_ONLY,
     );
+    let dep_modules = prepared_deps.modules;
     let neutral_policy = NeutralAllocPolicy;
     let result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             alloc_policy: Some(&neutral_policy),
             dep_modules: &dep_modules,
             run_interp_lower: false,

--- a/src/runtime/wasm_gc.rs
+++ b/src/runtime/wasm_gc.rs
@@ -320,6 +320,15 @@ fn run_wasm_gc_with_host(
     // async stack at 12 MiB to keep both paths happy. No-op when async
     // support is off (unrelated builds).
     config.async_stack_size(12 * 1024 * 1024);
+    // Wasm emission and Cranelift are separate compilation stages. Persist the
+    // latter in Wasmtime's content/config-addressed cache so repeated
+    // `aver run --wasm-gc` processes rehydrate native code instead of JITing
+    // the identical module again.
+    // A missing/unwritable user cache must not turn a valid program into a
+    // runtime failure; it only forfeits the warm-start optimisation.
+    if let Ok(cache) = Cache::from_file(None) {
+        config.cache(Some(cache));
+    }
     let engine = Engine::new(&config).map_err(|e| format!("engine: {e:#}"))?;
     let module = Module::new(&engine, wasm_bytes).map_err(|e| format!("module: {e:#}"))?;
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::{Path, PathBuf};
 
@@ -1032,25 +1032,26 @@ pub fn loaded_to_module_info(loaded: &[LoadedModule]) -> Vec<crate::codegen::Mod
         .collect()
 }
 
-/// Load every dependency of the program behind `items` — written
-/// `depends`, their transitive closure, and the standard modules implied by
-/// builtin calls — into `codegen::ModuleInfo` records ready to hand to
-/// `PipelineConfig.dep_modules`.
+/// Both views of a dependency graph prepared for one entry pipeline.
+/// `modules` is target-lowered codegen input; `loaded` is the pristine,
+/// already-checked closure the entry uses to rebuild import surfaces without
+/// walking dependency bodies again.
+pub struct PreparedCompileDeps {
+    pub modules: Vec<crate::codegen::ModuleInfo>,
+    pub loaded: Vec<LoadedModule>,
+}
+
+/// Prepare a codegen dependency graph once, leaves-first, and retain the
+/// pristine loaded closure for the entry module's `WithCheckedLoaded` pass.
 ///
-/// Each dependency goes through the same canonical pipeline as the entry —
-/// `pipeline::run` with `TypecheckMode::Full { base_dir: module_root }`,
-/// the mutable builder/cursor passes disabled, String indexing enabled,
-/// and the neutral alloc policy. Type errors in any dependency surface as
-/// `Err`, parent before child.
-///
-/// The CLI's `commands::load_compile_deps` is the sibling that applies a
-/// per-target lowering matrix and exits on failure; every other call site —
-/// `vm_verify`, `wasm_gc_verify`, `bench/runner`, the research test — goes
-/// through here so the dependency contract stays in one place.
+/// This is the library counterpart of the CLI's target-aware loader. The old
+/// implementation selected `Full` separately for every dependency, causing
+/// each importer to reload and recheck its complete transitive cone before
+/// callers checked the entry in full once more.
 pub fn load_compile_deps(
     items: &[TopLevel],
     module_root: &str,
-) -> Result<Vec<crate::codegen::ModuleInfo>, String> {
+) -> Result<PreparedCompileDeps, String> {
     let program = load_program(
         Path::new("<entry>"),
         "",
@@ -1064,8 +1065,6 @@ pub fn load_compile_deps(
         }
         other => other.to_string(),
     })?;
-    let neutral_policy = crate::ir::NeutralAllocPolicy;
-    let mut lowered = BTreeMap::new();
     for module in program.dependencies_in_discovery_order() {
         if let Some(fault) = &module.fault {
             return Err(match fault {
@@ -1075,13 +1074,19 @@ pub fn load_compile_deps(
                 other => other.to_string(),
             });
         }
+    }
+
+    let neutral_policy = crate::ir::NeutralAllocPolicy;
+    let mut modules = Vec::with_capacity(program.dependencies().len());
+    for module in program.dependencies() {
+        let loaded = program
+            .loaded_dependencies_for(module)
+            .map_err(|error| error.to_string())?;
         let mut module_items = module.items.clone();
         let pipeline_result = crate::ir::pipeline::run(
             &mut module_items,
             crate::ir::PipelineConfig {
-                typecheck: Some(crate::ir::TypecheckMode::Full {
-                    base_dir: Some(module_root),
-                }),
+                typecheck: Some(crate::ir::TypecheckMode::WithCheckedLoaded(&loaded)),
                 run_interp_lower: false,
                 run_buffer_build: false,
                 run_chars_fusion: false,
@@ -1104,29 +1109,92 @@ pub fn load_compile_deps(
                     .join("\n")
             ));
         }
-        lowered.insert(
-            module.discovery_index,
-            crate::codegen::ModuleInfo::from_items(
-                module.dep_name.clone(),
-                &module_items,
-                pipeline_result.analysis,
-            ),
-        );
+        modules.push(crate::codegen::ModuleInfo::from_items(
+            module.dep_name.clone(),
+            &module_items,
+            pipeline_result.analysis,
+        ));
     }
-    Ok(program
-        .dependencies()
-        .iter()
-        .filter_map(|module| lowered.remove(&module.discovery_index))
-        .collect())
+
+    let loaded = program
+        .loaded_dependencies_for(program.entry())
+        .map_err(|error| error.to_string())?;
+    Ok(PreparedCompileDeps { modules, loaded })
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
         LoadMode, ProgramLoadCache, collect_stdlib_shadowed, collect_stdlib_shadowed_in_map,
-        load_module_tree, load_module_tree_from_map, load_program_with_cache, parse_source,
-        require_module_declaration, resolve_module_source, stdlib_shadowed_project_file,
+        load_compile_deps, load_module_tree, load_module_tree_from_map, load_program_with_cache,
+        parse_source, require_module_declaration, resolve_module_source,
+        stdlib_shadowed_project_file,
     };
+
+    #[test]
+    fn compile_dependency_preparation_checks_bodies_once_leaves_first() {
+        let root = tempfile::tempdir().expect("module root");
+        std::fs::write(
+            root.path().join("B.av"),
+            "module B\n    exposes [value]\n\nfn value() -> Int\n    1\n",
+        )
+        .expect("write B");
+        std::fs::write(
+            root.path().join("A.av"),
+            "module A\n    depends [B]\n    exposes [value]\n\nfn value() -> Int\n    B.value()\n",
+        )
+        .expect("write A");
+        let entry =
+            parse_source("module Main\n    depends [A]\n\nfn main() -> Int\n    A.value()\n")
+                .expect("parse entry");
+        let root_str = root.path().to_string_lossy();
+
+        let mut prepared = load_compile_deps(&entry, &root_str).expect("prepare valid graph");
+        assert_eq!(
+            prepared
+                .modules
+                .iter()
+                .map(|module| module.prefix.as_str())
+                .collect::<Vec<_>>(),
+            vec!["B", "A"]
+        );
+
+        // The entry seam trusts only a graph returned by the preparation
+        // above: changing a dependency body afterwards does not recursively
+        // recheck it, but its signature remains visible to the importer.
+        let broken_b = parse_source(
+            "module B\n    exposes [value]\n\nfn value() -> Int\n    \"not an Int\"\n",
+        )
+        .expect("parse deliberately ill-typed B");
+        prepared
+            .loaded
+            .iter_mut()
+            .find(|module| module.dep_name == "B")
+            .expect("loaded B")
+            .items = broken_b;
+        let entry_check = crate::ir::pipeline::typecheck(
+            &entry,
+            &crate::ir::TypecheckMode::WithCheckedLoaded(&prepared.loaded),
+        );
+        assert!(entry_check.errors.is_empty(), "{:?}", entry_check.errors);
+
+        // The trust seam is not public input: preparing that same broken body
+        // from source rejects it before an importer can select
+        // `WithCheckedLoaded`.
+        std::fs::write(
+            root.path().join("B.av"),
+            "module B\n    exposes [value]\n\nfn value() -> Int\n    \"not an Int\"\n",
+        )
+        .expect("replace B");
+        let error = match load_compile_deps(&entry, &root_str) {
+            Ok(_) => panic!("preparation must check B's body"),
+            Err(error) => error,
+        };
+        assert!(
+            error.contains("Type errors in dependency module 'B'"),
+            "{error}"
+        );
+    }
 
     #[test]
     fn standard_bytes_module_resolves_without_a_filesystem_root() {

--- a/src/types/checker/mod.rs
+++ b/src/types/checker/mod.rs
@@ -223,6 +223,20 @@ pub fn run_type_check_with_loaded_self_host(
     finalize_check_result(checker, items)
 }
 
+/// Self-host variant of [`run_type_check_with_checked_loaded`]. The caller
+/// has already checked every dependency body leaves-first under the same
+/// opaque-type bypass, so only importer-visible surfaces and `items` are
+/// rebuilt here.
+pub(crate) fn run_type_check_with_checked_loaded_self_host(
+    items: &[TopLevel],
+    loaded: &[crate::source::LoadedModule],
+) -> TypeCheckResult {
+    let mut checker = TypeChecker::new_with_symbols(build_symbols_with_loaded(items, loaded));
+    checker.self_host_mode = true;
+    checker.check_with_checked_loaded(items, loaded);
+    finalize_check_result(checker, items)
+}
+
 fn finalize_check_result(mut checker: TypeChecker, items: &[TopLevel]) -> TypeCheckResult {
     // Phase B (post peer-review #148): flatten the internal split
     // (`fn_sigs` keyed by `FnId`, `extra_sigs` keyed by canonical

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -26,14 +26,13 @@ use aver::vm;
 fn run_mir(src: &str, entry: &str) -> Value {
     let module_root = env!("CARGO_MANIFEST_DIR");
     let mut items = parse_source(src).expect("parse failed");
-    let dep_modules =
+    let prepared_deps =
         aver::source::load_compile_deps(&items, module_root).expect("load implicit dependencies");
+    let dep_modules = prepared_deps.modules;
     let result = pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             dep_modules: &dep_modules,
             ..Default::default()
         },
@@ -68,14 +67,13 @@ fn run_mir_with_modules(
     let source_file = source_file.to_string_lossy().into_owned();
     let module_root = module_root.to_string_lossy().into_owned();
     let mut items = parse_source(src).expect("parse failed");
-    let dep_modules =
+    let prepared_deps =
         aver::source::load_compile_deps(&items, &module_root).expect("load benchmark dependencies");
+    let dep_modules = prepared_deps.modules;
     let result = pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             dep_modules: &dep_modules,
             ..Default::default()
         },

--- a/tests/hostile_readbytes_stub_fidelity.rs
+++ b/tests/hostile_readbytes_stub_fidelity.rs
@@ -76,8 +76,9 @@ fn stub_vm() -> (vm::VM, String) {
     let mut parser = aver::parser::Parser::new(tokens);
     let mut items = parser.parse().expect("parse stub program");
     aver::tco::transform_program(&mut items);
-    let dep_modules =
+    let prepared_deps =
         aver::source::load_compile_deps(&items, env!("CARGO_MANIFEST_DIR")).expect("load Bytes");
+    let dep_modules = prepared_deps.modules;
     aver::resolver::resolve_program(&mut items);
     let mut arena = Arena::new();
     vm::register_service_types(&mut arena);

--- a/tests/research_archetype_clustering.rs
+++ b/tests/research_archetype_clustering.rs
@@ -70,14 +70,13 @@ fn analyze_file(path: &Path) -> Result<FileResult, String> {
         format!("deps: cannot locate module root for {:?}", dep_names)
     })?;
 
-    let dep_modules = aver::source::load_compile_deps(&items, &module_root)
+    let prepared_deps = aver::source::load_compile_deps(&items, &module_root)
         .map_err(|e| format!("deps: {}", e))?;
+    let dep_modules = prepared_deps.modules;
     let pipeline_result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(&module_root),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             dep_modules: &dep_modules,
             ..Default::default()
         },

--- a/tests/shape_module_patterns_spec.rs
+++ b/tests/shape_module_patterns_spec.rs
@@ -16,7 +16,7 @@ fn detect_in_file(path: &str) -> Vec<ModulePattern> {
         .unwrap_or(".");
     let deps = aver::source::load_compile_deps(&items, module_root)
         .unwrap_or_else(|e| panic!("deps: {e}"));
-    detect_module_patterns(&items, &deps)
+    detect_module_patterns(&items, &deps.modules)
 }
 
 #[test]
@@ -140,7 +140,9 @@ fn detection_payload_matches_refinement_info_for() {
     let source = std::fs::read_to_string(path).unwrap();
     let items = aver::source::parse_source(&source).unwrap();
     let module_root = std::path::Path::new(path).parent().unwrap();
-    let deps = aver::source::load_compile_deps(&items, module_root.to_str().unwrap()).unwrap();
+    let deps = aver::source::load_compile_deps(&items, module_root.to_str().unwrap())
+        .unwrap()
+        .modules;
     let module_prefixes: std::collections::HashSet<String> =
         deps.iter().map(|m| m.prefix.clone()).collect();
     let recursive_fns: std::collections::HashSet<aver::ir::FnId> = std::collections::HashSet::new();
@@ -421,7 +423,7 @@ fn inductable_in_file(path: &str) -> std::collections::HashSet<String> {
         .unwrap_or(".");
     let deps = aver::source::load_compile_deps(&items, module_root)
         .unwrap_or_else(|e| panic!("deps: {e}"));
-    collect_inductable_sum_types(&items, &deps)
+    collect_inductable_sum_types(&items, &deps.modules)
 }
 
 #[test]

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -101,6 +101,9 @@ fn parse_pipeline_with_module_root(
     let tokens = lexer.tokenize().map_err(|e| format!("lex: {:?}", e))?;
     let mut parser = Parser::new(tokens);
     let mut items = parser.parse().map_err(|e| format!("parse: {:?}", e))?;
+    let prepared_deps = module_root
+        .map(|root| aver::source::load_compile_deps(&items, root))
+        .transpose()?;
     // Mirror what `aver compile --target wasm-gc` does internally:
     // skip the VM-specific `run_interp_lower` + `run_buffer_build`
     // passes (they emit `__buf_*` / `__interp_*` calls the wasm-gc
@@ -109,8 +112,11 @@ fn parse_pipeline_with_module_root(
     let result = ir::pipeline::run(
         &mut items,
         ir::PipelineConfig {
-            typecheck: Some(ir::TypecheckMode::Full {
-                base_dir: module_root,
+            typecheck: Some(match prepared_deps.as_ref() {
+                Some(prepared) => ir::TypecheckMode::WithCheckedLoaded(&prepared.loaded),
+                None => ir::TypecheckMode::Full {
+                    base_dir: module_root,
+                },
             }),
             run_interp_lower: false,
             run_buffer_build: false,
@@ -129,8 +135,8 @@ fn parse_pipeline_with_module_root(
         ));
     }
     let mut type_aliases = std::collections::HashMap::new();
-    if let Some(root) = module_root {
-        let dep_modules = aver::source::load_compile_deps(&items, root)?;
+    if let Some(prepared) = prepared_deps {
+        let dep_modules = prepared.modules;
         type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
             &mut items,
             &dep_modules,

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -92,6 +92,9 @@ fn parse_pipeline_with_module_root(
     let tokens = lexer.tokenize().map_err(|e| format!("lex: {:?}", e))?;
     let mut parser = Parser::new(tokens);
     let mut items = parser.parse().map_err(|e| format!("parse: {:?}", e))?;
+    let prepared_deps = module_root
+        .map(|root| aver::source::load_compile_deps(&items, root))
+        .transpose()?;
     // Mirror what `aver compile --target wasm-gc` does internally:
     // skip the VM-specific `run_interp_lower` + `run_buffer_build`
     // passes (they emit `__buf_*` / `__interp_*` calls the wasm-gc
@@ -100,8 +103,11 @@ fn parse_pipeline_with_module_root(
     let result = ir::pipeline::run(
         &mut items,
         ir::PipelineConfig {
-            typecheck: Some(ir::TypecheckMode::Full {
-                base_dir: module_root,
+            typecheck: Some(match prepared_deps.as_ref() {
+                Some(prepared) => ir::TypecheckMode::WithCheckedLoaded(&prepared.loaded),
+                None => ir::TypecheckMode::Full {
+                    base_dir: module_root,
+                },
             }),
             run_interp_lower: false,
             run_buffer_build: false,
@@ -120,8 +126,8 @@ fn parse_pipeline_with_module_root(
         ));
     }
     let mut type_aliases = std::collections::HashMap::new();
-    if let Some(root) = module_root {
-        let dep_modules = aver::source::load_compile_deps(&items, root)?;
+    if let Some(prepared) = prepared_deps {
+        let dep_modules = prepared.modules;
         type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
             &mut items,
             &dep_modules,

--- a/tests/wasm_gc_differential_mir.rs
+++ b/tests/wasm_gc_differential_mir.rs
@@ -86,12 +86,12 @@ fn run_pipeline(
     let tokens = lexer.tokenize().map_err(|e| format!("lex: {:?}", e))?;
     let mut parser = Parser::new(tokens);
     let mut items = parser.parse().map_err(|e| format!("parse: {:?}", e))?;
+    let prepared_deps = aver::source::load_compile_deps(&items, module_root)?;
+    let dep_modules = prepared_deps.modules;
     let result = ir::pipeline::run(
         &mut items,
         ir::PipelineConfig {
-            typecheck: Some(ir::TypecheckMode::Full {
-                base_dir: Some(module_root),
-            }),
+            typecheck: Some(ir::TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             run_interp_lower: false,
             run_buffer_build: false,
             run_chars_fusion: false,
@@ -108,7 +108,6 @@ fn run_pipeline(
             tc.errors.first()
         ));
     }
-    let dep_modules = aver::source::load_compile_deps(&items, module_root)?;
     let type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
         &mut items,
         &dep_modules,

--- a/tests/wasm_gc_effect_arg_overflow_regression.rs
+++ b/tests/wasm_gc_effect_arg_overflow_regression.rs
@@ -45,14 +45,13 @@ fn run_wasm_gc_with_mode(
     let tokens = lexer.tokenize().expect("lex");
     let mut parser = aver::parser::Parser::new(tokens);
     let mut items = parser.parse().expect("parse");
-    let dep_modules = aver::source::load_compile_deps(&items, env!("CARGO_MANIFEST_DIR"))?;
+    let prepared_deps = aver::source::load_compile_deps(&items, env!("CARGO_MANIFEST_DIR"))?;
+    let dep_modules = prepared_deps.modules;
     let neutral_policy = NeutralAllocPolicy;
     let result = aver::ir::pipeline::run(
         &mut items,
         PipelineConfig {
-            typecheck: Some(TypecheckMode::Full {
-                base_dir: Some(env!("CARGO_MANIFEST_DIR")),
-            }),
+            typecheck: Some(TypecheckMode::WithCheckedLoaded(&prepared_deps.loaded)),
             dep_modules: &dep_modules,
             alloc_policy: Some(&neutral_policy),
             run_interp_lower: false,


### PR DESCRIPTION
## What changed

- Load the complete dependency graph once, check module bodies leaves-first once, and let importers rebuild only their visible surfaces from that checked graph. All run, compile, verify, diagnostics, and benchmark entry points use the same prepared graph.
- Upgrade the embedded engine to Wasmtime 48.0.1 and enable its official content/config-addressed native-code cache for both wasm-gc and wasip2. Cache setup is best-effort, so an unwritable user cache never makes a valid program fail.
- Canonicalize generated map/equality/hash helper slots. Identical source now emits byte-identical wasm across compiler processes, which is required for a content-addressed JIT cache to hit.

## Measurements

Full `btc-listener` module graph, release compiler. Compile numbers are medians of 7 runs:

| Target | Before | After | Change |
|---|---:|---:|---:|
| wasm-gc source → wasm | ~9.68 s | 2.111 s | -78% |
| Rust source → generated project | ~9.43 s | 2.253 s | -76% |

The runtime exercise runs the complete node through handshake and a deliberately corrupt 3,500,000-byte `ping`. Every engine saw exactly 3,500,171 bytes host→guest and wrote 157 bytes guest→host. Warm values are medians of 9 runs:

| Runtime | Full process wall | Payload → checksum/drop |
|---|---:|---:|
| Wasmtime 48, first JIT | 38.509 s | 77.61 ms |
| Wasmtime 48, cached | 4.135 s | 76.18 ms |
| Node 26 + JSPI, precompiled wasm | 248.04 ms | 148.93 ms |
| generated native Rust | 64.88 ms | 29.32 ms |

The full-process column is intentionally not an engine comparison: `aver run --wasm-gc` still recompiles Aver source and starts the configured Rust provider host, while Node consumes an existing wasm file and native Rust consumes an existing executable. The payload column isolates the same work: Wasmtime is about 1.95× faster than Node and 2.60× slower than native Rust here.

Two independent compiler processes emitted the same 519,370-byte module with SHA-256 `3783f71384a16b35720cd04c6554cace7ef57440339d7afbe6255ac3c6f4164f`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p aver-lang --lib --features wasm slot_assignment_is_independent_of_discovery_order`
- `cargo test -p aver-lang --lib compile_dependency_preparation_checks_bodies_once_leaves_first`
- `cargo check -p aver-lang --tests --features wasm,wasip2`
- full btc-listener differential run on Wasmtime, Node, and generated Rust

This does not close #1159. Directly running a precompiled `.wasm` artifact and caching the source→wasm stage remain the follow-up described there.
