### PR TITLE
Fix record-wrapped Map ownership and Rust parameter collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 - **Maps have one deterministic order on every backend.** Iteration is sorted by key, `keys[i]` pairs with `values[i]`, and equality uses the same canonical form in execution and proof. Map keys must have a modelled total order; `Float` keys are rejected instead of giving NaN or proof-model divergences.
 
-- **Execution and compilation avoid several formerly quadratic paths.** Collection, string, byte, map, and generated-Rust hot paths preserve sharing, ownership, or proven ranges instead of rebuilding live data. Commands prepare each module graph once rather than recursively rechecking dependency cones. Embedded Wasmtime 48 uses its copying collector and caches reproducibly emitted wasm as native code across runs.
+- **Execution and compilation avoid several formerly quadratic paths.** Collection, string, byte, map, and generated-Rust hot paths preserve sharing, ownership, or proven ranges instead of rebuilding live data, including maps threaded through record-returning helpers. Commands prepare each module graph once rather than recursively rechecking dependency cones. Embedded Wasmtime 48 uses its copying collector and caches reproducibly emitted wasm as native code across runs. Closes [#1160](https://github.com/jasisz/aver/issues/1160).
 
 - **Generated projects pin the compiler's actual source provenance.** Path builds emit path dependencies, git builds pin the repository and revision, and registry builds emit exact registry versions for both `aver-lang` and `aver-rt`.
 
@@ -65,7 +65,7 @@ Aver 0.29 turns the host boundary into explicit, source-owned contracts. Standar
 
 - **Proof export is substantially harder to make green for the wrong reason.** Fixes cover nested effect evaluation order, refused-claim accounting, defaults introduced by `?`, opaque capability resources, mutual-recursion measures and fuel, method applications in argument position, map-order observations through callbacks/tail calls/interpolation, and symbolic provider calls hidden behind transparent wrappers.
 
-- **Module and type identity no longer depends on load order or bare-name collisions.** Lean, Dafny, generated Rust, wasm-gc constructor patterns, equality/hash derivation, and diagnostics retain the declaration's owning module through resolution and rendering. Generated Rust also keeps local `let` bindings unambiguous when multiple dependencies expose functions with the same name.
+- **Module and type identity no longer depends on load order or bare-name collisions.** Lean, Dafny, generated Rust, wasm-gc constructor patterns, equality/hash derivation, and diagnostics retain the declaration's owning module through resolution and rendering. Generated Rust keeps every local binder — including parameters and TCO-generated bindings — unambiguous when dependencies expose functions with the same name. Closes [#1162](https://github.com/jasisz/aver/issues/1162).
 
 - **Cross-backend runtime behaviour is aligned.** wasm-gc maps grow and delete colliding keys correctly; generated Rust preserves borrows, evaluates policy-checked effect arguments once, and agrees on negative `List.take/drop`; `Http.head`, 204, and 304 responses accept an empty body; `Args.get` and browser `Http.*` calls appear in verify traces.
 

--- a/aver-memory/src/arena.rs
+++ b/aver-memory/src/arena.rs
@@ -23,6 +23,7 @@ impl<T: ArenaTypes> Arena<T> {
             rewrite_out_of_region_roots: false,
             holds_any_map: false,
             holds_any_vector: false,
+            holds_any_record: false,
             inplace_visit_stamps: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             inplace_visit_epoch: 0,
             type_keys: Vec::new(),
@@ -76,6 +77,7 @@ impl<T: ArenaTypes> Arena<T> {
             // still a map here.
             holds_any_map: self.holds_any_map,
             holds_any_vector: self.holds_any_vector,
+            holds_any_record: self.holds_any_record,
             inplace_visit_stamps: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             inplace_visit_epoch: 0,
             type_keys: self.type_keys.clone(),
@@ -248,7 +250,9 @@ impl<T: ArenaTypes> Arena<T> {
                 let idx = self.push_vector(imported);
                 NanValue::new_vector(idx)
             }
-            ArenaEntry::Record { type_id, fields } => {
+            ArenaEntry::Record {
+                type_id, fields, ..
+            } => {
                 let imported: Vec<NanValue> = fields
                     .iter()
                     .map(|v| self.deep_import(*v, source))
@@ -256,6 +260,7 @@ impl<T: ArenaTypes> Arena<T> {
                 let idx = self.push(ArenaEntry::Record {
                     type_id,
                     fields: imported,
+                    holder_count: 0,
                 });
                 NanValue::new_record(idx)
             }
@@ -288,17 +293,18 @@ impl<T: ArenaTypes> Arena<T> {
     /// Record that something other than the caller's own handle now holds
     /// `value`'s slot.
     ///
-    /// A no-op for anything but a heap-backed map or vector — the two entries
-    /// that carry the flag, because they are the two anything ever empties in
-    /// place (`take_map_value` / `take_vector_value`). The consumer calls this
+    /// A no-op for anything but a heap-backed map, vector, or record — the
+    /// entries the runtime may empty in place. The consumer calls this
     /// for the roots the arena cannot see for itself — a global it stores
     /// into, a constant table it hands the program, a value it writes into an
-    /// entry that already exists. `ArenaEntry::Map`'s `held_elsewhere` carries
-    /// the full list of marking sites; the vector flag rides the same choke
-    /// points.
+    /// entry that already exists. The `holder_count` fields carry the full list
+    /// of marking sites for maps, vectors, and records.
     #[inline(always)]
     pub fn note_held_elsewhere(&mut self, value: NanValue) {
-        if value.is_heap_map() || (value.is_vector() && !value.is_empty_vector_immediate()) {
+        if value.is_heap_map()
+            || (value.is_vector() && !value.is_empty_vector_immediate())
+            || value.is_record()
+        {
             self.mark_held_elsewhere(value.arena_index());
         }
     }
@@ -312,30 +318,65 @@ impl<T: ArenaTypes> Arena<T> {
     #[inline(never)]
     fn mark_held_elsewhere(&mut self, index: u32) {
         match self.get_mut(index) {
-            ArenaEntry::Map { held_elsewhere, .. } | ArenaEntry::Vector { held_elsewhere, .. } => {
-                *held_elsewhere = true
+            ArenaEntry::Map { holder_count, .. }
+            | ArenaEntry::Vector { holder_count, .. }
+            | ArenaEntry::Record { holder_count, .. } => {
+                *holder_count = holder_count.saturating_add(1);
             }
             _ => {}
         }
     }
 
-    /// Mark every map or vector `entry` holds DIRECTLY, so the entry counts as
-    /// a holder of those slots from here on.
+    /// Remove one registered holder after a uniquely-owned aggregate has
+    /// physically stopped holding `value`.
+    #[inline(always)]
+    fn release_held_elsewhere(&mut self, value: NanValue) {
+        if value.is_heap_map()
+            || (value.is_vector() && !value.is_empty_vector_immediate())
+            || value.is_record()
+        {
+            self.release_holder(value.arena_index());
+        }
+    }
+
+    #[inline(never)]
+    fn release_holder(&mut self, index: u32) {
+        match self.get_mut(index) {
+            ArenaEntry::Map { holder_count, .. }
+            | ArenaEntry::Vector { holder_count, .. }
+            | ArenaEntry::Record { holder_count, .. } => {
+                // Saturation is sticky. Once exact cardinality is lost, the
+                // safe answer is "held" forever rather than a future false 0.
+                if *holder_count == u32::MAX {
+                    return;
+                }
+                debug_assert!(
+                    *holder_count > 0,
+                    "removed aggregate field had no registered holder"
+                );
+                *holder_count = holder_count.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    /// Mark every map, vector, or record `entry` holds DIRECTLY, so the entry
+    /// counts as a holder of those slots from here on.
     ///
-    /// Direct is enough: a map or vector reachable from the arena at all is a
-    /// direct child of SOME entry, and that entry came through here. What it
+    /// Direct is enough: a takeable value reachable from the arena at all is a
+    /// direct child of SOME entry, and that entry came through here. What this
     /// does not do is walk a map's own table or a vector entry's own elements —
     /// that would put an `O(size)` pass in front of the one insert that is
     /// `O(1)`. The builders mark their own children instead: [`Arena::push_map`]
     /// and the owned map insert for tables, [`Arena::push_vector`] and the
     /// owned `Vector.set` (which marks the one element it stores) for vectors.
     ///
-    /// Reached only when the arena has stored a map or vector at all —
+    /// Reached only when the arena has stored a map, vector, or record at all —
     /// [`Arena::push`] reads that off the same discriminant it was already
     /// reading — and deliberately not inlined into it, so a program that never
     /// builds a collection carries none of this in its allocation path.
     #[inline(never)]
-    fn note_entry_holds_collections(&mut self, entry: &ArenaEntry<T>) {
+    fn note_entry_holds_takeable(&mut self, entry: &ArenaEntry<T>) {
         match entry {
             ArenaEntry::Boxed(value) => self.note_held_elsewhere(*value),
             ArenaEntry::Tuple(items) => {
@@ -350,7 +391,7 @@ impl<T: ArenaTypes> Arena<T> {
             }
             ArenaEntry::List(list) => match list {
                 ArenaList::Flat { items, start, .. } => {
-                    if items.holds_collection() {
+                    if items.holds_takeable() {
                         for value in &items[(*start).min(items.len())..] {
                             self.note_held_elsewhere(*value);
                         }
@@ -371,7 +412,7 @@ impl<T: ArenaTypes> Arena<T> {
                     ..
                 } => {
                     self.note_held_elsewhere(*current);
-                    if rest.holds_collection() {
+                    if rest.holds_takeable() {
                         for value in &rest[(*start).min(rest.len())..] {
                             self.note_held_elsewhere(*value);
                         }
@@ -398,14 +439,14 @@ impl<T: ArenaTypes> Arena<T> {
 
     #[inline]
     pub fn push(&mut self, entry: ArenaEntry<T>) -> u32 {
-        // The collection bookkeeping rides on the discriminant read this match
-        // was already doing, so an allocation that has nothing to do with maps
-        // or vectors pays one bool for it.
+        // The ownership bookkeeping rides on the discriminant read this match
+        // was already doing, so an allocation that has nothing to do with a
+        // takeable map, vector, or record pays one guard check for it.
         //
-        // A map or vector entry is where its flag comes from: nothing else in
-        // this arena can carry such an index until one exists, and the only
-        // way one comes to exist is its arm. Everything else asks the flags
-        // first and walks its children only if the answer could be yes.
+        // A takeable entry is where its arena-wide guard comes from: nothing
+        // can carry such an index before the value itself exists. Everything
+        // else asks the guards first and walks its children only if the answer
+        // could be yes.
         match &entry {
             ArenaEntry::Fn(_) | ArenaEntry::Builtin(_) | ArenaEntry::Namespace { .. } => {}
             ArenaEntry::Map { .. } => {
@@ -428,6 +469,13 @@ impl<T: ArenaTypes> Arena<T> {
                 }
                 return self.push_heap(entry);
             }
+            ArenaEntry::Record { .. } => {
+                if self.holds_any_map || self.holds_any_vector || self.holds_any_record {
+                    self.note_entry_holds_takeable(&entry);
+                }
+                self.holds_any_record = true;
+                return self.push_heap(entry);
+            }
             // Nothing here holds a `NanValue`, so there is nothing to mark and
             // no reason to leave the match to find that out. A map fold
             // allocates one of these per step for its keys.
@@ -435,8 +483,8 @@ impl<T: ArenaTypes> Arena<T> {
                 return self.push_heap(entry);
             }
             _ => {
-                if self.holds_any_map || self.holds_any_vector {
-                    self.note_entry_holds_collections(&entry);
+                if self.holds_any_map || self.holds_any_vector || self.holds_any_record {
+                    self.note_entry_holds_takeable(&entry);
                 }
                 return self.push_heap(entry);
             }
@@ -840,7 +888,11 @@ impl<T: ArenaTypes> Arena<T> {
         self.push(ArenaEntry::Boxed(val))
     }
     pub fn push_record(&mut self, type_id: u32, fields: Vec<NanValue>) -> u32 {
-        self.push(ArenaEntry::Record { type_id, fields })
+        self.push(ArenaEntry::Record {
+            type_id,
+            fields,
+            holder_count: 0,
+        })
     }
     pub fn push_variant(&mut self, type_id: u32, variant_id: u16, fields: Vec<NanValue>) -> u32 {
         self.push(ArenaEntry::Variant {
@@ -873,7 +925,9 @@ impl<T: ArenaTypes> Arena<T> {
         for (key, value) in map.values() {
             all_immediate &= key.is_immediate() && value.is_immediate();
             for child in [*key, *value] {
-                if child.is_heap_map() || (child.is_vector() && !child.is_empty_vector_immediate())
+                if child.is_heap_map()
+                    || (child.is_vector() && !child.is_empty_vector_immediate())
+                    || child.is_record()
                 {
                     held.get_or_insert_default().push(child);
                 }
@@ -888,7 +942,7 @@ impl<T: ArenaTypes> Arena<T> {
             all_immediate,
             scan_receipt,
             pending_scan_keys: Vec::new(),
-            held_elsewhere: false,
+            holder_count: 0,
         })
     }
     pub fn push_tuple(&mut self, items: Vec<NanValue>) -> u32 {
@@ -901,10 +955,12 @@ impl<T: ArenaTypes> Arena<T> {
     /// here is the owned `Vector.set`, which is `O(1)` per write and marks the
     /// single element it stores itself (see `vec_set_nv_owned`).
     pub fn push_vector(&mut self, items: Vec<NanValue>) -> u32 {
-        if self.holds_any_map || self.holds_any_vector {
+        if self.holds_any_map || self.holds_any_vector || self.holds_any_record {
             let mut held: Option<Vec<NanValue>> = None;
             for child in &items {
-                if child.is_heap_map() || (child.is_vector() && !child.is_empty_vector_immediate())
+                if child.is_heap_map()
+                    || (child.is_vector() && !child.is_empty_vector_immediate())
+                    || child.is_record()
                 {
                     held.get_or_insert_default().push(*child);
                 }
@@ -915,7 +971,7 @@ impl<T: ArenaTypes> Arena<T> {
         }
         self.push(ArenaEntry::Vector {
             items,
-            held_elsewhere: false,
+            holder_count: 0,
         })
     }
     pub fn push_fn(&mut self, f: Rc<T::Fn>) -> u32 {
@@ -977,9 +1033,37 @@ impl<T: ArenaTypes> Arena<T> {
     }
     pub fn get_record(&self, index: u32) -> (u32, &[NanValue]) {
         match self.get(index) {
-            ArenaEntry::Record { type_id, fields } => (*type_id, fields),
+            ArenaEntry::Record {
+                type_id, fields, ..
+            } => (*type_id, fields),
             _ => panic!("Arena: expected Record at {}", index),
         }
+    }
+
+    /// Whether a root or another arena entry has registered a reference to
+    /// this record. Operand-stack aliases are deliberately not represented
+    /// here; the VM can inspect those directly after popping its operand.
+    pub fn record_is_held_elsewhere(&self, record: NanValue) -> bool {
+        match self.get(record.arena_index()) {
+            ArenaEntry::Record { holder_count, .. } => *holder_count != 0,
+            _ => false,
+        }
+    }
+
+    /// Remove and return one field from a record whose uniqueness the caller
+    /// has already established. Removing the direct reference releases exactly
+    /// one registered holder on a nested map, vector, or record.
+    pub fn take_record_field(&mut self, record: NanValue, field_idx: usize) -> NanValue {
+        debug_assert!(!self.record_is_held_elsewhere(record));
+        debug_assert!(!self.any_entry_holds_slot(record.arena_index()));
+        let value = match self.get_mut(record.arena_index()) {
+            ArenaEntry::Record { fields, .. } => {
+                std::mem::replace(&mut fields[field_idx], NanValue::UNIT)
+            }
+            _ => panic!("Arena: expected Record at {}", record.arena_index()),
+        };
+        self.release_held_elsewhere(value);
+        value
     }
     pub fn get_variant(&self, index: u32) -> (u32, u16, &[NanValue]) {
         match self.get(index) {
@@ -1027,9 +1111,9 @@ impl<T: ArenaTypes> Arena<T> {
         match self.get(value.arena_index()) {
             ArenaEntry::Vector {
                 items,
-                held_elsewhere,
+                holder_count,
             } => Some(VectorSlot {
-                held_elsewhere: *held_elsewhere,
+                held_elsewhere: *holder_count != 0,
                 len: items.len(),
             }),
             _ => panic!("Arena: expected Vector at {}", value.arena_index()),
@@ -1050,7 +1134,7 @@ impl<T: ArenaTypes> Arena<T> {
     }
     /// Take ownership of a vector, replacing the arena slot with an empty vec.
     ///
-    /// `held_elsewhere` is deliberately left alone, for the same reason
+    /// `holder_count` is deliberately left alone, for the same reason
     /// [`Arena::take_map_value`] leaves the map's: emptying the slot does not
     /// discharge a holder, and a second take over the same slot must be
     /// refused for the same reason the first one should have been.
@@ -1188,11 +1272,9 @@ impl<T: ArenaTypes> Arena<T> {
         }
         match self.get(map.arena_index()) {
             ArenaEntry::Map {
-                map,
-                held_elsewhere,
-                ..
+                map, holder_count, ..
             } => Some(MapSlot {
-                held_elsewhere: *held_elsewhere,
+                held_elsewhere: *holder_count != 0,
                 entries: map.len(),
             }),
             _ => panic!("Arena: expected Map at {}", map.arena_index()),

--- a/aver-memory/src/arena/tests.rs
+++ b/aver-memory/src/arena/tests.rs
@@ -20,6 +20,25 @@ impl ArenaTypes for TestTypes {
 type TestArena = Arena<TestTypes>;
 
 #[test]
+fn taking_record_fields_releases_exactly_the_removed_holders() {
+    let mut arena = TestArena::new();
+    let map = NanValue::new_map(arena.push_map(PersistentMap::new()));
+    let record = NanValue::new_record(arena.push_record(1, vec![map, map]));
+
+    assert!(arena.map_slot(map).unwrap().held_elsewhere);
+    assert_eq!(arena.take_record_field(record, 0).bits(), map.bits());
+    assert!(
+        arena.map_slot(map).unwrap().held_elsewhere,
+        "the record's second field still holds the map"
+    );
+    assert_eq!(arena.take_record_field(record, 1).bits(), map.bits());
+    assert!(
+        !arena.map_slot(map).unwrap().held_elsewhere,
+        "removing both fields must release both registered holders"
+    );
+}
+
+#[test]
 fn lane_receipts_must_not_be_newer_than_the_frame_serial() {
     let mut arena = TestArena::new();
     let early_receipt = arena.lane_mark();
@@ -86,7 +105,7 @@ fn clone_static_preserves_the_clock_and_stable_receipts_by_value() {
     arena.stable_entries.push(ArenaEntry::Map {
         map: PersistentMap::new(),
         all_immediate: true,
-        held_elsewhere: false,
+        holder_count: 0,
         scan_receipt: entry_receipt,
         pending_scan_keys: Vec::new(),
     });

--- a/aver-memory/src/lib.rs
+++ b/aver-memory/src/lib.rs
@@ -1453,6 +1453,11 @@ pub struct Arena<T: ArenaTypes> {
     /// job: no vector entry means no value here can carry a vector's index,
     /// so the per-push marking pass has nothing to find.
     holds_any_vector: bool,
+    /// Whether this arena has ever stored a record. Records can be consumed by
+    /// the VM's last-use field projection, so an aggregate that stores one has
+    /// to register itself as an off-stack holder just like it does for maps and
+    /// vectors.
+    holds_any_record: bool,
     /// Which out-of-region slots the descent above has already rewritten, one
     /// stamp array per heap space, indexed by raw arena index.
     ///
@@ -1534,15 +1539,15 @@ pub enum ArenaEntry<T: ArenaTypes> {
         /// pairs, clears the set, and renews the bulk receipt. A full rewrite
         /// also clears it. The set is empty for every from-scratch builder.
         pending_scan_keys: Vec<u64>,
-        /// Whether anything OTHER than a handle in the consumer's own working
-        /// set holds this slot: another arena entry, or a root the consumer
-        /// registered through [`Arena::note_held_elsewhere`] — a global, a
-        /// chunk constant.
+        /// How many registered holders outside the consumer's own working set
+        /// hold this slot: arena entries and roots registered through
+        /// [`Arena::note_held_elsewhere`]. The count lets a destructively
+        /// consumed record release exactly the field reference it removed.
         ///
         /// It exists for one caller, [`Arena::take_map_value`], which empties
         /// the slot it takes from. That is only safe when nobody is left to
         /// read it, and a consumer that can enumerate its own handles still
-        /// cannot see a holder that lives INSIDE the arena. This flag is that
+        /// cannot see a holder that lives INSIDE the arena. This count is that
         /// half of the answer, and it is maintained where the reference is
         /// MADE. A site that forgets to mark is the way this goes wrong, so the
         /// list is here in full and nothing else may add one silently:
@@ -1581,28 +1586,29 @@ pub enum ArenaEntry<T: ArenaTypes> {
         /// one against the other at every grant under debug assertions, for as
         /// long as it can afford to.
         ///
-        /// `true` is always safe: it only costs the in-place path. `false` when
-        /// something does hold the slot is not, and does not fail loudly on its
-        /// own — the other holder reads an empty map. So the direction that
-        /// needs proof is `false`, which is why nothing sets it back to `false`
-        /// once set and why entries born `false` are exactly the ones this
-        /// arena has just built and not yet handed to anybody.
-        held_elsewhere: bool,
+        /// An over-count is always safe: it only costs the in-place path. An
+        /// under-count is not, so ordinary holders only increment it. The sole
+        /// decrement is paired with removing a field from a uniquely-owned
+        /// record.
+        holder_count: u32,
     },
     Vector {
         items: Vec<NanValue>,
-        /// The vector spelling of [`ArenaEntry::Map::held_elsewhere`] — see
+        /// The vector spelling of [`ArenaEntry::Map`]'s `holder_count` — see
         /// that field for the full contract; the marking choke points
         /// ([`Arena::note_held_elsewhere`] and everything that funnels into
         /// it) cover heap vectors and heap maps alike. It exists for the
         /// interpreter's runtime fence on the owned `Vector.set`, which
         /// empties the slot it takes from (`Arena::take_vector_value`) and
         /// may only do so when no off-stack holder is left to read it.
-        held_elsewhere: bool,
+        holder_count: u32,
     },
     Record {
         type_id: u32,
         fields: Vec<NanValue>,
+        /// Registered off-stack holders of this record. Stack aliases are
+        /// checked by the VM immediately before a destructive field take.
+        holder_count: u32,
     },
     Variant {
         type_id: u32,
@@ -1652,21 +1658,22 @@ pub enum ArenaSymbol<T: ArenaTypes> {
 pub struct ListBody {
     items: Vec<NanValue>,
     all_immediate: bool,
-    holds_collection: bool,
+    holds_takeable: bool,
 }
 
 impl ListBody {
     pub fn new(items: Vec<NanValue>) -> Self {
         let mut all_immediate = true;
-        let mut holds_collection = false;
+        let mut holds_takeable = false;
         for value in &items {
             all_immediate &= value.is_immediate();
-            holds_collection |= (value.is_map() || value.is_vector()) && !value.is_immediate();
+            holds_takeable |=
+                (value.is_map() || value.is_vector() || value.is_record()) && !value.is_immediate();
         }
         Self {
             items,
             all_immediate,
-            holds_collection,
+            holds_takeable,
         }
     }
 
@@ -1677,9 +1684,9 @@ impl ListBody {
         self.all_immediate
     }
 
-    /// Whether any element is a heap-backed map or vector, so pushing an entry
-    /// over this body puts a second holder on a slot the owned in-place write
-    /// path could otherwise empty.
+    /// Whether any element is a heap-backed map, vector, or record, so pushing
+    /// an entry over this body puts a second holder on a slot an owned
+    /// in-place path could otherwise empty.
     ///
     /// Decided in the same pass as `all_immediate` and for the same reason: a
     /// body is immutable once built, and a body a collection views at an
@@ -1688,8 +1695,8 @@ impl ListBody {
     /// of a walk over elements that are never collections. Was `holds_map`
     /// until the vector fence needed the same record for vector slots.
     #[inline]
-    pub fn holds_collection(&self) -> bool {
-        self.holds_collection
+    pub fn holds_takeable(&self) -> bool {
+        self.holds_takeable
     }
 }
 

--- a/aver-memory/src/memory.rs
+++ b/aver-memory/src/memory.rs
@@ -370,9 +370,9 @@ impl<T: ArenaTypes> Arena<T> {
             }
             ArenaEntry::Vector {
                 mut items,
-                held_elsewhere,
+                holder_count,
             } => {
-                // `held_elsewhere` travels with the entry untouched — same
+                // `holder_count` travels with the entry untouched — same
                 // argument as the map arm: a rewrite renames indices, it
                 // neither creates a reference nor discharges one.
                 for value in &mut items {
@@ -380,7 +380,7 @@ impl<T: ArenaTypes> Arena<T> {
                 }
                 ArenaEntry::Vector {
                     items,
-                    held_elsewhere,
+                    holder_count,
                 }
             }
             ArenaEntry::Map {
@@ -388,23 +388,28 @@ impl<T: ArenaTypes> Arena<T> {
                 all_immediate,
                 scan_receipt,
                 pending_scan_keys,
-                held_elsewhere,
+                holder_count,
             } => self.rewrite_map_with(
                 map,
                 all_immediate,
                 scan_receipt,
                 pending_scan_keys,
-                held_elsewhere,
+                holder_count,
                 rewrite,
             ),
             ArenaEntry::Record {
                 type_id,
                 mut fields,
+                holder_count,
             } => {
                 for value in &mut fields {
                     *value = rewrite(self, *value);
                 }
-                ArenaEntry::Record { type_id, fields }
+                ArenaEntry::Record {
+                    type_id,
+                    fields,
+                    holder_count,
+                }
             }
             ArenaEntry::Variant {
                 type_id,
@@ -460,7 +465,7 @@ impl<T: ArenaTypes> Arena<T> {
     /// code layout in the collector's hot loop, which is the cost of admission
     /// for taking a `Map<Int, Int>` fold from 12.2 s to 0.03 s at 64,000 keys.
     ///
-    /// `held_elsewhere` travels with the entry untouched. A rewrite renames
+    /// `holder_count` travels with the entry untouched. A rewrite renames
     /// indices; it neither creates a reference nor discharges one, so whoever
     /// held this slot before holds it after.
     fn rewrite_map_with<F>(
@@ -469,7 +474,7 @@ impl<T: ArenaTypes> Arena<T> {
         all_immediate: bool,
         scan_receipt: LaneMark,
         mut pending_scan_keys: Vec<u64>,
-        held_elsewhere: bool,
+        holder_count: u32,
         rewrite: &mut F,
     ) -> ArenaEntry<T>
     where
@@ -490,7 +495,7 @@ impl<T: ArenaTypes> Arena<T> {
                 all_immediate: true,
                 scan_receipt,
                 pending_scan_keys,
-                held_elsewhere,
+                holder_count,
             };
         }
         if self.lane_receipt_can_skip(scan_receipt) {
@@ -507,7 +512,7 @@ impl<T: ArenaTypes> Arena<T> {
                     all_immediate: false,
                     scan_receipt: self.renewed_lane_receipt(),
                     pending_scan_keys,
-                    held_elsewhere,
+                    holder_count,
                 };
             }
             return ArenaEntry::Map {
@@ -515,7 +520,7 @@ impl<T: ArenaTypes> Arena<T> {
                 all_immediate: false,
                 scan_receipt,
                 pending_scan_keys,
-                held_elsewhere,
+                holder_count,
             };
         }
         self.note_map_entries_scanned(map.len());
@@ -531,7 +536,7 @@ impl<T: ArenaTypes> Arena<T> {
             all_immediate: false,
             scan_receipt: self.renewed_lane_receipt(),
             pending_scan_keys: Vec::new(),
-            held_elsewhere,
+            holder_count,
         }
     }
 

--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -32,6 +32,21 @@ pub(super) fn explicit_binding_pattern(name: &str) -> String {
     format!("{} @ _", aver_name_to_rust(name))
 }
 
+/// Render a function parameter as an explicit Rust binding pattern.
+///
+/// Parameters occupy pattern position just like `let` and match binders, so a
+/// bare name can be ambiguous with identically named items from dependency
+/// glob imports (#1162). Keep the source name available to the body while
+/// making item resolution impossible at the binding site.
+pub(super) fn explicit_parameter_pattern(name: &str, mutable: bool) -> String {
+    let binding = explicit_binding_pattern(name);
+    if mutable {
+        format!("mut {binding}")
+    } else {
+        binding
+    }
+}
+
 /// Predicate adapter shared by every resolved-shape classifier — the
 /// shared classifiers don't know about [`CodegenContext`] (it lives in
 /// the codegen crate, classifiers live in the IR), so they take a

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -67,7 +67,8 @@ use super::expr::{
     callee_borrow_mask, constructor_boxed_positions, emit_dispatch_table_match, emit_list_match,
     emit_literal, emit_parallel_result_tuple_unwrap, emit_pattern_rebindings,
     emit_ref_match_rebindings, emit_result_tuple_unwrap, emit_tuple_from_vars,
-    explicit_binding_pattern, has_list_patterns, has_string_literal_patterns,
+    explicit_binding_pattern, explicit_parameter_pattern, has_list_patterns,
+    has_string_literal_patterns,
 };
 use super::pattern::emit_pattern;
 use super::syntax::aver_name_to_rust;
@@ -510,7 +511,7 @@ impl MirFnEmitPolicy {
                 continue;
             };
             let returned_record_successor = matches!(ty, Type::Named { .. })
-                && result_contains_record_update_of(&mir_fn.body.node, param.local);
+                && result_contains_record_successor_of(&mir_fn.body.node, param.local);
             // `own_param`'s `prone`/clearing both index `aliased_slots`
             // by PARAM POSITION `i` (its `(0..nparams).filter(|&i| …)`),
             // matching `MirParam.local = LocalId(i)`; match that exactly.
@@ -549,34 +550,50 @@ fn is_owned_collection_candidate(ty: &Type) -> bool {
 /// call argument does not qualify because moving its base could invalidate a
 /// later read in the same function. `Construct` covers `Result.Ok(update)`;
 /// branches and the body side of `Let` preserve result position.
-fn result_contains_record_update_of(expr: &MirExpr, slot: LocalId) -> bool {
+fn result_contains_record_successor_of(expr: &MirExpr, slot: LocalId) -> bool {
     match expr {
         MirExpr::RecordUpdate(update) => {
             local_of(&update.node.base.node).is_some_and(|base| base.slot == slot)
         }
-        MirExpr::Let(let_expr) => result_contains_record_update_of(&let_expr.node.body.node, slot),
+        MirExpr::RecordCreate(record) => record.node.fields.iter().any(|field| {
+            let MirExpr::Call(call) = &field.value.node else {
+                return false;
+            };
+            let Some(target) = call.node.args.first() else {
+                return false;
+            };
+            let MirExpr::Project(project) = &target.node else {
+                return false;
+            };
+            local_of(&project.node.base.node).is_some_and(|base| {
+                base.slot == slot && base.last_use && project.node.field == field.name
+            })
+        }),
+        MirExpr::Let(let_expr) => {
+            result_contains_record_successor_of(&let_expr.node.body.node, slot)
+        }
         MirExpr::Match(match_expr) => match_expr
             .node
             .arms
             .iter()
-            .any(|arm| result_contains_record_update_of(&arm.body.node, slot)),
+            .any(|arm| result_contains_record_successor_of(&arm.body.node, slot)),
         MirExpr::IfThenElse(branches) => {
-            result_contains_record_update_of(&branches.node.then_branch.node, slot)
-                || result_contains_record_update_of(&branches.node.else_branch.node, slot)
+            result_contains_record_successor_of(&branches.node.then_branch.node, slot)
+                || result_contains_record_successor_of(&branches.node.else_branch.node, slot)
         }
         MirExpr::Return(inner)
         | MirExpr::Try(inner)
         | MirExpr::Box(inner)
         | MirExpr::Unbox(inner)
-        | MirExpr::Neg(inner) => result_contains_record_update_of(&inner.node, slot),
+        | MirExpr::Neg(inner) => result_contains_record_successor_of(&inner.node, slot),
         MirExpr::Construct(construct) => construct
             .node
             .args
             .iter()
-            .any(|arg| result_contains_record_update_of(&arg.node, slot)),
+            .any(|arg| result_contains_record_successor_of(&arg.node, slot)),
         MirExpr::Tuple(items) => items
             .iter()
-            .any(|item| result_contains_record_update_of(&item.node, slot)),
+            .any(|item| result_contains_record_successor_of(&item.node, slot)),
         _ => false,
     }
 }
@@ -598,7 +615,7 @@ pub(super) fn owned_collection_param_names(
     for (i, (name, ty)) in param_types.iter().enumerate() {
         let returned_record_successor = matches!(ty, Type::Named { .. })
             && mir_fn.params.get(i).is_some_and(|param| {
-                result_contains_record_update_of(&mir_fn.body.node, param.local)
+                result_contains_record_successor_of(&mir_fn.body.node, param.local)
             });
         let collection_graduated = is_owned_collection_candidate(ty)
             && !mir_fn.aliased_slots.get(i).copied().unwrap_or(true);
@@ -1499,8 +1516,12 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             };
             let mut parts = Vec::with_capacity(rec.fields.len());
             for f in &rec.fields {
-                let mut val =
-                    mir_clone_arg(emit_mir_expr(&f.value, emit_ctx)?, &f.value.node, emit_ctx);
+                let mut val = match emit_owned_record_field_successor(None, f, emit_ctx) {
+                    Some(val) => val,
+                    None => {
+                        mir_clone_arg(emit_mir_expr(&f.value, emit_ctx)?, &f.value.node, emit_ctx)
+                    }
+                };
                 if packed_u8 {
                     val = pack_u8_list(val);
                 }
@@ -1522,7 +1543,8 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
             let mut parts = Vec::with_capacity(upd.updates.len());
             let mut moved_replaced_field = false;
             for f in &upd.updates {
-                let val = match emit_owned_record_field_successor(upd, f, emit_ctx) {
+                let update_base = local_of(&upd.base.node).map(|base| base.slot);
+                let val = match emit_owned_record_field_successor(update_base, f, emit_ctx) {
                     Some(val) => {
                         moved_replaced_field = true;
                         val
@@ -1682,15 +1704,10 @@ pub(super) fn emit_mir_expr(expr: &Spanned<MirExpr>, emit_ctx: &MirEmitCtx<'_>) 
 /// moving `store.values` to initialize a *different* field would leave
 /// `..store` needing an already-moved field.
 fn emit_owned_record_field_successor(
-    update: &crate::ir::mir::MirRecordUpdate,
+    required_base: Option<LocalId>,
     field: &crate::ir::mir::MirRecordField,
     ctx: &MirEmitCtx<'_>,
 ) -> Option<String> {
-    let update_base = local_of(&update.base.node)?;
-    if !ctx.is_owned_param(&update_base.name) {
-        return None;
-    }
-
     let MirExpr::Call(call) = &field.value.node else {
         return None;
     };
@@ -1710,7 +1727,8 @@ fn emit_owned_record_field_successor(
         return None;
     };
     let target_base = local_of(&project.node.base.node)?;
-    if target_base.slot != update_base.slot
+    if required_base.is_some_and(|base| target_base.slot != base)
+        || !ctx.is_owned_param(&target_base.name)
         || !target_base.last_use
         || project.node.field != field.name
     {
@@ -3625,10 +3643,8 @@ fn emit_self_tco_rc_wraps(params: &[(String, String)], rc_indices: &HashSet<usiz
         .filter(|(i, _)| rc_indices.contains(i))
         .map(|(_, (name, _))| {
             let rust_name = aver_name_to_rust(name);
-            format!(
-                "    let {} = std::sync::Arc::new({});",
-                rust_name, rust_name
-            )
+            let binding = explicit_binding_pattern(name);
+            format!("    let {} = std::sync::Arc::new({});", binding, rust_name)
         })
         .collect()
 }
@@ -3655,11 +3671,10 @@ fn emit_tco_params_mir(
             } else {
                 super::types::type_annotation_to_rust_scoped(type_ann, ctx, scope)
             };
-            let rust_name = aver_name_to_rust(name);
             if rc_indices.contains(&i) {
-                format!("{}: {}", rust_name, rust_type)
+                format!("{}: {}", explicit_parameter_pattern(name, false), rust_type)
             } else {
-                format!("mut {}: {}", rust_name, rust_type)
+                format!("{}: {}", explicit_parameter_pattern(name, true), rust_type)
             }
         })
         .collect::<Vec<_>>()
@@ -4051,7 +4066,7 @@ pub(super) fn emit_mir_mutual_tco_block(
             .params
             .iter()
             .filter(|(name, _)| !rc_names.contains(name))
-            .map(|(name, _)| format!("mut {}", aver_name_to_rust(name)))
+            .map(|(name, _)| explicit_parameter_pattern(name, true))
             .collect();
         let binding = if param_bindings.is_empty() {
             format!("{}::{}", enum_name, variant)
@@ -4146,7 +4161,7 @@ fn mutual_rc_param_sig(
         .map(|(name, ty)| {
             format!(
                 "{}: &{}",
-                aver_name_to_rust(name),
+                explicit_parameter_pattern(name, false),
                 super::types::type_to_rust_scoped(ty, ctx, scope)
             )
         })
@@ -4166,12 +4181,11 @@ fn emit_resolved_fn_params(
     params
         .iter()
         .map(|(name, ty)| {
-            let rust_name = aver_name_to_rust(name);
             let rust_type = super::types::type_to_rust_scoped(ty, ctx, scope);
             if should_borrow_param(ty) {
-                format!("{rust_name}: &{rust_type}")
+                format!("{}: &{rust_type}", explicit_parameter_pattern(name, false))
             } else {
-                format!("{rust_name}: {rust_type}")
+                format!("{}: {rust_type}", explicit_parameter_pattern(name, false))
             }
         })
         .collect::<Vec<_>>()
@@ -5726,9 +5740,9 @@ mod tests {
         assert_eq!(
             emit_self_tco_rc_wraps(&params, &rc_indices),
             [
-                "    let first = std::sync::Arc::new(first);",
-                "    let second = std::sync::Arc::new(second);",
-                "    let third = std::sync::Arc::new(third);",
+                "    let first @ _ = std::sync::Arc::new(first);",
+                "    let second @ _ = std::sync::Arc::new(second);",
+                "    let third @ _ = std::sync::Arc::new(third);",
             ]
         );
     }

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -2250,7 +2250,7 @@ fn getName(user: User) -> String
         let out = transpile(&mut ctx);
         let entry = generated_rust_entry_file(&out);
 
-        assert!(entry.contains("pub fn getName(user: &User) -> AverStr"));
+        assert!(entry.contains("pub fn getName(user @ _: &User) -> AverStr"));
         assert!(
             entry.contains("user.name.clone()"),
             "missing owned clone:\n{}",

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -1,5 +1,8 @@
 use super::emit_ctx::{EmitCtx, should_borrow_param};
-use super::expr::{aver_name_to_rust, classify_thin_fn_def_for_rust, explicit_binding_pattern};
+use super::expr::{
+    aver_name_to_rust, classify_thin_fn_def_for_rust, explicit_binding_pattern,
+    explicit_parameter_pattern,
+};
 use super::types::type_annotation_to_rust_scoped;
 use crate::ast::*;
 use crate::codegen::CodegenContext;
@@ -987,7 +990,7 @@ fn emit_fn_params_with_bare(
         .enumerate()
         .map(|(i, (name, type_ann))| {
             if bare_facts.is_some_and(|f| f.param_is_bare(i)) {
-                return format!("{}: i64", aver_name_to_rust(name));
+                return format!("{}: i64", explicit_parameter_pattern(name, false));
             }
             // Fall back to the single-param shape the inner emitter would
             // produce for a non-bare, non-rc param.
@@ -1020,23 +1023,31 @@ fn emit_fn_params_inner(
             let rust_name = aver_name_to_rust(name);
             if rc_indices.contains(&i) {
                 // Borrowed pass-through param: &T instead of owned T
-                format!("{}: &{}", rust_name, rust_type)
+                format!(
+                    "{}: &{}",
+                    explicit_parameter_pattern(name, false),
+                    rust_type
+                )
             } else if mutable {
-                format!("mut {}: {}", rust_name, rust_type)
+                format!("{}: {}", explicit_parameter_pattern(name, true), rust_type)
             } else if owned_params.contains(&rust_name) {
                 // own_param proved this collection param uniquely owned:
                 // take it by value (`mut p: T`) so the body's in-place
                 // mutate runs on a refcount-1 backing. `mut` because the
                 // owned-mutate builtins (`Vector.set` → `set_owned`,
                 // `Map.set` → `insert_owned`) consume `self` by value.
-                format!("mut {}: {}", rust_name, rust_type)
+                format!("{}: {}", explicit_parameter_pattern(name, true), rust_type)
             } else {
                 // Borrow-by-default: non-Copy, non-Str params are `&T`
                 let ty = parse_type_str(type_ann);
                 if should_borrow_param(&ty) {
-                    format!("{}: &{}", rust_name, rust_type)
+                    format!(
+                        "{}: &{}",
+                        explicit_parameter_pattern(name, false),
+                        rust_type
+                    )
                 } else {
-                    format!("{}: {}", rust_name, rust_type)
+                    format!("{}: {}", explicit_parameter_pattern(name, false), rust_type)
                 }
             }
         })

--- a/src/nan_value/tests.rs
+++ b/src/nan_value/tests.rs
@@ -201,7 +201,7 @@ fn the_cheap_heap_reference_filter_turns_nothing_heap_backed_away() {
     ));
     cases.push(NanValue::new_vector(arena.push(ArenaEntry::Vector {
         items: vec![NanValue::UNIT],
-        held_elsewhere: false,
+        holder_count: 0,
     })));
     cases.push(NanValue::new_list(arena.push(ArenaEntry::List(
         ArenaList::Flat {

--- a/src/self_host/aver_generated/bytes/mod.rs
+++ b/src/self_host/aver_generated/bytes/mod.rs
@@ -104,7 +104,7 @@ impl aver_replay::ReplayValue for Bytes {
 
 /// Return true when every integer in the list is an octet.
 #[inline(always)]
-pub fn allInRange(mut xs: aver_rt::AverIntList) -> bool {
+pub fn allInRange(mut xs @ _: aver_rt::AverIntList) -> bool {
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(xs, [] => { return true; }, [head, tail] => { if ((head >= aver_rt::AverInt::from_i64(0)) && (head <= aver_rt::AverInt::from_i64(255))) { {
@@ -117,7 +117,7 @@ pub fn allInRange(mut xs: aver_rt::AverIntList) -> bool {
 
 /// Return the first non-octet value; -1 when every value is an octet.
 #[inline(always)]
-pub fn firstOutOfRange(mut xs: aver_rt::AverIntList) -> aver_rt::AverInt {
+pub fn firstOutOfRange(mut xs @ _: aver_rt::AverIntList) -> aver_rt::AverInt {
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(xs, [] => { return aver_rt::AverInt::from_i64(-1); }, [head, tail] => { if ((head >= aver_rt::AverInt::from_i64(0)) && (head <= aver_rt::AverInt::from_i64(255))) { {
@@ -130,14 +130,14 @@ pub fn firstOutOfRange(mut xs: aver_rt::AverIntList) -> aver_rt::AverInt {
 
 /// Return the index of the first non-octet value; the length when every value is an octet.
 #[inline(always)]
-pub fn firstOutOfRangeIndex(xs: &aver_rt::AverIntList) -> aver_rt::AverInt {
+pub fn firstOutOfRangeIndex(xs @ _: &aver_rt::AverIntList) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     aver_list_match!(xs.clone(), [] => aver_rt::AverInt::from_i64(0), [head, tail] => if ((head >= aver_rt::AverInt::from_i64(0)) && (head <= aver_rt::AverInt::from_i64(255))) { aver_rt::AverInt::from_i64(1).add(&crate::aver_generated::bytes::firstOutOfRangeIndex(&tail)) } else { aver_rt::AverInt::from_i64(0) })
 }
 
 /// Validate raw integers and construct a byte sequence.
 #[inline(always)]
-pub fn fromList(xs: &aver_rt::AverIntList) -> Result<Bytes, AverStr> {
+pub fn fromList(xs @ _: &aver_rt::AverIntList) -> Result<Bytes, AverStr> {
     crate::cancel_checkpoint();
     if let Some(__packed) = xs.as_packed() {
         return Ok(Bytes {
@@ -182,7 +182,7 @@ pub fn fromList(xs: &aver_rt::AverIntList) -> Result<Bytes, AverStr> {
 
 /// Expose the validated octets for ordinary List operations.
 #[inline(always)]
-pub fn octets(bytes: &Bytes) -> aver_rt::AverIntList {
+pub fn octets(bytes @ _: &Bytes) -> aver_rt::AverIntList {
     crate::cancel_checkpoint();
     (bytes.values).to_int_list().clone()
 }
@@ -198,13 +198,13 @@ pub fn empty() -> Bytes {
 
 /// The number of octets in a byte sequence.
 #[inline(always)]
-pub fn len(bytes: &Bytes) -> aver_rt::AverInt {
+pub fn len(bytes @ _: &Bytes) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     aver_rt::AverInt::from_i64((bytes.values).to_int_list().len() as i64)
 }
 
 /// The octets of left followed by the octets of right.
-pub fn concat(left: &Bytes, right: &Bytes) -> Bytes {
+pub fn concat(mut left @ _: Bytes, right @ _: &Bytes) -> Bytes {
     crate::cancel_checkpoint();
     crate::aver_generated::bytes::Bytes {
         values: aver_rt::into_packed_u8(aver_rt::AverIntList::concat(
@@ -216,7 +216,7 @@ pub fn concat(left: &Bytes, right: &Bytes) -> Bytes {
 }
 
 /// At most count octets from the front; non-positive counts give empty bytes.
-pub fn take(bytes: &Bytes, count: aver_rt::AverInt) -> Bytes {
+pub fn take(mut bytes @ _: Bytes, count @ _: aver_rt::AverInt) -> Bytes {
     crate::cancel_checkpoint();
     crate::aver_generated::bytes::Bytes {
         values: aver_rt::into_packed_u8({
@@ -228,7 +228,7 @@ pub fn take(bytes: &Bytes, count: aver_rt::AverInt) -> Bytes {
 }
 
 /// The octets after count positions; non-positive counts preserve all bytes.
-pub fn drop(bytes: &Bytes, count: aver_rt::AverInt) -> Bytes {
+pub fn drop(mut bytes @ _: Bytes, count @ _: aver_rt::AverInt) -> Bytes {
     crate::cancel_checkpoint();
     crate::aver_generated::bytes::Bytes {
         values: aver_rt::into_packed_u8({
@@ -242,8 +242,8 @@ pub fn drop(bytes: &Bytes, count: aver_rt::AverInt) -> Bytes {
 /// Parse hexadecimal pairs into octets from left to right.
 #[inline(always)]
 pub fn parseHexChars(
-    mut chars: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverIntList,
+    mut chars @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverIntList,
 ) -> Result<aver_rt::AverIntList, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -259,7 +259,7 @@ pub fn parseHexChars(
 
 /// Decode one case-insensitive hexadecimal digit.
 #[inline(always)]
-pub fn hexDigitValue(digit: AverStr) -> Option<aver_rt::AverInt> {
+pub fn hexDigitValue(digit @ _: AverStr) -> Option<aver_rt::AverInt> {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1_lower(&digit));
@@ -346,7 +346,7 @@ pub fn hexDigitValue(digit: AverStr) -> Option<aver_rt::AverInt> {
 
 /// Decode an even-length hexadecimal string into validated bytes.
 #[inline(always)]
-pub fn fromHex(text: AverStr) -> Result<Bytes, AverStr> {
+pub fn fromHex(text @ _: AverStr) -> Result<Bytes, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::bytes::parseHexChars__cursor__collected(
         text,
@@ -357,7 +357,7 @@ pub fn fromHex(text: AverStr) -> Result<Bytes, AverStr> {
 
 /// Encode one integer in 0..=15 as lowercase hexadecimal.
 #[inline(always)]
-pub fn hexDigit(value: aver_rt::AverInt) -> AverStr {
+pub fn hexDigit(value @ _: aver_rt::AverInt) -> AverStr {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = value;
@@ -439,7 +439,7 @@ pub fn hexDigit(value: aver_rt::AverInt) -> AverStr {
 
 /// Compute a validated octet's high nibble by total division on a literal divisor.
 #[inline(always)]
-pub fn highNibble(value: aver_rt::AverInt) -> aver_rt::AverInt {
+pub fn highNibble(value @ _: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     (value)
         .div_euclid(&(aver_rt::AverInt::from_i64(16)))
@@ -448,7 +448,7 @@ pub fn highNibble(value: aver_rt::AverInt) -> aver_rt::AverInt {
 
 /// Compute a validated octet's low nibble by total modulo on a literal divisor.
 #[inline(always)]
-pub fn lowNibble(value: aver_rt::AverInt) -> aver_rt::AverInt {
+pub fn lowNibble(value @ _: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     (value)
         .rem_euclid(&(aver_rt::AverInt::from_i64(16)))
@@ -456,7 +456,7 @@ pub fn lowNibble(value: aver_rt::AverInt) -> aver_rt::AverInt {
 }
 
 /// Encode one validated octet as two lowercase hexadecimal characters.
-pub fn byteToHex(value: aver_rt::AverInt) -> AverStr {
+pub fn byteToHex(value @ _: aver_rt::AverInt) -> AverStr {
     crate::cancel_checkpoint();
     (crate::aver_generated::bytes::hexDigit(crate::aver_generated::bytes::highNibble(
         value.clone(),
@@ -466,8 +466,8 @@ pub fn byteToHex(value: aver_rt::AverInt) -> AverStr {
 /// Encode validated octets into lowercase two-character pieces.
 #[inline(always)]
 pub fn hexParts(
-    mut values: aver_rt::AverIntList,
-    mut acc: aver_rt::AverList<AverStr>,
+    mut values @ _: aver_rt::AverIntList,
+    mut acc @ _: aver_rt::AverList<AverStr>,
 ) -> aver_rt::AverList<AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -483,7 +483,7 @@ pub fn hexParts(
 
 /// Encode bytes as lowercase hexadecimal; total because Bytes contains only octets.
 #[inline(always)]
-pub fn toHex(bytes: &Bytes) -> AverStr {
+pub fn toHex(bytes @ _: &Bytes) -> AverStr {
     crate::cancel_checkpoint();
     aver_rt::AverStr::from(crate::aver_generated::bytes::hexParts__buffered(
         crate::aver_generated::bytes::octets(bytes),
@@ -495,9 +495,9 @@ pub fn toHex(bytes: &Bytes) -> AverStr {
 /// Synthesized buffered variant of `hexParts` for deforestation lowering. Call sites that match `String.join(hexParts(...), sep)` are rewritten to alloc a buffer + call this variant + finalize, skipping the intermediate List.
 #[inline(always)]
 pub fn hexParts__buffered(
-    mut values: aver_rt::AverIntList,
-    mut __buf: Buffer,
-    mut __sep: AverStr,
+    mut values @ _: aver_rt::AverIntList,
+    mut __buf @ _: Buffer,
+    mut __sep @ _: AverStr,
 ) -> Buffer {
     loop {
         crate::cancel_checkpoint();
@@ -514,9 +514,9 @@ pub fn hexParts__buffered(
 /// Synthesized cursor variant of `parseHexChars`. Call sites that hand it `String.chars(s)` walk `s` directly — a byte offset stepped one codepoint at a time — instead of materialising the list of one-character strings.
 #[inline(always)]
 pub fn parseHexChars__cursor(
-    mut __cur_s: AverStr,
-    mut __cur_i: aver_rt::AverInt,
-    mut acc: aver_rt::AverIntList,
+    mut __cur_s @ _: AverStr,
+    mut __cur_i @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverIntList,
 ) -> Result<aver_rt::AverIntList, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -644,7 +644,7 @@ pub fn parseHexChars__cursor(
 
 /// Synthesized codepoint variant of `hexDigitValue`. A cursor loop whose head only ever reaches this classifier hands over the character's code instead of materialising a one-character string.
 #[inline(always)]
-pub fn hexDigitValue__code(__str_code: i64) -> Option<aver_rt::AverInt> {
+pub fn hexDigitValue__code(__str_code @ _: i64) -> Option<aver_rt::AverInt> {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = aver_rt::str_fold_lower(__str_code);
@@ -724,9 +724,9 @@ pub fn hexDigitValue__code(__str_code: i64) -> Option<aver_rt::AverInt> {
 /// Synthesized collecting variant of `parseHexChars__cursor`. Appends to a builder where `parseHexChars__cursor` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here. Its only reader handed the collected list straight to the standard library's `fromList`, so the builder collects bytes: the range check rides every push, and the exits answer the `Result<Bytes, String>` the pair used to compute.
 #[inline(always)]
 pub fn parseHexChars__cursor__collected(
-    mut __cur_s: AverStr,
-    mut __cur_i: aver_rt::AverInt,
-    mut acc: ByteBuilder,
+    mut __cur_s @ _: AverStr,
+    mut __cur_i @ _: aver_rt::AverInt,
+    mut acc @ _: ByteBuilder,
 ) -> Result<Bytes, AverStr> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/ast/mod.rs
+++ b/src/self_host/aver_generated/domain/ast/mod.rs
@@ -3019,7 +3019,7 @@ pub fn userTagSpan() -> aver_rt::AverInt {
 
 /// Map constructor names to tag IDs. Builtins keep fixed tags; user constructors get stable hashed tags.
 #[inline(always)]
-pub fn ctorNameToTag(name: AverStr) -> aver_rt::AverInt {
+pub fn ctorNameToTag(name @ _: AverStr) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::ctorNameToTag__indexed(
         name.clone(),
@@ -3029,7 +3029,7 @@ pub fn ctorNameToTag(name: AverStr) -> aver_rt::AverInt {
 
 /// Compute a stable non-zero offset for a user-defined constructor tag from its full dotted name.
 #[inline(always)]
-pub fn userCtorTagOffset(name: AverStr) -> aver_rt::AverInt {
+pub fn userCtorTagOffset(name @ _: AverStr) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::userCtorTagOffset__indexed(
         name.clone(),
@@ -3040,9 +3040,9 @@ pub fn userCtorTagOffset(name: AverStr) -> aver_rt::AverInt {
 /// Walk the constructor name and accumulate a bounded rolling hash.
 #[inline(always)]
 pub fn userCtorTagOffsetLoop(
-    name: AverStr,
-    pos: aver_rt::AverInt,
-    acc: aver_rt::AverInt,
+    name @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::userCtorTagOffsetLoop__indexed(
@@ -3054,7 +3054,7 @@ pub fn userCtorTagOffsetLoop(
 }
 
 /// Update the user constructor rolling hash and keep it in a bounded range.
-pub fn userCtorTagStep(acc: aver_rt::AverInt, code: aver_rt::AverInt) -> aver_rt::AverInt {
+pub fn userCtorTagStep(acc @ _: aver_rt::AverInt, code @ _: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     let next @ _ = acc.mul(&aver_rt::AverInt::from_i64(131)).add(&code);
     (next)
@@ -3064,7 +3064,7 @@ pub fn userCtorTagStep(acc: aver_rt::AverInt, code: aver_rt::AverInt) -> aver_rt
 
 /// One spelling per constructor: drop the declaring-module qualifier from a Module.Type.Variant reference, so a variant a dependency builds as Shade.Dark and its caller writes as Palette.Shade.Dark is the same constructor.
 #[inline(always)]
-pub fn canonicalCtorName(name: AverStr) -> AverStr {
+pub fn canonicalCtorName(name @ _: AverStr) -> AverStr {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::canonicalCtorName__indexed(
         name.clone(),
@@ -3075,9 +3075,9 @@ pub fn canonicalCtorName(name: AverStr) -> AverStr {
 /// A name with at most one dot is already the shortest spelling it has.
 #[inline(always)]
 pub fn canonicalCtorNameAtLastDot(
-    name: AverStr,
-    total: aver_rt::AverInt,
-    lastDot: aver_rt::AverInt,
+    name @ _: AverStr,
+    total @ _: aver_rt::AverInt,
+    lastDot @ _: aver_rt::AverInt,
 ) -> AverStr {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::canonicalCtorNameAtLastDot__indexed(
@@ -3091,10 +3091,10 @@ pub fn canonicalCtorNameAtLastDot(
 /// Keep only the trailing pair when a module qualifier precedes a Type.Variant reference; leave every other dotted name whole.
 #[inline(always)]
 pub fn canonicalCtorNameAtBothDots(
-    name: AverStr,
-    total: aver_rt::AverInt,
-    lastDot: aver_rt::AverInt,
-    prevDot: aver_rt::AverInt,
+    name @ _: AverStr,
+    total @ _: aver_rt::AverInt,
+    lastDot @ _: aver_rt::AverInt,
+    prevDot @ _: aver_rt::AverInt,
 ) -> AverStr {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::canonicalCtorNameAtBothDots__indexed(
@@ -3108,7 +3108,7 @@ pub fn canonicalCtorNameAtBothDots(
 
 /// Whether the trailing two segments spell Type.Variant. Both begin with an uppercase letter, the same rule the surface parser applies to constructor patterns.
 #[inline(always)]
-pub fn isTypeVariantTail(typeName: AverStr, variantName: AverStr) -> bool {
+pub fn isTypeVariantTail(typeName @ _: AverStr, variantName @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     (crate::aver_generated::domain::ast::beginsUppercase(typeName)
         && crate::aver_generated::domain::ast::beginsUppercase(variantName))
@@ -3116,7 +3116,7 @@ pub fn isTypeVariantTail(typeName: AverStr, variantName: AverStr) -> bool {
 
 /// Whether a dotted-name segment begins with an uppercase letter.
 #[inline(always)]
-pub fn beginsUppercase(segment: AverStr) -> bool {
+pub fn beginsUppercase(segment @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     match ((aver_rt::AverInt::from_i64(0))
         .to_usize()
@@ -3130,7 +3130,7 @@ pub fn beginsUppercase(segment: AverStr) -> bool {
 
 /// Index of the last '.' at or before pos, or -1 when that prefix holds none.
 #[inline(always)]
-pub fn lastDotAtOrBefore(name: AverStr, pos: aver_rt::AverInt) -> aver_rt::AverInt {
+pub fn lastDotAtOrBefore(name @ _: AverStr, pos @ _: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::lastDotAtOrBefore__indexed(
         name.clone(),
@@ -3141,7 +3141,7 @@ pub fn lastDotAtOrBefore(name: AverStr, pos: aver_rt::AverInt) -> aver_rt::AverI
 
 /// Map builtin function names to integer IDs for fast dispatch.
 #[inline(always)]
-pub fn builtinNameToId(name: AverStr) -> Option<aver_rt::AverInt> {
+pub fn builtinNameToId(name @ _: AverStr) -> Option<aver_rt::AverInt> {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = name;
@@ -3237,8 +3237,8 @@ pub fn builtinNameToId(name: AverStr) -> Option<aver_rt::AverInt> {
 /// Synthesized indexed worker of `ctorNameToTag`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn ctorNameToTag__indexed(
-    name: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     {
@@ -3271,8 +3271,8 @@ pub fn ctorNameToTag__indexed(
 /// Synthesized indexed worker of `userCtorTagOffset`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn userCtorTagOffset__indexed(
-    name: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::userCtorTagOffsetLoop__indexed(
@@ -3286,12 +3286,12 @@ pub fn userCtorTagOffset__indexed(
 /// Synthesized indexed worker of `userCtorTagOffsetLoop`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn userCtorTagOffsetLoop__indexed(
-    mut name: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut acc: aver_rt::AverInt,
-    __str_index: aver_rt::StringIndex,
+    mut name @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverInt,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> aver_rt::AverInt {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         let accPlusOne @ _ = acc.add(&aver_rt::AverInt::from_i64(1));
@@ -3322,7 +3322,10 @@ pub fn userCtorTagOffsetLoop__indexed(
 
 /// Synthesized indexed worker of `canonicalCtorName`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
-pub fn canonicalCtorName__indexed(name: AverStr, __str_index: &aver_rt::StringIndex) -> AverStr {
+pub fn canonicalCtorName__indexed(
+    name @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
+) -> AverStr {
     crate::cancel_checkpoint();
     let total @ _ = aver_rt::AverInt::from_i64(name.chars().count() as i64);
     crate::aver_generated::domain::ast::canonicalCtorNameAtLastDot__indexed(
@@ -3340,10 +3343,10 @@ pub fn canonicalCtorName__indexed(name: AverStr, __str_index: &aver_rt::StringIn
 /// Synthesized indexed worker of `canonicalCtorNameAtLastDot`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn canonicalCtorNameAtLastDot__indexed(
-    name: AverStr,
-    total: aver_rt::AverInt,
-    lastDot: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    total @ _: aver_rt::AverInt,
+    lastDot @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> AverStr {
     crate::cancel_checkpoint();
     if (lastDot > aver_rt::AverInt::from_i64(0)) {
@@ -3366,11 +3369,11 @@ pub fn canonicalCtorNameAtLastDot__indexed(
 /// Synthesized indexed worker of `canonicalCtorNameAtBothDots`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn canonicalCtorNameAtBothDots__indexed(
-    name: AverStr,
-    total: aver_rt::AverInt,
-    lastDot: aver_rt::AverInt,
-    prevDot: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    total @ _: aver_rt::AverInt,
+    lastDot @ _: aver_rt::AverInt,
+    prevDot @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> AverStr {
     crate::cancel_checkpoint();
     if (prevDot < aver_rt::AverInt::from_i64(0)) {
@@ -3405,11 +3408,11 @@ pub fn canonicalCtorNameAtBothDots__indexed(
 /// Synthesized indexed worker of `lastDotAtOrBefore`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn lastDotAtOrBefore__indexed(
-    mut name: AverStr,
-    mut pos: aver_rt::AverInt,
-    __str_index: aver_rt::StringIndex,
+    mut name @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> aver_rt::AverInt {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         if (pos < aver_rt::AverInt::from_i64(0)) {

--- a/src/self_host/aver_generated/domain/builtins/helpers/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/helpers/mod.rs
@@ -5,7 +5,7 @@ use crate::*;
 
 /// Extract single argument from args list.
 pub fn oneArg(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -27,7 +27,7 @@ pub fn oneArg(
 
 /// Extract two arguments from args list.
 pub fn twoArgs(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<
     (
         crate::aver_generated::domain::value::Val,
@@ -62,7 +62,7 @@ pub fn twoArgs(
 
 /// Extract list from Val or error.
 pub fn expectList(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -73,7 +73,7 @@ pub fn expectList(
 
 /// Extract int from Val or error.
 pub fn expectInt(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverInt, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -83,7 +83,7 @@ pub fn expectInt(
 }
 
 /// Extract string from Val or error.
-pub fn expectStr(v: &crate::aver_generated::domain::value::Val) -> Result<AverStr, AverStr> {
+pub fn expectStr(v @ _: &crate::aver_generated::domain::value::Val) -> Result<AverStr, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
         crate::aver_generated::domain::value::Val::ValStr(s) => Ok(s),

--- a/src/self_host/aver_generated/domain/builtins/list/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/list/mod.rs
@@ -8,8 +8,8 @@ use crate::*;
 /// Dispatch List.* builtins.
 #[inline(always)]
 pub fn call(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -79,7 +79,7 @@ pub fn call(
 
 /// List.prepend(value, list) -> list with value at front.
 pub fn builtinListPrepend(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -91,8 +91,8 @@ pub fn builtinListPrepend(
 
 /// Inner impl of List.prepend.
 pub fn builtinListPrependInner(
-    v: &crate::aver_generated::domain::value::Val,
-    lstV: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    lstV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
@@ -103,7 +103,7 @@ pub fn builtinListPrependInner(
 
 /// List.len(list) -> length as Int.
 pub fn builtinListLen(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -115,7 +115,7 @@ pub fn builtinListLen(
 
 /// List.take(list, n) -> first n elements.
 pub fn builtinListTake(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -127,8 +127,8 @@ pub fn builtinListTake(
 
 /// Inner impl of List.take.
 pub fn builtinListTakeInner(
-    lstV: &crate::aver_generated::domain::value::Val,
-    nV: &crate::aver_generated::domain::value::Val,
+    lstV @ _: &crate::aver_generated::domain::value::Val,
+    nV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
@@ -141,8 +141,8 @@ pub fn builtinListTakeInner(
 /// Keep the first count elements; negative counts produce empty lists.
 #[inline(always)]
 pub fn listTake(
-    items: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    count: aver_rt::AverInt,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    count @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     crate::cancel_checkpoint();
     if (count > aver_rt::AverInt::from_i64(0)) {
@@ -154,7 +154,7 @@ pub fn listTake(
 
 /// List.drop(list, n) -> all but the first n elements.
 pub fn builtinListDrop(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -166,8 +166,8 @@ pub fn builtinListDrop(
 
 /// Inner impl of List.drop.
 pub fn builtinListDropInner(
-    lstV: &crate::aver_generated::domain::value::Val,
-    nV: &crate::aver_generated::domain::value::Val,
+    lstV @ _: &crate::aver_generated::domain::value::Val,
+    nV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
@@ -180,8 +180,8 @@ pub fn builtinListDropInner(
 /// Skip the first count elements; negative counts leave the list unchanged.
 #[inline(always)]
 pub fn listDrop(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut count: aver_rt::AverInt,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut count @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -201,7 +201,7 @@ pub fn listDrop(
 
 /// List.reverse(list) -> reversed list.
 pub fn builtinListReverse(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -213,7 +213,7 @@ pub fn builtinListReverse(
 
 /// List.concat(a, b) -> concatenated list.
 pub fn builtinListConcat(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -225,8 +225,8 @@ pub fn builtinListConcat(
 
 /// Inner impl of List.concat.
 pub fn builtinListConcatInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let aItems @ _ = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
@@ -238,7 +238,7 @@ pub fn builtinListConcatInner(
 
 /// List.contains(list, value) -> Bool.
 pub fn builtinListContains(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -250,8 +250,8 @@ pub fn builtinListContains(
 
 /// Inner impl of List.contains.
 pub fn builtinListContainsInner(
-    lstV: &crate::aver_generated::domain::value::Val,
-    needle: &crate::aver_generated::domain::value::Val,
+    lstV @ _: &crate::aver_generated::domain::value::Val,
+    needle @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
@@ -263,10 +263,10 @@ pub fn builtinListContainsInner(
 /// Check if a value is in a list by repr comparison.
 #[inline(always)]
 pub fn listContainsVal(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    needle: crate::aver_generated::domain::value::Val,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    needle @ _: crate::aver_generated::domain::value::Val,
 ) -> bool {
-    let needle = std::sync::Arc::new(needle);
+    let needle @ _ = std::sync::Arc::new(needle);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(items, [] => { return false; }, [v, rest] => { if (crate::aver_generated::domain::value::valRepr(&v) == crate::aver_generated::domain::value::valRepr(&*needle)) { return true; } else { {
@@ -279,7 +279,7 @@ pub fn listContainsVal(
 
 /// List.zip(a, b) -> list of tuples.
 pub fn builtinListZip(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -291,8 +291,8 @@ pub fn builtinListZip(
 
 /// Inner impl of List.zip.
 pub fn builtinListZipInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let aItems @ _ = crate::aver_generated::domain::builtins::helpers::expectList(aV)?;
@@ -305,8 +305,8 @@ pub fn builtinListZipInner(
 /// Zip two lists into list of ValTuple.
 #[inline(always)]
 pub fn zipLists(
-    a: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    b: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    a @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    b @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::list::zipListsAcc(
@@ -319,9 +319,9 @@ pub fn zipLists(
 /// Accumulate zipped pairs in reverse, then reverse at end.
 #[inline(always)]
 pub fn zipListsAcc(
-    mut a: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut b: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut a @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut b @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -340,7 +340,7 @@ pub fn zipListsAcc(
 
 /// List.head(list) -> Option of first element.
 pub fn builtinListHead(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -350,7 +350,7 @@ pub fn builtinListHead(
 
 /// List.tail(list) -> Option of rest.
 pub fn builtinListTail(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;

--- a/src/self_host/aver_generated/domain/builtins/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/mod.rs
@@ -51,7 +51,7 @@ fn __mutual_tco_trampoline_1(
 ) -> aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val> {
     loop {
         __state = match __state {
-            __MutualTco1::TuplesToMap(mut items, mut acc) => {
+            __MutualTco1::TuplesToMap(mut items @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(items, [] => { return acc }, [item, rest] => match item {
                     crate::aver_generated::domain::value::Val::ValTuple(parts) => {
@@ -62,7 +62,7 @@ fn __mutual_tco_trampoline_1(
                     }
                 })
             }
-            __MutualTco1::TuplesToMapOne(mut parts, mut rest, mut acc) => {
+            __MutualTco1::TuplesToMapOne(mut parts @ _, mut rest @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(parts, [] => __MutualTco1::TuplesToMap(rest, acc), [kV, tail] => aver_list_match!(tail, [] => __MutualTco1::TuplesToMap(rest, acc), [vV, ignored] => __MutualTco1::TuplesToMap(rest, acc.insert_owned(crate::aver_generated::domain::value::mapKeyRepr(&kV), vV))))
             }
@@ -72,17 +72,17 @@ fn __mutual_tco_trampoline_1(
 
 /// Convert list of (key, value) tuples to a Map.
 pub fn tuplesToMap(
-    items: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    acc: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    acc @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val> {
     __mutual_tco_trampoline_1(__MutualTco1::TuplesToMap(items.clone(), acc.clone()))
 }
 
 /// Extract key-value from tuple parts.
 pub fn tuplesToMapOne(
-    parts: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    acc: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    parts @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    acc @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val> {
     __mutual_tco_trampoline_1(__MutualTco1::TuplesToMapOne(
         parts.clone(),
@@ -93,8 +93,8 @@ pub fn tuplesToMapOne(
 
 /// Dispatch qualified builtin calls to sub-module implementations.
 pub fn callBuiltin(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::callBuiltin__indexed(
@@ -107,8 +107,8 @@ pub fn callBuiltin(
 /// Fast exact-match dispatch for the hottest builtins.
 #[inline(always)]
 pub fn callBuiltinFast(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Option<Result<crate::aver_generated::domain::value::Val, AverStr>> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::callBuiltinFast__indexed(
@@ -121,8 +121,8 @@ pub fn callBuiltinFast(
 /// Dispatch pre-evaluated args by integer builtin ID. IDs assigned in Ast.builtinNameToId.
 #[inline(always)]
 pub fn callBuiltinByIdValues(
-    id: aver_rt::AverInt,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    id @ _: aver_rt::AverInt,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -215,8 +215,8 @@ pub fn callBuiltinByIdValues(
 
 /// Continue dispatch after List.
 pub fn callBuiltinAfterList(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::callBuiltinAfterList__indexed(
@@ -228,8 +228,8 @@ pub fn callBuiltinAfterList(
 
 /// Handle non-prefixed builtins: Result.*, Option.*, Bool.*, Map.*, services, and variant constructors.
 pub fn callBuiltinOther(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::callBuiltinOther__indexed(
@@ -241,7 +241,7 @@ pub fn callBuiltinOther(
 
 /// Console.print(v) -> print any value and return Unit.
 pub fn builtinConsolePrint(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -270,7 +270,7 @@ pub fn builtinConsolePrint(
 
 /// Console.error(v) -> print to stderr.
 pub fn builtinConsoleError(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -299,7 +299,7 @@ pub fn builtinConsoleError(
 
 /// Console.warn(v) -> print warning.
 pub fn builtinConsoleWarn(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -328,7 +328,7 @@ pub fn builtinConsoleWarn(
 
 /// Console.readLine() -> Result<String, String>.
 pub fn builtinConsoleReadLine(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match {
@@ -354,7 +354,7 @@ pub fn builtinConsoleReadLine(
 
 /// Disk.readText(path) -> Result string.
 pub fn builtinDiskReadText(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -390,7 +390,7 @@ pub fn builtinDiskReadText(
 
 /// Args.get() -> list of string args.
 pub fn builtinArgsGet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let rawArgs @ _ = {
@@ -415,7 +415,7 @@ pub fn builtinArgsGet(
 
 /// Env.get(key) -> Option<String>.
 pub fn builtinEnvGet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -449,7 +449,7 @@ pub fn builtinEnvGet(
 
 /// Env.set(key, value) -> Result<Unit, String>.
 pub fn builtinEnvSet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -461,8 +461,8 @@ pub fn builtinEnvSet(
 
 /// Inner Env.set.
 pub fn builtinEnvSetInner(
-    keyV: &crate::aver_generated::domain::value::Val,
-    valueV: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
+    valueV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let key @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(keyV)?;
@@ -504,8 +504,8 @@ pub fn builtinEnvSetInner(
 /// Convert list of strings to list of ValStr.
 #[inline(always)]
 pub fn stringsToVals(
-    mut strs: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut strs @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -521,7 +521,7 @@ pub fn stringsToVals(
 
 /// Map.entries(map) -> List of tuples.
 pub fn builtinMapEntries(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -548,8 +548,8 @@ pub fn builtinMapEntries(
 /// Convert entries to list of (key, value) tuples.
 #[inline(always)]
 pub fn mapEntriesToTuples(
-    mut entries: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut entries @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -565,7 +565,7 @@ pub fn mapEntriesToTuples(
 
 /// Map.keys(map) -> List of keys.
 pub fn builtinMapKeys(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -590,7 +590,7 @@ pub fn builtinMapKeys(
 
 /// Map.values(map) -> List of values.
 pub fn builtinMapValues(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -608,7 +608,7 @@ pub fn builtinMapValues(
 
 /// Map.fromList(entries) -> Map.
 pub fn builtinMapFromList(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -620,7 +620,7 @@ pub fn builtinMapFromList(
 
 /// Map.size(map) -> Int.
 pub fn builtinMapSize(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -636,7 +636,7 @@ pub fn builtinMapSize(
 
 /// Map.remove(map, key) -> Map.
 pub fn builtinMapRemove(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -648,8 +648,8 @@ pub fn builtinMapRemove(
 
 /// Inner Map.remove.
 pub fn builtinMapRemoveInner(
-    mapV: &crate::aver_generated::domain::value::Val,
-    keyV: &crate::aver_generated::domain::value::Val,
+    mapV @ _: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
@@ -664,8 +664,8 @@ pub fn builtinMapRemoveInner(
 
 /// Dispatch Terminal.*, Time.*, Random.*, Http.*, Tcp.* service builtins.
 pub fn callBuiltinServices(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::callBuiltinServices__indexed(
@@ -677,7 +677,7 @@ pub fn callBuiltinServices(
 
 /// Random.int(min, max) -> random integer.
 pub fn builtinRandomInt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -689,8 +689,8 @@ pub fn builtinRandomInt(
 
 /// Inner Random.int.
 pub fn builtinRandomIntInner(
-    minV: &crate::aver_generated::domain::value::Val,
-    maxV: &crate::aver_generated::domain::value::Val,
+    minV @ _: &crate::aver_generated::domain::value::Val,
+    maxV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let minN @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(minV)?;
@@ -731,7 +731,7 @@ pub fn builtinRandomIntInner(
 
 /// Time.sleep(ms) -> Result<Unit, String>.
 pub fn builtinTimeSleep(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -767,7 +767,7 @@ pub fn builtinTimeSleep(
 
 /// Time.unixMs() -> Int.
 pub fn builtinTimeUnixMs(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     Ok(crate::aver_generated::domain::value::Val::ValInt({
@@ -786,8 +786,8 @@ pub fn builtinTimeUnixMs(
 
 /// Terminal no-arg commands: clear, flush, enableRawMode, etc.
 pub fn builtinTerminalNoArg(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::builtinTerminalNoArg__indexed(
@@ -992,7 +992,7 @@ pub fn termResetColor() -> Result<crate::aver_generated::domain::value::Val, Ave
 
 /// Terminal.readKey() -> Result<Option<String>, String>.
 pub fn builtinTerminalReadKey(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match {
@@ -1025,7 +1025,7 @@ pub fn builtinTerminalReadKey(
 
 /// Terminal.size() -> Result record with width and height.
 pub fn builtinTerminalSize(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match {
@@ -1063,7 +1063,7 @@ pub fn builtinTerminalSize(
 
 /// Terminal.print(s) -> Result<Unit, String>.
 pub fn builtinTerminalPrint(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1078,7 +1078,7 @@ pub fn builtinTerminalPrint(
 }
 
 /// Print string to terminal.
-pub fn termPrintStr(s: AverStr) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
+pub fn termPrintStr(s @ _: AverStr) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match {
         let __provider_arg0: AverStr = s;
@@ -1111,7 +1111,7 @@ pub fn termPrintStr(s: AverStr) -> Result<crate::aver_generated::domain::value::
 
 /// Terminal.setColor(color) -> Result<Unit, String>.
 pub fn builtinTerminalSetColor(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1147,7 +1147,7 @@ pub fn builtinTerminalSetColor(
 
 /// Terminal.moveTo(x, y) -> Result<Unit, String>.
 pub fn builtinTerminalMoveTo(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1159,8 +1159,8 @@ pub fn builtinTerminalMoveTo(
 
 /// Inner Terminal.moveTo.
 pub fn builtinTerminalMoveToInner(
-    xV: &crate::aver_generated::domain::value::Val,
-    yV: &crate::aver_generated::domain::value::Val,
+    xV @ _: &crate::aver_generated::domain::value::Val,
+    yV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let x @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(xV)?;
@@ -1201,7 +1201,7 @@ pub fn builtinTerminalMoveToInner(
 
 /// Disk.writeText(path, content) -> Result.
 pub fn builtinDiskWriteText(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1213,8 +1213,8 @@ pub fn builtinDiskWriteText(
 
 /// Inner Disk.writeText.
 pub fn builtinDiskWriteTextInner(
-    pathV: &crate::aver_generated::domain::value::Val,
-    contentV: &crate::aver_generated::domain::value::Val,
+    pathV @ _: &crate::aver_generated::domain::value::Val,
+    contentV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(pathV)?;
@@ -1255,7 +1255,7 @@ pub fn builtinDiskWriteTextInner(
 
 /// Disk.appendText(path, content) -> Result.
 pub fn builtinDiskAppendText(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1267,8 +1267,8 @@ pub fn builtinDiskAppendText(
 
 /// Inner Disk.appendText.
 pub fn builtinDiskAppendTextInner(
-    pathV: &crate::aver_generated::domain::value::Val,
-    contentV: &crate::aver_generated::domain::value::Val,
+    pathV @ _: &crate::aver_generated::domain::value::Val,
+    contentV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let path @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(pathV)?;
@@ -1309,7 +1309,7 @@ pub fn builtinDiskAppendTextInner(
 
 /// Disk.delete(path) -> Result.
 pub fn builtinDiskDelete(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1345,7 +1345,7 @@ pub fn builtinDiskDelete(
 
 /// Disk.deleteDir(path) -> Result.
 pub fn builtinDiskDeleteDir(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1381,7 +1381,7 @@ pub fn builtinDiskDeleteDir(
 
 /// Disk.makeDir(path) -> Result.
 pub fn builtinDiskMakeDir(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1417,7 +1417,7 @@ pub fn builtinDiskMakeDir(
 
 /// Disk.exists(path) -> Bool.
 pub fn builtinDiskExists(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1446,7 +1446,7 @@ pub fn builtinDiskExists(
 
 /// Disk.listDir(path) -> Result<List<String>, String>.
 pub fn builtinDiskListDir(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1490,8 +1490,8 @@ pub fn builtinDiskListDir(
 /// Try to construct a variant value from a dotted name like Type.Ctor. Uses stable tags for both builtin and user constructors.
 #[inline(always)]
 pub fn tryVariantConstructor(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::tryVariantConstructor__indexed(
@@ -1503,7 +1503,7 @@ pub fn tryVariantConstructor(
 
 /// Split 'Type.Ctor' into (Type, Ctor). Returns None if no dot.
 #[inline(always)]
-pub fn splitDotted(name: AverStr) -> Option<(AverStr, AverStr)> {
+pub fn splitDotted(name @ _: AverStr) -> Option<(AverStr, AverStr)> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::splitDotted__indexed(
         name.clone(),
@@ -1514,9 +1514,9 @@ pub fn splitDotted(name: AverStr) -> Option<(AverStr, AverStr)> {
 /// Find first dot and split.
 #[inline(always)]
 pub fn splitDottedLoop(
-    name: AverStr,
-    pos: aver_rt::AverInt,
-    total: aver_rt::AverInt,
+    name @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    total @ _: aver_rt::AverInt,
 ) -> Option<(AverStr, AverStr)> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::splitDottedLoop__indexed(
@@ -1529,7 +1529,7 @@ pub fn splitDottedLoop(
 
 /// Bool.or(a, b) -> a || b.
 pub fn builtinBoolOr(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1541,8 +1541,8 @@ pub fn builtinBoolOr(
 
 /// Inner Bool.or.
 pub fn builtinBoolOrInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match aV.clone() {
@@ -1562,7 +1562,7 @@ pub fn builtinBoolOrInner(
 
 /// Bool.and(a, b) -> a && b.
 pub fn builtinBoolAnd(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1574,8 +1574,8 @@ pub fn builtinBoolAnd(
 
 /// Inner Bool.and.
 pub fn builtinBoolAndInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match aV.clone() {
@@ -1595,7 +1595,7 @@ pub fn builtinBoolAndInner(
 
 /// Bool.not(a) -> negation.
 pub fn builtinBoolNot(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1613,7 +1613,7 @@ pub fn builtinBoolNot(
 
 /// Map.set(map, key, value) -> updated map.
 pub fn builtinMapSet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -1644,9 +1644,9 @@ pub fn builtinMapSet(
 
 /// Set a key in the map. O(1).
 pub fn builtinMapSetInner(
-    mapV: &crate::aver_generated::domain::value::Val,
-    keyV: &crate::aver_generated::domain::value::Val,
-    valV: &crate::aver_generated::domain::value::Val,
+    mapV @ _: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
+    valV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
@@ -1662,7 +1662,7 @@ pub fn builtinMapSetInner(
 
 /// Map.get(map, key) -> Option<Val>. O(1).
 pub fn builtinMapGet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1674,8 +1674,8 @@ pub fn builtinMapGet(
 
 /// Look up key in map. O(1).
 pub fn builtinMapGetInner(
-    mapV: &crate::aver_generated::domain::value::Val,
-    keyV: &crate::aver_generated::domain::value::Val,
+    mapV @ _: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
@@ -1696,7 +1696,7 @@ pub fn builtinMapGetInner(
 
 /// Map.has(map, key) -> Bool. O(1).
 pub fn builtinMapHas(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1708,8 +1708,8 @@ pub fn builtinMapHas(
 
 /// Check if key exists in map. O(1).
 pub fn builtinMapHasInner(
-    mapV: &crate::aver_generated::domain::value::Val,
-    keyV: &crate::aver_generated::domain::value::Val,
+    mapV @ _: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
@@ -1724,7 +1724,7 @@ pub fn builtinMapHasInner(
 
 /// Time.now() -> ISO timestamp string.
 pub fn builtinTimeNow(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     Ok(crate::aver_generated::domain::value::Val::ValStr({
@@ -1737,8 +1737,8 @@ pub fn builtinTimeNow(
 
 /// Http.get/head/delete(url) -> Result<Http.Response, String> forwarded to host.
 pub fn builtinHttpSimple(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    method: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    method @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1828,8 +1828,8 @@ pub fn builtinHttpSimple(
 
 /// Http.post/put/patch(url, body, contentType, headers) forwarded to host.
 pub fn builtinHttpBody(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    method: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    method @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -1869,11 +1869,11 @@ pub fn builtinHttpBody(
 
 /// Inner Http body method.
 pub fn builtinHttpBodyInner(
-    urlV: &crate::aver_generated::domain::value::Val,
-    bodyV: &crate::aver_generated::domain::value::Val,
-    ctV: &crate::aver_generated::domain::value::Val,
-    hdrsV: &crate::aver_generated::domain::value::Val,
-    method: AverStr,
+    urlV @ _: &crate::aver_generated::domain::value::Val,
+    bodyV @ _: &crate::aver_generated::domain::value::Val,
+    ctV @ _: &crate::aver_generated::domain::value::Val,
+    hdrsV @ _: &crate::aver_generated::domain::value::Val,
+    method @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let url @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(urlV)?;
@@ -2001,7 +2001,7 @@ pub fn builtinHttpBodyInner(
 /// Convert host Http.Response to Val.
 #[inline(always)]
 pub fn httpResponseToVal(
-    result: &Result<crate::aver_generated::http::Response, AverStr>,
+    result @ _: &Result<crate::aver_generated::http::Response, AverStr>,
 ) -> crate::aver_generated::domain::value::Val {
     crate::cancel_checkpoint();
     match result.clone() {
@@ -2032,7 +2032,7 @@ pub fn httpResponseToVal(
 
 /// Convert host headers Map<String, List<String>> to a Val.ValMap whose values are Val.ValList of Val.ValStr.
 pub fn headersToVal(
-    headers: &aver_rt::AverMap<AverStr, aver_rt::AverList<AverStr>>,
+    headers @ _: &aver_rt::AverMap<AverStr, aver_rt::AverList<AverStr>>,
 ) -> crate::aver_generated::domain::value::Val {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::value::Val::ValMap(
@@ -2051,11 +2051,11 @@ pub fn headersToVal(
 /// Walk header keys, converting each value list to a Val.ValList.
 #[inline(always)]
 pub fn headersToValMap(
-    headers: aver_rt::AverMap<AverStr, aver_rt::AverList<AverStr>>,
-    mut names: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    headers @ _: aver_rt::AverMap<AverStr, aver_rt::AverList<AverStr>>,
+    mut names @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val> {
-    let headers = std::sync::Arc::new(headers);
+    let headers @ _ = std::sync::Arc::new(headers);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(names, [] => { return acc; }, [name, rest] => { match headers.get(&name).cloned() { Some(values @ _) => { {
@@ -2077,8 +2077,8 @@ pub fn headersToValMap(
 /// Convert a list of strings into a list of Val.ValStr (tail-recursive).
 #[inline(always)]
 pub fn stringsToValStrs(
-    mut values: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut values @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -2094,7 +2094,7 @@ pub fn stringsToValStrs(
 
 /// Tcp.send(host, port, message) -> Result<String, String>.
 pub fn builtinTcpSend(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -2125,9 +2125,9 @@ pub fn builtinTcpSend(
 
 /// Inner Tcp.send.
 pub fn builtinTcpSendInner(
-    hostV: &crate::aver_generated::domain::value::Val,
-    portV: &crate::aver_generated::domain::value::Val,
-    msgV: &crate::aver_generated::domain::value::Val,
+    hostV @ _: &crate::aver_generated::domain::value::Val,
+    portV @ _: &crate::aver_generated::domain::value::Val,
+    msgV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
@@ -2172,7 +2172,7 @@ pub fn builtinTcpSendInner(
 
 /// Tcp.ping(host, port) -> Result<Unit, String>.
 pub fn builtinTcpPing(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -2184,8 +2184,8 @@ pub fn builtinTcpPing(
 
 /// Inner Tcp.ping.
 pub fn builtinTcpPingInner(
-    hostV: &crate::aver_generated::domain::value::Val,
-    portV: &crate::aver_generated::domain::value::Val,
+    hostV @ _: &crate::aver_generated::domain::value::Val,
+    portV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
@@ -2226,7 +2226,7 @@ pub fn builtinTcpPingInner(
 
 /// Tcp.connect(host, port) -> Result<Tcp.Connection, String>.
 pub fn builtinTcpConnect(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -2238,8 +2238,8 @@ pub fn builtinTcpConnect(
 
 /// Inner Tcp.connect.
 pub fn builtinTcpConnectInner(
-    hostV: &crate::aver_generated::domain::value::Val,
-    portV: &crate::aver_generated::domain::value::Val,
+    hostV @ _: &crate::aver_generated::domain::value::Val,
+    portV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
@@ -2282,7 +2282,7 @@ pub fn builtinTcpConnectInner(
 
 /// Preserve an opaque host Tcp.Connection resource inside Val.
 pub fn tcpConnToVal(
-    conn: &crate::aver_generated::tcp::Connection,
+    conn @ _: &crate::aver_generated::tcp::Connection,
 ) -> crate::aver_generated::domain::value::Val {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::value::Val::ValTcpConnection(conn.clone())
@@ -2290,7 +2290,7 @@ pub fn tcpConnToVal(
 
 /// Recover an opaque host Tcp.Connection resource from Val.
 pub fn valToTcpConn(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::tcp::Connection, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -2301,7 +2301,7 @@ pub fn valToTcpConn(
 
 /// Tcp.beginConnect(host, port) -> Result<Tcp.Dial, String>.
 pub fn builtinTcpBeginConnect(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -2313,8 +2313,8 @@ pub fn builtinTcpBeginConnect(
 
 /// Inner Tcp.beginConnect.
 pub fn builtinTcpBeginConnectInner(
-    hostV: &crate::aver_generated::domain::value::Val,
-    portV: &crate::aver_generated::domain::value::Val,
+    hostV @ _: &crate::aver_generated::domain::value::Val,
+    portV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let host @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hostV)?;
@@ -2355,7 +2355,7 @@ pub fn builtinTcpBeginConnectInner(
 
 /// Recover an opaque host Tcp.Dial resource from Val.
 pub fn valToTcpDial(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::tcp::Dial, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -2366,7 +2366,7 @@ pub fn valToTcpDial(
 
 /// Tcp.dialled(dial) -> Result<Option<Tcp.Connection>, String>.
 pub fn builtinTcpDialled(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2413,7 +2413,7 @@ pub fn builtinTcpDialled(
 
 /// Tcp.listen(port, backlog) -> Result<Tcp.Listener, String>.
 pub fn builtinTcpListen(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -2425,8 +2425,8 @@ pub fn builtinTcpListen(
 
 /// Inner Tcp.listen.
 pub fn builtinTcpListenInner(
-    portV: &crate::aver_generated::domain::value::Val,
-    backlogV: &crate::aver_generated::domain::value::Val,
+    portV @ _: &crate::aver_generated::domain::value::Val,
+    backlogV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let port @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(portV)?;
@@ -2471,7 +2471,7 @@ pub fn builtinTcpListenInner(
 
 /// Recover an opaque host Tcp.Listener resource from Val.
 pub fn valToTcpListener(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::tcp::Listener, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -2482,7 +2482,7 @@ pub fn valToTcpListener(
 
 /// Tcp.accept(listener) -> Result<Option<Tcp.Connection>, String>.
 pub fn builtinTcpAccept(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2529,7 +2529,7 @@ pub fn builtinTcpAccept(
 
 /// Tcp.peerAddress(connection) -> Result<String, String>.
 pub fn builtinTcpPeerAddress(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2565,7 +2565,7 @@ pub fn builtinTcpPeerAddress(
 
 /// Decode the self-host's nominal variant carrier into Tcp.Socket.
 pub fn valToTcpSocket(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::tcp::Socket, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -2579,8 +2579,8 @@ pub fn valToTcpSocket(
 /// Decode one named Tcp.Socket variant.
 #[inline(always)]
 pub fn valVariantToTcpSocket(
-    name: AverStr,
-    fields: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    fields @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::tcp::Socket, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -2619,8 +2619,8 @@ pub fn valVariantToTcpSocket(
 /// Recover integer caller keys and typed socket states from a self-host Val map.
 #[inline(always)]
 pub fn tcpSocketEntriesToMap(
-    mut entries: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut acc: aver_rt::AverMap<aver_rt::AverInt, crate::aver_generated::tcp::Socket>,
+    mut entries @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut acc @ _: aver_rt::AverMap<aver_rt::AverInt, crate::aver_generated::tcp::Socket>,
 ) -> Result<aver_rt::AverMap<aver_rt::AverInt, crate::aver_generated::tcp::Socket>, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -2637,8 +2637,8 @@ pub fn tcpSocketEntriesToMap(
 /// Convert ready caller keys back into self-host values.
 #[inline(always)]
 pub fn tcpReadyKeysToVals(
-    mut keys: aver_rt::AverIntList,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut keys @ _: aver_rt::AverIntList,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -2654,7 +2654,7 @@ pub fn tcpReadyKeysToVals(
 
 /// Tcp.poll(sockets, timeoutMs) over the single caller-owned socket map.
 pub fn builtinTcpPoll(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -2673,8 +2673,8 @@ pub fn builtinTcpPoll(
 
 /// Inner Tcp.poll.
 pub fn builtinTcpPollInner(
-    sockets: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    timeoutV: &crate::aver_generated::domain::value::Val,
+    sockets @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    timeoutV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let timeoutMs @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(timeoutV)?;
@@ -2735,7 +2735,7 @@ pub fn builtinTcpPollInner(
 
 /// Tcp.closeDial(dial) -> Result<Unit, String>.
 pub fn builtinTcpCloseDial(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2771,7 +2771,7 @@ pub fn builtinTcpCloseDial(
 
 /// Tcp.closeListener(listener) -> Result<Unit, String>.
 pub fn builtinTcpCloseListener(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2807,7 +2807,7 @@ pub fn builtinTcpCloseListener(
 
 /// Tcp.writeLine(conn, line) -> Result<Unit, String>.
 pub fn builtinTcpWriteLine(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -2819,8 +2819,8 @@ pub fn builtinTcpWriteLine(
 
 /// Inner Tcp.writeLine.
 pub fn builtinTcpWriteLineInner(
-    connV: &crate::aver_generated::domain::value::Val,
-    lineV: &crate::aver_generated::domain::value::Val,
+    connV @ _: &crate::aver_generated::domain::value::Val,
+    lineV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let tc @ _ = crate::aver_generated::domain::builtins::valToTcpConn(connV)?;
@@ -2861,7 +2861,7 @@ pub fn builtinTcpWriteLineInner(
 
 /// Tcp.readLine(conn) -> Result<String, String>.
 pub fn builtinTcpReadLine(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2897,7 +2897,7 @@ pub fn builtinTcpReadLine(
 
 /// Tcp.close(conn) -> Result<Unit, String>.
 pub fn builtinTcpClose(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -2933,9 +2933,9 @@ pub fn builtinTcpClose(
 
 /// Synthesized indexed worker of `callBuiltin`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn callBuiltin__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::builtins::callBuiltinFast__indexed(
@@ -2961,9 +2961,9 @@ pub fn callBuiltin__indexed(
 /// Synthesized indexed worker of `callBuiltinFast`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn callBuiltinFast__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Option<Result<crate::aver_generated::domain::value::Val, AverStr>> {
     crate::cancel_checkpoint();
     {
@@ -3065,9 +3065,9 @@ pub fn callBuiltinFast__indexed(
 
 /// Synthesized indexed worker of `callBuiltinAfterList`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn callBuiltinAfterList__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if name.starts_with("Vector.") {
@@ -3095,9 +3095,9 @@ pub fn callBuiltinAfterList__indexed(
 
 /// Synthesized indexed worker of `callBuiltinOther`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn callBuiltinOther__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -3190,9 +3190,9 @@ pub fn callBuiltinOther__indexed(
 
 /// Synthesized indexed worker of `callBuiltinServices`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn callBuiltinServices__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -3300,9 +3300,9 @@ pub fn callBuiltinServices__indexed(
 
 /// Synthesized indexed worker of `builtinTerminalNoArg`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn builtinTerminalNoArg__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -3358,9 +3358,9 @@ pub fn builtinTerminalNoArg__indexed(
 /// Synthesized indexed worker of `tryVariantConstructor`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tryVariantConstructor__indexed(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::builtins::splitDotted__indexed(name.clone(), __str_index) {
@@ -3386,8 +3386,8 @@ pub fn tryVariantConstructor__indexed(
 /// Synthesized indexed worker of `splitDotted`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn splitDotted__indexed(
-    name: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Option<(AverStr, AverStr)> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::splitDottedLoop__indexed(
@@ -3401,12 +3401,12 @@ pub fn splitDotted__indexed(
 /// Synthesized indexed worker of `splitDottedLoop`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn splitDottedLoop__indexed(
-    mut name: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut total: aver_rt::AverInt,
-    __str_index: aver_rt::StringIndex,
+    mut name @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut total @ _: aver_rt::AverInt,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> Option<(AverStr, AverStr)> {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         if (pos < total) {
@@ -3448,8 +3448,8 @@ pub fn splitDottedLoop__indexed(
 /// Synthesized collecting variant of `stringsToVals`. Appends to a builder where `stringsToVals` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn stringsToVals__collected(
-    mut strs: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut strs @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -3466,8 +3466,8 @@ pub fn stringsToVals__collected(
 /// Synthesized collecting variant of `mapEntriesToTuples`. Appends to a builder where `mapEntriesToTuples` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn mapEntriesToTuples__collected(
-    mut entries: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut entries @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -3484,8 +3484,8 @@ pub fn mapEntriesToTuples__collected(
 /// Synthesized collecting variant of `stringsToValStrs`. Appends to a builder where `stringsToValStrs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn stringsToValStrs__collected(
-    mut values: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut values @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -3502,8 +3502,8 @@ pub fn stringsToValStrs__collected(
 /// Synthesized collecting variant of `tcpReadyKeysToVals`. Appends to a builder where `tcpReadyKeysToVals` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn tcpReadyKeysToVals__collected(
-    mut keys: aver_rt::AverIntList,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut keys @ _: aver_rt::AverIntList,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/primitives/mod.rs
@@ -8,8 +8,8 @@ use crate::*;
 /// Dispatch Int.* builtins.
 #[inline(always)]
 pub fn callInt(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -70,7 +70,7 @@ pub fn callInt(
 
 /// Int.max(a, b) -> larger of a and b.
 pub fn builtinIntMax(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -82,8 +82,8 @@ pub fn builtinIntMax(
 
 /// Inner Int.max.
 pub fn builtinIntMaxInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
@@ -97,7 +97,7 @@ pub fn builtinIntMaxInner(
 
 /// Int.min(a, b) -> smaller of a and b.
 pub fn builtinIntMin(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -109,8 +109,8 @@ pub fn builtinIntMin(
 
 /// Inner Int.min.
 pub fn builtinIntMinInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
@@ -125,8 +125,8 @@ pub fn builtinIntMinInner(
 /// Dispatch String.* builtins.
 #[inline(always)]
 pub fn callString(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -221,7 +221,7 @@ pub fn callString(
 
 /// Float.fromInt(n) -> Float value.
 pub fn builtinIntToFloat(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -233,7 +233,7 @@ pub fn builtinIntToFloat(
 
 /// String.fromInt(n) -> string representation.
 pub fn builtinIntToString(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -245,7 +245,7 @@ pub fn builtinIntToString(
 
 /// Int.abs(n) -> absolute value.
 pub fn builtinIntAbs(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -255,7 +255,7 @@ pub fn builtinIntAbs(
 
 /// Int.mod(a, b) -> a mod b as Result.
 pub fn builtinIntMod(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -267,8 +267,8 @@ pub fn builtinIntMod(
 
 /// Inner impl of Int.mod.
 pub fn builtinIntModInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
@@ -295,7 +295,7 @@ pub fn builtinIntModInner(
 
 /// Int.div(a, b) -> a div b as a Result value.
 pub fn builtinIntDiv(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -307,8 +307,8 @@ pub fn builtinIntDiv(
 
 /// Inner impl of Int.div — Euclidean, Err on zero divisor or overflow.
 pub fn builtinIntDivInner(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let a @ _ = crate::aver_generated::domain::builtins::helpers::expectInt(aV)?;
@@ -330,7 +330,7 @@ pub fn builtinIntDivInner(
 
 /// String.len(s) -> length as Int.
 pub fn builtinStringLen(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -342,7 +342,7 @@ pub fn builtinStringLen(
 
 /// String.charAt(s, index) -> single character string or error.
 pub fn builtinStringCharAt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -354,8 +354,8 @@ pub fn builtinStringCharAt(
 
 /// Inner impl of String.charAt.
 pub fn builtinStringCharAtInner(
-    sV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -374,7 +374,7 @@ pub fn builtinStringCharAtInner(
 
 /// String.join(list, separator) -> joined string.
 pub fn builtinStringJoin(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -386,8 +386,8 @@ pub fn builtinStringJoin(
 
 /// Inner impl of String.join.
 pub fn builtinStringJoinInner(
-    lstV: &crate::aver_generated::domain::value::Val,
-    sepV: &crate::aver_generated::domain::value::Val,
+    lstV @ _: &crate::aver_generated::domain::value::Val,
+    sepV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::builtins::helpers::expectList(lstV)?;
@@ -404,8 +404,8 @@ pub fn builtinStringJoinInner(
 /// Convert list of ValStr to list of String.
 #[inline(always)]
 pub fn extractStrings(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<AverStr>,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<AverStr>,
 ) -> Result<aver_rt::AverList<AverStr>, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -428,7 +428,7 @@ pub fn extractStrings(
 
 /// String.slice(s, start, end) -> substring.
 pub fn builtinStringSlice(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -464,9 +464,9 @@ pub fn builtinStringSlice(
 
 /// Inner impl of String.slice.
 pub fn builtinStringSliceInner(
-    sV: &crate::aver_generated::domain::value::Val,
-    startV: &crate::aver_generated::domain::value::Val,
-    endV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    startV @ _: &crate::aver_generated::domain::value::Val,
+    endV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -484,7 +484,7 @@ pub fn builtinStringSliceInner(
 
 /// String.fromBool(b) -> string.
 pub fn builtinStringFromBool(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -498,7 +498,7 @@ pub fn builtinStringFromBool(
 
 /// String.fromInt(n) -> string (alias for String.fromInt).
 pub fn builtinStringFromInt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -510,7 +510,7 @@ pub fn builtinStringFromInt(
 
 /// String.fromFloat(f) -> string.
 pub fn builtinStringFromFloat(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -524,7 +524,7 @@ pub fn builtinStringFromFloat(
 
 /// String.contains(haystack, needle) -> Bool.
 pub fn builtinStringContains(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -536,8 +536,8 @@ pub fn builtinStringContains(
 
 /// Inner impl of String.contains.
 pub fn builtinStringContainsInner(
-    hV: &crate::aver_generated::domain::value::Val,
-    nV: &crate::aver_generated::domain::value::Val,
+    hV @ _: &crate::aver_generated::domain::value::Val,
+    nV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let h @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(hV)?;
@@ -549,7 +549,7 @@ pub fn builtinStringContainsInner(
 
 /// String.startsWith(s, prefix) -> Bool.
 pub fn builtinStringStartsWith(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -561,8 +561,8 @@ pub fn builtinStringStartsWith(
 
 /// Inner impl of String.startsWith.
 pub fn builtinStringStartsWithInner(
-    sV: &crate::aver_generated::domain::value::Val,
-    pV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    pV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -574,7 +574,7 @@ pub fn builtinStringStartsWithInner(
 
 /// String.toLower(s) -> lowercase string.
 pub fn builtinStringToLower(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -586,7 +586,7 @@ pub fn builtinStringToLower(
 
 /// String.fromCodePoint(n) -> single character string.
 pub fn builtinStringFromCodePoint(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -601,7 +601,7 @@ pub fn builtinStringFromCodePoint(
 
 /// String.firstCodePoint(s) -> optional first Unicode code point.
 pub fn builtinStringFirstCodePoint(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -620,7 +620,7 @@ pub fn builtinStringFirstCodePoint(
 
 /// Int.fromString(s) -> Result<Int, String>.
 pub fn builtinIntFromString(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -643,7 +643,7 @@ pub fn builtinIntFromString(
 
 /// String.chars(s) -> list of single-character strings.
 pub fn builtinStringChars(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -661,10 +661,10 @@ pub fn builtinStringChars(
 /// Split string into list of ValStr chars.
 #[inline(always)]
 pub fn stringToCharList(
-    s: AverStr,
-    pos: aver_rt::AverInt,
-    total: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    s @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    total @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::builtins::primitives::stringToCharList__indexed(
@@ -679,8 +679,8 @@ pub fn stringToCharList(
 /// Dispatch Float.* builtins.
 #[inline(always)]
 pub fn callFloat(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -766,7 +766,7 @@ pub fn callFloat(
 
 /// Float.fromString(s) -> Result<Float, String>.
 pub fn builtinFloatFromString(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -789,7 +789,7 @@ pub fn builtinFloatFromString(
 
 /// Float.fromInt(n) -> Float.
 pub fn builtinFloatFromInt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -801,7 +801,7 @@ pub fn builtinFloatFromInt(
 
 /// Float.round(f) -> Int.
 pub fn builtinFloatRound(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -817,7 +817,7 @@ pub fn builtinFloatRound(
 
 /// String.fromFloat(f) -> string representation.
 pub fn builtinFloatToString(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -831,7 +831,7 @@ pub fn builtinFloatToString(
 
 /// Float.abs(f) -> Float.
 pub fn builtinFloatAbs(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -845,7 +845,7 @@ pub fn builtinFloatAbs(
 
 /// Float.floor(f) -> Int.
 pub fn builtinFloatFloor(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -861,7 +861,7 @@ pub fn builtinFloatFloor(
 
 /// Float.ceil(f) -> Int.
 pub fn builtinFloatCeil(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -877,7 +877,7 @@ pub fn builtinFloatCeil(
 
 /// Float.min(a, b) -> Float.
 pub fn builtinFloatMin(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -894,7 +894,7 @@ pub fn builtinFloatMin(
 
 /// Float.max(a, b) -> Float.
 pub fn builtinFloatMax(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -911,7 +911,7 @@ pub fn builtinFloatMax(
 
 /// Float.sin(f) -> Float.
 pub fn builtinFloatSin(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -925,7 +925,7 @@ pub fn builtinFloatSin(
 
 /// Float.cos(f) -> Float.
 pub fn builtinFloatCos(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -939,7 +939,7 @@ pub fn builtinFloatCos(
 
 /// Float.sqrt(f) -> Float.
 pub fn builtinFloatSqrt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -953,7 +953,7 @@ pub fn builtinFloatSqrt(
 
 /// Float.pow(base, exp) -> Float.
 pub fn builtinFloatPow(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -970,7 +970,7 @@ pub fn builtinFloatPow(
 
 /// Float.atan2(y, x) -> Float.
 pub fn builtinFloatAtan2(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -987,7 +987,7 @@ pub fn builtinFloatAtan2(
 
 /// Float.pi() -> Float.
 pub fn builtinFloatPi(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -1004,7 +1004,7 @@ pub fn builtinFloatPi(
 
 /// String.toUpper(s) -> uppercase string.
 pub fn builtinStringToUpper(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1016,7 +1016,7 @@ pub fn builtinStringToUpper(
 
 /// String.trim(s) -> trimmed string.
 pub fn builtinStringTrim(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -1028,7 +1028,7 @@ pub fn builtinStringTrim(
 
 /// String.endsWith(s, suffix) -> Bool.
 pub fn builtinStringEndsWith(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1040,8 +1040,8 @@ pub fn builtinStringEndsWith(
 
 /// Inner String.endsWith.
 pub fn builtinStringEndsWithInner(
-    sV: &crate::aver_generated::domain::value::Val,
-    pV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    pV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -1053,7 +1053,7 @@ pub fn builtinStringEndsWithInner(
 
 /// String.split(s, sep) -> List<String>.
 pub fn builtinStringSplit(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1065,8 +1065,8 @@ pub fn builtinStringSplit(
 
 /// Inner String.split.
 pub fn builtinStringSplitInner(
-    sV: &crate::aver_generated::domain::value::Val,
-    sepV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    sepV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -1085,8 +1085,8 @@ pub fn builtinStringSplitInner(
 /// Convert string list to ValStr list.
 #[inline(always)]
 pub fn strPartsToVals(
-    mut parts: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut parts @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -1102,7 +1102,7 @@ pub fn strPartsToVals(
 
 /// String.repeat(s, n) -> repeated string.
 pub fn builtinStringRepeat(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -1114,8 +1114,8 @@ pub fn builtinStringRepeat(
 
 /// Inner String.repeat.
 pub fn builtinStringRepeatInner(
-    sV: &crate::aver_generated::domain::value::Val,
-    nV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    nV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -1127,7 +1127,7 @@ pub fn builtinStringRepeatInner(
 
 /// Repeat string n times.
 #[inline(always)]
-pub fn repeatStr(mut s: AverStr, mut n: aver_rt::AverInt, mut acc: AverStr) -> AverStr {
+pub fn repeatStr(mut s @ _: AverStr, mut n @ _: aver_rt::AverInt, mut acc @ _: AverStr) -> AverStr {
     loop {
         crate::cancel_checkpoint();
         if (n > aver_rt::AverInt::from_i64(0)) {
@@ -1147,7 +1147,7 @@ pub fn repeatStr(mut s: AverStr, mut n: aver_rt::AverInt, mut acc: AverStr) -> A
 /// String.replace(s, from, to) -> String with all occurrences replaced.
 #[inline(always)]
 pub fn builtinStringReplaceAll(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if (aver_rt::AverInt::from_i64(args.len() as i64) == aver_rt::AverInt::from_i64(3)) {
@@ -1160,7 +1160,7 @@ pub fn builtinStringReplaceAll(
 /// Extract args for String.replace.
 #[inline(always)]
 pub fn builtinStringReplaceAllExtract(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(args.clone(), [] => Err(AverStr::from("String.replace takes 3 arguments")), [sV, r1] => aver_list_match!(r1, [] => Err(AverStr::from("String.replace takes 3 arguments")), [fromV, r2] => aver_list_match!(r2, [] => Err(AverStr::from("String.replace takes 3 arguments")), [toV, r3] => crate::aver_generated::domain::builtins::primitives::builtinStringReplaceAllDo(&sV, &fromV, &toV))))
@@ -1168,9 +1168,9 @@ pub fn builtinStringReplaceAllExtract(
 
 /// Inner impl of String.replace.
 pub fn builtinStringReplaceAllDo(
-    sV: &crate::aver_generated::domain::value::Val,
-    fromV: &crate::aver_generated::domain::value::Val,
-    toV: &crate::aver_generated::domain::value::Val,
+    sV @ _: &crate::aver_generated::domain::value::Val,
+    fromV @ _: &crate::aver_generated::domain::value::Val,
+    toV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let s @ _ = crate::aver_generated::domain::builtins::helpers::expectStr(sV)?;
@@ -1184,13 +1184,13 @@ pub fn builtinStringReplaceAllDo(
 /// Synthesized indexed worker of `stringToCharList`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn stringToCharList__indexed(
-    mut s: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut total: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    __str_index: aver_rt::StringIndex,
+    mut s @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut total @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         let reversed @ _ = acc.reverse();
@@ -1219,8 +1219,8 @@ pub fn stringToCharList__indexed(
 /// Synthesized collecting variant of `extractStrings`. Appends to a builder where `extractStrings` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn extractStrings__collected(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<AverStr>,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<AverStr>,
 ) -> Result<aver_rt::AverList<AverStr>, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -1244,8 +1244,8 @@ pub fn extractStrings__collected(
 /// Synthesized collecting variant of `strPartsToVals`. Appends to a builder where `strPartsToVals` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn strPartsToVals__collected(
-    mut parts: aver_rt::AverList<AverStr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut parts @ _: aver_rt::AverList<AverStr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/builtins/vector/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/vector/mod.rs
@@ -8,8 +8,8 @@ use crate::*;
 /// Dispatch Vector.* builtins.
 #[inline(always)]
 pub fn call(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -62,7 +62,7 @@ pub fn call(
 
 /// Vector.new(size, default) -> Result<Vector<T>, String>.
 pub fn builtinVectorNew(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -81,7 +81,7 @@ pub fn builtinVectorNew(
 
 /// Vector.get(vec, idx) -> Option<T>.
 pub fn builtinVectorGet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -101,7 +101,7 @@ pub fn builtinVectorGet(
 
 /// Vector.set(vec, idx, val) -> Option<Vector<T>>.
 pub fn builtinVectorSet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -133,9 +133,9 @@ pub fn builtinVectorSet(
 
 /// Validate types and bounds before delegating to builtinVectorSetInBounds.
 pub fn builtinVectorSetInner(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    valV: &crate::aver_generated::domain::value::Val,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    valV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
@@ -162,9 +162,9 @@ pub fn builtinVectorSetInner(
 /// Set a vector element when bounds have already been checked.
 #[inline(always)]
 pub fn builtinVectorSetInBounds(
-    vec: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    idx: aver_rt::AverInt,
-    valV: &crate::aver_generated::domain::value::Val,
+    vec @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    idx @ _: aver_rt::AverInt,
+    valV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match (idx)
@@ -180,7 +180,7 @@ pub fn builtinVectorSetInBounds(
 
 /// Vector.len(vec) -> Int.
 pub fn builtinVectorLen(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -196,7 +196,7 @@ pub fn builtinVectorLen(
 
 /// Vector.fromList(list) -> Vector<T>.
 pub fn builtinVectorFromList(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -212,7 +212,7 @@ pub fn builtinVectorFromList(
 
 /// List.fromVector(vec) -> List<T>.
 pub fn builtinVectorToList(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;

--- a/src/self_host/aver_generated/domain/builtins/wrappers/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/wrappers/mod.rs
@@ -8,8 +8,8 @@ use crate::*;
 /// Dispatch Result.* and Option.* builtins.
 #[inline(always)]
 pub fn call(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -54,7 +54,7 @@ pub fn call(
 
 /// Result.Ok(value) -> wrapped Ok value.
 pub fn builtinResultOk(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -65,7 +65,7 @@ pub fn builtinResultOk(
 
 /// Result.Err(value) -> wrapped Err value.
 pub fn builtinResultErr(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -76,7 +76,7 @@ pub fn builtinResultErr(
 
 /// Result.withDefault(result, default) -> unwrap Ok or return default.
 pub fn builtinResultWithDefault(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -95,7 +95,7 @@ pub fn builtinResultWithDefault(
 
 /// Option.Some(value) -> wrapped Some value.
 pub fn builtinOptionSome(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::builtins::helpers::oneArg(args)?;
@@ -106,7 +106,7 @@ pub fn builtinOptionSome(
 
 /// Option.withDefault(option, default) -> unwrap Some or return default.
 pub fn builtinOptionWithDefault(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;
@@ -125,7 +125,7 @@ pub fn builtinOptionWithDefault(
 
 /// Result.fromOption(option, errMsg) -> Result.
 pub fn callResultFromOption(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let pair @ _ = crate::aver_generated::domain::builtins::helpers::twoArgs(args)?;

--- a/src/self_host/aver_generated/domain/eval/common/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/common/mod.rs
@@ -12,8 +12,8 @@ use crate::*;
 /// If variable not in env, try a top-level binding, then a named function reference, then a nullary variant.
 #[inline(always)]
 pub fn evalVarFallback(
-    name: AverStr,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupGlobal(fns, name.clone()) {
@@ -25,8 +25,8 @@ pub fn evalVarFallback(
 /// Resolve a name that is neither a local nor a top-level binding: function reference, then nullary variant.
 #[inline(always)]
 pub fn evalVarFallbackNamed(
-    name: AverStr,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
@@ -61,14 +61,14 @@ pub fn propagationPrefix() -> AverStr {
 }
 
 /// Mark a language-level Result.Err so function boundaries can convert it back into a value.
-pub fn wrapPropagatedError(msg: AverStr) -> AverStr {
+pub fn wrapPropagatedError(msg @ _: AverStr) -> AverStr {
     crate::cancel_checkpoint();
     (AverStr::from("__aver_prop__:") + &msg)
 }
 
 /// Return the propagated payload when the evaluator error is an internal ? marker.
 #[inline(always)]
-pub fn unwrapPropagatedError(err: AverStr) -> Option<AverStr> {
+pub fn unwrapPropagatedError(err @ _: AverStr) -> Option<AverStr> {
     crate::cancel_checkpoint();
     let prefix @ _ = AverStr::from("__aver_prop__:");
     if err.starts_with(&*prefix) {
@@ -90,7 +90,7 @@ pub fn unwrapPropagatedError(err: AverStr) -> Option<AverStr> {
 /// Catch internal ? propagation at a function boundary and turn it back into Result.Err(value).
 #[inline(always)]
 pub fn normalizeFnReturn(
-    result: &Result<crate::aver_generated::domain::value::Val, AverStr>,
+    result @ _: &Result<crate::aver_generated::domain::value::Val, AverStr>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match result.clone() {
@@ -109,8 +109,8 @@ pub fn normalizeFnReturn(
 /// Look up a record field by name.
 #[inline(always)]
 pub fn lookupField(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut name: AverStr,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut name @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -218,18 +218,18 @@ enum __MutualTco1 {
 
 fn __mutual_tco_trampoline_1(
     mut __state: __MutualTco1,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco1::EvalExpr(mut expr, mut env) => {
+            __MutualTco1::EvalExpr(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::core::evalImmediateNamedExpr(&expr) {
                     Some(v @ _) => return Ok(v),
                     None => __MutualTco1::EvalExprBasic(expr, env),
                 }
             }
-            __MutualTco1::EvalExprBasic(mut expr, mut env) => {
+            __MutualTco1::EvalExprBasic(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
@@ -259,7 +259,7 @@ fn __mutual_tco_trampoline_1(
                     _ => __MutualTco1::EvalExprInternal(expr, env),
                 }
             }
-            __MutualTco1::EvalExprInternal(mut expr, mut env) => {
+            __MutualTco1::EvalExprInternal(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprCmpSlotInt(_, _, _) => {
@@ -373,7 +373,7 @@ fn __mutual_tco_trampoline_1(
                     _ => __MutualTco1::EvalExprAggregate(expr, env),
                 }
             }
-            __MutualTco1::EvalExprAggregate(mut expr, mut env) => {
+            __MutualTco1::EvalExprAggregate(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
@@ -457,7 +457,7 @@ fn __mutual_tco_trampoline_1(
                     _ => __MutualTco1::EvalExprCalls(expr, env),
                 }
             }
-            __MutualTco1::EvalExprCalls(mut expr, mut env) => {
+            __MutualTco1::EvalExprCalls(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
@@ -506,7 +506,12 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::EvalBoolBranch(mut cond, mut thenExpr, mut elseExpr, mut env) => {
+            __MutualTco1::EvalBoolBranch(
+                mut cond @ _,
+                mut thenExpr @ _,
+                mut elseExpr @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let condV @ _ =
                     crate::aver_generated::domain::eval::core::evalExpr(&cond, &env, &*fns)?;
@@ -525,14 +530,14 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::EvalMatchExpr(mut scrutinee, mut arms, mut env) => {
+            __MutualTco1::EvalMatchExpr(mut scrutinee @ _, mut arms @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::core::evalExpr(&scrutinee, &env, &*fns) {
                     Ok(v @ _) => __MutualTco1::EvalMatch(v, arms, env),
                     Err(e @ _) => return Err(e),
                 }
             }
-            __MutualTco1::EvalCallBuiltinById(mut id, mut argExprs, mut env) => {
+            __MutualTco1::EvalCallBuiltinById(mut id @ _, mut argExprs @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 {
                     let __int_match_subject = id.clone();
@@ -543,7 +548,11 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::EvalCallBuiltinMaybeSpecial(mut name, mut argExprs, mut env) => {
+            __MutualTco1::EvalCallBuiltinMaybeSpecial(
+                mut name @ _,
+                mut argExprs @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 match &*name.clone() {
                     "Option.withDefault" => __MutualTco1::EvalOptionWithDefaultExpr(argExprs, env),
@@ -554,7 +563,7 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::EvalOptionWithDefaultExpr(mut argExprs, mut env) => {
+            __MutualTco1::EvalOptionWithDefaultExpr(mut argExprs @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 {
                     let __list_subject = argExprs.clone();
@@ -589,9 +598,9 @@ fn __mutual_tco_trampoline_1(
                 }
             }
             __MutualTco1::EvalOptionWithDefaultExprInner(
-                mut optionExpr,
-                mut defaultExpr,
-                mut env,
+                mut optionExpr @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match optionExpr.clone() {
@@ -626,7 +635,11 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::EvalVectorSetWithDefaultExpr(mut vecArgs, mut defaultExpr, mut env) => {
+            __MutualTco1::EvalVectorSetWithDefaultExpr(
+                mut vecArgs @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 {
                     let __list_subject = vecArgs.clone();
@@ -684,11 +697,11 @@ fn __mutual_tco_trampoline_1(
                 }
             }
             __MutualTco1::EvalVectorSetWithDefaultExprValues(
-                mut vecExpr,
-                mut idxExpr,
-                mut valueExpr,
-                mut defaultExpr,
-                mut env,
+                mut vecExpr @ _,
+                mut idxExpr @ _,
+                mut valueExpr @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let vecV @ _ =
@@ -706,11 +719,11 @@ fn __mutual_tco_trampoline_1(
                 )
             }
             __MutualTco1::EvalVectorSetWithDefaultExprResult(
-                mut vecV,
-                mut idxV,
-                mut valueV,
-                mut defaultExpr,
-                mut env,
+                mut vecV @ _,
+                mut idxV @ _,
+                mut valueV @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::ops::evalVectorSetMaybeDefault(
@@ -723,7 +736,11 @@ fn __mutual_tco_trampoline_1(
                     Err(err @ _) => return Err(err),
                 }
             }
-            __MutualTco1::EvalVectorGetWithDefaultExpr(mut vecArgs, mut defaultExpr, mut env) => {
+            __MutualTco1::EvalVectorGetWithDefaultExpr(
+                mut vecArgs @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 {
                     let __list_subject = vecArgs.clone();
@@ -771,10 +788,10 @@ fn __mutual_tco_trampoline_1(
                 }
             }
             __MutualTco1::EvalVectorGetWithDefaultExprValues(
-                mut vecExpr,
-                mut idxExpr,
-                mut defaultExpr,
-                mut env,
+                mut vecExpr @ _,
+                mut idxExpr @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let vecV @ _ =
@@ -784,10 +801,10 @@ fn __mutual_tco_trampoline_1(
                 __MutualTco1::EvalVectorGetWithDefaultExprResult(vecV, idxV, defaultExpr, env)
             }
             __MutualTco1::EvalVectorGetWithDefaultExprResult(
-                mut vecV,
-                mut idxV,
-                mut defaultExpr,
-                mut env,
+                mut vecV @ _,
+                mut idxV @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::ops::evalVectorGetMaybeDefault(
@@ -800,7 +817,7 @@ fn __mutual_tco_trampoline_1(
                     Err(err @ _) => return Err(err),
                 }
             }
-            __MutualTco1::EvalMatch(mut v, mut arms, mut env) => {
+            __MutualTco1::EvalMatch(mut v @ _, mut arms @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings @ _) => { __MutualTco1::EvalExpr(arm.body.clone(), crate::aver_generated::domain::eval::store::mergeBindings(bindings, env)) }, Err(_) => { __MutualTco1::EvalMatch(v, rest, env) } })
             }
@@ -810,27 +827,27 @@ fn __mutual_tco_trampoline_1(
 
 /// Evaluate an expression in the given environment.
 pub fn evalExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(__MutualTco1::EvalExpr(expr.clone(), env.clone()), &fns)
 }
 
 /// Continue named-env evaluation for branch, vars, and slot-only internal nodes.
 pub fn evalExprBasic(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(__MutualTco1::EvalExprBasic(expr.clone(), env.clone()), &fns)
 }
 
 /// Continue named-env expression evaluation for comparisons and arithmetic.
 pub fn evalExprInternal(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalExprInternal(expr.clone(), env.clone()),
@@ -840,9 +857,9 @@ pub fn evalExprInternal(
 
 /// Continue named-env evaluation for aggregate expression forms.
 pub fn evalExprAggregate(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalExprAggregate(expr.clone(), env.clone()),
@@ -852,20 +869,20 @@ pub fn evalExprAggregate(
 
 /// Finish named-env evaluation for calls, matches, propagation, and products.
 pub fn evalExprCalls(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(__MutualTco1::EvalExprCalls(expr.clone(), env.clone()), &fns)
 }
 
 /// Evaluate a direct bool branch in map path.
 pub fn evalBoolBranch(
-    cond: &crate::aver_generated::domain::ast::Expr,
-    thenExpr: &crate::aver_generated::domain::ast::Expr,
-    elseExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    cond @ _: &crate::aver_generated::domain::ast::Expr,
+    thenExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    elseExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalBoolBranch(
@@ -880,10 +897,10 @@ pub fn evalBoolBranch(
 
 /// Evaluate a match expression.
 pub fn evalMatchExpr(
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalMatchExpr(scrutinee.clone(), arms.clone(), env.clone()),
@@ -893,10 +910,10 @@ pub fn evalMatchExpr(
 
 /// Builtin dispatch by integer ID — no string comparison.
 pub fn evalCallBuiltinById(
-    id: aver_rt::AverInt,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    id @ _: aver_rt::AverInt,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalCallBuiltinById(id, argExprs.clone(), env.clone()),
@@ -906,10 +923,10 @@ pub fn evalCallBuiltinById(
 
 /// Builtin dispatch with fast-path peepholes for hot patterns.
 pub fn evalCallBuiltinMaybeSpecial(
-    name: AverStr,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalCallBuiltinMaybeSpecial(name, argExprs.clone(), env.clone()),
@@ -919,9 +936,9 @@ pub fn evalCallBuiltinMaybeSpecial(
 
 /// Specialize hot Option.withDefault(Vector.get/Vector.set, default) patterns in map path.
 pub fn evalOptionWithDefaultExpr(
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalOptionWithDefaultExpr(argExprs.clone(), env.clone()),
@@ -931,10 +948,10 @@ pub fn evalOptionWithDefaultExpr(
 
 /// Dispatch specialized Option.withDefault cases in map path.
 pub fn evalOptionWithDefaultExprInner(
-    optionExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    optionExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalOptionWithDefaultExprInner(
@@ -948,10 +965,10 @@ pub fn evalOptionWithDefaultExprInner(
 
 /// Specialized Vector.set + Option.withDefault in map path.
 pub fn evalVectorSetWithDefaultExpr(
-    vecArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalVectorSetWithDefaultExpr(
@@ -965,12 +982,12 @@ pub fn evalVectorSetWithDefaultExpr(
 
 /// Evaluate Vector.set operands in map path and defer the default expression until needed.
 pub fn evalVectorSetWithDefaultExprValues(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    valueExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    valueExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalVectorSetWithDefaultExprValues(
@@ -986,12 +1003,12 @@ pub fn evalVectorSetWithDefaultExprValues(
 
 /// Finish specialized Vector.set + Option.withDefault in map path with lazy default evaluation.
 pub fn evalVectorSetWithDefaultExprResult(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    valueV: &crate::aver_generated::domain::value::Val,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    valueV @ _: &crate::aver_generated::domain::value::Val,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalVectorSetWithDefaultExprResult(
@@ -1007,10 +1024,10 @@ pub fn evalVectorSetWithDefaultExprResult(
 
 /// Specialized Vector.get + Option.withDefault in map path.
 pub fn evalVectorGetWithDefaultExpr(
-    vecArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalVectorGetWithDefaultExpr(
@@ -1024,11 +1041,11 @@ pub fn evalVectorGetWithDefaultExpr(
 
 /// Evaluate Vector.get operands in map path and defer the default expression until needed.
 pub fn evalVectorGetWithDefaultExprValues(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalVectorGetWithDefaultExprValues(
@@ -1043,11 +1060,11 @@ pub fn evalVectorGetWithDefaultExprValues(
 
 /// Finish specialized Vector.get + Option.withDefault in map path with lazy default evaluation.
 pub fn evalVectorGetWithDefaultExprResult(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalVectorGetWithDefaultExprResult(
@@ -1062,10 +1079,10 @@ pub fn evalVectorGetWithDefaultExprResult(
 
 /// Try each match arm until one matches. Self-recursive for codegen TCO.
 pub fn evalMatch(
-    v: &crate::aver_generated::domain::value::Val,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::EvalMatch(v.clone(), arms.clone(), env.clone()),
@@ -1107,12 +1124,17 @@ enum __MutualTco2 {
 
 fn __mutual_tco_trampoline_2(
     mut __state: __MutualTco2,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco2::EvalTailExprSlot(mut selfId, mut expr, mut slotCount, mut env) => {
+            __MutualTco2::EvalTailExprSlot(
+                mut selfId @ _,
+                mut expr @ _,
+                mut slotCount @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
@@ -1144,12 +1166,12 @@ fn __mutual_tco_trampoline_2(
                 }
             }
             __MutualTco2::EvalTailBoolBranchSlot(
-                mut selfId,
-                mut cond,
-                mut thenExpr,
-                mut elseExpr,
-                mut slotCount,
-                mut env,
+                mut selfId @ _,
+                mut cond @ _,
+                mut thenExpr @ _,
+                mut elseExpr @ _,
+                mut slotCount @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let condV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
@@ -1171,11 +1193,11 @@ fn __mutual_tco_trampoline_2(
                 }
             }
             __MutualTco2::EvalTailMatchExprSlot(
-                mut selfId,
-                mut scrutinee,
-                mut arms,
-                mut slotCount,
-                mut env,
+                mut selfId @ _,
+                mut scrutinee @ _,
+                mut arms @ _,
+                mut slotCount @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
@@ -1184,11 +1206,11 @@ fn __mutual_tco_trampoline_2(
                 __MutualTco2::EvalTailMatchSlot(selfId, v, arms, slotCount, env)
             }
             __MutualTco2::EvalTailMatchSlot(
-                mut selfId,
-                mut v,
-                mut arms,
-                mut slotCount,
-                mut env,
+                mut selfId @ _,
+                mut v @ _,
+                mut arms @ _,
+                mut slotCount @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings @ _) => { __MutualTco2::EvalTailExprSlot(selfId, arm.body.clone(), slotCount, crate::aver_generated::domain::eval::core::mergeBindingsSlot(&bindings, &arm.bindingSlots, &env)) }, Err(_) => { __MutualTco2::EvalTailMatchSlot(selfId, v, rest, slotCount, env) } })
@@ -1199,12 +1221,12 @@ fn __mutual_tco_trampoline_2(
 
 /// Evaluate a tail-position expression in slot mode, converting self-recursive direct calls into loop re-entry.
 pub fn evalTailExprSlot(
-    selfId: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_2(
         __MutualTco2::EvalTailExprSlot(selfId, expr.clone(), slotCount, env.clone()),
@@ -1215,14 +1237,14 @@ pub fn evalTailExprSlot(
 
 /// Evaluate a tail-position bool branch in slot mode.
 pub fn evalTailBoolBranchSlot(
-    selfId: aver_rt::AverInt,
-    cond: &crate::aver_generated::domain::ast::Expr,
-    thenExpr: &crate::aver_generated::domain::ast::Expr,
-    elseExpr: &crate::aver_generated::domain::ast::Expr,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    cond @ _: &crate::aver_generated::domain::ast::Expr,
+    thenExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    elseExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_2(
         __MutualTco2::EvalTailBoolBranchSlot(
@@ -1240,13 +1262,13 @@ pub fn evalTailBoolBranchSlot(
 
 /// Evaluate a tail-position match expression in slot mode.
 pub fn evalTailMatchExprSlot(
-    selfId: aver_rt::AverInt,
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_2(
         __MutualTco2::EvalTailMatchExprSlot(
@@ -1263,13 +1285,13 @@ pub fn evalTailMatchExprSlot(
 
 /// Evaluate a tail-position match arm in slot mode, preserving binding slots.
 pub fn evalTailMatchSlot(
-    selfId: aver_rt::AverInt,
-    v: &crate::aver_generated::domain::value::Val,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_2(
         __MutualTco2::EvalTailMatchSlot(selfId, v.clone(), arms.clone(), slotCount, env.clone()),
@@ -1375,12 +1397,12 @@ enum __MutualTco3 {
 
 fn __mutual_tco_trampoline_3(
     mut __state: __MutualTco3,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco3::EvalExprSlot(mut expr, mut env) => {
+            __MutualTco3::EvalExprSlot(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::core::evalImmediateSlotExpr(&expr, &env)
                 {
@@ -1388,7 +1410,7 @@ fn __mutual_tco_trampoline_3(
                     None => __MutualTco3::EvalExprSlotBasic(expr, env),
                 }
             }
-            __MutualTco3::EvalExprSlotBasic(mut expr, mut env) => {
+            __MutualTco3::EvalExprSlotBasic(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
@@ -1422,7 +1444,7 @@ fn __mutual_tco_trampoline_3(
                     _ => __MutualTco3::EvalExprSlotInternal(expr, env),
                 }
             }
-            __MutualTco3::EvalExprSlotInternal(mut expr, mut env) => {
+            __MutualTco3::EvalExprSlotInternal(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprCmpSlots(op, lhs, rhs) => {
@@ -1536,7 +1558,7 @@ fn __mutual_tco_trampoline_3(
                     _ => __MutualTco3::EvalExprSlotAggregate(expr, env),
                 }
             }
-            __MutualTco3::EvalExprSlotAggregate(mut expr, mut env) => {
+            __MutualTco3::EvalExprSlotAggregate(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprLt(a, b) => {
@@ -1625,7 +1647,7 @@ fn __mutual_tco_trampoline_3(
                     _ => __MutualTco3::EvalExprSlotCalls(expr, env),
                 }
             }
-            __MutualTco3::EvalExprSlotCalls(mut expr, mut env) => {
+            __MutualTco3::EvalExprSlotCalls(mut expr @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
         crate::aver_generated::domain::ast::Expr::ExprCallDirect(fnId, argExprs) => {
@@ -1653,7 +1675,12 @@ fn __mutual_tco_trampoline_3(
         }
     }
             }
-            __MutualTco3::EvalBoolBranchSlot(mut cond, mut thenExpr, mut elseExpr, mut env) => {
+            __MutualTco3::EvalBoolBranchSlot(
+                mut cond @ _,
+                mut thenExpr @ _,
+                mut elseExpr @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let condV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &cond, &env, &*slotMap, &*fns,
@@ -1673,7 +1700,7 @@ fn __mutual_tco_trampoline_3(
                     }
                 }
             }
-            __MutualTco3::EvalCallBuiltinByIdSlot(mut id, mut argExprs, mut env) => {
+            __MutualTco3::EvalCallBuiltinByIdSlot(mut id @ _, mut argExprs @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 {
                     let __int_match_subject = id.clone();
@@ -1684,7 +1711,11 @@ fn __mutual_tco_trampoline_3(
                     }
                 }
             }
-            __MutualTco3::EvalCallBuiltinSlotMaybeSpecial(mut name, mut argExprs, mut env) => {
+            __MutualTco3::EvalCallBuiltinSlotMaybeSpecial(
+                mut name @ _,
+                mut argExprs @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 match &*name.clone() {
                     "Option.withDefault" => {
@@ -1697,7 +1728,7 @@ fn __mutual_tco_trampoline_3(
                     }
                 }
             }
-            __MutualTco3::EvalOptionWithDefaultExprSlot(mut argExprs, mut env) => {
+            __MutualTco3::EvalOptionWithDefaultExprSlot(mut argExprs @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 {
                     let __list_subject = argExprs.clone();
@@ -1728,9 +1759,9 @@ fn __mutual_tco_trampoline_3(
                 }
             }
             __MutualTco3::EvalOptionWithDefaultExprSlotInner(
-                mut optionExpr,
-                mut defaultExpr,
-                mut env,
+                mut optionExpr @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match optionExpr.clone() {
@@ -1766,9 +1797,9 @@ fn __mutual_tco_trampoline_3(
                 }
             }
             __MutualTco3::EvalVectorSetWithDefaultExprSlot(
-                mut vecArgs,
-                mut defaultExpr,
-                mut env,
+                mut vecArgs @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 {
@@ -1817,11 +1848,11 @@ fn __mutual_tco_trampoline_3(
                 }
             }
             __MutualTco3::EvalVectorSetWithDefaultExprSlotValues(
-                mut vecExpr,
-                mut idxExpr,
-                mut valueExpr,
-                mut defaultExpr,
-                mut env,
+                mut vecExpr @ _,
+                mut idxExpr @ _,
+                mut valueExpr @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let vecV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
@@ -1842,11 +1873,11 @@ fn __mutual_tco_trampoline_3(
                 )
             }
             __MutualTco3::EvalVectorSetWithDefaultExprSlotResult(
-                mut vecV,
-                mut idxV,
-                mut valueV,
-                mut defaultExpr,
-                mut env,
+                mut vecV @ _,
+                mut idxV @ _,
+                mut valueV @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::ops::evalVectorSetMaybeDefault(
@@ -1860,9 +1891,9 @@ fn __mutual_tco_trampoline_3(
                 }
             }
             __MutualTco3::EvalVectorGetWithDefaultExprSlot(
-                mut vecArgs,
-                mut defaultExpr,
-                mut env,
+                mut vecArgs @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 {
@@ -1901,10 +1932,10 @@ fn __mutual_tco_trampoline_3(
                 }
             }
             __MutualTco3::EvalVectorGetWithDefaultExprSlotValues(
-                mut vecExpr,
-                mut idxExpr,
-                mut defaultExpr,
-                mut env,
+                mut vecExpr @ _,
+                mut idxExpr @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let vecV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
@@ -1916,10 +1947,10 @@ fn __mutual_tco_trampoline_3(
                 __MutualTco3::EvalVectorGetWithDefaultExprSlotResult(vecV, idxV, defaultExpr, env)
             }
             __MutualTco3::EvalVectorGetWithDefaultExprSlotResult(
-                mut vecV,
-                mut idxV,
-                mut defaultExpr,
-                mut env,
+                mut vecV @ _,
+                mut idxV @ _,
+                mut defaultExpr @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::eval::ops::evalVectorGetMaybeDefault(
@@ -1932,14 +1963,14 @@ fn __mutual_tco_trampoline_3(
                     Err(err @ _) => return Err(err),
                 }
             }
-            __MutualTco3::EvalMatchExprSlot(mut scrutinee, mut arms, mut env) => {
+            __MutualTco3::EvalMatchExprSlot(mut scrutinee @ _, mut arms @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &scrutinee, &env, &*slotMap, &*fns,
                 )?;
                 __MutualTco3::EvalMatchSlot(v, arms, env)
             }
-            __MutualTco3::EvalMatchSlot(mut v, mut arms, mut env) => {
+            __MutualTco3::EvalMatchSlot(mut v @ _, mut arms @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(arms, [] => { return Err(AverStr::from("no matching arm")) }, [arm, rest] => match crate::aver_generated::domain::match_mod::matchPattern(&arm.pattern, &v) { Ok(bindings @ _) => { __MutualTco3::EvalExprSlot(arm.body.clone(), crate::aver_generated::domain::eval::core::mergeBindingsSlot(&bindings, &arm.bindingSlots, &env)) }, Err(_) => { __MutualTco3::EvalMatchSlot(v, rest, env) } })
             }
@@ -1949,10 +1980,10 @@ fn __mutual_tco_trampoline_3(
 
 /// Evaluate an expression using slot-based environment.
 pub fn evalExprSlot(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalExprSlot(expr.clone(), env.clone()),
@@ -1963,10 +1994,10 @@ pub fn evalExprSlot(
 
 /// Continue slot-based evaluation for branches, vars, and slot-only nodes.
 pub fn evalExprSlotBasic(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalExprSlotBasic(expr.clone(), env.clone()),
@@ -1977,10 +2008,10 @@ pub fn evalExprSlotBasic(
 
 /// Continue slot-based expression evaluation for comparisons and arithmetic.
 pub fn evalExprSlotInternal(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalExprSlotInternal(expr.clone(), env.clone()),
@@ -1991,10 +2022,10 @@ pub fn evalExprSlotInternal(
 
 /// Continue slot-based evaluation for aggregate and call expression forms.
 pub fn evalExprSlotAggregate(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalExprSlotAggregate(expr.clone(), env.clone()),
@@ -2005,10 +2036,10 @@ pub fn evalExprSlotAggregate(
 
 /// Finish slot-based evaluation for calls, matches, propagation, and products.
 pub fn evalExprSlotCalls(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalExprSlotCalls(expr.clone(), env.clone()),
@@ -2019,12 +2050,12 @@ pub fn evalExprSlotCalls(
 
 /// Evaluate a direct bool branch in slot path.
 pub fn evalBoolBranchSlot(
-    cond: &crate::aver_generated::domain::ast::Expr,
-    thenExpr: &crate::aver_generated::domain::ast::Expr,
-    elseExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    cond @ _: &crate::aver_generated::domain::ast::Expr,
+    thenExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    elseExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalBoolBranchSlot(
@@ -2040,11 +2071,11 @@ pub fn evalBoolBranchSlot(
 
 /// Builtin dispatch by integer ID (slot-based path) — no string comparison.
 pub fn evalCallBuiltinByIdSlot(
-    id: aver_rt::AverInt,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    id @ _: aver_rt::AverInt,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalCallBuiltinByIdSlot(id, argExprs.clone(), env.clone()),
@@ -2055,11 +2086,11 @@ pub fn evalCallBuiltinByIdSlot(
 
 /// Builtin dispatch with fast-path peepholes for hot patterns in slot path.
 pub fn evalCallBuiltinSlotMaybeSpecial(
-    name: AverStr,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalCallBuiltinSlotMaybeSpecial(name, argExprs.clone(), env.clone()),
@@ -2070,10 +2101,10 @@ pub fn evalCallBuiltinSlotMaybeSpecial(
 
 /// Specialize hot Option.withDefault(Vector.get/Vector.set, default) patterns in slot path.
 pub fn evalOptionWithDefaultExprSlot(
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalOptionWithDefaultExprSlot(argExprs.clone(), env.clone()),
@@ -2084,11 +2115,11 @@ pub fn evalOptionWithDefaultExprSlot(
 
 /// Dispatch specialized Option.withDefault cases in slot path.
 pub fn evalOptionWithDefaultExprSlotInner(
-    optionExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    optionExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalOptionWithDefaultExprSlotInner(
@@ -2103,11 +2134,11 @@ pub fn evalOptionWithDefaultExprSlotInner(
 
 /// Specialized Vector.set + Option.withDefault in slot path.
 pub fn evalVectorSetWithDefaultExprSlot(
-    vecArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalVectorSetWithDefaultExprSlot(
@@ -2122,13 +2153,13 @@ pub fn evalVectorSetWithDefaultExprSlot(
 
 /// Evaluate Vector.set operands in slot path and defer the default expression until needed.
 pub fn evalVectorSetWithDefaultExprSlotValues(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    valueExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    valueExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalVectorSetWithDefaultExprSlotValues(
@@ -2145,13 +2176,13 @@ pub fn evalVectorSetWithDefaultExprSlotValues(
 
 /// Finish specialized Vector.set + Option.withDefault in slot path with lazy default evaluation.
 pub fn evalVectorSetWithDefaultExprSlotResult(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    valueV: &crate::aver_generated::domain::value::Val,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    valueV @ _: &crate::aver_generated::domain::value::Val,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalVectorSetWithDefaultExprSlotResult(
@@ -2168,11 +2199,11 @@ pub fn evalVectorSetWithDefaultExprSlotResult(
 
 /// Specialized Vector.get + Option.withDefault in slot path.
 pub fn evalVectorGetWithDefaultExprSlot(
-    vecArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalVectorGetWithDefaultExprSlot(
@@ -2187,12 +2218,12 @@ pub fn evalVectorGetWithDefaultExprSlot(
 
 /// Evaluate Vector.get operands in slot path and defer the default expression until needed.
 pub fn evalVectorGetWithDefaultExprSlotValues(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalVectorGetWithDefaultExprSlotValues(
@@ -2208,12 +2239,12 @@ pub fn evalVectorGetWithDefaultExprSlotValues(
 
 /// Finish specialized Vector.get + Option.withDefault in slot path with lazy default evaluation.
 pub fn evalVectorGetWithDefaultExprSlotResult(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalVectorGetWithDefaultExprSlotResult(
@@ -2229,11 +2260,11 @@ pub fn evalVectorGetWithDefaultExprSlotResult(
 
 /// Match expression in slot path.
 pub fn evalMatchExprSlot(
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalMatchExprSlot(scrutinee.clone(), arms.clone(), env.clone()),
@@ -2244,11 +2275,11 @@ pub fn evalMatchExprSlot(
 
 /// Try each match arm in slot path.
 pub fn evalMatchSlot(
-    v: &crate::aver_generated::domain::value::Val,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::EvalMatchSlot(v.clone(), arms.clone(), env.clone()),
@@ -2274,16 +2305,21 @@ enum __MutualTco4 {
 
 fn __mutual_tco_trampoline_4(
     mut __state: __MutualTco4,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco4::EvalArgsMapToNamedEnv(mut exprs, mut params, mut acc) => {
+            __MutualTco4::EvalArgsMapToNamedEnv(mut exprs @ _, mut params @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(exprs, [] => { return Ok(acc) }, [e, restExprs] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &*env, &*fns) { Err(err @ _) => { return Err(err) }, Ok(v @ _) => { __MutualTco4::EvalArgsMapToNamedEnvBind(restExprs, params, acc, v) } } })
             }
-            __MutualTco4::EvalArgsMapToNamedEnvBind(mut restExprs, mut params, mut acc, mut v) => {
+            __MutualTco4::EvalArgsMapToNamedEnvBind(
+                mut restExprs @ _,
+                mut params @ _,
+                mut acc @ _,
+                mut v @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(params, [] => __MutualTco4::EvalArgsMapToNamedEnv(restExprs, aver_rt::AverList::empty(), acc), [param, restParams] => __MutualTco4::EvalArgsMapToNamedEnv(restExprs, restParams, acc.insert_owned(param, v)))
             }
@@ -2293,11 +2329,11 @@ fn __mutual_tco_trampoline_4(
 
 /// Evaluate arg expressions directly into a callee named env from map caller state.
 pub fn evalArgsMapToNamedEnv(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    params: &aver_rt::AverList<AverStr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    acc: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    params @ _: &aver_rt::AverList<AverStr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    acc @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>, AverStr> {
     __mutual_tco_trampoline_4(
         __MutualTco4::EvalArgsMapToNamedEnv(exprs.clone(), params.clone(), acc.clone()),
@@ -2308,12 +2344,12 @@ pub fn evalArgsMapToNamedEnv(
 
 /// Bind one evaluated arg into the callee named env when a parameter exists.
 pub fn evalArgsMapToNamedEnvBind(
-    restExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    params: &aver_rt::AverList<AverStr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    acc: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    v: &crate::aver_generated::domain::value::Val,
+    restExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    params @ _: &aver_rt::AverList<AverStr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    acc @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>, AverStr> {
     __mutual_tco_trampoline_4(
         __MutualTco4::EvalArgsMapToNamedEnvBind(
@@ -2344,17 +2380,22 @@ enum __MutualTco5 {
 
 fn __mutual_tco_trampoline_5(
     mut __state: __MutualTco5,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco5::EvalArgsSlotToNamedEnv(mut exprs, mut params, mut acc) => {
+            __MutualTco5::EvalArgsSlotToNamedEnv(mut exprs @ _, mut params @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(exprs, [] => { return Ok(acc) }, [e, restExprs] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &*env, &*slotMap, &*fns) { Err(err @ _) => { return Err(err) }, Ok(v @ _) => { __MutualTco5::EvalArgsSlotToNamedEnvBind(restExprs, params, acc, v) } } })
             }
-            __MutualTco5::EvalArgsSlotToNamedEnvBind(mut restExprs, mut params, mut acc, mut v) => {
+            __MutualTco5::EvalArgsSlotToNamedEnvBind(
+                mut restExprs @ _,
+                mut params @ _,
+                mut acc @ _,
+                mut v @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(params, [] => __MutualTco5::EvalArgsSlotToNamedEnv(restExprs, aver_rt::AverList::empty(), acc), [param, restParams] => __MutualTco5::EvalArgsSlotToNamedEnv(restExprs, restParams, acc.insert_owned(param, v)))
             }
@@ -2364,12 +2405,12 @@ fn __mutual_tco_trampoline_5(
 
 /// Evaluate arg expressions directly into a callee named env from slot caller state.
 pub fn evalArgsSlotToNamedEnv(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    params: &aver_rt::AverList<AverStr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    acc: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    params @ _: &aver_rt::AverList<AverStr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    acc @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>, AverStr> {
     __mutual_tco_trampoline_5(
         __MutualTco5::EvalArgsSlotToNamedEnv(exprs.clone(), params.clone(), acc.clone()),
@@ -2381,13 +2422,13 @@ pub fn evalArgsSlotToNamedEnv(
 
 /// Bind one evaluated arg into the callee named env when a parameter exists.
 pub fn evalArgsSlotToNamedEnvBind(
-    restExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    params: &aver_rt::AverList<AverStr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    acc: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    v: &crate::aver_generated::domain::value::Val,
+    restExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    params @ _: &aver_rt::AverList<AverStr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    acc @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>, AverStr> {
     __mutual_tco_trampoline_5(
         __MutualTco5::EvalArgsSlotToNamedEnvBind(
@@ -2418,15 +2459,20 @@ enum __MutualTco6 {
 
 fn __mutual_tco_trampoline_6(
     mut __state: __MutualTco6,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> aver_rt::AverVector<crate::aver_generated::domain::value::Val> {
     loop {
         __state = match __state {
-            __MutualTco6::MergeBindingsSlot(mut bindings, mut env) => {
+            __MutualTco6::MergeBindingsSlot(mut bindings @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(bindings, [] => { return env }, [pair, rest] => { { let (name, val) = pair; __MutualTco6::MergeOneBindingSlot(name, val, rest, env) } })
             }
-            __MutualTco6::MergeOneBindingSlot(mut name, mut val, mut rest, mut env) => {
+            __MutualTco6::MergeOneBindingSlot(
+                mut name @ _,
+                mut val @ _,
+                mut rest @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 match bindingSlots.get(&name).cloned() {
                     Some(slot @ _) => __MutualTco6::MergeBindingsSlot(
@@ -2442,9 +2488,9 @@ fn __mutual_tco_trampoline_6(
 
 /// Merge pattern bindings into slot env using the slots assigned for this specific arm.
 pub fn mergeBindingsSlot(
-    bindings: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    bindings @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverVector<crate::aver_generated::domain::value::Val> {
     __mutual_tco_trampoline_6(
         __MutualTco6::MergeBindingsSlot(bindings.clone(), env.clone()),
@@ -2454,11 +2500,11 @@ pub fn mergeBindingsSlot(
 
 /// Merge one pattern binding into slot env.
 pub fn mergeOneBindingSlot(
-    name: AverStr,
-    val: &crate::aver_generated::domain::value::Val,
-    rest: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    val @ _: &crate::aver_generated::domain::value::Val,
+    rest @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverVector<crate::aver_generated::domain::value::Val> {
     __mutual_tco_trampoline_6(
         __MutualTco6::MergeOneBindingSlot(name, val.clone(), rest.clone(), env.clone()),
@@ -2493,12 +2539,17 @@ enum __MutualTco7 {
 
 fn __mutual_tco_trampoline_7(
     mut __state: __MutualTco7,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco7::EvalStmtBindSlotNext(mut slot, mut e, mut rest, mut env) => {
+            __MutualTco7::EvalStmtBindSlotNext(
+                mut slot @ _,
+                mut e @ _,
+                mut rest @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
@@ -2514,7 +2565,7 @@ fn __mutual_tco_trampoline_7(
                     }
                 }
             }
-            __MutualTco7::EvalStmtExprSlotNext(mut e, mut rest, mut env) => {
+            __MutualTco7::EvalStmtExprSlotNext(mut e @ _, mut rest @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
@@ -2528,7 +2579,12 @@ fn __mutual_tco_trampoline_7(
                     }
                 }
             }
-            __MutualTco7::EvalStmtBindFallbackSlotNext(mut name, mut e, mut rest, mut env) => {
+            __MutualTco7::EvalStmtBindFallbackSlotNext(
+                mut name @ _,
+                mut e @ _,
+                mut rest @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
                     &e, &env, &*slotMap, &*fns,
@@ -2542,7 +2598,7 @@ fn __mutual_tco_trampoline_7(
                     }
                 }
             }
-            __MutualTco7::EvalStmtsSlot(mut stmts, mut env) => {
+            __MutualTco7::EvalStmtsSlot(mut stmts @ _, mut env @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValUnit) }, [stmt, rest] => match stmt {
                     crate::aver_generated::domain::ast::Stmt::StmtBindSlot(slot, e) => {
@@ -2562,12 +2618,12 @@ fn __mutual_tco_trampoline_7(
 
 /// Evaluate a slot binding and continue statement execution without packing a tuple.
 pub fn evalStmtBindSlotNext(
-    slot: aver_rt::AverInt,
-    e: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    slot @ _: aver_rt::AverInt,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_7(
         __MutualTco7::EvalStmtBindSlotNext(slot, e.clone(), rest.clone(), env.clone()),
@@ -2578,11 +2634,11 @@ pub fn evalStmtBindSlotNext(
 
 /// Evaluate an expression statement and continue statement execution without packing a tuple.
 pub fn evalStmtExprSlotNext(
-    e: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_7(
         __MutualTco7::EvalStmtExprSlotNext(e.clone(), rest.clone(), env.clone()),
@@ -2593,12 +2649,12 @@ pub fn evalStmtExprSlotNext(
 
 /// Fallback for unresolved StmtBind in slot path without packing a tuple.
 pub fn evalStmtBindFallbackSlotNext(
-    name: AverStr,
-    e: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_7(
         __MutualTco7::EvalStmtBindFallbackSlotNext(name, e.clone(), rest.clone(), env.clone()),
@@ -2609,10 +2665,10 @@ pub fn evalStmtBindFallbackSlotNext(
 
 /// Evaluate statements in slot path, threading env.
 pub fn evalStmtsSlot(
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     __mutual_tco_trampoline_7(
         __MutualTco7::EvalStmtsSlot(stmts.clone(), env.clone()),
@@ -2655,21 +2711,26 @@ enum __MutualTco8 {
 
 fn __mutual_tco_trampoline_8(
     mut __state: __MutualTco8,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco8::EvalStmtsSlotTail(mut selfId, mut stmts, mut slotCount, mut env) => {
+            __MutualTco8::EvalStmtsSlotTail(
+                mut selfId @ _,
+                mut stmts @ _,
+                mut slotCount @ _,
+                mut env @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::eval::core::SlotTailStep::SlotTailDone(crate::aver_generated::domain::value::Val::ValUnit)) }, [stmt, rest] => { { let __list_subject = rest.clone(); if __list_subject.is_empty() { return crate::aver_generated::domain::eval::core::evalTailStmtSlot(selfId, &stmt, slotCount, &env, &*slotMap, &*fns) } else { __MutualTco8::EvalStmtsSlotTailNext(selfId, stmt, rest, slotCount, env) } } })
             }
             __MutualTco8::EvalStmtsSlotTailNext(
-                mut selfId,
-                mut stmt,
-                mut rest,
-                mut slotCount,
-                mut env,
+                mut selfId @ _,
+                mut stmt @ _,
+                mut rest @ _,
+                mut slotCount @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 match stmt {
@@ -2685,12 +2746,12 @@ fn __mutual_tco_trampoline_8(
                 }
             }
             __MutualTco8::EvalStmtsSlotTailBind(
-                mut selfId,
-                mut slot,
-                mut e,
-                mut rest,
-                mut slotCount,
-                mut env,
+                mut selfId @ _,
+                mut slot @ _,
+                mut e @ _,
+                mut rest @ _,
+                mut slotCount @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(
@@ -2704,11 +2765,11 @@ fn __mutual_tco_trampoline_8(
                 )
             }
             __MutualTco8::EvalStmtsSlotTailExpr(
-                mut selfId,
-                mut e,
-                mut rest,
-                mut slotCount,
-                mut env,
+                mut selfId @ _,
+                mut e @ _,
+                mut rest @ _,
+                mut slotCount @ _,
+                mut env @ _,
             ) => {
                 crate::cancel_checkpoint();
                 crate::aver_generated::domain::eval::core::evalExprSlot(
@@ -2722,12 +2783,12 @@ fn __mutual_tco_trampoline_8(
 
 /// Evaluate slot statements when the final expression may self-tail-recur.
 pub fn evalStmtsSlotTail(
-    selfId: aver_rt::AverInt,
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::EvalStmtsSlotTail(selfId, stmts.clone(), slotCount, env.clone()),
@@ -2738,13 +2799,13 @@ pub fn evalStmtsSlotTail(
 
 /// Evaluate one non-final slot statement before continuing the tail-aware slot loop.
 pub fn evalStmtsSlotTailNext(
-    selfId: aver_rt::AverInt,
-    stmt: &crate::aver_generated::domain::ast::Stmt,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::EvalStmtsSlotTailNext(
@@ -2761,14 +2822,14 @@ pub fn evalStmtsSlotTailNext(
 
 /// Evaluate one slot binding before continuing the tail-aware slot loop.
 pub fn evalStmtsSlotTailBind(
-    selfId: aver_rt::AverInt,
-    slot: aver_rt::AverInt,
-    e: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    slot @ _: aver_rt::AverInt,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::EvalStmtsSlotTailBind(
@@ -2786,13 +2847,13 @@ pub fn evalStmtsSlotTailBind(
 
 /// Evaluate one non-final expression statement before continuing the tail-aware slot loop.
 pub fn evalStmtsSlotTailExpr(
-    selfId: aver_rt::AverInt,
-    e: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::EvalStmtsSlotTailExpr(
@@ -2809,7 +2870,7 @@ pub fn evalStmtsSlotTailExpr(
 
 /// Recognize immediate literal expressions in named-env mode.
 pub fn evalImmediateNamedExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::value::Val> {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -2830,7 +2891,7 @@ pub fn evalImmediateNamedExpr(
 }
 
 /// Name the AST node kind for diagnostics; interpolation renders primitives only, so an Expr needs a named conversion.
-pub fn exprLabel(expr: &crate::aver_generated::domain::ast::Expr) -> AverStr {
+pub fn exprLabel(expr @ _: &crate::aver_generated::domain::ast::Expr) -> AverStr {
     crate::cancel_checkpoint();
     match expr {
         crate::aver_generated::domain::ast::Expr::ExprInt(_) => AverStr::from("ExprInt"),
@@ -2872,7 +2933,7 @@ pub fn exprLabel(expr: &crate::aver_generated::domain::ast::Expr) -> AverStr {
 }
 
 /// Continue naming AST node kinds for the comparison, aggregate, and call forms.
-pub fn exprLabelAggregate(expr: &crate::aver_generated::domain::ast::Expr) -> AverStr {
+pub fn exprLabelAggregate(expr @ _: &crate::aver_generated::domain::ast::Expr) -> AverStr {
     crate::cancel_checkpoint();
     match expr {
         crate::aver_generated::domain::ast::Expr::ExprLt(_, _) => AverStr::from("ExprLt"),
@@ -2910,9 +2971,9 @@ pub fn exprLabelAggregate(expr: &crate::aver_generated::domain::ast::Expr) -> Av
 /// Look up variable, Option.None, a named function reference, or a nullary variant constructor.
 #[inline(always)]
 pub fn evalVar(
-    name: AverStr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -2936,11 +2997,11 @@ pub fn evalVar(
 
 /// Evaluate a fused Vector.get + Option.withDefault in map path.
 pub fn evalVectorGetOrIntExpr(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultValue: aver_rt::AverInt,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultValue @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let vecV @ _ = crate::aver_generated::domain::eval::core::evalExpr(vecExpr, env, fns)?;
@@ -2950,11 +3011,11 @@ pub fn evalVectorGetOrIntExpr(
 
 /// Evaluate a fused Int.mod + Result.withDefault in map path.
 pub fn evalIntModOrIntExpr(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    defaultValue: aver_rt::AverInt,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultValue @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let aV @ _ = crate::aver_generated::domain::eval::core::evalExpr(a, env, fns)?;
@@ -2964,9 +3025,9 @@ pub fn evalIntModOrIntExpr(
 
 /// Evaluate ? operator: unwrap Ok or propagate Err.
 pub fn evalPropagate(
-    inner: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    inner @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExpr(inner, env, fns)?;
@@ -2994,10 +3055,10 @@ pub fn evalPropagate(
 
 /// Evaluate independent product using the self-host's own divide-and-conquer ?!, then unwrap guest Results if needed.
 pub fn evalIndependentProduct(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    unwrap: bool,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    unwrap @ _: bool,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ =
@@ -3014,9 +3075,9 @@ pub fn evalIndependentProduct(
 
 /// Evaluate guest independent-product branches through a balanced tree of the self-host's own ?!.
 pub fn evalIndependentItems(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match crate::aver_generated::domain::eval::core::evalExpr(&a, env, fns) { Ok(va @ _) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e @ _) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalExpr(&a, env, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalExpr(&b, env, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = { let env = env; let fns = fns; let a = a.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExpr(&a, env, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = { let env = env; let fns = fns; let b = b.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExpr(&b, env, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = crate::aver_generated::domain::eval::core::splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalIndependentItems(&leftExprs, env, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalIndependentItems(&rightExprs, env, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = { let env = env; let fns = fns; let leftExprs = leftExprs.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItems(&leftExprs, env, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = { let env = env; let fns = fns; let rightExprs = rightExprs.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItems(&rightExprs, env, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(crate::aver_generated::domain::eval::core::interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
@@ -3025,10 +3086,10 @@ pub fn evalIndependentItems(
 /// Split a product into alternating branches so recursive ?! can cover all items.
 #[inline(always)]
 pub fn splitIndependentExprs(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut leftAcc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut rightAcc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut sendLeft: bool,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut leftAcc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut rightAcc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut sendLeft @ _: bool,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
     aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
@@ -3058,10 +3119,10 @@ pub fn splitIndependentExprs(
 /// Restore original product order after alternating recursive split.
 #[inline(always)]
 pub fn interleaveIndependentVals(
-    mut left: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut right: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut takeLeft: bool,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut left @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut right @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut takeLeft @ _: bool,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -3092,8 +3153,8 @@ pub fn interleaveIndependentVals(
 /// Append remaining values after interleaving and return in forward order.
 #[inline(always)]
 pub fn finishIndependentVals(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -3110,8 +3171,8 @@ pub fn finishIndependentVals(
 /// Unwrap all Result values in an independent product (?!).
 #[inline(always)]
 pub fn unwrapProductResults(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -3146,11 +3207,11 @@ pub fn unwrapProductResults(
 
 /// Evaluate right side of binop and apply.
 pub fn evalBinopRight(
-    va: &crate::aver_generated::domain::value::Val,
-    b: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    op: &crate::aver_generated::domain::ast::BinOp,
+    va @ _: &crate::aver_generated::domain::value::Val,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalExpr(b, env, fns) {
@@ -3161,11 +3222,11 @@ pub fn evalBinopRight(
 
 /// Evaluate a binary operation on two expressions.
 pub fn evalBinop(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    op: &crate::aver_generated::domain::ast::BinOp,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalExpr(a, env, fns) {
@@ -3178,9 +3239,9 @@ pub fn evalBinop(
 
 /// Evaluate unary minus on the named-env path.
 pub fn evalNeg(
-    inner: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    inner @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalExpr(inner, env, fns) {
@@ -3191,11 +3252,11 @@ pub fn evalNeg(
 
 /// Evaluate right side of comparison and apply.
 pub fn evalCmpRight(
-    va: &crate::aver_generated::domain::value::Val,
-    b: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    va @ _: &crate::aver_generated::domain::value::Val,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalExpr(b, env, fns) {
@@ -3206,11 +3267,11 @@ pub fn evalCmpRight(
 
 /// Evaluate a comparison expression.
 pub fn evalCmp(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalExpr(a, env, fns) {
@@ -3221,9 +3282,9 @@ pub fn evalCmp(
 
 /// Evaluate string interpolation: concat all parts as strings.
 pub fn evalConcatExpr(
-    parts: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    parts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalConcatParts(
@@ -3236,13 +3297,13 @@ pub fn evalConcatExpr(
 
 /// Concatenate interpolation parts. Self-recursive for codegen TCO.
 pub fn evalConcatParts(
-    mut parts: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: AverStr,
+    mut parts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(parts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValStr(acc)); }, [p, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&p, &*env, &*fns) { Err(e @ _) => { return Err(e); }, Ok(v @ _) => { {
@@ -3257,9 +3318,9 @@ pub fn evalConcatParts(
 
 /// Evaluate tuple literal.
 pub fn evalTupleExpr(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::eval::core::evalListItems(exprs, env, fns)?;
@@ -3268,10 +3329,10 @@ pub fn evalTupleExpr(
 
 /// Evaluate record constructor.
 pub fn evalRecordExpr(
-    name: AverStr,
-    fieldExprs: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    fieldExprs @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let fields @ _ =
@@ -3283,9 +3344,9 @@ pub fn evalRecordExpr(
 
 /// Evaluate record field expressions.
 pub fn evalRecordFields(
-    fieldExprs: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fieldExprs @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(fieldExprs.clone(), [] => Ok(aver_rt::AverList::empty()), [pair, rest] => { { let (fname, expr) = pair; crate::aver_generated::domain::eval::core::evalRecordFieldOne(fname, &expr, &rest, env, fns) } })
@@ -3293,11 +3354,11 @@ pub fn evalRecordFields(
 
 /// Evaluate one record field and continue.
 pub fn evalRecordFieldOne(
-    fname: AverStr,
-    expr: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fname @ _: AverStr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExpr(expr, env, fns)?;
@@ -3308,10 +3369,10 @@ pub fn evalRecordFieldOne(
 
 /// Evaluate field access: obj.field.
 pub fn evalFieldAccess(
-    obj: &crate::aver_generated::domain::ast::Expr,
-    field: AverStr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    obj @ _: &crate::aver_generated::domain::ast::Expr,
+    field @ _: AverStr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExpr(obj, env, fns)?;
@@ -3325,9 +3386,9 @@ pub fn evalFieldAccess(
 
 /// Evaluate a list literal.
 pub fn evalListExpr(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalListItems(exprs, env, fns) {
@@ -3338,9 +3399,9 @@ pub fn evalListExpr(
 
 /// Evaluate list of expressions into list of values.
 pub fn evalListItems(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalListItemsRev(
@@ -3353,13 +3414,13 @@ pub fn evalListItems(
 
 /// Tail-recursive worker for evalListItems. Accumulates in reverse.
 pub fn evalListItemsRev(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &*env, &*fns) { Err(err @ _) => { return Err(err); }, Ok(v @ _) => { {
@@ -3374,9 +3435,9 @@ pub fn evalListItemsRev(
 
 /// Evaluate a list of argument expressions.
 pub fn evalArgs(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalArgsRev(
@@ -3389,13 +3450,13 @@ pub fn evalArgs(
 
 /// Tail-recursive worker for evalArgs. Accumulates in reverse.
 pub fn evalArgsRev(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &*env, &*fns) { Err(err @ _) => { return Err(err); }, Ok(v @ _) => { {
@@ -3410,9 +3471,9 @@ pub fn evalArgsRev(
 
 /// Dispatch call: record update if Type.update, else normal call.
 pub fn callWithArgs(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    name: AverStr,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::eval::records::isRecordUpdate(name.clone(), args) {
@@ -3424,9 +3485,9 @@ pub fn callWithArgs(
 
 /// Normal function call dispatch. Uses slot-based eval for resolved fns.
 pub fn callWithArgsNormal(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    name: AverStr,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
@@ -3437,9 +3498,9 @@ pub fn callWithArgsNormal(
 
 /// Call a function: slot-based if resolved, map-based otherwise.
 pub fn callResolved(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let fnId @ _ = crate::aver_generated::domain::eval::store::lookupFnId(fns, fd.name.clone())?;
@@ -3448,10 +3509,10 @@ pub fn callResolved(
 
 /// Call a function with a known store id: slot-based if resolved, map-based otherwise.
 pub fn callResolvedById(
-    fnId: aver_rt::AverInt,
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if (fd.slotCount > aver_rt::AverInt::from_i64(0)) {
@@ -3476,10 +3537,10 @@ pub fn callResolvedById(
 
 /// Evaluate a resolved function body in slot mode, looping self-tail-calls instead of recursing on the host stack.
 pub fn evalResolvedSlotFn(
-    fnId: aver_rt::AverInt,
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if fd.tailLoop {
@@ -3496,13 +3557,13 @@ pub fn evalResolvedSlotFn(
 
 /// Run the tail-aware slot evaluator only for functions that actually end in self-tail-calls.
 pub fn evalResolvedSlotLoop(
-    mut fnId: aver_rt::AverInt,
-    fd: crate::aver_generated::domain::ast::FnDef,
-    mut calleeEnv: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
+    mut fnId @ _: aver_rt::AverInt,
+    fd @ _: crate::aver_generated::domain::ast::FnDef,
+    mut calleeEnv @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
-    let fd = std::sync::Arc::new(fd);
-    let fns = std::sync::Arc::new(fns);
+    let fd @ _ = std::sync::Arc::new(fd);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         let step @ _ = crate::aver_generated::domain::eval::core::evalResolvedSlotStep(
@@ -3526,9 +3587,9 @@ pub fn evalResolvedSlotLoop(
 
 /// Evaluate a resolved function body in slot mode without the tail-loop machinery.
 pub fn evalResolvedSlotDirect(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let result @ _ = match fd.fastPath.clone() {
@@ -3602,10 +3663,10 @@ pub fn evalResolvedSlotDirect(
 
 /// Run one slot-frame step and either finish with a value or request a self-tail-call re-entry.
 pub fn evalResolvedSlotStep(
-    fnId: aver_rt::AverInt,
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     crate::cancel_checkpoint();
     match fd.fastPath.clone() {
@@ -3727,9 +3788,9 @@ pub fn evalResolvedSlotStep(
 
 /// Evaluate a resolved function body in named-env mode, using a fast expr tag when available.
 pub fn evalResolvedNamedFn(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    calleeEnv: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    calleeEnv @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let result @ _ = match fd.fastPath.clone() {
@@ -3759,10 +3820,10 @@ pub fn evalResolvedNamedFn(
 
 /// Fast path for a single expression body in slot mode.
 pub fn evalResolvedSingleExprSlot(
-    body: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -3785,12 +3846,12 @@ pub fn evalResolvedSingleExprSlot(
 
 /// Tail-aware version of the single-expression fast path for slot functions.
 pub fn evalResolvedSingleExprSlotTail(
-    selfId: aver_rt::AverInt,
-    body: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slotCount: aver_rt::AverInt,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slotCount @ _: aver_rt::AverInt,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -3825,12 +3886,12 @@ pub fn evalResolvedSingleExprSlotTail(
 
 /// Evaluate a final statement in slot mode, capturing self-tail-calls as loop re-entry requests.
 pub fn evalTailStmtSlot(
-    selfId: aver_rt::AverInt,
-    stmt: &crate::aver_generated::domain::ast::Stmt,
-    slotCount: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    selfId @ _: aver_rt::AverInt,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
+    slotCount @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<SlotTailStep, AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -3857,10 +3918,10 @@ pub fn evalTailStmtSlot(
 
 /// Run the single expression stmt fast path in slot mode.
 pub fn evalResolvedSingleStmtSlot(
-    stmt: &crate::aver_generated::domain::ast::Stmt,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -3878,9 +3939,9 @@ pub fn evalResolvedSingleStmtSlot(
 
 /// Fast path for a single expression body in named-env mode.
 pub fn evalResolvedSingleExprNamed(
-    body: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    calleeEnv: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    calleeEnv @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -3909,9 +3970,9 @@ pub fn evalResolvedSingleExprNamed(
 
 /// Run the single expression stmt fast path in named-env mode.
 pub fn evalResolvedSingleStmtNamed(
-    stmt: &crate::aver_generated::domain::ast::Stmt,
-    calleeEnv: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
+    calleeEnv @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -3928,10 +3989,10 @@ pub fn evalResolvedSingleStmtNamed(
 
 /// Execute named-env leaves directly when they are pure constants; otherwise fall back.
 pub fn runFastLeafNamed(
-    leaf: &crate::aver_generated::domain::ast::FastLeaf,
-    body: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    calleeEnv: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    leaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    calleeEnv @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match leaf.clone() {
@@ -3955,10 +4016,10 @@ pub fn runFastLeafNamed(
 
 /// Forward a direct call by reading already-resolved slot arguments without evaluating an AST arg list.
 pub fn fastForwardCall(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    fnId: aver_rt::AverInt,
-    slotArgs: &aver_rt::AverIntList,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    fnId @ _: aver_rt::AverInt,
+    slotArgs @ _: &aver_rt::AverIntList,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let args @ _ = crate::aver_generated::domain::eval::core::collectFastForwardArgs__collected(
@@ -3973,11 +4034,11 @@ pub fn fastForwardCall(
 /// Collect forwarded slot arguments in call order.
 #[inline(always)]
 pub fn collectFastForwardArgs(
-    mut slotArgs: aver_rt::AverIntList,
-    calleeEnv: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut slotArgs @ _: aver_rt::AverIntList,
+    calleeEnv @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
-    let calleeEnv = std::sync::Arc::new(calleeEnv);
+    let calleeEnv @ _ = std::sync::Arc::new(calleeEnv);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(slotArgs, [] => { return Ok(acc.reverse()); }, [slot, rest] => { match crate::aver_generated::domain::eval::slots::lookupSlot(&*calleeEnv, slot) { Ok(v @ _) => { {
@@ -3992,10 +4053,10 @@ pub fn collectFastForwardArgs(
 
 /// Evaluate a function call.
 pub fn evalCall(
-    name: AverStr,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalArgs(argExprs, env, fns) {
@@ -4006,10 +4067,10 @@ pub fn evalCall(
 
 /// Call a pre-resolved function directly using the function store.
 pub fn evalCallDirect(
-    fnId: aver_rt::AverInt,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let fd @ _ = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
@@ -4024,11 +4085,11 @@ pub fn evalCallDirect(
 
 /// Call resolved function by evaluating args directly into the callee slot env.
 pub fn evalCallDirectMapToSlot(
-    fnId: aver_rt::AverInt,
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsMapToSlotEnv(
@@ -4049,10 +4110,10 @@ pub fn evalCallDirectMapToSlot(
 
 /// Call resolved function by evaluating args directly into the callee named env.
 pub fn evalCallDirectMapToNamed(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsMapToNamedEnv(
@@ -4067,10 +4128,10 @@ pub fn evalCallDirectMapToNamed(
 
 /// Call a builtin directly, skipping fns lookup.
 pub fn evalCallBuiltin(
-    name: AverStr,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::core::evalArgs(argExprs, env, fns) {
@@ -4081,9 +4142,9 @@ pub fn evalCallBuiltin(
 
 /// Evaluate a statement expression.
 pub fn evalStmtExpr(
-    e: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<
     (
         crate::aver_generated::domain::value::Val,
@@ -4100,10 +4161,10 @@ pub fn evalStmtExpr(
 
 /// Evaluate a binding statement.
 pub fn evalStmtBind(
-    name: AverStr,
-    e: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    e @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<
     (
         crate::aver_generated::domain::value::Val,
@@ -4120,9 +4181,9 @@ pub fn evalStmtBind(
 
 /// Evaluate a statement, returning the result and updated environment.
 pub fn evalStmt(
-    stmt: &crate::aver_generated::domain::ast::Stmt,
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<
     (
         crate::aver_generated::domain::value::Val,
@@ -4146,11 +4207,11 @@ pub fn evalStmt(
 
 /// Evaluate statements, threading env. Self-recursive for codegen TCO.
 pub fn evalStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
-    let fns = std::sync::Arc::new(fns);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(stmts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValUnit); }, [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &*fns) { Err(e @ _) => { return Err(e); }, Ok(pair @ _) => { { let (v, newEnv) = pair; { let __list_subject = rest.clone(); if __list_subject.is_empty() { return Ok(v); } else { {
@@ -4165,10 +4226,10 @@ pub fn evalStmts(
 
 /// Evaluate top-level statements in source order and keep the resulting env, so top-level bindings stay visible to functions. Each statement sees the bindings before it, both directly and through any function it calls.
 pub fn evalTopLevelStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    mut last: crate::aver_generated::domain::value::Val,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    mut last @ _: crate::aver_generated::domain::value::Val,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<
     (
         crate::aver_generated::domain::value::Val,
@@ -4176,7 +4237,7 @@ pub fn evalTopLevelStmts(
     ),
     AverStr,
 > {
-    let fns = std::sync::Arc::new(fns);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(stmts, [] => { return Ok((last, env)); }, [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &crate::aver_generated::domain::eval::store::withGlobals(&*fns, &env)) { Err(e @ _) => { return Err(e); }, Ok(pair @ _) => { { let (v, newEnv) = pair; {
@@ -4193,7 +4254,7 @@ pub fn evalTopLevelStmts(
 
 /// Evaluate a complete program: run top-level stmts, then call main() if it exists.
 pub fn evalProgram(
-    prog: &crate::aver_generated::domain::ast::Program,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let fnsStore @ _ = crate::aver_generated::domain::eval::store::fnsToStore(&prog.fns);
@@ -4214,8 +4275,8 @@ pub fn evalProgram(
 
 /// Evaluate a program with additional functions from loaded modules.
 pub fn evalProgramWithFns(
-    prog: &crate::aver_generated::domain::ast::Program,
-    extraFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    extraFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let allFns @ _ = crate::aver_generated::domain::eval::store::fnsToStore(
@@ -4238,8 +4299,8 @@ pub fn evalProgramWithFns(
 
 /// If a main() function exists, call it. Otherwise return fallback value.
 pub fn maybeCallMain(
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    fallback: &crate::aver_generated::domain::value::Val,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    fallback @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, AverStr::from("main")) {
@@ -4254,8 +4315,8 @@ pub fn maybeCallMain(
 
 /// Recognize immediate slot and literal expressions in slot mode.
 pub fn evalImmediateSlotExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Option<Result<crate::aver_generated::domain::value::Val, AverStr>> {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -4281,8 +4342,8 @@ pub fn evalImmediateSlotExpr(
 /// Resolve unresolved var in slot path: builtins, named function refs, and constructors.
 #[inline(always)]
 pub fn evalVarSlot(
-    name: AverStr,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -4301,10 +4362,10 @@ pub fn evalVarSlot(
 
 /// Evaluate a specialized slot-vs-int arithmetic expression.
 pub fn evalBinopSlotInt(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    slot: aver_rt::AverInt,
-    rhs: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    slot @ _: aver_rt::AverInt,
+    rhs @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
@@ -4317,10 +4378,10 @@ pub fn evalBinopSlotInt(
 
 /// Evaluate a specialized slot-vs-slot arithmetic expression.
 pub fn evalBinopSlots(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    lhs: aver_rt::AverInt,
-    rhs: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    lhs @ _: aver_rt::AverInt,
+    rhs @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, lhs)?;
@@ -4330,10 +4391,10 @@ pub fn evalBinopSlots(
 
 /// Evaluate a specialized slot-vs-int comparison.
 pub fn evalCmpSlotInt(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    slot: aver_rt::AverInt,
-    rhs: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    slot @ _: aver_rt::AverInt,
+    rhs @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, slot)?;
@@ -4346,10 +4407,10 @@ pub fn evalCmpSlotInt(
 
 /// Evaluate a specialized slot-vs-slot comparison.
 pub fn evalCmpSlots(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    lhs: aver_rt::AverInt,
-    rhs: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    lhs @ _: aver_rt::AverInt,
+    rhs @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let left @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(env, lhs)?;
@@ -4359,12 +4420,12 @@ pub fn evalCmpSlots(
 
 /// Evaluate a fused Vector.get + Option.withDefault in slot path.
 pub fn evalVectorGetOrIntExprSlot(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultValue: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultValue @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let vecV @ _ =
@@ -4376,12 +4437,12 @@ pub fn evalVectorGetOrIntExprSlot(
 
 /// Evaluate a fused Int.mod + Result.withDefault in slot path.
 pub fn evalIntModOrIntExprSlot(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    defaultValue: aver_rt::AverInt,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultValue @ _: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let aV @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
@@ -4391,12 +4452,12 @@ pub fn evalIntModOrIntExprSlot(
 
 /// Binary op in slot path.
 pub fn evalBinopSlot(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    op: &crate::aver_generated::domain::ast::BinOp,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let va @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
@@ -4406,10 +4467,10 @@ pub fn evalBinopSlot(
 
 /// Unary minus in slot path.
 pub fn evalNegSlot(
-    inner: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    inner @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
@@ -4418,12 +4479,12 @@ pub fn evalNegSlot(
 
 /// Comparison in slot path.
 pub fn evalCmpSlot(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let va @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(a, env, slotMap, fns)?;
@@ -4433,10 +4494,10 @@ pub fn evalCmpSlot(
 
 /// String interpolation in slot path.
 pub fn evalConcatSlot(
-    parts: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    parts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalConcatPartsSlot(
@@ -4450,15 +4511,15 @@ pub fn evalConcatSlot(
 
 /// Concatenate interpolation parts in slot path.
 pub fn evalConcatPartsSlot(
-    mut parts: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: AverStr,
+    mut parts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let slotMap = std::sync::Arc::new(slotMap);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let slotMap @ _ = std::sync::Arc::new(slotMap);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(parts, [] => { return Ok(crate::aver_generated::domain::value::Val::ValStr(acc)); }, [p, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&p, &*env, &*slotMap, &*fns) { Err(e @ _) => { return Err(e); }, Ok(v @ _) => { {
@@ -4473,10 +4534,10 @@ pub fn evalConcatPartsSlot(
 
 /// Tuple literal in slot path.
 pub fn evalTupleSlot(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ =
@@ -4486,10 +4547,10 @@ pub fn evalTupleSlot(
 
 /// List literal in slot path.
 pub fn evalListSlot(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ =
@@ -4499,10 +4560,10 @@ pub fn evalListSlot(
 
 /// Evaluate list of expressions in slot path.
 pub fn evalListItemsSlot(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalListItemsSlotRev(
@@ -4516,15 +4577,15 @@ pub fn evalListItemsSlot(
 
 /// Tail-recursive worker for evalListItemsSlot. Accumulates in reverse.
 pub fn evalListItemsSlotRev(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let slotMap = std::sync::Arc::new(slotMap);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let slotMap @ _ = std::sync::Arc::new(slotMap);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &*env, &*slotMap, &*fns) { Err(err @ _) => { return Err(err); }, Ok(v @ _) => { {
@@ -4539,11 +4600,11 @@ pub fn evalListItemsSlotRev(
 
 /// Record constructor in slot path.
 pub fn evalRecordSlot(
-    name: AverStr,
-    fieldExprs: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    fieldExprs @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let fields @ _ = crate::aver_generated::domain::eval::core::evalRecordFieldsSlot(
@@ -4556,10 +4617,10 @@ pub fn evalRecordSlot(
 
 /// Evaluate record fields in slot path.
 pub fn evalRecordFieldsSlot(
-    fieldExprs: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fieldExprs @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(fieldExprs.clone(), [] => Ok(aver_rt::AverList::empty()), [pair, rest] => { { let (fname, expr) = pair; crate::aver_generated::domain::eval::core::evalRecordFieldOneSlot(fname, &expr, &rest, env, slotMap, fns) } })
@@ -4567,12 +4628,12 @@ pub fn evalRecordFieldsSlot(
 
 /// Evaluate one record field in slot path.
 pub fn evalRecordFieldOneSlot(
-    fname: AverStr,
-    expr: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fname @ _: AverStr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(expr, env, slotMap, fns)?;
@@ -4583,11 +4644,11 @@ pub fn evalRecordFieldOneSlot(
 
 /// Field access in slot path.
 pub fn evalFieldAccessSlot(
-    obj: &crate::aver_generated::domain::ast::Expr,
-    field: AverStr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    obj @ _: &crate::aver_generated::domain::ast::Expr,
+    field @ _: AverStr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(obj, env, slotMap, fns)?;
@@ -4601,11 +4662,11 @@ pub fn evalFieldAccessSlot(
 
 /// Function call in slot path.
 pub fn evalCallSlot(
-    name: AverStr,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let args @ _ =
@@ -4615,11 +4676,11 @@ pub fn evalCallSlot(
 
 /// Call a pre-resolved function directly from slot mode using the function store.
 pub fn evalCallDirectSlot(
-    fnId: aver_rt::AverInt,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let fd @ _ = crate::aver_generated::domain::eval::store::lookupFnById(fns, fnId.clone())?;
@@ -4636,12 +4697,12 @@ pub fn evalCallDirectSlot(
 
 /// Call resolved function by evaluating args directly into a callee slot env from slot caller state.
 pub fn evalCallDirectSlotToSlot(
-    fnId: aver_rt::AverInt,
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fnId @ _: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsSlotToSlotEnv(
@@ -4663,11 +4724,11 @@ pub fn evalCallDirectSlotToSlot(
 
 /// Call resolved function by evaluating args directly into a named env from slot caller state.
 pub fn evalCallDirectSlotToNamed(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let calleeEnv @ _ = crate::aver_generated::domain::eval::core::evalArgsSlotToNamedEnv(
@@ -4683,11 +4744,11 @@ pub fn evalCallDirectSlotToNamed(
 
 /// Call a builtin directly, skipping fns lookup (slot-based path).
 pub fn evalCallBuiltinSlot(
-    name: AverStr,
-    argExprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    name @ _: AverStr,
+    argExprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let args @ _ =
@@ -4697,10 +4758,10 @@ pub fn evalCallBuiltinSlot(
 
 /// Evaluate argument expressions in slot path.
 pub fn evalArgsSlot(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [e0, rest] => { aver_list_match!(rest, [] => crate::aver_generated::domain::eval::core::evalArgsSlot1(&e0, env, slotMap, fns), [e1, rest2] => { aver_list_match!(rest2, [] => crate::aver_generated::domain::eval::core::evalArgsSlot2(&e0, &e1, env, slotMap, fns), [e2, rest3] => { { let __list_subject = rest3; if __list_subject.is_empty() { crate::aver_generated::domain::eval::core::evalArgsSlot3(&e0, &e1, &e2, env, slotMap, fns) } else { crate::aver_generated::domain::eval::core::evalArgsSlotRev(exprs.clone(), env.clone(), slotMap.clone(), fns.clone(), aver_rt::AverList::empty()) } } }) }) })
@@ -4708,10 +4769,10 @@ pub fn evalArgsSlot(
 
 /// Fast path for one slot-path argument.
 pub fn evalArgsSlot1(
-    e0: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    e0 @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     let v0 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
@@ -4720,11 +4781,11 @@ pub fn evalArgsSlot1(
 
 /// Fast path for two slot-path arguments.
 pub fn evalArgsSlot2(
-    e0: &crate::aver_generated::domain::ast::Expr,
-    e1: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    e0 @ _: &crate::aver_generated::domain::ast::Expr,
+    e1 @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     let v0 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
@@ -4734,12 +4795,12 @@ pub fn evalArgsSlot2(
 
 /// Fast path for three slot-path arguments.
 pub fn evalArgsSlot3(
-    e0: &crate::aver_generated::domain::ast::Expr,
-    e1: &crate::aver_generated::domain::ast::Expr,
-    e2: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    e0 @ _: &crate::aver_generated::domain::ast::Expr,
+    e1 @ _: &crate::aver_generated::domain::ast::Expr,
+    e2 @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     let v0 @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(e0, env, slotMap, fns)?;
@@ -4750,15 +4811,15 @@ pub fn evalArgsSlot3(
 
 /// Tail-recursive worker for evalArgsSlot. Accumulates in reverse.
 pub fn evalArgsSlotRev(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let slotMap = std::sync::Arc::new(slotMap);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let slotMap @ _ = std::sync::Arc::new(slotMap);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return Ok(acc.reverse()); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &*env, &*slotMap, &*fns) { Err(err @ _) => { return Err(err); }, Ok(v @ _) => { {
@@ -4773,14 +4834,14 @@ pub fn evalArgsSlotRev(
 
 /// Evaluate arg expressions directly into a callee slot env from map caller state.
 pub fn evalArgsMapToSlotEnv(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mut idx: aver_rt::AverInt,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mut idx @ _: aver_rt::AverInt,
 ) -> Result<aver_rt::AverVector<crate::aver_generated::domain::value::Val>, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return Ok(acc); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExpr(&e, &*env, &*fns) { Err(err @ _) => { return Err(err); }, Ok(v @ _) => { {
@@ -4797,16 +4858,16 @@ pub fn evalArgsMapToSlotEnv(
 
 /// Evaluate arg expressions directly into a callee slot env from slot caller state.
 pub fn evalArgsSlotToSlotEnv(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: crate::aver_generated::domain::eval::store::FnStore,
-    mut acc: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mut idx: aver_rt::AverInt,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: crate::aver_generated::domain::eval::store::FnStore,
+    mut acc @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mut idx @ _: aver_rt::AverInt,
 ) -> Result<aver_rt::AverVector<crate::aver_generated::domain::value::Val>, AverStr> {
-    let env = std::sync::Arc::new(env);
-    let slotMap = std::sync::Arc::new(slotMap);
-    let fns = std::sync::Arc::new(fns);
+    let env @ _ = std::sync::Arc::new(env);
+    let slotMap @ _ = std::sync::Arc::new(slotMap);
+    let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return Ok(acc); }, [e, rest] => { match crate::aver_generated::domain::eval::core::evalExprSlot(&e, &*env, &*slotMap, &*fns) { Err(err @ _) => { return Err(err); }, Ok(v @ _) => { {
@@ -4823,10 +4884,10 @@ pub fn evalArgsSlotToSlotEnv(
 
 /// Evaluate ? operator in slot path.
 pub fn evalPropagateSlot(
-    inner: &crate::aver_generated::domain::ast::Expr,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    inner @ _: &crate::aver_generated::domain::ast::Expr,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let v @ _ = crate::aver_generated::domain::eval::core::evalExprSlot(inner, env, slotMap, fns)?;
@@ -4854,11 +4915,11 @@ pub fn evalPropagateSlot(
 
 /// Evaluate independent product in slot path using the self-host's own divide-and-conquer ?!, then unwrap guest Results if needed.
 pub fn evalIndependentProductSlot(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    unwrap: bool,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    unwrap @ _: bool,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let items @ _ = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(
@@ -4876,10 +4937,10 @@ pub fn evalIndependentProductSlot(
 
 /// Evaluate guest independent-product branches in slot path through a balanced tree of the self-host's own ?!.
 pub fn evalIndependentItemsSlot(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(exprs.clone(), [] => Ok(aver_rt::AverList::empty()), [a, rest] => { aver_list_match!(rest, [] => match crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns) { Ok(va @ _) => { Ok(aver_rt::AverList::from_vec(vec![va])) }, Err(e @ _) => { Err(e) } }, [b, rest2] => { { let __list_subject = rest2; if __list_subject.is_empty() { { let (va, vb) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalExprSlot(&b, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = { let env = env; let slotMap = slotMap; let fns = fns; let a = a.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExprSlot(&a, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = { let env = env; let slotMap = slotMap; let fns = fns; let b = b.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalExprSlot(&b, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(aver_rt::AverList::from_vec(vec![va, vb])) } } else { { let (leftExprs, rightExprs) = crate::aver_generated::domain::eval::core::splitIndependentExprs(exprs.clone(), aver_rt::AverList::empty(), aver_rt::AverList::empty(), true); { let (leftVals, rightVals) = if crate::aver_replay::is_effect_tracking_active() { crate::aver_replay::enter_effect_group(); crate::aver_replay::set_effect_branch(0); let _r0 = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); crate::aver_replay::set_effect_branch(1); let _r1 = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); crate::aver_replay::exit_effect_group(); match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }? } else { { let __parallel_scope = crate::aver_replay::capture_parallel_scope_context(); let __cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)); std::thread::scope(|_s| { let __parallel_scope0 = __parallel_scope.clone(); let __cancel_flag0 = __cancel_flag.clone(); let _h0 = { let env = env; let slotMap = slotMap; let fns = fns; let leftExprs = leftExprs.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope0.clone(), move || { crate::run_cancelable_branch(__cancel_flag0.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&leftExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag0.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let __parallel_scope1 = __parallel_scope.clone(); let __cancel_flag1 = __cancel_flag.clone(); let _h1 = { let env = env; let slotMap = slotMap; let fns = fns; let rightExprs = rightExprs.clone(); _s.spawn(move || crate::aver_replay::with_parallel_scope_context(__parallel_scope1.clone(), move || { crate::run_cancelable_branch(__cancel_flag1.clone(), move || { let __result = crate::aver_generated::domain::eval::core::evalIndependentItemsSlot(&rightExprs, env, slotMap, fns); if let Err(_) = &__result { __cancel_flag1.store(true, std::sync::atomic::Ordering::Relaxed); } __result }) })) }; let _b0 = _h0.join().unwrap(); let _b1 = _h1.join().unwrap(); match (_b0, _b1) { (crate::ParallelBranch::Completed(_r0), crate::ParallelBranch::Completed(_r1)) => match (_r0, _r1) { (Ok(__v0), Ok(__v1)) => Ok((__v0, __v1)), (_r0, _r1) => { if let Err(__err) = _r0 { Err(__err) } else if let Err(__err) = _r1 { Err(__err) } else { unreachable!("independent product unwrap requires Result branches") } } }, (_b0, _b1) => { if let crate::ParallelBranch::Completed(Err(__err)) = _b0 { Err(__err) } else if let crate::ParallelBranch::Completed(Err(__err)) = _b1 { Err(__err) } else { panic!("independent product branch cancelled by sibling branch") } } } })? }}; Ok(crate::aver_generated::domain::eval::core::interleaveIndependentVals(leftVals, rightVals, true, aver_rt::AverList::empty())) } } } } }) })
@@ -4888,8 +4949,8 @@ pub fn evalIndependentItemsSlot(
 /// Synthesized collecting variant of `unwrapProductResults`. Appends to a builder where `unwrapProductResults` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn unwrapProductResults__collected(
-    mut items: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut items @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     loop {
         crate::cancel_checkpoint();
@@ -4925,11 +4986,11 @@ pub fn unwrapProductResults__collected(
 /// Synthesized collecting variant of `collectFastForwardArgs`. Appends to a builder where `collectFastForwardArgs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn collectFastForwardArgs__collected(
-    mut slotArgs: aver_rt::AverIntList,
-    calleeEnv: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut slotArgs @ _: aver_rt::AverIntList,
+    calleeEnv @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<crate::aver_generated::domain::value::Val>, AverStr> {
-    let calleeEnv = std::sync::Arc::new(calleeEnv);
+    let calleeEnv @ _ = std::sync::Arc::new(calleeEnv);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(slotArgs, [] => { return Ok(aver_rt::list_builder_finalize(acc)); }, [slot, rest] => { match crate::aver_generated::domain::eval::slots::lookupSlot(&*calleeEnv, slot) { Ok(v @ _) => { {

--- a/src/self_host/aver_generated/domain/eval/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/fast/mod.rs
@@ -13,8 +13,8 @@ use crate::*;
 
 /// Execute a leaf-like fast path directly from slots.
 pub fn runFastLeafSlot(
-    leaf: &crate::aver_generated::domain::ast::FastLeaf,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    leaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match leaf.clone() {
@@ -79,10 +79,10 @@ pub fn runFastLeafSlot(
 
 /// Execute a bool-slot branch with precomputed leaf results.
 pub fn fastBoolSlotBranch(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let slotV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
@@ -98,11 +98,11 @@ pub fn fastBoolSlotBranch(
 
 /// Execute an int equality branch with precomputed leaf results.
 pub fn fastEqIntBranch(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
-    expected: aver_rt::AverInt,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
+    expected @ _: aver_rt::AverInt,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let slotV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
@@ -121,11 +121,11 @@ pub fn fastEqIntBranch(
 
 /// Execute a string equality branch with precomputed leaf results.
 pub fn fastEqStringBranch(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
-    expected: AverStr,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
+    expected @ _: AverStr,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let slotV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
@@ -144,11 +144,11 @@ pub fn fastEqStringBranch(
 
 /// Execute an int less-than branch with precomputed leaf results.
 pub fn fastLtIntSlotsBranch(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    lhsSlot: aver_rt::AverInt,
-    rhsSlot: aver_rt::AverInt,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    lhsSlot @ _: aver_rt::AverInt,
+    rhsSlot @ _: aver_rt::AverInt,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let lhsV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, lhsSlot)?;
@@ -172,10 +172,10 @@ pub fn fastLtIntSlotsBranch(
 /// Choose and execute one of two leaf results.
 #[inline(always)]
 pub fn selectFastLeaf(
-    cond: bool,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    cond @ _: bool,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if cond {
@@ -187,12 +187,12 @@ pub fn selectFastLeaf(
 
 /// Execute a two-arm [] / [h, ..t] list branch with precomputed leaf bodies.
 pub fn fastListSlotBranch(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
-    emptyLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    headSlot: aver_rt::AverInt,
-    tailSlot: aver_rt::AverInt,
-    consLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
+    emptyLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    headSlot @ _: aver_rt::AverInt,
+    tailSlot @ _: aver_rt::AverInt,
+    consLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let listV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
@@ -209,12 +209,12 @@ pub fn fastListSlotBranch(
 /// Finish [] / [h, ..t] list branching once the list payload is extracted.
 #[inline(always)]
 pub fn fastListSlotBranchItems(
-    items: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    emptyLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    headSlot: aver_rt::AverInt,
-    tailSlot: aver_rt::AverInt,
-    consLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    emptyLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    headSlot @ _: aver_rt::AverInt,
+    tailSlot @ _: aver_rt::AverInt,
+    consLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(items.clone(), [] => crate::aver_generated::domain::eval::fast::runFastLeafSlot(emptyLeaf, calleeEnv), [head, tail] => crate::aver_generated::domain::eval::fast::runFastLeafSlot(consLeaf, &crate::aver_generated::domain::eval::slots::setSlot(&crate::aver_generated::domain::eval::slots::setSlot(calleeEnv, headSlot, &head), tailSlot, &crate::aver_generated::domain::value::Val::ValList(tail))))
@@ -222,9 +222,9 @@ pub fn fastListSlotBranchItems(
 
 /// Read a record field directly from a resolved slot.
 pub fn fastFieldAccessSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
-    field: AverStr,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
+    field @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let recordV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slot)?;
@@ -238,9 +238,9 @@ pub fn fastFieldAccessSlot(
 
 /// Read a map key directly from resolved slots.
 pub fn fastMapGetSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mapSlot: aver_rt::AverInt,
-    keySlot: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mapSlot @ _: aver_rt::AverInt,
+    keySlot @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
@@ -250,8 +250,8 @@ pub fn fastMapGetSlot(
 
 /// Look up a key in a ValMap without going through builtin dispatch.
 pub fn fastMapGetSlotInner(
-    mapV: &crate::aver_generated::domain::value::Val,
-    keyV: &crate::aver_generated::domain::value::Val,
+    mapV @ _: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
@@ -272,10 +272,10 @@ pub fn fastMapGetSlotInner(
 
 /// Update a map directly from resolved slots.
 pub fn fastMapSetSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mapSlot: aver_rt::AverInt,
-    keySlot: aver_rt::AverInt,
-    valueSlot: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mapSlot @ _: aver_rt::AverInt,
+    keySlot @ _: aver_rt::AverInt,
+    valueSlot @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
@@ -286,9 +286,9 @@ pub fn fastMapSetSlot(
 
 /// Set a key in a ValMap without going through builtin dispatch.
 pub fn fastMapSetSlotInner(
-    mapV: &crate::aver_generated::domain::value::Val,
-    keyV: &crate::aver_generated::domain::value::Val,
-    valueV: &crate::aver_generated::domain::value::Val,
+    mapV @ _: &crate::aver_generated::domain::value::Val,
+    keyV @ _: &crate::aver_generated::domain::value::Val,
+    valueV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match mapV.clone() {
@@ -304,9 +304,9 @@ pub fn fastMapSetSlotInner(
 
 /// Fast path for Vector.new(slot, int) wrappers.
 pub fn fastVectorNewSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    sizeSlot: aver_rt::AverInt,
-    fill: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    sizeSlot @ _: aver_rt::AverInt,
+    fill @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let sizeV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, sizeSlot)?;
@@ -315,8 +315,8 @@ pub fn fastVectorNewSlot(
 
 /// Allocate a vector when the wrapper shape is known in advance.
 pub fn fastVectorNewSlotInner(
-    sizeV: &crate::aver_generated::domain::value::Val,
-    fill: aver_rt::AverInt,
+    sizeV @ _: &crate::aver_generated::domain::value::Val,
+    fill @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match sizeV.clone() {
@@ -337,10 +337,10 @@ pub fn fastVectorNewSlotInner(
 
 /// Fast path for Option.withDefault(Vector.get(slotVec, slotIdx), int).
 pub fn fastVectorGetOrIntSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    vecSlot: aver_rt::AverInt,
-    idxSlot: aver_rt::AverInt,
-    defaultValue: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    vecSlot @ _: aver_rt::AverInt,
+    idxSlot @ _: aver_rt::AverInt,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let vecV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
@@ -354,9 +354,9 @@ pub fn fastVectorGetOrIntSlot(
 
 /// Read a vector cell with an integer default without going through builtin dispatch.
 pub fn fastVectorGetOrIntSlotInner(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    defaultValue: aver_rt::AverInt,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
@@ -377,9 +377,9 @@ pub fn fastVectorGetOrIntSlotInner(
 
 /// Check map membership directly from resolved slots.
 pub fn fastMapHasSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mapSlot: aver_rt::AverInt,
-    keySlot: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mapSlot @ _: aver_rt::AverInt,
+    keySlot @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
@@ -396,9 +396,9 @@ pub fn fastMapHasSlot(
 
 /// Remove a map key directly from resolved slots.
 pub fn fastMapRemoveSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mapSlot: aver_rt::AverInt,
-    keySlot: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mapSlot @ _: aver_rt::AverInt,
+    keySlot @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let mapV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, mapSlot)?;
@@ -415,8 +415,8 @@ pub fn fastMapRemoveSlot(
 
 /// Get vector length directly from a resolved slot.
 pub fn fastVectorLenSlot(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    vecSlot: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    vecSlot @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let vecV @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, vecSlot)?;
@@ -432,10 +432,10 @@ pub fn fastVectorLenSlot(
 
 /// Execute arithmetic on two slot values without entering the full eval.
 pub fn fastBinopSlots(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    op: &crate::aver_generated::domain::ast::BinOp,
-    slotA: aver_rt::AverInt,
-    slotB: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    slotA @ _: aver_rt::AverInt,
+    slotB @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let va @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotA)?;
@@ -445,10 +445,10 @@ pub fn fastBinopSlots(
 
 /// Execute comparison on two slot values without entering the full eval.
 pub fn fastCmpSlots(
-    calleeEnv: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    slotA: aver_rt::AverInt,
-    slotB: aver_rt::AverInt,
+    calleeEnv @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    slotA @ _: aver_rt::AverInt,
+    slotB @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let va @ _ = crate::aver_generated::domain::eval::slots::lookupSlot(calleeEnv, slotA)?;

--- a/src/self_host/aver_generated/domain/eval/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/mod.rs
@@ -11,7 +11,7 @@ use crate::*;
 
 /// Evaluate a complete program through the self-hosted evaluator.
 pub fn evalProgram(
-    prog: &crate::aver_generated::domain::ast::Program,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalProgram(prog)
@@ -19,8 +19,8 @@ pub fn evalProgram(
 
 /// Evaluate a program with additional loaded module functions.
 pub fn evalProgramWithFns(
-    prog: &crate::aver_generated::domain::ast::Program,
-    extraFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    extraFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::evalProgramWithFns(prog, extraFns)
@@ -28,9 +28,9 @@ pub fn evalProgramWithFns(
 
 /// Stable facade for calling an already-resolved self-hosted function.
 pub fn callResolved(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    fns: &crate::aver_generated::domain::eval::store::FnStore,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    fns @ _: &crate::aver_generated::domain::eval::store::FnStore,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::core::callResolved(fd, args, fns)

--- a/src/self_host/aver_generated/domain/eval/ops/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/ops/mod.rs
@@ -7,9 +7,9 @@ use crate::*;
 
 /// Apply a binary operation to two integers.
 pub fn applyBinop(
-    x: aver_rt::AverInt,
-    y: aver_rt::AverInt,
-    op: &crate::aver_generated::domain::ast::BinOp,
+    x @ _: aver_rt::AverInt,
+    y @ _: aver_rt::AverInt,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
@@ -37,9 +37,9 @@ pub fn applyBinop(
 
 /// Apply a binary operation to two floats.
 pub fn applyBinopFloat(
-    x: f64,
-    y: f64,
-    op: &crate::aver_generated::domain::ast::BinOp,
+    x @ _: f64,
+    y @ _: f64,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
@@ -64,9 +64,9 @@ pub fn applyBinopFloat(
 
 /// Apply a comparison operation to two integers.
 pub fn applyCmp(
-    x: aver_rt::AverInt,
-    y: aver_rt::AverInt,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    x @ _: aver_rt::AverInt,
+    y @ _: aver_rt::AverInt,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> crate::aver_generated::domain::value::Val {
     crate::cancel_checkpoint();
     match op {
@@ -93,9 +93,9 @@ pub fn applyCmp(
 
 /// Apply a comparison to two floats.
 pub fn applyCmpFloat(
-    x: f64,
-    y: f64,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    x @ _: f64,
+    y @ _: f64,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> crate::aver_generated::domain::value::Val {
     crate::cancel_checkpoint();
     match op {
@@ -122,9 +122,9 @@ pub fn applyCmpFloat(
 
 /// Apply binary op to two evaluated values.
 pub fn evalBinopVals(
-    va: &crate::aver_generated::domain::value::Val,
-    vb: &crate::aver_generated::domain::value::Val,
-    op: &crate::aver_generated::domain::ast::BinOp,
+    va @ _: &crate::aver_generated::domain::value::Val,
+    vb @ _: &crate::aver_generated::domain::value::Val,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match (va.clone(), vb.clone()) {
@@ -159,7 +159,7 @@ pub fn evalBinopVals(
 
 /// Apply unary minus to an evaluated value. Numeric only.
 pub fn evalNegVals(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -177,9 +177,9 @@ pub fn evalNegVals(
 
 /// Apply comparison to two evaluated values (Int, Float, or String).
 pub fn evalCmpVals(
-    va: &crate::aver_generated::domain::value::Val,
-    vb: &crate::aver_generated::domain::value::Val,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    va @ _: &crate::aver_generated::domain::value::Val,
+    vb @ _: &crate::aver_generated::domain::value::Val,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match (va.clone(), vb.clone()) {
@@ -225,9 +225,9 @@ pub fn evalCmpVals(
 
 /// String comparison: all operators supported.
 pub fn applyStrCmp(
-    x: AverStr,
-    y: AverStr,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    x @ _: AverStr,
+    y @ _: AverStr,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> crate::aver_generated::domain::value::Val {
     crate::cancel_checkpoint();
     match op {
@@ -254,9 +254,9 @@ pub fn applyStrCmp(
 
 /// Bool comparison: eq and neq.
 pub fn applyBoolCmp(
-    x: bool,
-    y: bool,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    x @ _: bool,
+    y @ _: bool,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
@@ -272,9 +272,9 @@ pub fn applyBoolCmp(
 
 /// Fallback comparison using repr (for variants, lists, etc).
 pub fn evalCmpRepr(
-    va: &crate::aver_generated::domain::value::Val,
-    vb: &crate::aver_generated::domain::value::Val,
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    va @ _: &crate::aver_generated::domain::value::Val,
+    vb @ _: &crate::aver_generated::domain::value::Val,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match op {
@@ -327,7 +327,7 @@ pub fn evalCmpRepr(
 }
 
 /// Human-readable comparison operator.
-pub fn cmpOpName(op: &crate::aver_generated::domain::ast::CmpOp) -> AverStr {
+pub fn cmpOpName(op @ _: &crate::aver_generated::domain::ast::CmpOp) -> AverStr {
     crate::cancel_checkpoint();
     match op {
         crate::aver_generated::domain::ast::CmpOp::CmpEq => AverStr::from("=="),
@@ -342,9 +342,9 @@ pub fn cmpOpName(op: &crate::aver_generated::domain::ast::CmpOp) -> AverStr {
 /// Read a vector cell and return an integer fallback when the index misses.
 #[inline(always)]
 pub fn evalVectorGetOrIntVals(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    defaultValue: aver_rt::AverInt,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::ops::evalVectorGetMaybeDefault(vecV, idxV) {
@@ -360,9 +360,9 @@ pub fn evalVectorGetOrIntVals(
 
 /// Apply Int.mod and return an integer fallback when the result would be Err.
 pub fn evalIntModOrIntVals(
-    aV: &crate::aver_generated::domain::value::Val,
-    bV: &crate::aver_generated::domain::value::Val,
-    defaultValue: aver_rt::AverInt,
+    aV @ _: &crate::aver_generated::domain::value::Val,
+    bV @ _: &crate::aver_generated::domain::value::Val,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match aV.clone() {
@@ -391,9 +391,9 @@ pub fn evalIntModOrIntVals(
 
 /// Apply Vector.set and return None when the caller should fall back to its default expression.
 pub fn evalVectorSetMaybeDefault(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
-    valueV: &crate::aver_generated::domain::value::Val,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
+    valueV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<Option<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {
@@ -427,8 +427,8 @@ pub fn evalVectorSetMaybeDefault(
 
 /// Apply Vector.get and return None when the caller should fall back to its default expression.
 pub fn evalVectorGetMaybeDefault(
-    vecV: &crate::aver_generated::domain::value::Val,
-    idxV: &crate::aver_generated::domain::value::Val,
+    vecV @ _: &crate::aver_generated::domain::value::Val,
+    idxV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<Option<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     match vecV.clone() {

--- a/src/self_host/aver_generated/domain/eval/records/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/records/mod.rs
@@ -6,8 +6,8 @@ use crate::*;
 /// Check if this is a Type.update(record, _named(...)) call.
 #[inline(always)]
 pub fn isRecordUpdate(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> bool {
     crate::cancel_checkpoint();
     if name.contains(".update") {
@@ -19,7 +19,9 @@ pub fn isRecordUpdate(
 
 /// Check if last arg is a _named record sentinel.
 #[inline(always)]
-pub fn hasNamedRecord(args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>) -> bool {
+pub fn hasNamedRecord(
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+) -> bool {
     crate::cancel_checkpoint();
     if (aver_rt::AverInt::from_i64(args.len() as i64) == aver_rt::AverInt::from_i64(2)) {
         crate::aver_generated::domain::eval::records::isNamedSentinel(args)
@@ -31,7 +33,7 @@ pub fn hasNamedRecord(args: &aver_rt::AverList<crate::aver_generated::domain::va
 /// Check second element is ValRecord with _named tag.
 #[inline(always)]
 pub fn isNamedSentinel(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> bool {
     crate::cancel_checkpoint();
     {
@@ -51,7 +53,7 @@ pub fn isNamedSentinel(
 /// Check first element of rest is a _named record.
 #[inline(always)]
 pub fn isNamedSentinelInner(
-    rest: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> bool {
     crate::cancel_checkpoint();
     aver_list_match!(rest.clone(), [] => false, [v, ignored] => match v {
@@ -67,7 +69,7 @@ pub fn isNamedSentinelInner(
 /// Perform record update: merge named fields into base record.
 #[inline(always)]
 pub fn doRecordUpdate(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(args.clone(), [] => Err(AverStr::from("record update requires (record, named fields)")), [baseVal, rest] => crate::aver_generated::domain::eval::records::doRecordUpdateInner(&baseVal, &rest))
@@ -76,8 +78,8 @@ pub fn doRecordUpdate(
 /// Extract named fields from rest and apply update.
 #[inline(always)]
 pub fn doRecordUpdateInner(
-    baseVal: &crate::aver_generated::domain::value::Val,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    baseVal @ _: &crate::aver_generated::domain::value::Val,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(rest.clone(), [] => Err(AverStr::from("record update requires named fields")), [namedVal, ignored] => match namedVal {
@@ -92,8 +94,8 @@ pub fn doRecordUpdateInner(
 
 /// Override fields in a record value.
 pub fn applyRecordUpdate(
-    baseVal: &crate::aver_generated::domain::value::Val,
-    namedFields: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    baseVal @ _: &crate::aver_generated::domain::value::Val,
+    namedFields @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match baseVal.clone() {
@@ -113,8 +115,8 @@ pub fn applyRecordUpdate(
 /// For each field in existing: use override if present, otherwise keep.
 #[inline(always)]
 pub fn mergeRecordFields(
-    existing: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    overrides: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    existing @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    overrides @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::records::mergeRecordFieldsAcc__collected(
@@ -127,9 +129,9 @@ pub fn mergeRecordFields(
 /// Accumulate merged fields.
 #[inline(always)]
 pub fn mergeRecordFieldsAcc(
-    mut existing: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut overrides: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut existing @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut overrides @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     loop {
         crate::cancel_checkpoint();
@@ -154,11 +156,11 @@ pub fn mergeRecordFieldsAcc(
 /// Check if field k has an override.
 #[inline(always)]
 pub fn mergeOneField(
-    k: AverStr,
-    v: &crate::aver_generated::domain::value::Val,
-    rest: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    overrides: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    acc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    k @ _: AverStr,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    rest @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    overrides @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    acc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::records::findOverride(k.clone(), overrides.clone()) {
@@ -178,8 +180,8 @@ pub fn mergeOneField(
 /// Find a field value in the overrides list.
 #[inline(always)]
 pub fn findOverride(
-    mut k: AverStr,
-    mut overrides: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut k @ _: AverStr,
+    mut overrides @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> Option<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -194,8 +196,8 @@ pub fn findOverride(
 /// Remove a field from overrides list.
 #[inline(always)]
 pub fn removeOverride(
-    k: AverStr,
-    overrides: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    k @ _: AverStr,
+    overrides @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::records::removeOverrideAcc(
@@ -208,9 +210,9 @@ pub fn removeOverride(
 /// Accumulate non-matching fields, then concat remainder when match found.
 #[inline(always)]
 pub fn removeOverrideAcc(
-    mut k: AverStr,
-    mut overrides: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut k @ _: AverStr,
+    mut overrides @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     loop {
         crate::cancel_checkpoint();
@@ -228,9 +230,9 @@ pub fn removeOverrideAcc(
 /// Synthesized collecting variant of `mergeRecordFieldsAcc`. Appends to a builder where `mergeRecordFieldsAcc` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn mergeRecordFieldsAcc__collected(
-    mut existing: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut overrides: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut existing @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut overrides @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/eval/slots/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/slots/mod.rs
@@ -5,8 +5,8 @@ use crate::*;
 
 /// Create slot env: Vector<Val> of slotCount, args at 0..n-1.
 pub fn buildSlotEnv(
-    args: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    slotCount: aver_rt::AverInt,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    slotCount @ _: aver_rt::AverInt,
 ) -> Result<aver_rt::AverVector<crate::aver_generated::domain::value::Val>, AverStr> {
     crate::cancel_checkpoint();
     Ok(
@@ -27,9 +27,9 @@ pub fn buildSlotEnv(
 /// Fill slot env from arg list.
 #[inline(always)]
 pub fn buildSlotEnvLoop(
-    mut args: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    mut idx: aver_rt::AverInt,
+    mut args @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mut idx @ _: aver_rt::AverInt,
 ) -> aver_rt::AverVector<crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -48,8 +48,8 @@ pub fn buildSlotEnvLoop(
 /// Look up a variable by slot index. O(1).
 #[inline(always)]
 pub fn lookupSlot(
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match (slot).to_usize().and_then(|__i| env.get(__i).cloned()) {
@@ -73,9 +73,9 @@ pub fn lookupSlot(
 /// Set slot value. O(1).
 #[inline(always)]
 pub fn setSlot(
-    env: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
-    slot: aver_rt::AverInt,
-    v: &crate::aver_generated::domain::value::Val,
+    env @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    slot @ _: aver_rt::AverInt,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> aver_rt::AverVector<crate::aver_generated::domain::value::Val> {
     crate::cancel_checkpoint();
     {

--- a/src/self_host/aver_generated/domain/eval/store/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/store/mod.rs
@@ -93,8 +93,8 @@ impl aver_replay::ReplayValue for FnStore {
 /// Look up a variable in the environment.
 #[inline(always)]
 pub fn lookupVar(
-    env: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
-    name: AverStr,
+    env @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    name @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match env.get(&name).cloned() {
@@ -115,8 +115,8 @@ pub fn emptyFnStore() -> FnStore {
 
 /// Attach evaluated top-level bindings so function bodies can read them.
 pub fn withGlobals(
-    fns: &FnStore,
-    globals: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    fns @ _: &FnStore,
+    globals @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> FnStore {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::store::FnStore {
@@ -129,8 +129,8 @@ pub fn withGlobals(
 /// Look up a top-level binding value by name.
 #[inline(always)]
 pub fn lookupGlobal(
-    fns: &FnStore,
-    name: AverStr,
+    fns @ _: &FnStore,
+    name @ _: AverStr,
 ) -> Option<crate::aver_generated::domain::value::Val> {
     crate::cancel_checkpoint();
     fns.globals.get(&name).cloned()
@@ -138,7 +138,7 @@ pub fn lookupGlobal(
 
 /// Look up a function id by name.
 #[inline(always)]
-pub fn lookupFnId(fns: &FnStore, name: AverStr) -> Result<aver_rt::AverInt, AverStr> {
+pub fn lookupFnId(fns @ _: &FnStore, name @ _: AverStr) -> Result<aver_rt::AverInt, AverStr> {
     crate::cancel_checkpoint();
     match fns.nameToId.get(&name).cloned() {
         Some(id @ _) => Ok(id),
@@ -149,8 +149,8 @@ pub fn lookupFnId(fns: &FnStore, name: AverStr) -> Result<aver_rt::AverInt, Aver
 /// Look up a function definition by id.
 #[inline(always)]
 pub fn lookupFnById(
-    fns: &FnStore,
-    id: aver_rt::AverInt,
+    fns @ _: &FnStore,
+    id @ _: aver_rt::AverInt,
 ) -> Result<crate::aver_generated::domain::ast::FnDef, AverStr> {
     crate::cancel_checkpoint();
     match (id).to_usize().and_then(|__i| fns.byId.get(__i).cloned()) {
@@ -174,8 +174,8 @@ pub fn lookupFnById(
 /// Look up a function definition by name without wrapping success in Result.
 #[inline(always)]
 pub fn lookupFnOption(
-    fns: &FnStore,
-    name: AverStr,
+    fns @ _: &FnStore,
+    name @ _: AverStr,
 ) -> Option<crate::aver_generated::domain::ast::FnDef> {
     crate::cancel_checkpoint();
     match fns.nameToId.get(&name).cloned() {
@@ -187,8 +187,8 @@ pub fn lookupFnOption(
 /// Look up a function definition by name through the function store.
 #[inline(always)]
 pub fn lookupFn(
-    fns: &FnStore,
-    name: AverStr,
+    fns @ _: &FnStore,
+    name @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::ast::FnDef, AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::eval::store::lookupFnOption(fns, name.clone()) {
@@ -200,9 +200,9 @@ pub fn lookupFn(
 /// Build env map from parameter names and argument values.
 #[inline(always)]
 pub fn zipArgs(
-    mut params: aver_rt::AverList<AverStr>,
-    mut args: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    mut params @ _: aver_rt::AverList<AverStr>,
+    mut args @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -221,8 +221,8 @@ pub fn zipArgs(
 /// Add pattern match bindings to an env map.
 #[inline(always)]
 pub fn mergeBindings(
-    mut bindings: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
-    mut env: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    mut bindings @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut env @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val> {
     loop {
         crate::cancel_checkpoint();
@@ -237,7 +237,9 @@ pub fn mergeBindings(
 }
 
 /// Build a function store with a name->id index and id->FnDef table.
-pub fn fnsToStore(fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>) -> FnStore {
+pub fn fnsToStore(
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+) -> FnStore {
     crate::cancel_checkpoint();
     let nameToId @ _ = crate::aver_generated::domain::eval::store::fnsToIdMap(
         fns.clone(),
@@ -254,9 +256,9 @@ pub fn fnsToStore(fns: &aver_rt::AverList<crate::aver_generated::domain::ast::Fn
 /// Convert a list of FnDefs to a name->id map. Later defs shadow earlier ones.
 #[inline(always)]
 pub fn fnsToIdMap(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    mut acc: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut idx: aver_rt::AverInt,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut acc @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut idx @ _: aver_rt::AverInt,
 ) -> aver_rt::AverMap<AverStr, aver_rt::AverInt> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/lexer/chars/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/chars/mod.rs
@@ -5,7 +5,7 @@ use crate::*;
 
 /// Check if a single character is a digit.
 #[inline(always)]
-pub fn isDigit(c: AverStr) -> bool {
+pub fn isDigit(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
@@ -56,7 +56,7 @@ pub fn isDigit(c: AverStr) -> bool {
 
 /// Check if a character is a lowercase letter.
 #[inline(always)]
-pub fn isLower(c: AverStr) -> bool {
+pub fn isLower(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     if (c < AverStr::from("a")) {
         false
@@ -67,7 +67,7 @@ pub fn isLower(c: AverStr) -> bool {
 
 /// Check if a character is an uppercase letter.
 #[inline(always)]
-pub fn isUpper(c: AverStr) -> bool {
+pub fn isUpper(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     if (c < AverStr::from("A")) {
         false
@@ -78,7 +78,7 @@ pub fn isUpper(c: AverStr) -> bool {
 
 /// Check if a character is a letter or underscore.
 #[inline(always)]
-pub fn isLetterOrUnderscore(c: AverStr) -> bool {
+pub fn isLetterOrUnderscore(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::lexer::chars::isLower(c.clone()) {
         true
@@ -93,7 +93,7 @@ pub fn isLetterOrUnderscore(c: AverStr) -> bool {
 
 /// Check if a single character is a letter or underscore.
 #[inline(always)]
-pub fn isAlpha(c: AverStr) -> bool {
+pub fn isAlpha(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     if (aver_rt::AverInt::from_i64(c.chars().count() as i64) == aver_rt::AverInt::from_i64(1)) {
         crate::aver_generated::domain::lexer::chars::isLetterOrUnderscore(c)
@@ -104,7 +104,7 @@ pub fn isAlpha(c: AverStr) -> bool {
 
 /// Check if a character is alphanumeric or underscore.
 #[inline(always)]
-pub fn isAlphaNum(c: AverStr) -> bool {
+pub fn isAlphaNum(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::lexer::chars::isAlpha(c.clone()) {
         true
@@ -115,7 +115,7 @@ pub fn isAlphaNum(c: AverStr) -> bool {
 
 /// Convert a digit character to its integer value.
 #[inline(always)]
-pub fn digitVal(c: AverStr) -> aver_rt::AverInt {
+pub fn digitVal(c @ _: AverStr) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = aver_rt::AverInt::from_i64(aver_rt::str_code1(&c));
@@ -167,9 +167,9 @@ pub fn digitVal(c: AverStr) -> aver_rt::AverInt {
 /// Read consecutive digits from pos, return (number, newPos).
 #[inline(always)]
 pub fn readNumberLoop(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: aver_rt::AverInt,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::readNumberLoop__indexed(
@@ -183,9 +183,9 @@ pub fn readNumberLoop(
 /// Read consecutive digits from pos, return (number, newPos).
 #[inline(always)]
 pub fn readNumber(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: aver_rt::AverInt,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::readNumber__indexed(
@@ -198,7 +198,7 @@ pub fn readNumber(
 
 /// Check if character can continue a dotted identifier (alphanumeric, underscore, or dot).
 #[inline(always)]
-pub fn isIdentCharDotted(c: AverStr) -> bool {
+pub fn isIdentCharDotted(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::lexer::chars::isAlphaNum(c.clone()) {
         true
@@ -209,7 +209,7 @@ pub fn isIdentCharDotted(c: AverStr) -> bool {
 
 /// Check if character can continue a plain identifier (alphanumeric, underscore only).
 #[inline(always)]
-pub fn isIdentCharPlain(c: AverStr) -> bool {
+pub fn isIdentCharPlain(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::isAlphaNum(c)
 }
@@ -217,9 +217,9 @@ pub fn isIdentCharPlain(c: AverStr) -> bool {
 /// Read identifier including dots (for qualified names like List.prepend).
 #[inline(always)]
 pub fn readIdentLoopDotted(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> (AverStr, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::readIdentLoopDotted__indexed(
@@ -233,9 +233,9 @@ pub fn readIdentLoopDotted(
 /// Read identifier without dots (for local variables).
 #[inline(always)]
 pub fn readIdentLoopPlain(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> (AverStr, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::readIdentLoopPlain__indexed(
@@ -249,10 +249,10 @@ pub fn readIdentLoopPlain(
 /// Read identifier, dotted if starts with uppercase.
 #[inline(always)]
 pub fn readIdent(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    dotted: bool,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    dotted @ _: bool,
 ) -> (AverStr, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::readIdent__indexed(
@@ -266,7 +266,7 @@ pub fn readIdent(
 
 /// Classify an identifier as keyword or plain ident.
 #[inline(always)]
-pub fn keywordOrIdent(s: AverStr) -> crate::aver_generated::domain::token::Token {
+pub fn keywordOrIdent(s @ _: AverStr) -> crate::aver_generated::domain::token::Token {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = s.clone();
@@ -337,12 +337,12 @@ pub fn keywordOrIdent(s: AverStr) -> crate::aver_generated::domain::token::Token
 /// Synthesized indexed worker of `readNumberLoop`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn readNumberLoop__indexed(
-    mut src: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut acc: aver_rt::AverInt,
-    __str_index: aver_rt::StringIndex,
+    mut src @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverInt,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
@@ -378,10 +378,10 @@ pub fn readNumberLoop__indexed(
 /// Synthesized indexed worker of `readNumber`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn readNumber__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::chars::readNumberLoop__indexed(
@@ -395,12 +395,12 @@ pub fn readNumber__indexed(
 /// Synthesized indexed worker of `readIdentLoopDotted`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn readIdentLoopDotted__indexed(
-    mut src: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut acc: AverStr,
-    __str_index: aver_rt::StringIndex,
+    mut src @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut acc @ _: AverStr,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> (AverStr, aver_rt::AverInt) {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
@@ -431,12 +431,12 @@ pub fn readIdentLoopDotted__indexed(
 /// Synthesized indexed worker of `readIdentLoopPlain`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn readIdentLoopPlain__indexed(
-    mut src: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut acc: AverStr,
-    __str_index: aver_rt::StringIndex,
+    mut src @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut acc @ _: AverStr,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> (AverStr, aver_rt::AverInt) {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
@@ -467,11 +467,11 @@ pub fn readIdentLoopPlain__indexed(
 /// Synthesized indexed worker of `readIdent`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn readIdent__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    dotted: bool,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    dotted @ _: bool,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> (AverStr, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     if dotted {
@@ -493,7 +493,7 @@ pub fn readIdent__indexed(
 
 /// Synthesized codepoint variant of `digitVal` for indexed character dispatch. Parameter `c` is the Unicode scalar of the one-character String accepted by the source function.
 #[inline(always)]
-pub fn digitVal__code(__str_index_code: i64) -> aver_rt::AverInt {
+pub fn digitVal__code(__str_index_code @ _: i64) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = __str_index_code;
@@ -543,7 +543,7 @@ pub fn digitVal__code(__str_index_code: i64) -> aver_rt::AverInt {
 
 /// Synthesized codepoint variant of `isDigit` for indexed character dispatch. Parameter `c` is the Unicode scalar of the one-character String accepted by the source function.
 #[inline(always)]
-pub fn isDigit__code(__str_index_code: i64) -> bool {
+pub fn isDigit__code(__str_index_code @ _: i64) -> bool {
     crate::cancel_checkpoint();
     {
         let __dispatch_subject = __str_index_code;

--- a/src/self_host/aver_generated/domain/lexer/mod.rs
+++ b/src/self_host/aver_generated/domain/lexer/mod.rs
@@ -17,11 +17,11 @@ enum __MutualTco1 {
 
 fn __mutual_tco_trampoline_1(
     mut __state: __MutualTco1,
-    __str_index: &aver_rt::StringIndex,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     loop {
         __state = match __state {
-            __MutualTco1::TokenizeDefault__indexed(mut c, mut src, mut pos) => {
+            __MutualTco1::TokenizeDefault__indexed(mut c @ _, mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::lexer::chars::isDigit(c.clone()) {
                     return crate::aver_generated::domain::lexer::tokenizeDigit__indexed(
@@ -41,7 +41,7 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::TokenizeBraceOrSkip__indexed(mut c, mut src, mut pos) => {
+            __MutualTco1::TokenizeBraceOrSkip__indexed(mut c @ _, mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 if (c == crate::aver_generated::domain::lexer::openBrace()) {
@@ -68,7 +68,7 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::TokenizeChar__indexed(mut c, mut src, mut pos) => {
+            __MutualTco1::TokenizeChar__indexed(mut c @ _, mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
@@ -148,11 +148,11 @@ fn __mutual_tco_trampoline_1(
                     }
                 }
             }
-            __MutualTco1::TokenizeSome__indexed(mut c, mut src, mut pos) => {
+            __MutualTco1::TokenizeSome__indexed(mut c @ _, mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 __MutualTco1::TokenizeChar__indexed(c, src, pos)
             }
-            __MutualTco1::TokenizeAtPos__indexed(mut src, mut pos) => {
+            __MutualTco1::TokenizeAtPos__indexed(mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                     None => {
@@ -163,7 +163,7 @@ fn __mutual_tco_trampoline_1(
                     Some(c @ _) => __MutualTco1::TokenizeSome__indexed(c, src, pos),
                 }
             }
-            __MutualTco1::Tokenize__indexed(mut src, mut pos) => {
+            __MutualTco1::Tokenize__indexed(mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
                     __MutualTco1::TokenizeAtPos__indexed(src, pos)
@@ -179,10 +179,10 @@ fn __mutual_tco_trampoline_1(
 
 /// Synthesized indexed worker of `tokenizeDefault`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeDefault__indexed(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_1(
         __MutualTco1::TokenizeDefault__indexed(c, src, pos),
@@ -192,10 +192,10 @@ pub fn tokenizeDefault__indexed(
 
 /// Synthesized indexed worker of `tokenizeBraceOrSkip`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeBraceOrSkip__indexed(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_1(
         __MutualTco1::TokenizeBraceOrSkip__indexed(c, src, pos),
@@ -205,10 +205,10 @@ pub fn tokenizeBraceOrSkip__indexed(
 
 /// Synthesized indexed worker of `tokenizeChar`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeChar__indexed(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_1(
         __MutualTco1::TokenizeChar__indexed(c, src, pos),
@@ -218,10 +218,10 @@ pub fn tokenizeChar__indexed(
 
 /// Synthesized indexed worker of `tokenizeSome`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeSome__indexed(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_1(
         __MutualTco1::TokenizeSome__indexed(c, src, pos),
@@ -231,18 +231,18 @@ pub fn tokenizeSome__indexed(
 
 /// Synthesized indexed worker of `tokenizeAtPos`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeAtPos__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_1(__MutualTco1::TokenizeAtPos__indexed(src, pos), &__str_index)
 }
 
 /// Synthesized indexed worker of `tokenize`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenize__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_1(__MutualTco1::Tokenize__indexed(src, pos), &__str_index)
 }
@@ -260,11 +260,11 @@ enum __MutualTco2 {
 
 fn __mutual_tco_trampoline_2(
     mut __state: __MutualTco2,
-    __str_index: &aver_rt::StringIndex,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     loop {
         __state = match __state {
-            __MutualTco2::TokenizeString__indexed(mut src, mut pos, mut acc) => {
+            __MutualTco2::TokenizeString__indexed(mut src @ _, mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
                     __MutualTco2::TokenizeStringAt__indexed(src, pos, acc)
@@ -275,7 +275,7 @@ fn __mutual_tco_trampoline_2(
                     ]);
                 }
             }
-            __MutualTco2::TokenizeStringAt__indexed(mut src, mut pos, mut acc) => {
+            __MutualTco2::TokenizeStringAt__indexed(mut src @ _, mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                     Some(c @ _) => {
@@ -297,7 +297,7 @@ fn __mutual_tco_trampoline_2(
                     }
                 }
             }
-            __MutualTco2::TokenizeStringEscape__indexed(mut src, mut pos, mut acc) => {
+            __MutualTco2::TokenizeStringEscape__indexed(mut src @ _, mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
@@ -376,7 +376,12 @@ fn __mutual_tco_trampoline_2(
                     }
                 }
             }
-            __MutualTco2::TokenizeStringChar__indexed(mut src, mut pos, mut acc, mut c) => {
+            __MutualTco2::TokenizeStringChar__indexed(
+                mut src @ _,
+                mut pos @ _,
+                mut acc @ _,
+                mut c @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 if (&*c == "\"") {
                     return aver_rt::AverList::prepend(
@@ -391,7 +396,12 @@ fn __mutual_tco_trampoline_2(
                     __MutualTco2::TokenizeStringCharInner__indexed(src, pos, acc, c)
                 }
             }
-            __MutualTco2::TokenizeStringCharInner__indexed(mut src, mut pos, mut acc, mut c) => {
+            __MutualTco2::TokenizeStringCharInner__indexed(
+                mut src @ _,
+                mut pos @ _,
+                mut acc @ _,
+                mut c @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 if (c == crate::aver_generated::domain::lexer::openBrace()) {
                     __MutualTco2::TokenizeStringMaybeEscapedBrace__indexed(src, pos, acc)
@@ -407,7 +417,11 @@ fn __mutual_tco_trampoline_2(
                     }
                 }
             }
-            __MutualTco2::TokenizeStringMaybeEscapedBrace__indexed(mut src, mut pos, mut acc) => {
+            __MutualTco2::TokenizeStringMaybeEscapedBrace__indexed(
+                mut src @ _,
+                mut pos @ _,
+                mut acc @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match aver_rt::string_index_char_at(&src, &__str_index, &nextPos) {
@@ -437,7 +451,11 @@ fn __mutual_tco_trampoline_2(
                     }
                 }
             }
-            __MutualTco2::TokenizeStringMaybeEscapedClose__indexed(mut src, mut pos, mut acc) => {
+            __MutualTco2::TokenizeStringMaybeEscapedClose__indexed(
+                mut src @ _,
+                mut pos @ _,
+                mut acc @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 let accBrace @ _ = (acc + &crate::aver_generated::domain::lexer::closeBrace());
@@ -462,10 +480,10 @@ fn __mutual_tco_trampoline_2(
 
 /// Synthesized indexed worker of `tokenizeString`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeString__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeString__indexed(src, pos, acc),
@@ -475,10 +493,10 @@ pub fn tokenizeString__indexed(
 
 /// Synthesized indexed worker of `tokenizeStringAt`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeStringAt__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeStringAt__indexed(src, pos, acc),
@@ -488,10 +506,10 @@ pub fn tokenizeStringAt__indexed(
 
 /// Synthesized indexed worker of `tokenizeStringEscape`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeStringEscape__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeStringEscape__indexed(src, pos, acc),
@@ -501,11 +519,11 @@ pub fn tokenizeStringEscape__indexed(
 
 /// Synthesized indexed worker of `tokenizeStringChar`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeStringChar__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    c: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    c @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeStringChar__indexed(src, pos, acc, c),
@@ -515,11 +533,11 @@ pub fn tokenizeStringChar__indexed(
 
 /// Synthesized indexed worker of `tokenizeStringCharInner`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeStringCharInner__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    c: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    c @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeStringCharInner__indexed(src, pos, acc, c),
@@ -529,10 +547,10 @@ pub fn tokenizeStringCharInner__indexed(
 
 /// Synthesized indexed worker of `tokenizeStringMaybeEscapedBrace`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeStringMaybeEscapedBrace__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeStringMaybeEscapedBrace__indexed(src, pos, acc),
@@ -542,10 +560,10 @@ pub fn tokenizeStringMaybeEscapedBrace__indexed(
 
 /// Synthesized indexed worker of `tokenizeStringMaybeEscapedClose`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeStringMaybeEscapedClose__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_2(
         __MutualTco2::TokenizeStringMaybeEscapedClose__indexed(src, pos, acc),
@@ -566,11 +584,11 @@ enum __MutualTco3 {
 
 fn __mutual_tco_trampoline_3(
     mut __state: __MutualTco3,
-    __str_index: &aver_rt::StringIndex,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     loop {
         __state = match __state {
-            __MutualTco3::TokenizeInterpExpr__indexed(mut src, mut pos) => {
+            __MutualTco3::TokenizeInterpExpr__indexed(mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
                     __MutualTco3::TokenizeInterpExprAt__indexed(src, pos)
@@ -581,7 +599,7 @@ fn __mutual_tco_trampoline_3(
                     ]);
                 }
             }
-            __MutualTco3::TokenizeInterpExprAt__indexed(mut src, mut pos) => {
+            __MutualTco3::TokenizeInterpExprAt__indexed(mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                     Some(c @ _) => __MutualTco3::TokenizeInterpExprC__indexed(src, pos, c),
@@ -593,7 +611,7 @@ fn __mutual_tco_trampoline_3(
                     }
                 }
             }
-            __MutualTco3::TokenizeInterpExprC__indexed(mut src, mut pos, mut c) => {
+            __MutualTco3::TokenizeInterpExprC__indexed(mut src @ _, mut pos @ _, mut c @ _) => {
                 crate::cancel_checkpoint();
                 if (c == crate::aver_generated::domain::lexer::closeBrace()) {
                     return aver_rt::AverList::prepend(
@@ -609,7 +627,7 @@ fn __mutual_tco_trampoline_3(
                     __MutualTco3::TokenizeInterpExprChar__indexed(src, pos, c)
                 }
             }
-            __MutualTco3::TokenizeInterpExprChar__indexed(mut src, mut pos, mut c) => {
+            __MutualTco3::TokenizeInterpExprChar__indexed(mut src @ _, mut pos @ _, mut c @ _) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::lexer::chars::isDigit(c.clone()) {
                     return crate::aver_generated::domain::lexer::tokenizeInterpDigit__indexed(
@@ -621,7 +639,7 @@ fn __mutual_tco_trampoline_3(
                     __MutualTco3::TokenizeInterpNonDigit__indexed(src, pos, c)
                 }
             }
-            __MutualTco3::TokenizeInterpNonDigit__indexed(mut src, mut pos, mut c) => {
+            __MutualTco3::TokenizeInterpNonDigit__indexed(mut src @ _, mut pos @ _, mut c @ _) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::lexer::chars::isAlpha(c.clone()) {
                     __MutualTco3::TokenizeInterpAlpha__indexed(src, pos)
@@ -629,7 +647,7 @@ fn __mutual_tco_trampoline_3(
                     __MutualTco3::TokenizeInterpPunct__indexed(src, pos, c)
                 }
             }
-            __MutualTco3::TokenizeInterpPunct__indexed(mut src, mut pos, mut c) => {
+            __MutualTco3::TokenizeInterpPunct__indexed(mut src @ _, mut pos @ _, mut c @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
@@ -697,7 +715,7 @@ fn __mutual_tco_trampoline_3(
                     }
                 }
             }
-            __MutualTco3::TokenizeInterpAlpha__indexed(mut src, mut pos) => {
+            __MutualTco3::TokenizeInterpAlpha__indexed(mut src @ _, mut pos @ _) => {
                 crate::cancel_checkpoint();
                 match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
                     Some(c @ _) => {
@@ -725,9 +743,9 @@ fn __mutual_tco_trampoline_3(
 
 /// Synthesized indexed worker of `tokenizeInterpExpr`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpExpr__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpExpr__indexed(src, pos),
@@ -737,9 +755,9 @@ pub fn tokenizeInterpExpr__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpExprAt`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpExprAt__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpExprAt__indexed(src, pos),
@@ -749,10 +767,10 @@ pub fn tokenizeInterpExprAt__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpExprC`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpExprC__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpExprC__indexed(src, pos, c),
@@ -762,10 +780,10 @@ pub fn tokenizeInterpExprC__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpExprChar`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpExprChar__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpExprChar__indexed(src, pos, c),
@@ -775,10 +793,10 @@ pub fn tokenizeInterpExprChar__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpNonDigit`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpNonDigit__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpNonDigit__indexed(src, pos, c),
@@ -788,10 +806,10 @@ pub fn tokenizeInterpNonDigit__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpPunct`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpPunct__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpPunct__indexed(src, pos, c),
@@ -801,9 +819,9 @@ pub fn tokenizeInterpPunct__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpAlpha`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpAlpha__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     __mutual_tco_trampoline_3(
         __MutualTco3::TokenizeInterpAlpha__indexed(src, pos),
@@ -819,11 +837,11 @@ enum __MutualTco4 {
 
 fn __mutual_tco_trampoline_4(
     mut __state: __MutualTco4,
-    __str_index: &aver_rt::StringIndex,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     loop {
         __state = match __state {
-            __MutualTco4::CountIndent__indexed(mut src, mut pos, mut spaces) => {
+            __MutualTco4::CountIndent__indexed(mut src @ _, mut pos @ _, mut spaces @ _) => {
                 crate::cancel_checkpoint();
                 if (pos < aver_rt::AverInt::from_i64(src.chars().count() as i64)) {
                     __MutualTco4::CountIndentChar__indexed(src, pos, spaces)
@@ -831,7 +849,7 @@ fn __mutual_tco_trampoline_4(
                     return (spaces, pos);
                 }
             }
-            __MutualTco4::CountIndentChar__indexed(mut src, mut pos, mut spaces) => {
+            __MutualTco4::CountIndentChar__indexed(mut src @ _, mut pos @ _, mut spaces @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
@@ -870,10 +888,10 @@ fn __mutual_tco_trampoline_4(
 
 /// Synthesized indexed worker of `countIndent`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn countIndent__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    spaces: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    spaces @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     __mutual_tco_trampoline_4(
         __MutualTco4::CountIndent__indexed(src, pos, spaces),
@@ -883,10 +901,10 @@ pub fn countIndent__indexed(
 
 /// Synthesized indexed worker of `countIndentChar`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn countIndentChar__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    spaces: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    spaces @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     __mutual_tco_trampoline_4(
         __MutualTco4::CountIndentChar__indexed(src, pos, spaces),
@@ -897,8 +915,8 @@ pub fn countIndentChar__indexed(
 /// Tokenize starting from a digit character.
 #[inline(always)]
 pub fn tokenizeDigit(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeDigit__indexed(
@@ -911,9 +929,9 @@ pub fn tokenizeDigit(
 /// After reading integer part, check for decimal point to form a float.
 #[inline(always)]
 pub fn tokenizeAfterInt(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeAfterInt__indexed(
@@ -927,9 +945,9 @@ pub fn tokenizeAfterInt(
 /// After integer and dot, check if next char is digit (float) or not (int + dot).
 #[inline(always)]
 pub fn tokenizeAfterIntDot(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeAfterIntDot__indexed(
@@ -943,9 +961,9 @@ pub fn tokenizeAfterIntDot(
 /// Read decimal digits and build float token.
 #[inline(always)]
 pub fn tokenizeFloat(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeFloat__indexed(
@@ -959,11 +977,11 @@ pub fn tokenizeFloat(
 /// Construct float from integer and decimal parts.
 #[inline(always)]
 pub fn buildFloat(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
-    decPart: aver_rt::AverInt,
-    decDigits: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
+    decPart @ _: aver_rt::AverInt,
+    decDigits @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::buildFloat__indexed(
@@ -978,14 +996,14 @@ pub fn buildFloat(
 
 /// Compute 10^n as Float.
 #[inline(always)]
-pub fn pow10(n: aver_rt::AverInt) -> f64 {
+pub fn pow10(n @ _: aver_rt::AverInt) -> f64 {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::pow10Acc(n, 1.0f64)
 }
 
 /// Accumulate 10^n as Float.
 #[inline(always)]
-pub fn pow10Acc(mut n: aver_rt::AverInt, mut acc: f64) -> f64 {
+pub fn pow10Acc(mut n @ _: aver_rt::AverInt, mut acc @ _: f64) -> f64 {
     loop {
         crate::cancel_checkpoint();
         if (n > aver_rt::AverInt::from_i64(0)) {
@@ -1005,8 +1023,8 @@ pub fn pow10Acc(mut n: aver_rt::AverInt, mut acc: f64) -> f64 {
 /// Tokenize starting from an alpha character.
 #[inline(always)]
 pub fn tokenizeAlpha(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeAlpha__indexed(
@@ -1019,9 +1037,9 @@ pub fn tokenizeAlpha(
 /// Tokenize identifier with known dotted mode.
 #[inline(always)]
 pub fn tokenizeAlphaWith(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    dotted: bool,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    dotted @ _: bool,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeAlphaWith__indexed(
@@ -1033,7 +1051,7 @@ pub fn tokenizeAlphaWith(
 }
 
 /// Check if a character is the greater-than sign.
-pub fn isGreaterThan(c: AverStr) -> bool {
+pub fn isGreaterThan(c @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     (&*c == ">")
 }
@@ -1041,8 +1059,8 @@ pub fn isGreaterThan(c: AverStr) -> bool {
 /// Tokenize a minus or arrow token.
 #[inline(always)]
 pub fn tokenizeMinus(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeMinus__indexed(
@@ -1055,9 +1073,9 @@ pub fn tokenizeMinus(
 /// Tokenize a character that is not a known single-char token.
 #[inline(always)]
 pub fn tokenizeDefault(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeDefault__indexed(
@@ -1071,9 +1089,9 @@ pub fn tokenizeDefault(
 /// Handle brace tokens or skip unknown chars.
 #[inline(always)]
 pub fn tokenizeBraceOrSkip(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeBraceOrSkip__indexed(
@@ -1087,9 +1105,9 @@ pub fn tokenizeBraceOrSkip(
 /// Read string literal with interpolation and escape sequences.
 #[inline(always)]
 pub fn tokenizeString(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeString__indexed(
@@ -1103,9 +1121,9 @@ pub fn tokenizeString(
 /// Read one character of string.
 #[inline(always)]
 pub fn tokenizeStringAt(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeStringAt__indexed(
@@ -1119,9 +1137,9 @@ pub fn tokenizeStringAt(
 /// Handle escape sequence in string: \n -> newline, \t -> tab, etc.
 #[inline(always)]
 pub fn tokenizeStringEscape(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeStringEscape__indexed(
@@ -1147,10 +1165,10 @@ pub fn openBrace() -> AverStr {
 /// Handle one character inside a string literal.
 #[inline(always)]
 pub fn tokenizeStringChar(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    c: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    c @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeStringChar__indexed(
@@ -1165,10 +1183,10 @@ pub fn tokenizeStringChar(
 /// Check for interpolation start, { escape, or continue string.
 #[inline(always)]
 pub fn tokenizeStringCharInner(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    c: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    c @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeStringCharInner__indexed(
@@ -1183,9 +1201,9 @@ pub fn tokenizeStringCharInner(
 /// Check for { (escaped brace) or start interpolation.
 #[inline(always)]
 pub fn tokenizeStringMaybeEscapedBrace(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeStringMaybeEscapedBrace__indexed(
@@ -1199,9 +1217,9 @@ pub fn tokenizeStringMaybeEscapedBrace(
 /// Check for } (escaped close brace) or continue.
 #[inline(always)]
 pub fn tokenizeStringMaybeEscapedClose(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeStringMaybeEscapedClose__indexed(
@@ -1215,9 +1233,9 @@ pub fn tokenizeStringMaybeEscapedClose(
 /// Start interpolation: emit accumulated string, TkInterpStart, expr tokens, TkInterpEnd.
 #[inline(always)]
 pub fn tokenizeInterp(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterp__indexed(
@@ -1231,8 +1249,8 @@ pub fn tokenizeInterp(
 /// Tokenize expression inside interpolation braces.
 #[inline(always)]
 pub fn tokenizeInterpExpr(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpExpr__indexed(
@@ -1245,8 +1263,8 @@ pub fn tokenizeInterpExpr(
 /// Read one token of interpolation expression.
 #[inline(always)]
 pub fn tokenizeInterpExprAt(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpExprAt__indexed(
@@ -1271,9 +1289,9 @@ pub fn closeBrace() -> AverStr {
 /// Dispatch interpolation char.
 #[inline(always)]
 pub fn tokenizeInterpExprC(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpExprC__indexed(
@@ -1287,9 +1305,9 @@ pub fn tokenizeInterpExprC(
 /// Tokenize one char of interpolation expression.
 #[inline(always)]
 pub fn tokenizeInterpExprChar(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpExprChar__indexed(
@@ -1303,9 +1321,9 @@ pub fn tokenizeInterpExprChar(
 /// Handle non-digit char in interpolation.
 #[inline(always)]
 pub fn tokenizeInterpNonDigit(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpNonDigit__indexed(
@@ -1319,9 +1337,9 @@ pub fn tokenizeInterpNonDigit(
 /// Handle punctuation in interpolation.
 #[inline(always)]
 pub fn tokenizeInterpPunct(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    c: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    c @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpPunct__indexed(
@@ -1335,9 +1353,9 @@ pub fn tokenizeInterpPunct(
 /// Read string literal inside interpolation braces.
 #[inline(always)]
 pub fn tokenizeInterpString(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpString__indexed(
@@ -1351,8 +1369,8 @@ pub fn tokenizeInterpString(
 /// Read number inside interpolation; may be an int or a float literal.
 #[inline(always)]
 pub fn tokenizeInterpDigit(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpDigit__indexed(
@@ -1365,9 +1383,9 @@ pub fn tokenizeInterpDigit(
 /// After integer part inside interpolation, check for a decimal point.
 #[inline(always)]
 pub fn tokenizeInterpAfterInt(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpAfterInt__indexed(
@@ -1381,9 +1399,9 @@ pub fn tokenizeInterpAfterInt(
 /// After integer and dot inside interpolation: digit -> float, else int + dot.
 #[inline(always)]
 pub fn tokenizeInterpAfterIntDot(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpAfterIntDot__indexed(
@@ -1397,9 +1415,9 @@ pub fn tokenizeInterpAfterIntDot(
 /// Read decimal digits and build a float token inside interpolation.
 #[inline(always)]
 pub fn tokenizeInterpFloat(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpFloat__indexed(
@@ -1413,11 +1431,11 @@ pub fn tokenizeInterpFloat(
 /// Construct a float from integer and decimal parts inside interpolation.
 #[inline(always)]
 pub fn tokenizeInterpBuildFloat(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
-    decPart: aver_rt::AverInt,
-    decDigits: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
+    decPart @ _: aver_rt::AverInt,
+    decDigits @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpBuildFloat__indexed(
@@ -1433,8 +1451,8 @@ pub fn tokenizeInterpBuildFloat(
 /// Read identifier inside interpolation.
 #[inline(always)]
 pub fn tokenizeInterpAlpha(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeInterpAlpha__indexed(
@@ -1447,8 +1465,8 @@ pub fn tokenizeInterpAlpha(
 /// Tokenize / (division) or // (line comment).
 #[inline(always)]
 pub fn tokenizeSlashOrComment(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeSlashOrComment__indexed(
@@ -1461,8 +1479,8 @@ pub fn tokenizeSlashOrComment(
 /// Skip characters until newline or EOF. Newline goes through indent handling.
 #[inline(always)]
 pub fn skipLineComment(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::skipLineComment__indexed(
@@ -1475,8 +1493,8 @@ pub fn skipLineComment(
 /// Tokenize . (field access) or .. (rest pattern).
 #[inline(always)]
 pub fn tokenizeDot(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeDot__indexed(
@@ -1489,8 +1507,8 @@ pub fn tokenizeDot(
 /// Tokenize < or <=.
 #[inline(always)]
 pub fn tokenizeLt(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeLt__indexed(
@@ -1503,8 +1521,8 @@ pub fn tokenizeLt(
 /// Tokenize > or >=.
 #[inline(always)]
 pub fn tokenizeGt(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeGt__indexed(
@@ -1517,8 +1535,8 @@ pub fn tokenizeGt(
 /// Tokenize ! or !=.
 #[inline(always)]
 pub fn tokenizeBang(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeBang__indexed(
@@ -1531,8 +1549,8 @@ pub fn tokenizeBang(
 /// Tokenize =, ==, or =>.
 #[inline(always)]
 pub fn tokenizeEq(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeEq__indexed(
@@ -1545,9 +1563,9 @@ pub fn tokenizeEq(
 /// Tokenize based on the current character.
 #[inline(always)]
 pub fn tokenizeChar(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeChar__indexed(
@@ -1561,9 +1579,9 @@ pub fn tokenizeChar(
 /// Tokenize when charAt returned Some.
 #[inline(always)]
 pub fn tokenizeSome(
-    c: AverStr,
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    c @ _: AverStr,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeSome__indexed(
@@ -1577,8 +1595,8 @@ pub fn tokenizeSome(
 /// Tokenize at given position after bounds check.
 #[inline(always)]
 pub fn tokenizeAtPos(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeAtPos__indexed(
@@ -1591,8 +1609,8 @@ pub fn tokenizeAtPos(
 /// Tokenize source string starting from pos.
 #[inline(always)]
 pub fn tokenize(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenize__indexed(
@@ -1605,8 +1623,8 @@ pub fn tokenize(
 /// Handle newline: count indent of next line, emit NEWLINE + raw indent marker.
 #[inline(always)]
 pub fn tokenizeNewline(
-    src: AverStr,
-    pos: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::tokenizeNewline__indexed(
@@ -1619,9 +1637,9 @@ pub fn tokenizeNewline(
 /// Count leading spaces after newline. Skip blank lines (reset on another newline).
 #[inline(always)]
 pub fn countIndent(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    spaces: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    spaces @ _: aver_rt::AverInt,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::countIndent__indexed(
@@ -1635,9 +1653,9 @@ pub fn countIndent(
 /// Check one character for indent counting.
 #[inline(always)]
 pub fn countIndentChar(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    spaces: aver_rt::AverInt,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    spaces @ _: aver_rt::AverInt,
 ) -> (aver_rt::AverInt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::countIndentChar__indexed(
@@ -1650,7 +1668,7 @@ pub fn countIndentChar(
 
 /// Tokenize a complete source string with INDENT/DEDENT.
 #[inline(always)]
-pub fn lex(src: AverStr) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
+pub fn lex(src @ _: AverStr) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::lex__indexed(
         src.clone(),
@@ -1661,8 +1679,8 @@ pub fn lex(src: AverStr) -> aver_rt::AverList<crate::aver_generated::domain::tok
 /// Convert raw indent markers (negative TkInt after TkNewline) into INDENT/DEDENT tokens.
 #[inline(always)]
 pub fn processIndentation(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    stack: &aver_rt::AverIntList,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     aver_list_match!(tokens.clone(), [] => crate::aver_generated::domain::lexer::emitFinalDedents(stack), [t, rest] => crate::aver_generated::domain::lexer::processIndentToken(&t, &rest, stack))
@@ -1670,9 +1688,9 @@ pub fn processIndentation(
 
 /// Process one token in the indentation pass.
 pub fn processIndentToken(
-    t: &crate::aver_generated::domain::token::Token,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    stack: &aver_rt::AverIntList,
+    t @ _: &crate::aver_generated::domain::token::Token,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     match t {
@@ -1693,8 +1711,8 @@ pub fn processIndentToken(
 /// After TkNewline, check for raw indent marker (negative TkInt).
 #[inline(always)]
 pub fn processAfterNewline(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    stack: &aver_rt::AverIntList,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     aver_list_match!(tokens.clone(), [] => aver_rt::AverList::prepend(crate::aver_generated::domain::token::Token::TkNewline, &crate::aver_generated::domain::lexer::emitFinalDedents(stack)), [t, rest] => crate::aver_generated::domain::lexer::processAfterNewlineToken(&t, &rest, stack))
@@ -1702,9 +1720,9 @@ pub fn processAfterNewline(
 
 /// Check if token after newline is a raw indent marker.
 pub fn processAfterNewlineToken(
-    t: &crate::aver_generated::domain::token::Token,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    stack: &aver_rt::AverIntList,
+    t @ _: &crate::aver_generated::domain::token::Token,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     match t.clone() {
@@ -1740,9 +1758,9 @@ pub fn processAfterNewlineToken(
 /// Compare indent level to stack top and emit INDENT, DEDENT, or NEWLINE.
 #[inline(always)]
 pub fn emitIndentChange(
-    indent: aver_rt::AverInt,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    stack: &aver_rt::AverIntList,
+    indent @ _: aver_rt::AverInt,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let currentIndent @ _ = crate::aver_generated::domain::lexer::stackTop(stack);
@@ -1771,9 +1789,9 @@ pub fn emitIndentChange(
 
 /// Emit DEDENT tokens until stack matches target indent.
 pub fn emitDedents(
-    targetIndent: aver_rt::AverInt,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    stack: &aver_rt::AverIntList,
+    targetIndent @ _: aver_rt::AverInt,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::emitDedentsAcc(
@@ -1787,12 +1805,12 @@ pub fn emitDedents(
 /// Accumulate DEDENT tokens until stack matches target indent.
 #[inline(always)]
 pub fn emitDedentsAcc(
-    mut targetIndent: aver_rt::AverInt,
-    rest: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut stack: aver_rt::AverIntList,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut targetIndent @ _: aver_rt::AverInt,
+    rest @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut stack @ _: aver_rt::AverIntList,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
-    let rest = std::sync::Arc::new(rest);
+    let rest @ _ = std::sync::Arc::new(rest);
     loop {
         crate::cancel_checkpoint();
         let reversed @ _ = acc.reverse();
@@ -1809,7 +1827,7 @@ pub fn emitDedentsAcc(
 /// At EOF, emit DEDENT for each indent level above 0.
 #[inline(always)]
 pub fn emitFinalDedents(
-    stack: &aver_rt::AverIntList,
+    stack @ _: &aver_rt::AverIntList,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::lexer::emitFinalDedentsAcc(
@@ -1821,8 +1839,8 @@ pub fn emitFinalDedents(
 /// Accumulate DEDENT tokens for each indent level above 0.
 #[inline(always)]
 pub fn emitFinalDedentsAcc(
-    mut stack: aver_rt::AverIntList,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut stack @ _: aver_rt::AverIntList,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     loop {
         crate::cancel_checkpoint();
@@ -1839,16 +1857,16 @@ pub fn emitFinalDedentsAcc(
 
 /// Return top of indent stack, or 0 if empty.
 #[inline(always)]
-pub fn stackTop(stack: &aver_rt::AverIntList) -> aver_rt::AverInt {
+pub fn stackTop(stack @ _: &aver_rt::AverIntList) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     aver_list_match!(stack.clone(), [] => aver_rt::AverInt::from_i64(0), [top, rest] => top)
 }
 
 /// Synthesized indexed worker of `tokenizeDigit`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeDigit__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     {
@@ -1864,10 +1882,10 @@ pub fn tokenizeDigit__indexed(
 /// Synthesized indexed worker of `tokenizeAfterInt`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeAfterInt__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
@@ -1896,10 +1914,10 @@ pub fn tokenizeAfterInt__indexed(
 /// Synthesized indexed worker of `tokenizeAfterIntDot`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeAfterIntDot__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1928,10 +1946,10 @@ pub fn tokenizeAfterIntDot__indexed(
 
 /// Synthesized indexed worker of `tokenizeFloat`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeFloat__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     {
@@ -1953,12 +1971,12 @@ pub fn tokenizeFloat__indexed(
 
 /// Synthesized indexed worker of `buildFloat`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn buildFloat__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
-    decPart: aver_rt::AverInt,
-    decDigits: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
+    decPart @ _: aver_rt::AverInt,
+    decDigits @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let f @ _ = (intPart.to_f64()
@@ -1972,9 +1990,9 @@ pub fn buildFloat__indexed(
 /// Synthesized indexed worker of `tokenizeAlpha`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeAlpha__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
@@ -1992,10 +2010,10 @@ pub fn tokenizeAlpha__indexed(
 
 /// Synthesized indexed worker of `tokenizeAlphaWith`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeAlphaWith__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    dotted: bool,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    dotted @ _: bool,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     {
@@ -2015,9 +2033,9 @@ pub fn tokenizeAlphaWith__indexed(
 /// Synthesized indexed worker of `tokenizeMinus`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeMinus__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2053,10 +2071,10 @@ pub fn tokenizeMinus__indexed(
 /// Synthesized indexed worker of `tokenizeInterp`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeInterp__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    acc: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     aver_rt::AverList::prepend(
@@ -2075,12 +2093,12 @@ pub fn tokenizeInterp__indexed(
 /// Synthesized indexed worker of `tokenizeInterpString`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeInterpString__indexed(
-    mut src: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut acc: AverStr,
-    __str_index: aver_rt::StringIndex,
+    mut src @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut acc @ _: AverStr,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2132,9 +2150,9 @@ pub fn tokenizeInterpString__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpDigit`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpDigit__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     {
@@ -2155,10 +2173,10 @@ pub fn tokenizeInterpDigit__indexed(
 /// Synthesized indexed worker of `tokenizeInterpAfterInt`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeInterpAfterInt__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     match aver_rt::string_index_char_at(&src, &__str_index, &pos) {
@@ -2195,10 +2213,10 @@ pub fn tokenizeInterpAfterInt__indexed(
 /// Synthesized indexed worker of `tokenizeInterpAfterIntDot`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeInterpAfterIntDot__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    n: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    n @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2235,10 +2253,10 @@ pub fn tokenizeInterpAfterIntDot__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpFloat`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpFloat__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     {
@@ -2260,12 +2278,12 @@ pub fn tokenizeInterpFloat__indexed(
 
 /// Synthesized indexed worker of `tokenizeInterpBuildFloat`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeInterpBuildFloat__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    intPart: aver_rt::AverInt,
-    decPart: aver_rt::AverInt,
-    decDigits: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    intPart @ _: aver_rt::AverInt,
+    decPart @ _: aver_rt::AverInt,
+    decDigits @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let f @ _ = (intPart.to_f64()
@@ -2279,9 +2297,9 @@ pub fn tokenizeInterpBuildFloat__indexed(
 /// Synthesized indexed worker of `tokenizeSlashOrComment`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeSlashOrComment__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2314,11 +2332,11 @@ pub fn tokenizeSlashOrComment__indexed(
 /// Synthesized indexed worker of `skipLineComment`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn skipLineComment__indexed(
-    mut src: AverStr,
-    mut pos: aver_rt::AverInt,
-    __str_index: aver_rt::StringIndex,
+    mut src @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2356,9 +2374,9 @@ pub fn skipLineComment__indexed(
 /// Synthesized indexed worker of `tokenizeDot`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeDot__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2394,9 +2412,9 @@ pub fn tokenizeDot__indexed(
 /// Synthesized indexed worker of `tokenizeLt`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeLt__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2432,9 +2450,9 @@ pub fn tokenizeLt__indexed(
 /// Synthesized indexed worker of `tokenizeGt`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeGt__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2470,9 +2488,9 @@ pub fn tokenizeGt__indexed(
 /// Synthesized indexed worker of `tokenizeBang`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn tokenizeBang__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2507,9 +2525,9 @@ pub fn tokenizeBang__indexed(
 
 /// Synthesized indexed worker of `tokenizeEq`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeEq__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -2562,9 +2580,9 @@ pub fn tokenizeEq__indexed(
 
 /// Synthesized indexed worker of `tokenizeNewline`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn tokenizeNewline__indexed(
-    src: AverStr,
-    pos: aver_rt::AverInt,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::lexer::countIndent__indexed(
@@ -2591,8 +2609,8 @@ pub fn tokenizeNewline__indexed(
 
 /// Synthesized indexed worker of `lex`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn lex__indexed(
-    src: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    src @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::token::Token> {
     crate::cancel_checkpoint();
     let raw @ _ = crate::aver_generated::domain::lexer::tokenize__indexed(

--- a/src/self_host/aver_generated/domain/match_mod/mod.rs
+++ b/src/self_host/aver_generated/domain/match_mod/mod.rs
@@ -26,16 +26,16 @@ fn __mutual_tco_trampoline_1(
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco1::MatchPatTupleItemsAcc(mut pats, mut items, mut acc) => {
+            __MutualTco1::MatchPatTupleItemsAcc(mut pats @ _, mut items @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(pats, [] => { return Ok(acc) }, [pat, restPats] => { aver_list_match!(items, [] => { return Err(AverStr::from("no match")) }, [item, restItems] => __MutualTco1::MatchPatTupleOne(pat, item, restPats, restItems, acc)) })
             }
             __MutualTco1::MatchPatTupleOne(
-                mut pat,
-                mut item,
-                mut restPats,
-                mut restItems,
-                mut acc,
+                mut pat @ _,
+                mut item @ _,
+                mut restPats @ _,
+                mut restItems @ _,
+                mut acc @ _,
             ) => {
                 crate::cancel_checkpoint();
                 let bindings @ _ =
@@ -52,9 +52,9 @@ fn __mutual_tco_trampoline_1(
 
 /// Accumulate bindings from tuple pattern matching.
 pub fn matchPatTupleItemsAcc(
-    pats: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    items: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    acc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    pats @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    acc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     __mutual_tco_trampoline_1(__MutualTco1::MatchPatTupleItemsAcc(
         pats.clone(),
@@ -65,11 +65,11 @@ pub fn matchPatTupleItemsAcc(
 
 /// Match one tuple element and continue with accumulated bindings.
 pub fn matchPatTupleOne(
-    pat: &crate::aver_generated::domain::ast::Pattern,
-    item: &crate::aver_generated::domain::value::Val,
-    restPats: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    restItems: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    acc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
+    item @ _: &crate::aver_generated::domain::value::Val,
+    restPats @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    restItems @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    acc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     __mutual_tco_trampoline_1(__MutualTco1::MatchPatTupleOne(
         pat.clone(),
@@ -82,8 +82,8 @@ pub fn matchPatTupleOne(
 
 /// Try to match a value against a pattern. Returns bindings on success.
 pub fn matchPattern(
-    pat: &crate::aver_generated::domain::ast::Pattern,
-    v: &crate::aver_generated::domain::value::Val,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match pat.clone() {
@@ -125,8 +125,8 @@ pub fn matchPattern(
 
 /// Match a PatInt pattern against a value.
 pub fn matchPatInt(
-    n: aver_rt::AverInt,
-    v: &crate::aver_generated::domain::value::Val,
+    n @ _: aver_rt::AverInt,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -143,8 +143,8 @@ pub fn matchPatInt(
 
 /// Match a PatFloat pattern against a value.
 pub fn matchPatFloat(
-    f: f64,
-    v: &crate::aver_generated::domain::value::Val,
+    f @ _: f64,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -161,8 +161,8 @@ pub fn matchPatFloat(
 
 /// Match a PatBool pattern against a value.
 pub fn matchPatBool(
-    b: bool,
-    v: &crate::aver_generated::domain::value::Val,
+    b @ _: bool,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -179,8 +179,8 @@ pub fn matchPatBool(
 
 /// Match a string literal pattern.
 pub fn matchPatStr(
-    s: AverStr,
-    v: &crate::aver_generated::domain::value::Val,
+    s @ _: AverStr,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -197,7 +197,7 @@ pub fn matchPatStr(
 
 /// Match empty list pattern [].
 pub fn matchPatEmpty(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -215,9 +215,9 @@ pub fn matchPatEmpty(
 
 /// Match cons pattern [h, ..t].
 pub fn matchPatCons(
-    h: AverStr,
-    t: AverStr,
-    v: &crate::aver_generated::domain::value::Val,
+    h @ _: AverStr,
+    t @ _: AverStr,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -231,9 +231,9 @@ pub fn matchPatCons(
 /// Match constructor pattern. Checks tag name and extracts inner values.
 #[inline(always)]
 pub fn matchPatConstructor(
-    ctorName: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
-    v: &crate::aver_generated::domain::value::Val,
+    ctorName @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -274,8 +274,8 @@ pub fn matchPatConstructor(
 
 /// Match tuple pattern with nested patterns.
 pub fn matchPatTuple(
-    pats: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    v: &crate::aver_generated::domain::value::Val,
+    pats @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -288,8 +288,8 @@ pub fn matchPatTuple(
 
 /// Match each pattern against corresponding tuple item.
 pub fn matchPatTupleItems(
-    pats: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    items: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    pats @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::match_mod::matchPatTupleItemsAcc(
@@ -301,9 +301,9 @@ pub fn matchPatTupleItems(
 
 /// Match a generic variant constructor pattern using the full name stored in the value.
 pub fn matchGenericConstructor(
-    ctorName: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
-    v: &crate::aver_generated::domain::value::Val,
+    ctorName @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -319,10 +319,10 @@ pub fn matchGenericConstructor(
 /// Check if variant full name matches constructor name.
 #[inline(always)]
 pub fn matchGenericCtorCheck(
-    ctorName: AverStr,
-    fullName: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
-    fields: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    ctorName @ _: AverStr,
+    fullName @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
+    fields @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     if (fullName == ctorName) {
@@ -337,10 +337,10 @@ pub fn matchGenericCtorCheck(
 /// Match constructor pattern by integer tag ID. Builtins dispatch directly; user variants confirm both tag and full name.
 #[inline(always)]
 pub fn matchPatConstructorById(
-    tag: aver_rt::AverInt,
-    ctorName: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
-    v: &crate::aver_generated::domain::value::Val,
+    tag @ _: aver_rt::AverInt,
+    ctorName @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -382,9 +382,9 @@ pub fn matchPatConstructorById(
 /// Match Ok/Err/Some wrapper by integer tag. 1=Ok, 2=Err, 3=Some.
 #[inline(always)]
 pub fn matchWrapperPatDirect(
-    v: &crate::aver_generated::domain::value::Val,
-    tag: aver_rt::AverInt,
-    bindings: &aver_rt::AverList<AverStr>,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    tag @ _: aver_rt::AverInt,
+    bindings @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -434,10 +434,10 @@ pub fn matchWrapperPatDirect(
 
 /// Match a user-defined variant by integer tag first, then full constructor name for collision safety.
 pub fn matchGenericCtorById(
-    tag: aver_rt::AverInt,
-    ctorName: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
-    v: &crate::aver_generated::domain::value::Val,
+    tag @ _: aver_rt::AverInt,
+    ctorName @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v.clone() {
@@ -460,7 +460,7 @@ pub fn matchGenericCtorById(
 
 /// Match Option.None pattern.
 pub fn matchNonePat(
-    v: &crate::aver_generated::domain::value::Val,
+    v @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     match v {
@@ -472,9 +472,9 @@ pub fn matchNonePat(
 /// Match Ok/Err/Some wrapper and bind inner value.
 #[inline(always)]
 pub fn matchWrapperPat(
-    v: &crate::aver_generated::domain::value::Val,
-    tag: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
+    v @ _: &crate::aver_generated::domain::value::Val,
+    tag @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>, AverStr> {
     crate::cancel_checkpoint();
     {
@@ -525,8 +525,8 @@ pub fn matchWrapperPat(
 /// Pair binding names with values.
 #[inline(always)]
 pub fn zipBindings(
-    names: &aver_rt::AverList<AverStr>,
-    vals: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    names @ _: &aver_rt::AverList<AverStr>,
+    vals @ _: &aver_rt::AverList<crate::aver_generated::domain::value::Val>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::match_mod::zipBindingsAcc(
@@ -539,9 +539,9 @@ pub fn zipBindings(
 /// Accumulate binding pairs in reverse, then reverse at end.
 #[inline(always)]
 pub fn zipBindingsAcc(
-    mut names: aver_rt::AverList<AverStr>,
-    mut vals: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
+    mut names @ _: aver_rt::AverList<AverStr>,
+    mut vals @ _: aver_rt::AverList<crate::aver_generated::domain::value::Val>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::value::Val)> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/parser/expr/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/expr/mod.rs
@@ -19,11 +19,11 @@ enum __MutualTco1 {
 
 fn __mutual_tco_trampoline_1(
     mut __state: __MutualTco1,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco1::ParseAddExprTail(mut pos, mut left) => {
+            __MutualTco1::ParseAddExprTail(mut pos @ _, mut left @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 let t @ _ =
@@ -46,7 +46,7 @@ fn __mutual_tco_trampoline_1(
                     _ => return Ok((left, pos)),
                 }
             }
-            __MutualTco1::ParseAddExprRight(mut pos, mut left, mut op) => {
+            __MutualTco1::ParseAddExprRight(mut pos @ _, mut left @ _, mut op @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ =
                     crate::aver_generated::domain::parser::expr::parseMulExpr(&*tokens, pos)?;
@@ -77,19 +77,19 @@ fn __mutual_tco_trampoline_1(
 
 /// Continue parsing additive operators.
 pub fn parseAddExprTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    left: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_1(__MutualTco1::ParseAddExprTail(pos, left.clone()), &tokens)
 }
 
 /// Parse right side of additive op.
 pub fn parseAddExprRight(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    left: &crate::aver_generated::domain::ast::Expr,
-    op: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    op @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_1(
         __MutualTco1::ParseAddExprRight(pos, left.clone(), op),
@@ -109,11 +109,11 @@ enum __MutualTco2 {
 
 fn __mutual_tco_trampoline_2(
     mut __state: __MutualTco2,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco2::ParseMulExprTail(mut pos, mut left) => {
+            __MutualTco2::ParseMulExprTail(mut pos @ _, mut left @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
@@ -134,7 +134,7 @@ fn __mutual_tco_trampoline_2(
                     _ => return Ok((left, pos)),
                 }
             }
-            __MutualTco2::ParseMulExprRight(mut pos, mut left, mut op) => {
+            __MutualTco2::ParseMulExprRight(mut pos @ _, mut left @ _, mut op @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::expr::parseAtom(&*tokens, pos)?;
                 {
@@ -164,19 +164,19 @@ fn __mutual_tco_trampoline_2(
 
 /// Continue parsing multiplicative operators.
 pub fn parseMulExprTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    left: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_2(__MutualTco2::ParseMulExprTail(pos, left.clone()), &tokens)
 }
 
 /// Parse right side of mul/div op.
 pub fn parseMulExprRight(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    left: &crate::aver_generated::domain::ast::Expr,
-    op: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    op @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_2(
         __MutualTco2::ParseMulExprRight(pos, left.clone(), op),
@@ -203,11 +203,11 @@ enum __MutualTco3 {
 
 fn __mutual_tco_trampoline_3(
     mut __state: __MutualTco3,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco3::ParseMapEntries(mut pos, mut acc) => {
+            __MutualTco3::ParseMapEntries(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let kr @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
@@ -215,7 +215,7 @@ fn __mutual_tco_trampoline_3(
                     __MutualTco3::ParseMapAfterKey(pos2, acc, keyExpr)
                 }
             }
-            __MutualTco3::ParseMapAfterKey(mut pos, mut acc, mut keyExpr) => {
+            __MutualTco3::ParseMapAfterKey(mut pos @ _, mut acc @ _, mut keyExpr @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
@@ -237,7 +237,7 @@ fn __mutual_tco_trampoline_3(
                     )
                 }
             }
-            __MutualTco3::ParseMapEntryTail(mut pos, mut acc) => {
+            __MutualTco3::ParseMapEntryTail(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos);
@@ -273,19 +273,19 @@ fn __mutual_tco_trampoline_3(
 
 /// Parse key => value pairs.
 pub fn parseMapEntries(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_3(__MutualTco3::ParseMapEntries(pos, acc.clone()), &tokens)
 }
 
 /// After key, expect => then value.
 pub fn parseMapAfterKey(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    keyExpr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    keyExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::ParseMapAfterKey(pos, acc.clone(), keyExpr.clone()),
@@ -295,9 +295,9 @@ pub fn parseMapAfterKey(
 
 /// After entry: , for more or } to end.
 pub fn parseMapEntryTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_3(__MutualTco3::ParseMapEntryTail(pos, acc.clone()), &tokens)
 }
@@ -324,11 +324,11 @@ enum __MutualTco4 {
 
 fn __mutual_tco_trampoline_4(
     mut __state: __MutualTco4,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco4::ParseInterpParts(mut pos, mut acc) => {
+            __MutualTco4::ParseInterpParts(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
@@ -336,7 +336,7 @@ fn __mutual_tco_trampoline_4(
                     __MutualTco4::ParseInterpAfterExpr(pos2, aver_rt::AverList::prepend(expr, &acc))
                 }
             }
-            __MutualTco4::ParseInterpAfterExpr(mut pos, mut acc) => {
+            __MutualTco4::ParseInterpAfterExpr(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkInterpEnd => {
@@ -348,7 +348,7 @@ fn __mutual_tco_trampoline_4(
                     _ => return Err(AverStr::from("Expected } in string interpolation")),
                 }
             }
-            __MutualTco4::ParseInterpContinue(mut pos, mut acc) => {
+            __MutualTco4::ParseInterpContinue(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
@@ -372,7 +372,7 @@ fn __mutual_tco_trampoline_4(
                     }
                 }
             }
-            __MutualTco4::ParseInterpAfterStr(mut pos, mut acc) => {
+            __MutualTco4::ParseInterpAfterStr(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkInterpStart => {
@@ -392,18 +392,18 @@ fn __mutual_tco_trampoline_4(
 
 /// Parse interpolation parts: expressions between TkInterpStart/TkInterpEnd and TkStr segments.
 pub fn parseInterpParts(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_4(__MutualTco4::ParseInterpParts(pos, acc.clone()), &tokens)
 }
 
 /// After interpolation expr: expect TkInterpEnd, then maybe more string.
 pub fn parseInterpAfterExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_4(
         __MutualTco4::ParseInterpAfterExpr(pos, acc.clone()),
@@ -413,18 +413,18 @@ pub fn parseInterpAfterExpr(
 
 /// After }: next TkStr continues, or end of string.
 pub fn parseInterpContinue(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_4(__MutualTco4::ParseInterpContinue(pos, acc.clone()), &tokens)
 }
 
 /// After string segment: more interpolation or end.
 pub fn parseInterpAfterStr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_4(__MutualTco4::ParseInterpAfterStr(pos, acc.clone()), &tokens)
 }
@@ -447,11 +447,11 @@ enum __MutualTco5 {
 
 fn __mutual_tco_trampoline_5(
     mut __state: __MutualTco5,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco5::ParseListItems(mut pos, mut acc) => {
+            __MutualTco5::ParseListItems(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
@@ -459,7 +459,7 @@ fn __mutual_tco_trampoline_5(
                     __MutualTco5::ParseListItemsTail(pos2, aver_rt::AverList::prepend(expr, &acc))
                 }
             }
-            __MutualTco5::ParseListItemsTail(mut pos0, mut items) => {
+            __MutualTco5::ParseListItemsTail(mut pos0 @ _, mut items @ _) => {
                 crate::cancel_checkpoint();
                 let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
@@ -482,7 +482,7 @@ fn __mutual_tco_trampoline_5(
                     _ => return Err(AverStr::from("Expected ',' or ']' in list literal")),
                 }
             }
-            __MutualTco5::ParseListAfterComma(mut pos, mut items) => {
+            __MutualTco5::ParseListAfterComma(mut pos @ _, mut items @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRBracket => {
@@ -500,18 +500,18 @@ fn __mutual_tco_trampoline_5(
 
 /// Parse comma-separated list items.
 pub fn parseListItems(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_5(__MutualTco5::ParseListItems(pos, acc.clone()), &tokens)
 }
 
 /// After a list item: ',' for more or ']' to end.
 pub fn parseListItemsTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos0: aver_rt::AverInt,
-    items: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos0 @ _: aver_rt::AverInt,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_5(
         __MutualTco5::ParseListItemsTail(pos0, items.clone()),
@@ -521,9 +521,9 @@ pub fn parseListItemsTail(
 
 /// Allow a trailing comma before ']' in list literals.
 pub fn parseListAfterComma(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    items: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_5(
         __MutualTco5::ParseListAfterComma(pos, items.clone()),
@@ -549,11 +549,11 @@ enum __MutualTco6 {
 
 fn __mutual_tco_trampoline_6(
     mut __state: __MutualTco6,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco6::ParseTupleRest(mut pos, mut acc) => {
+            __MutualTco6::ParseTupleRest(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
@@ -561,7 +561,7 @@ fn __mutual_tco_trampoline_6(
                     __MutualTco6::ParseTupleRestTail(pos2, aver_rt::AverList::prepend(expr, &acc))
                 }
             }
-            __MutualTco6::ParseTupleRestTail(mut pos0, mut items) => {
+            __MutualTco6::ParseTupleRestTail(mut pos0 @ _, mut items @ _) => {
                 crate::cancel_checkpoint();
                 let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
@@ -585,7 +585,7 @@ fn __mutual_tco_trampoline_6(
                     _ => return Err(AverStr::from("Expected ')' or ',' in tuple")),
                 }
             }
-            __MutualTco6::ParseTupleAfterComma(mut pos, mut items) => {
+            __MutualTco6::ParseTupleAfterComma(mut pos @ _, mut items @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -604,18 +604,18 @@ fn __mutual_tco_trampoline_6(
 
 /// Parse remaining tuple elements after first comma.
 pub fn parseTupleRest(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_6(__MutualTco6::ParseTupleRest(pos, acc.clone()), &tokens)
 }
 
 /// After tuple element: ',' for more or ')' to end.
 pub fn parseTupleRestTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos0: aver_rt::AverInt,
-    items: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos0 @ _: aver_rt::AverInt,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_6(
         __MutualTco6::ParseTupleRestTail(pos0, items.clone()),
@@ -625,9 +625,9 @@ pub fn parseTupleRestTail(
 
 /// Allow a trailing comma before ')' in tuples.
 pub fn parseTupleAfterComma(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    items: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_6(
         __MutualTco6::ParseTupleAfterComma(pos, items.clone()),
@@ -643,11 +643,11 @@ enum __MutualTco7 {
 
 fn __mutual_tco_trampoline_7(
     mut __state: __MutualTco7,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco7::ParseFieldAccess(mut pos, mut obj) => {
+            __MutualTco7::ParseFieldAccess(mut pos @ _, mut obj @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkIdent(field) => {
@@ -662,7 +662,7 @@ fn __mutual_tco_trampoline_7(
                     _ => return Err(AverStr::from("Expected field name after '.'")),
                 }
             }
-            __MutualTco7::ParseFieldAccessTail(mut pos, mut expr) => {
+            __MutualTco7::ParseFieldAccessTail(mut pos @ _, mut expr @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkDot => {
@@ -680,18 +680,18 @@ fn __mutual_tco_trampoline_7(
 
 /// Parse .field after an expression.
 pub fn parseFieldAccess(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    obj: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    obj @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_7(__MutualTco7::ParseFieldAccess(pos, obj.clone()), &tokens)
 }
 
 /// Check for chained field access.
 pub fn parseFieldAccessTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_7(
         __MutualTco7::ParseFieldAccessTail(pos, expr.clone()),
@@ -726,11 +726,11 @@ enum __MutualTco8 {
 
 fn __mutual_tco_trampoline_8(
     mut __state: __MutualTco8,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco8::ParseRecordFields(mut pos, mut name, mut acc) => {
+            __MutualTco8::ParseRecordFields(mut pos @ _, mut name @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkIdent(field) => {
@@ -744,7 +744,12 @@ fn __mutual_tco_trampoline_8(
                     _ => return Err(AverStr::from("Expected field name in record constructor")),
                 }
             }
-            __MutualTco8::ParseRecordField(mut pos, mut name, mut acc, mut field) => {
+            __MutualTco8::ParseRecordField(
+                mut pos @ _,
+                mut name @ _,
+                mut acc @ _,
+                mut field @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
@@ -761,7 +766,7 @@ fn __mutual_tco_trampoline_8(
                     )
                 }
             }
-            __MutualTco8::ParseRecordFieldsTail(mut pos, mut name, mut fields) => {
+            __MutualTco8::ParseRecordFieldsTail(mut pos @ _, mut name @ _, mut fields @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos);
@@ -788,7 +793,7 @@ fn __mutual_tco_trampoline_8(
                     _ => return Err(AverStr::from("Expected ',' or ')' in record constructor")),
                 }
             }
-            __MutualTco8::ParseRecordAfterComma(mut pos, mut name, mut fields) => {
+            __MutualTco8::ParseRecordAfterComma(mut pos @ _, mut name @ _, mut fields @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -806,10 +811,10 @@ fn __mutual_tco_trampoline_8(
 
 /// Parse record fields: field = expr, ...
 pub fn parseRecordFields(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    acc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    acc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::ParseRecordFields(pos, name, acc.clone()),
@@ -819,11 +824,11 @@ pub fn parseRecordFields(
 
 /// Parse = expr after field name.
 pub fn parseRecordField(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    acc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    field: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    acc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    field @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::ParseRecordField(pos, name, acc.clone(), field),
@@ -833,10 +838,10 @@ pub fn parseRecordField(
 
 /// After a field: ',' for more or ')' to end.
 pub fn parseRecordFieldsTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    fields: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    fields @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::ParseRecordFieldsTail(pos, name, fields.clone()),
@@ -846,10 +851,10 @@ pub fn parseRecordFieldsTail(
 
 /// Allow a trailing comma before ')' in record constructors.
 pub fn parseRecordAfterComma(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    fields: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    fields @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_8(
         __MutualTco8::ParseRecordAfterComma(pos, name, fields.clone()),
@@ -884,11 +889,11 @@ enum __MutualTco9 {
 
 fn __mutual_tco_trampoline_9(
     mut __state: __MutualTco9,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco9::ParseCallArgsList(mut pos, mut name, mut acc) => {
+            __MutualTco9::ParseCallArgsList(mut pos @ _, mut name @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(&*tokens, pos)?;
                 {
@@ -900,7 +905,7 @@ fn __mutual_tco_trampoline_9(
                     )
                 }
             }
-            __MutualTco9::ParseCallArgsListTail(mut pos0, mut name, mut args) => {
+            __MutualTco9::ParseCallArgsListTail(mut pos0 @ _, mut name @ _, mut args @ _) => {
                 crate::cancel_checkpoint();
                 let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
@@ -927,7 +932,7 @@ fn __mutual_tco_trampoline_9(
                     _ => return Err(AverStr::from("Expected ',' or ')' in argument list")),
                 }
             }
-            __MutualTco9::ParseCallArgsAfterComma(mut pos, mut name, mut args) => {
+            __MutualTco9::ParseCallArgsAfterComma(mut pos @ _, mut name @ _, mut args @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -945,7 +950,12 @@ fn __mutual_tco_trampoline_9(
                     _ => __MutualTco9::ParseCallArgsList(pos, name, args),
                 }
             }
-            __MutualTco9::ParseCallArgsCheckNamed(mut pos, mut name, mut args, mut field) => {
+            __MutualTco9::ParseCallArgsCheckNamed(
+                mut pos @ _,
+                mut name @ _,
+                mut args @ _,
+                mut field @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(
                     &*tokens,
@@ -969,10 +979,10 @@ fn __mutual_tco_trampoline_9(
 
 /// Parse comma-separated argument list.
 pub fn parseCallArgsList(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_9(
         __MutualTco9::ParseCallArgsList(pos, name, acc.clone()),
@@ -982,10 +992,10 @@ pub fn parseCallArgsList(
 
 /// After an argument: ',' for more or ')' to end. Detects named args (field = expr).
 pub fn parseCallArgsListTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos0: aver_rt::AverInt,
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos0 @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_9(
         __MutualTco9::ParseCallArgsListTail(pos0, name, args.clone()),
@@ -995,10 +1005,10 @@ pub fn parseCallArgsListTail(
 
 /// After comma in call args: check if next is ident = (named arg) or regular expr.
 pub fn parseCallArgsAfterComma(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_9(
         __MutualTco9::ParseCallArgsAfterComma(pos, name, args.clone()),
@@ -1008,11 +1018,11 @@ pub fn parseCallArgsAfterComma(
 
 /// Lookahead: if next token after ident is =, switch to named args mode.
 pub fn parseCallArgsCheckNamed(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    field: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    field @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_9(
         __MutualTco9::ParseCallArgsCheckNamed(pos, name, args.clone(), field),
@@ -1042,12 +1052,12 @@ enum __MutualTco10 {
 
 fn __mutual_tco_trampoline_10(
     mut __state: __MutualTco10,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    positionalArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    positionalArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco10::ParseNamedArgs(mut pos, mut name, mut namedAcc) => {
+            __MutualTco10::ParseNamedArgs(mut pos @ _, mut name @ _, mut namedAcc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkIdent(field) => {
@@ -1082,7 +1092,12 @@ fn __mutual_tco_trampoline_10(
                     }
                 }
             }
-            __MutualTco10::ParseNamedArgField(mut pos, mut name, mut namedAcc, mut field) => {
+            __MutualTco10::ParseNamedArgField(
+                mut pos @ _,
+                mut name @ _,
+                mut namedAcc @ _,
+                mut field @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
@@ -1099,7 +1114,7 @@ fn __mutual_tco_trampoline_10(
                     )
                 }
             }
-            __MutualTco10::ParseNamedArgsTail(mut pos0, mut name, mut namedAcc) => {
+            __MutualTco10::ParseNamedArgsTail(mut pos0 @ _, mut name @ _, mut namedAcc @ _) => {
                 crate::cancel_checkpoint();
                 let pos @ _ =
                     crate::aver_generated::domain::parser::expr::skipNl((*tokens).clone(), pos0);
@@ -1140,11 +1155,11 @@ fn __mutual_tco_trampoline_10(
 
 /// Parse field = expr pairs for named/record-update args.
 pub fn parseNamedArgs(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    positionalArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    namedAcc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    positionalArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    namedAcc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_10(
         __MutualTco10::ParseNamedArgs(pos, name, namedAcc.clone()),
@@ -1155,12 +1170,12 @@ pub fn parseNamedArgs(
 
 /// Parse = expr after field name in named args.
 pub fn parseNamedArgField(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    positionalArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    namedAcc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    field: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    positionalArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    namedAcc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    field @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_10(
         __MutualTco10::ParseNamedArgField(pos, name, namedAcc.clone(), field),
@@ -1171,11 +1186,11 @@ pub fn parseNamedArgField(
 
 /// After named arg: ',' for more or ')' to end.
 pub fn parseNamedArgsTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos0: aver_rt::AverInt,
-    name: AverStr,
-    positionalArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    namedAcc: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos0 @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    positionalArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    namedAcc @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_10(
         __MutualTco10::ParseNamedArgsTail(pos0, name, namedAcc.clone()),
@@ -1203,12 +1218,12 @@ enum __MutualTco11 {
 
 fn __mutual_tco_trampoline_11(
     mut __state: __MutualTco11,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    subject: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco11::ParseMatchArms(mut pos, mut acc) => {
+            __MutualTco11::ParseMatchArms(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(
                     (*tokens).clone(),
@@ -1246,7 +1261,7 @@ fn __mutual_tco_trampoline_11(
                     _ => __MutualTco11::ParseOneArm(pos2, acc),
                 }
             }
-            __MutualTco11::ParseOneArm(mut pos, mut acc) => {
+            __MutualTco11::ParseOneArm(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let pr @ _ =
                     crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
@@ -1255,7 +1270,7 @@ fn __mutual_tco_trampoline_11(
                     __MutualTco11::ParseOneArmBody(pos2, acc, pat)
                 }
             }
-            __MutualTco11::ParseOneArmBody(mut pos, mut acc, mut pat) => {
+            __MutualTco11::ParseOneArmBody(mut pos @ _, mut acc @ _, mut pat @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
@@ -1288,10 +1303,10 @@ fn __mutual_tco_trampoline_11(
 
 /// Parse match arms until DEDENT.
 pub fn parseMatchArms(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_11(
         __MutualTco11::ParseMatchArms(pos, acc.clone()),
@@ -1302,10 +1317,10 @@ pub fn parseMatchArms(
 
 /// Parse one match arm: pattern '->' expr NEWLINE
 pub fn parseOneArm(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_11(
         __MutualTco11::ParseOneArm(pos, acc.clone()),
@@ -1316,11 +1331,11 @@ pub fn parseOneArm(
 
 /// Parse arrow and body of a match arm.
 pub fn parseOneArmBody(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    pat: &crate::aver_generated::domain::ast::Pattern,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_11(
         __MutualTco11::ParseOneArmBody(pos, acc.clone(), pat.clone()),
@@ -1348,12 +1363,12 @@ enum __MutualTco12 {
 
 fn __mutual_tco_trampoline_12(
     mut __state: __MutualTco12,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    subject: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco12::ParseMatchArmsFlat(mut pos, mut acc) => {
+            __MutualTco12::ParseMatchArmsFlat(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::parser_match::isArmStart(&*tokens, pos.clone()) {
                     __MutualTco12::ParseOneArmFlat(pos, acc)
@@ -1374,7 +1389,7 @@ fn __mutual_tco_trampoline_12(
                     }
                 }
             }
-            __MutualTco12::ParseOneArmFlat(mut pos, mut acc) => {
+            __MutualTco12::ParseOneArmFlat(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let pr @ _ =
                     crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
@@ -1383,7 +1398,7 @@ fn __mutual_tco_trampoline_12(
                     __MutualTco12::ParseOneArmFlatBody(pos2, acc, pat)
                 }
             }
-            __MutualTco12::ParseOneArmFlatBody(mut pos, mut acc, mut pat) => {
+            __MutualTco12::ParseOneArmFlatBody(mut pos @ _, mut acc @ _, mut pat @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
                     &*tokens,
@@ -1416,10 +1431,10 @@ fn __mutual_tco_trampoline_12(
 
 /// Parse match arms without INDENT/DEDENT (fallback for flat token streams).
 pub fn parseMatchArmsFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_12(
         __MutualTco12::ParseMatchArmsFlat(pos, acc.clone()),
@@ -1430,10 +1445,10 @@ pub fn parseMatchArmsFlat(
 
 /// Parse one arm and continue in flat mode.
 pub fn parseOneArmFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_12(
         __MutualTco12::ParseOneArmFlat(pos, acc.clone()),
@@ -1444,11 +1459,11 @@ pub fn parseOneArmFlat(
 
 /// Parse arrow and body, then continue flat.
 pub fn parseOneArmFlatBody(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    pat: &crate::aver_generated::domain::ast::Pattern,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_12(
         __MutualTco12::ParseOneArmFlatBody(pos, acc.clone(), pat.clone()),
@@ -1459,8 +1474,8 @@ pub fn parseOneArmFlatBody(
 
 /// Parse an expression: comparison level, then optional ? postfix.
 pub fn parseExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseCmpExpr(tokens, pos)?;
@@ -1472,9 +1487,9 @@ pub fn parseExpr(
 
 /// Check for postfix ? (error propagation).
 pub fn parsePostfixQuestion(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> (crate::aver_generated::domain::ast::Expr, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -1490,8 +1505,8 @@ pub fn parsePostfixQuestion(
 
 /// Parse comparison: addExpr (('==' | '<' | '>') addExpr)?
 pub fn parseCmpExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
@@ -1503,9 +1518,9 @@ pub fn parseCmpExpr(
 
 /// Check for comparison operator.
 pub fn parseCmpExprTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    left: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1564,10 +1579,10 @@ pub fn parseCmpExprTail(
 
 /// Parse right side of comparison.
 pub fn parseCmpExprRight(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    left: &crate::aver_generated::domain::ast::Expr,
-    op: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    op @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseAddExpr(tokens, pos)?;
@@ -1580,10 +1595,10 @@ pub fn parseCmpExprRight(
 /// Build comparison AST node from op code.
 #[inline(always)]
 pub fn buildCmpExpr(
-    left: &crate::aver_generated::domain::ast::Expr,
-    right: &crate::aver_generated::domain::ast::Expr,
-    pos: aver_rt::AverInt,
-    op: aver_rt::AverInt,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
+    pos @ _: aver_rt::AverInt,
+    op @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     {
@@ -1654,8 +1669,8 @@ pub fn buildCmpExpr(
 
 /// Parse additive: mulExpr (('+' | '-') mulExpr)*
 pub fn parseAddExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseMulExpr(tokens, pos)?;
@@ -1667,8 +1682,8 @@ pub fn parseAddExpr(
 
 /// Parse multiplicative: atom ('*' atom)*
 pub fn parseMulExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
@@ -1680,8 +1695,8 @@ pub fn parseMulExpr(
 
 /// Parse atomic expression: literal, variable, call, match, or parenthesized.
 pub fn parseAtom(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1742,8 +1757,8 @@ pub fn parseAtom(
 
 /// Parse map literal into Map.fromList call.
 pub fn parseMapLiteral(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
@@ -1767,8 +1782,8 @@ pub fn parseMapLiteral(
 
 /// Parse unary minus into the first-class Expr.ExprNeg node.
 pub fn parseNegAtom(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseAtom(tokens, pos)?;
@@ -1783,9 +1798,9 @@ pub fn parseNegAtom(
 
 /// After TkStr: check for interpolation (TkInterpStart) or plain string.
 pub fn parseStringOrInterp(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    prefix: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    prefix @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -1807,8 +1822,8 @@ pub fn parseStringOrInterp(
 
 /// Parse list literal: [expr, expr, ...] or [].
 pub fn parseListExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos0: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos0 @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos @ _ = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos0);
@@ -1827,8 +1842,8 @@ pub fn parseListExpr(
 
 /// Parse parenthesized expression or tuple.
 pub fn parseParenExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
@@ -1852,9 +1867,9 @@ pub fn parseParenExpr(
 
 /// After tuple closing ')': check for ?! or ! postfix to form independent product.
 pub fn finishTupleOrProduct(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    items: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    items @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -1903,9 +1918,9 @@ pub fn finishTupleOrProduct(
 
 /// After reading an identifier: call, record constructor, field access, or variable?
 pub fn parseIdentOrCall(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1926,9 +1941,9 @@ pub fn parseIdentOrCall(
 
 /// Parse call/record then chain .field access if present.
 pub fn chainFieldAccess(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseCallOrRecord(tokens, pos, name)?;
@@ -1940,10 +1955,10 @@ pub fn chainFieldAccess(
 
 /// Skip newlines and indents inside parenthesized expressions.
 pub fn skipNl(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1972,9 +1987,9 @@ pub fn skipNl(
 
 /// After '(': is this a function call f(args) or record Foo(field = val)?
 pub fn parseCallOrRecord(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser::expr::skipNl(tokens.clone(), pos);
@@ -1999,10 +2014,10 @@ pub fn parseCallOrRecord(
 
 /// Lookahead after first ident in parens: '=' means record, otherwise call.
 pub fn parseCallOrRecordLookahead(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    first: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    first @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(
@@ -2028,8 +2043,8 @@ pub fn parseCallOrRecordLookahead(
 
 /// Parse: match expr NEWLINE INDENT arms DEDENT. Called after TkMatch is consumed.
 pub fn parseMatchExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos)?;
@@ -2041,9 +2056,9 @@ pub fn parseMatchExpr(
 
 /// Skip newlines, consume INDENT, then parse arms.
 pub fn parseMatchAfterSubject(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    subject: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    subject @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Expr, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);

--- a/src/self_host/aver_generated/domain/parser/mod.rs
+++ b/src/self_host/aver_generated/domain/parser/mod.rs
@@ -25,7 +25,7 @@ enum __MutualTco1 {
 
 fn __mutual_tco_trampoline_1(
     mut __state: __MutualTco1,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -35,7 +35,7 @@ fn __mutual_tco_trampoline_1(
 > {
     loop {
         __state = match __state {
-            __MutualTco1::ParseFnBodyStmtsIndented(mut pos, mut acc) => {
+            __MutualTco1::ParseFnBodyStmtsIndented(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(
                     (*tokens).clone(),
@@ -49,7 +49,7 @@ fn __mutual_tco_trampoline_1(
                     _ => __MutualTco1::ParseFnBodyOneStmtIndented(pos2, acc),
                 }
             }
-            __MutualTco1::ParseFnBodyOneStmtIndented(mut pos, mut acc) => {
+            __MutualTco1::ParseFnBodyOneStmtIndented(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
                 {
@@ -66,9 +66,9 @@ fn __mutual_tco_trampoline_1(
 
 /// Parse statements until DEDENT or EOF.
 pub fn parseFnBodyStmtsIndented(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -84,9 +84,9 @@ pub fn parseFnBodyStmtsIndented(
 
 /// Parse one statement and continue with indented body.
 pub fn parseFnBodyOneStmtIndented(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -118,7 +118,7 @@ enum __MutualTco2 {
 
 fn __mutual_tco_trampoline_2(
     mut __state: __MutualTco2,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -128,7 +128,7 @@ fn __mutual_tco_trampoline_2(
 > {
     loop {
         __state = match __state {
-            __MutualTco2::ParseFnBodyStmtsFlat(mut pos, mut acc) => {
+            __MutualTco2::ParseFnBodyStmtsFlat(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 if crate::aver_generated::domain::parser_match::isBodyEndFlat(&*tokens, pos.clone())
                 {
@@ -137,7 +137,7 @@ fn __mutual_tco_trampoline_2(
                     __MutualTco2::ParseFnBodyOneStmtFlat(pos, acc)
                 }
             }
-            __MutualTco2::ParseFnBodyOneStmtFlat(mut pos, mut acc) => {
+            __MutualTco2::ParseFnBodyOneStmtFlat(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
                 {
@@ -148,7 +148,7 @@ fn __mutual_tco_trampoline_2(
                     )
                 }
             }
-            __MutualTco2::ParseFnBodyAfterStmtFlat(mut pos, mut acc) => {
+            __MutualTco2::ParseFnBodyAfterStmtFlat(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkNewline => {
@@ -166,9 +166,9 @@ fn __mutual_tco_trampoline_2(
 
 /// Parse statements in function body (flat mode).
 pub fn parseFnBodyStmtsFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -184,9 +184,9 @@ pub fn parseFnBodyStmtsFlat(
 
 /// Parse one statement in function body and continue (flat mode).
 pub fn parseFnBodyOneStmtFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -202,9 +202,9 @@ pub fn parseFnBodyOneStmtFlat(
 
 /// After a body statement: single newline continues, anything else ends (flat mode).
 pub fn parseFnBodyAfterStmtFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
@@ -254,11 +254,11 @@ enum __MutualTco3 {
 
 fn __mutual_tco_trampoline_3(
     mut __state: __MutualTco3,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     loop {
         __state = match __state {
-            __MutualTco3::ParseProgram(mut pos, mut deps, mut fns, mut stmts) => {
+            __MutualTco3::ParseProgram(mut pos @ _, mut deps @ _, mut fns @ _, mut stmts @ _) => {
                 crate::cancel_checkpoint();
                 let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlinesAndDedents(
                     (*tokens).clone(),
@@ -286,7 +286,13 @@ fn __mutual_tco_trampoline_3(
                     _ => __MutualTco3::ParseProgramStmt(pos2, deps, fns, stmts),
                 }
             }
-            __MutualTco3::ParseProgramKeyword(mut pos, mut deps, mut fns, mut stmts, mut kw) => {
+            __MutualTco3::ParseProgramKeyword(
+                mut pos @ _,
+                mut deps @ _,
+                mut fns @ _,
+                mut stmts @ _,
+                mut kw @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 {
@@ -342,7 +348,7 @@ fn __mutual_tco_trampoline_3(
                     }
                 }
             }
-            __MutualTco3::ParseProgramModuleHeader(mut pos, mut fns, mut stmts) => {
+            __MutualTco3::ParseProgramModuleHeader(mut pos @ _, mut fns @ _, mut stmts @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ =
                     crate::aver_generated::domain::parser_match::parseModuleHeader(&*tokens, pos);
@@ -351,7 +357,7 @@ fn __mutual_tco_trampoline_3(
                     __MutualTco3::ParseProgram(endPos, depList, fns, stmts)
                 }
             }
-            __MutualTco3::ParseProgramFn(mut pos, mut deps, mut fns, mut stmts) => {
+            __MutualTco3::ParseProgramFn(mut pos @ _, mut deps @ _, mut fns @ _, mut stmts @ _) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::parseFnDef(&*tokens, pos)?;
                 {
@@ -367,7 +373,12 @@ fn __mutual_tco_trampoline_3(
                     )
                 }
             }
-            __MutualTco3::ParseProgramStmt(mut pos, mut deps, mut fns, mut stmts) => {
+            __MutualTco3::ParseProgramStmt(
+                mut pos @ _,
+                mut deps @ _,
+                mut fns @ _,
+                mut stmts @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let r @ _ = crate::aver_generated::domain::parser::parseStmt(&*tokens, pos)?;
                 {
@@ -389,11 +400,11 @@ fn __mutual_tco_trampoline_3(
 
 /// Parse top-level items until EOF.
 pub fn parseProgram(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    deps: &aver_rt::AverList<AverStr>,
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    deps @ _: &aver_rt::AverList<AverStr>,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::ParseProgram(pos, deps.clone(), fns.clone(), stmts.clone()),
@@ -403,12 +414,12 @@ pub fn parseProgram(
 
 /// Handle keywords: module (extract depends), type/record/verify/decision (skip).
 pub fn parseProgramKeyword(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    deps: &aver_rt::AverList<AverStr>,
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    kw: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    deps @ _: &aver_rt::AverList<AverStr>,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    kw @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::ParseProgramKeyword(pos, deps.clone(), fns.clone(), stmts.clone(), kw),
@@ -418,10 +429,10 @@ pub fn parseProgramKeyword(
 
 /// Parse module header and continue with program.
 pub fn parseProgramModuleHeader(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::ParseProgramModuleHeader(pos, fns.clone(), stmts.clone()),
@@ -431,11 +442,11 @@ pub fn parseProgramModuleHeader(
 
 /// Parse a function definition and continue.
 pub fn parseProgramFn(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    deps: &aver_rt::AverList<AverStr>,
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    deps @ _: &aver_rt::AverList<AverStr>,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::ParseProgramFn(pos, deps.clone(), fns.clone(), stmts.clone()),
@@ -445,11 +456,11 @@ pub fn parseProgramFn(
 
 /// Parse a statement and continue.
 pub fn parseProgramStmt(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    deps: &aver_rt::AverList<AverStr>,
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    stmts: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    deps @ _: &aver_rt::AverList<AverStr>,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    stmts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     __mutual_tco_trampoline_3(
         __MutualTco3::ParseProgramStmt(pos, deps.clone(), fns.clone(), stmts.clone()),
@@ -459,8 +470,8 @@ pub fn parseProgramStmt(
 
 /// Parse a statement: binding (name = expr) or expression.
 pub fn parseStmt(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
@@ -478,9 +489,9 @@ pub fn parseStmt(
 
 /// After ident: if '=' or ':' follows it's a binding, otherwise reparse as expr.
 pub fn parseStmtAfterIdent(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -504,8 +515,8 @@ pub fn parseStmtAfterIdent(
 
 /// Skip : Type = and return position after =.
 pub fn skipTypeAnnotationAndEq(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser_match::skipTypeAnnotation(tokens, pos);
@@ -519,9 +530,9 @@ pub fn skipTypeAnnotationAndEq(
 
 /// Parse: name = expr. Skips leading NL+INDENT and trailing DEDENT for multi-line exprs.
 pub fn parseBinding(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos.clone())?;
@@ -536,9 +547,9 @@ pub fn parseBinding(
 
 /// If expression consumed an INDENT (multi-line), skip the trailing DEDENT.
 pub fn skipTrailingDedent(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    startPos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    startPos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     {
@@ -560,12 +571,12 @@ pub fn skipTrailingDedent(
 /// Count net indent/dedent balance in a token range.
 #[inline(always)]
 pub fn countIndentsInRange(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut endPos: aver_rt::AverInt,
-    mut count: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut endPos @ _: aver_rt::AverInt,
+    mut count @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -600,11 +611,11 @@ pub fn countIndentsInRange(
 /// Skip n DEDENT tokens (and interleaved newlines) after multi-line expression.
 #[inline(always)]
 pub fn skipNDedents(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut n: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut n @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -634,8 +645,8 @@ pub fn skipNDedents(
 
 /// Parse an expression statement.
 pub fn parseStmtExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let r @ _ = crate::aver_generated::domain::parser::expr::parseExpr(tokens, pos.clone())?;
@@ -650,9 +661,9 @@ pub fn parseStmtExpr(
 
 /// Reparse as expression starting from an identifier (might be call or var in expr).
 pub fn parseStmtExprFrom(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let ir @ _ = crate::aver_generated::domain::parser::expr::parseIdentOrCall(tokens, pos, name)?;
@@ -664,9 +675,9 @@ pub fn parseStmtExprFrom(
 
 /// Continue parsing expression statement from multiplicative level.
 pub fn parseStmtExprFromMul(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let mr @ _ = crate::aver_generated::domain::parser::expr::parseMulExprTail(tokens, pos, expr)?;
@@ -678,9 +689,9 @@ pub fn parseStmtExprFromMul(
 
 /// Continue parsing expression statement from additive level.
 pub fn parseStmtExprFromAdd(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let ar @ _ = crate::aver_generated::domain::parser::expr::parseAddExprTail(tokens, pos, expr)?;
@@ -692,9 +703,9 @@ pub fn parseStmtExprFromAdd(
 
 /// Continue parsing expression statement from comparison level.
 pub fn parseStmtExprFromCmp(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Result<(crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let cr @ _ = crate::aver_generated::domain::parser::expr::parseCmpExprTail(tokens, pos, expr)?;
@@ -708,9 +719,9 @@ pub fn parseStmtExprFromCmp(
 
 /// Check for postfix ? on expression statement.
 pub fn parseStmtExprFromQ(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expr: &crate::aver_generated::domain::ast::Expr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> (crate::aver_generated::domain::ast::Stmt, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     let qr @ _ =
@@ -726,8 +737,8 @@ pub fn parseStmtExprFromQ(
 
 /// Parse: fn NAME(params) NEWLINE body
 pub fn parseFnDef(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
@@ -745,9 +756,9 @@ pub fn parseFnDef(
 
 /// Parse parameter list and body.
 pub fn parseFnDefParams(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser_match::expect(
@@ -768,10 +779,10 @@ pub fn parseFnDefParams(
 
 /// Parse function body: skip return type, newline, INDENT, ?, !, then statements until DEDENT.
 pub fn parseFnDefBody(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    params: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    params @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser_match::skipReturnType(tokens, pos);
@@ -791,10 +802,10 @@ pub fn parseFnDefBody(
 
 /// Parse function body with INDENT/DEDENT.
 pub fn parseFnDefBodyIndented(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    params: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    params @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ =
@@ -823,10 +834,10 @@ pub fn parseFnDefBodyIndented(
 
 /// Parse function body without INDENT/DEDENT (fallback).
 pub fn parseFnDefBodyFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    params: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    params @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<(crate::aver_generated::domain::ast::FnDef, aver_rt::AverInt), AverStr> {
     crate::cancel_checkpoint();
     let pos2 @ _ =
@@ -856,7 +867,7 @@ pub fn parseFnDefBodyFlat(
 /// Parse a token list into a Program.
 #[inline(always)]
 pub fn parse(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<crate::aver_generated::domain::ast::Program, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::parser::parseProgram(

--- a/src/self_host/aver_generated/domain/parser_match/mod.rs
+++ b/src/self_host/aver_generated/domain/parser_match/mod.rs
@@ -13,7 +13,7 @@ enum __MutualTco1 {
 
 fn __mutual_tco_trampoline_1(
     mut __state: __MutualTco1,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -23,7 +23,7 @@ fn __mutual_tco_trampoline_1(
 > {
     loop {
         __state = match __state {
-            __MutualTco1::ParseIdentPatternMaybeConstructor(mut pos, mut name) => {
+            __MutualTco1::ParseIdentPatternMaybeConstructor(mut pos @ _, mut name @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
@@ -38,7 +38,7 @@ fn __mutual_tco_trampoline_1(
         }
     }
             }
-            __MutualTco1::ParseIdentPatternDotted(mut pos, mut prefix) => {
+            __MutualTco1::ParseIdentPatternDotted(mut pos @ _, mut prefix @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkIdent(s) => {
@@ -56,9 +56,9 @@ fn __mutual_tco_trampoline_1(
 
 /// Check for dot-qualified name, constructor pattern, or plain variable.
 pub fn parseIdentPatternMaybeConstructor(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -74,9 +74,9 @@ pub fn parseIdentPatternMaybeConstructor(
 
 /// After dot: read next ident and check for ( or another dot.
 pub fn parseIdentPatternDotted(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    prefix: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    prefix @ _: AverStr,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -95,7 +95,7 @@ enum __MutualTco2 {
 
 fn __mutual_tco_trampoline_2(
     mut __state: __MutualTco2,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -105,7 +105,11 @@ fn __mutual_tco_trampoline_2(
 > {
     loop {
         __state = match __state {
-            __MutualTco2::ParseConstructorPatternBindings(mut pos, mut name, mut acc) => {
+            __MutualTco2::ParseConstructorPatternBindings(
+                mut pos @ _,
+                mut name @ _,
+                mut acc @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -131,7 +135,7 @@ fn __mutual_tco_trampoline_2(
                     }
                 }
             }
-            __MutualTco2::ParseConstructorPatternTail(mut pos, mut name, mut acc) => {
+            __MutualTco2::ParseConstructorPatternTail(mut pos @ _, mut name @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -159,10 +163,10 @@ fn __mutual_tco_trampoline_2(
 
 /// Parse bindings inside constructor pattern: Ctor(a, b) or Ctor().
 pub fn parseConstructorPatternBindings(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    acc: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    acc @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -178,10 +182,10 @@ pub fn parseConstructorPatternBindings(
 
 /// After binding: ',' for more or ')' to end.
 pub fn parseConstructorPatternTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
-    acc: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
+    acc @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -213,7 +217,7 @@ enum __MutualTco3 {
 
 fn __mutual_tco_trampoline_3(
     mut __state: __MutualTco3,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -223,7 +227,7 @@ fn __mutual_tco_trampoline_3(
 > {
     loop {
         __state = match __state {
-            __MutualTco3::ParseTuplePatternElements(mut pos, mut acc) => {
+            __MutualTco3::ParseTuplePatternElements(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -235,7 +239,7 @@ fn __mutual_tco_trampoline_3(
                     _ => __MutualTco3::ParseTuplePatternElement(pos, acc),
                 }
             }
-            __MutualTco3::ParseTuplePatternElement(mut pos, mut acc) => {
+            __MutualTco3::ParseTuplePatternElement(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 let pr @ _ =
                     crate::aver_generated::domain::parser_match::parsePattern(&*tokens, pos)?;
@@ -247,7 +251,7 @@ fn __mutual_tco_trampoline_3(
                     )
                 }
             }
-            __MutualTco3::ParseTuplePatternElementTail(mut pos, mut acc) => {
+            __MutualTco3::ParseTuplePatternElementTail(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkComma => {
@@ -271,9 +275,9 @@ fn __mutual_tco_trampoline_3(
 
 /// Parse elements of a tuple pattern.
 pub fn parseTuplePatternElements(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -289,9 +293,9 @@ pub fn parseTuplePatternElements(
 
 /// Parse one pattern element and continue.
 pub fn parseTuplePatternElement(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -307,9 +311,9 @@ pub fn parseTuplePatternElement(
 
 /// After element: ',' for more or ')' to end.
 pub fn parseTuplePatternElementTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -331,11 +335,11 @@ enum __MutualTco4 {
 
 fn __mutual_tco_trampoline_4(
     mut __state: __MutualTco4,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> aver_rt::AverInt {
     loop {
         __state = match __state {
-            __MutualTco4::SkipBlockFlat(mut pos) => {
+            __MutualTco4::SkipBlockFlat(mut pos @ _) => {
                 crate::cancel_checkpoint();
                 let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
@@ -346,7 +350,7 @@ fn __mutual_tco_trampoline_4(
                     _ => __MutualTco4::SkipBlockFlat(nextPos),
                 }
             }
-            __MutualTco4::SkipBlockFlatAfterNewline(mut pos) => {
+            __MutualTco4::SkipBlockFlatAfterNewline(mut pos @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkEof => return pos,
@@ -385,16 +389,16 @@ fn __mutual_tco_trampoline_4(
 
 /// Fallback: skip until blank line, fn, or EOF.
 pub fn skipBlockFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     __mutual_tco_trampoline_4(__MutualTco4::SkipBlockFlat(pos), &tokens)
 }
 
 /// After newline: another newline or fn/type/record/verify/EOF = end of block.
 pub fn skipBlockFlatAfterNewline(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     __mutual_tco_trampoline_4(__MutualTco4::SkipBlockFlatAfterNewline(pos), &tokens)
 }
@@ -407,11 +411,11 @@ enum __MutualTco5 {
 
 fn __mutual_tco_trampoline_5(
     mut __state: __MutualTco5,
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
 ) -> Result<(aver_rt::AverList<AverStr>, aver_rt::AverInt), AverStr> {
     loop {
         __state = match __state {
-            __MutualTco5::ParseParamList(mut pos, mut acc) => {
+            __MutualTco5::ParseParamList(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -429,7 +433,7 @@ fn __mutual_tco_trampoline_5(
                     _ => return Err(AverStr::from("Expected parameter name or ')'")),
                 }
             }
-            __MutualTco5::ParseParamListTail(mut pos, mut acc) => {
+            __MutualTco5::ParseParamListTail(mut pos @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
                     crate::aver_generated::domain::token::Token::TkRParen => {
@@ -447,18 +451,18 @@ fn __mutual_tco_trampoline_5(
 
 /// Parse comma-separated parameter names until ')'.
 pub fn parseParamList(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<(aver_rt::AverList<AverStr>, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_5(__MutualTco5::ParseParamList(pos, acc.clone()), &tokens)
 }
 
 /// After a param name: ',' for more or ')' to end.
 pub fn parseParamListTail(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    acc: &aver_rt::AverList<AverStr>,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<(aver_rt::AverList<AverStr>, aver_rt::AverInt), AverStr> {
     __mutual_tco_trampoline_5(__MutualTco5::ParseParamListTail(pos, acc.clone()), &tokens)
 }
@@ -466,8 +470,8 @@ pub fn parseParamListTail(
 /// Token at position, or TkEof if past end.
 #[inline(always)]
 pub fn tokenAt(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::token::Token {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::parser_match::tokenAtWalk(
@@ -480,9 +484,9 @@ pub fn tokenAt(
 /// Walk the list to find token at target index.
 #[inline(always)]
 pub fn tokenAtWalk(
-    mut tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut target: aver_rt::AverInt,
-    mut idx: aver_rt::AverInt,
+    mut tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut target @ _: aver_rt::AverInt,
+    mut idx @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::token::Token {
     loop {
         crate::cancel_checkpoint();
@@ -498,8 +502,8 @@ pub fn tokenAtWalk(
 
 /// Check if token matches expected (structural equality via repr).
 pub fn isToken(
-    t: &crate::aver_generated::domain::token::Token,
-    expected: &crate::aver_generated::domain::token::Token,
+    t @ _: &crate::aver_generated::domain::token::Token,
+    expected @ _: &crate::aver_generated::domain::token::Token,
 ) -> bool {
     crate::cancel_checkpoint();
     (crate::aver_generated::domain::token::tokenRepr(t)
@@ -509,9 +513,9 @@ pub fn isToken(
 /// Consume expected token, return new position.
 #[inline(always)]
 pub fn expect(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    expected: &crate::aver_generated::domain::token::Token,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    expected @ _: &crate::aver_generated::domain::token::Token,
 ) -> Result<aver_rt::AverInt, AverStr> {
     crate::cancel_checkpoint();
     let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone());
@@ -546,10 +550,10 @@ pub fn expect(
 
 /// Skip past any newline tokens.
 pub fn skipNewlines(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         match crate::aver_generated::domain::parser_match::tokenAt(&*tokens, pos.clone()) {
@@ -567,10 +571,10 @@ pub fn skipNewlines(
 
 /// Skip newlines and stray DEDENT tokens at top level.
 pub fn skipNewlinesAndDedents(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -594,8 +598,8 @@ pub fn skipNewlinesAndDedents(
 
 /// Parse a match pattern: INT literal, _ (wildcard), or variable.
 pub fn parsePattern(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -655,9 +659,9 @@ pub fn parsePattern(
 /// Parse ident pattern: wildcard _, variable, or constructor Foo.Bar(bindings).
 #[inline(always)]
 pub fn parseIdentPattern(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    name: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    name @ _: AverStr,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -677,8 +681,8 @@ pub fn parseIdentPattern(
 
 /// Parse tuple pattern: (pat, pat, ...).
 pub fn parseTuplePattern(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -696,8 +700,8 @@ pub fn parseTuplePattern(
 
 /// Parse [] or [h, ..t] list pattern.
 pub fn parseListPattern(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -724,9 +728,9 @@ pub fn parseListPattern(
 
 /// Parse [h, ..t] after reading head ident.
 pub fn parseConsPattern(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    head: AverStr,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    head @ _: AverStr,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Pattern,
@@ -761,8 +765,8 @@ pub fn parseConsPattern(
 
 /// Skip optional : Type annotation.
 pub fn skipTypeAnnotation(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -778,8 +782,8 @@ pub fn skipTypeAnnotation(
 
 /// Skip a type expression (ident, possibly with generics).
 pub fn skipTypeExpr(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -800,10 +804,10 @@ pub fn skipTypeExpr(
 
 /// After type ident: possibly <...> generics or .Qualified.
 pub fn skipTypeExprTail(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -837,11 +841,11 @@ pub fn skipTypeExprTail(
 /// Skip until matching > for generic type params.
 #[inline(always)]
 pub fn skipUntilGt(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut depth: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut depth @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -879,11 +883,11 @@ pub fn skipUntilGt(
 /// Skip until matching ) for tuple types.
 #[inline(always)]
 pub fn skipUntilClose(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut depth: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut depth @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -920,8 +924,8 @@ pub fn skipUntilClose(
 
 /// Skip optional -> ReturnType annotation.
 pub fn skipReturnType(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -937,10 +941,10 @@ pub fn skipReturnType(
 
 /// Skip optional ? description and ! [effects] lines (including multi-line effects).
 pub fn skipDescAndEffects(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -969,8 +973,8 @@ pub fn skipDescAndEffects(
 
 /// Skip ! [effects] block — may span multiple lines with INDENT/DEDENT.
 pub fn skipEffectsBlock(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -986,10 +990,10 @@ pub fn skipEffectsBlock(
 
 /// Skip tokens until ] then past any trailing newline.
 pub fn skipUntilRBracket(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1014,10 +1018,10 @@ pub fn skipUntilRBracket(
 
 /// Skip tokens until newline, then past it.
 pub fn skipToNextLine(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1039,8 +1043,8 @@ pub fn skipToNextLine(
 
 /// Skip tokens until matching DEDENT, or fall back to heuristic for flat streams.
 pub fn skipBlock(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     let pos2 @ _ = crate::aver_generated::domain::parser_match::skipNewlines(tokens.clone(), pos);
@@ -1059,11 +1063,11 @@ pub fn skipBlock(
 
 /// Skip until matching DEDENT.
 pub fn skipIndentBlock(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut depth: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut depth @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1102,8 +1106,8 @@ pub fn skipIndentBlock(
 
 /// Parse module header: find depends list, skip everything else. Returns (deps, endPos).
 pub fn parseModuleHeader(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> (aver_rt::AverList<AverStr>, aver_rt::AverInt) {
     crate::cancel_checkpoint();
     let endPos @ _ = crate::aver_generated::domain::parser_match::skipBlock(tokens, pos.clone());
@@ -1118,11 +1122,11 @@ pub fn parseModuleHeader(
 /// Scan token range for depends [...] and extract module names.
 #[inline(always)]
 pub fn findDependsInRange(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut endPos: aver_rt::AverInt,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut endPos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<AverStr> {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1155,9 +1159,9 @@ pub fn findDependsInRange(
 
 /// Parse [Name, Name] after depends keyword.
 pub fn findDependsListAt(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
-    endPos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
+    endPos @ _: aver_rt::AverInt,
 ) -> aver_rt::AverList<AverStr> {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::parser_match::tokenAt(tokens, pos.clone()) {
@@ -1176,12 +1180,12 @@ pub fn findDependsListAt(
 /// Collect module names until ].
 #[inline(always)]
 pub fn collectDependsNames(
-    tokens: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    mut pos: aver_rt::AverInt,
-    mut endPos: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<AverStr>,
+    tokens @ _: aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    mut pos @ _: aver_rt::AverInt,
+    mut endPos @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<AverStr>,
 ) -> aver_rt::AverList<AverStr> {
-    let tokens = std::sync::Arc::new(tokens);
+    let tokens @ _ = std::sync::Arc::new(tokens);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1211,8 +1215,8 @@ pub fn collectDependsNames(
 
 /// Check if we've reached the end of a function body (flat mode).
 pub fn isBodyEndFlat(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> bool {
     crate::cancel_checkpoint();
     let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);
@@ -1227,8 +1231,8 @@ pub fn isBodyEndFlat(
 
 /// Check if position looks like a match arm start.
 pub fn isArmStart(
-    tokens: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
-    pos: aver_rt::AverInt,
+    tokens @ _: &aver_rt::AverList<crate::aver_generated::domain::token::Token>,
+    pos @ _: aver_rt::AverInt,
 ) -> bool {
     crate::cancel_checkpoint();
     let t @ _ = crate::aver_generated::domain::parser_match::tokenAt(tokens, pos);

--- a/src/self_host/aver_generated/domain/resolver/calls/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/calls/mod.rs
@@ -6,9 +6,9 @@ use crate::*;
 /// Build name→fnId map from resolved function list.
 #[inline(always)]
 pub fn buildFnMap(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    mut acc: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut idx: aver_rt::AverInt,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut acc @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut idx @ _: aver_rt::AverInt,
 ) -> aver_rt::AverMap<AverStr, aver_rt::AverInt> {
     loop {
         crate::cancel_checkpoint();
@@ -27,11 +27,11 @@ pub fn buildFnMap(
 /// Transform ExprCall→ExprCallDirect for known functions in all fn bodies.
 #[inline(always)]
 pub fn resolveCallsInFns(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fns, [] => { return acc.reverse(); }, [f, rest] => { {
@@ -46,8 +46,8 @@ pub fn resolveCallsInFns(
 
 /// Transform calls in one function body.
 pub fn resolveCallsInFn(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::FnDef {
@@ -68,11 +68,11 @@ pub fn resolveCallsInFn(
 /// Resolve calls in a list of statements.
 #[inline(always)]
 pub fn resolveCallsInStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Stmt> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(stmts, [] => { return acc.reverse(); }, [s, rest] => { {
@@ -87,8 +87,8 @@ pub fn resolveCallsInStmts(
 
 /// Resolve calls in a single statement.
 pub fn resolveCallsInStmt(
-    s: &crate::aver_generated::domain::ast::Stmt,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    s @ _: &crate::aver_generated::domain::ast::Stmt,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Stmt {
     crate::cancel_checkpoint();
     match s.clone() {
@@ -114,8 +114,8 @@ pub fn resolveCallsInStmt(
 
 /// Replace ExprCall with ExprCallDirect for known user functions.
 pub fn resolveCallsInExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -200,8 +200,8 @@ pub fn resolveCallsInExpr(
 
 /// Continue direct-call linking for specialized internal and arithmetic forms.
 pub fn resolveCallsInExprInternal(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -303,8 +303,8 @@ pub fn resolveCallsInExprInternal(
 
 /// Finish direct-call linking for comparisons, aggregates, and product forms.
 pub fn resolveCallsInExprTail(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -476,9 +476,9 @@ pub fn resolveCallsInExprTail(
 /// User fn → ExprCallDirect, builtin → ExprCallBuiltin, record update → ExprCall.
 #[inline(always)]
 pub fn resolveOneCall(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     let resolvedArgs @ _ =
@@ -511,8 +511,8 @@ pub fn resolveOneCall(
 /// Link a builtin call, discharging a literal-divisor Int.div/Int.mod to a plain Int.
 #[inline(always)]
 pub fn resolveBuiltinCall(
-    name: AverStr,
-    resolvedArgs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    name @ _: AverStr,
+    resolvedArgs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::resolver::calls::isLiteralDivisorCall(
@@ -537,8 +537,8 @@ pub fn resolveBuiltinCall(
 /// Whether this is Int.div/Int.mod over a syntactic nonzero integer literal divisor.
 #[inline(always)]
 pub fn isLiteralDivisorCall(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> bool {
     crate::cancel_checkpoint();
     if (((&*name == "Int.div") || (&*name == "Int.mod"))
@@ -552,7 +552,7 @@ pub fn isLiteralDivisorCall(
 
 /// Whether the second of exactly two arguments is a nonzero integer literal.
 pub fn isNonzeroIntLiteralDivisor(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> bool {
     crate::cancel_checkpoint();
     {
@@ -573,7 +573,7 @@ pub fn isNonzeroIntLiteralDivisor(
 }
 
 /// Whether an expression is a nonzero integer literal under at most one unary minus.
-pub fn isNonzeroIntLiteral(expr: &crate::aver_generated::domain::ast::Expr) -> bool {
+pub fn isNonzeroIntLiteral(expr @ _: &crate::aver_generated::domain::ast::Expr) -> bool {
     crate::cancel_checkpoint();
     match expr.clone() {
         crate::aver_generated::domain::ast::Expr::ExprInt(k) => {
@@ -588,7 +588,7 @@ pub fn isNonzeroIntLiteral(expr: &crate::aver_generated::domain::ast::Expr) -> b
 }
 
 /// Whether an expression is a bare nonzero integer literal, with no unary minus of its own.
-pub fn isBareNonzeroIntLiteral(expr: &crate::aver_generated::domain::ast::Expr) -> bool {
+pub fn isBareNonzeroIntLiteral(expr @ _: &crate::aver_generated::domain::ast::Expr) -> bool {
     crate::cancel_checkpoint();
     match expr.clone() {
         crate::aver_generated::domain::ast::Expr::ExprInt(k) => {
@@ -600,7 +600,7 @@ pub fn isBareNonzeroIntLiteral(expr: &crate::aver_generated::domain::ast::Expr) 
 
 /// Return whether a call name is one of the exact builtin/service entrypoints.
 #[inline(always)]
-pub fn isBuiltinCallName(name: AverStr) -> bool {
+pub fn isBuiltinCallName(name @ _: AverStr) -> bool {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::resolver::calls::isBuiltinCallNameFrom(
         name,
@@ -740,8 +740,8 @@ pub fn isBuiltinCallName(name: AverStr) -> bool {
 /// Check builtin/service call names recursively by exact match.
 #[inline(always)]
 pub fn isBuiltinCallNameFrom(
-    mut name: AverStr,
-    mut knownNames: aver_rt::AverList<AverStr>,
+    mut name @ _: AverStr,
+    mut knownNames @ _: aver_rt::AverList<AverStr>,
 ) -> bool {
     loop {
         crate::cancel_checkpoint();
@@ -756,11 +756,11 @@ pub fn isBuiltinCallNameFrom(
 /// Resolve calls in a list of expressions.
 #[inline(always)]
 pub fn resolveCallsInExprs(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return acc.reverse(); }, [e, rest] => { {
@@ -776,11 +776,11 @@ pub fn resolveCallsInExprs(
 /// Resolve calls in match arm bodies.
 #[inline(always)]
 pub fn resolveCallsInArms(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(arms, [] => { return acc.reverse(); }, [arm, rest] => { {
@@ -796,11 +796,11 @@ pub fn resolveCallsInArms(
 /// Resolve calls in record field expressions.
 #[inline(always)]
 pub fn resolveCallsInFields(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fields, [] => { return acc.reverse(); }, [pair, rest] => { { let (name, expr) = pair; {
@@ -816,11 +816,11 @@ pub fn resolveCallsInFields(
 /// Synthesized collecting variant of `resolveCallsInStmts`. Appends to a builder where `resolveCallsInStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveCallsInStmts__collected(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Stmt> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(stmts, [] => { return aver_rt::list_builder_finalize(acc); }, [s, rest] => { {
@@ -836,11 +836,11 @@ pub fn resolveCallsInStmts__collected(
 /// Synthesized collecting variant of `resolveCallsInExprs`. Appends to a builder where `resolveCallsInExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveCallsInExprs__collected(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return aver_rt::list_builder_finalize(acc); }, [e, rest] => { {
@@ -856,11 +856,11 @@ pub fn resolveCallsInExprs__collected(
 /// Synthesized collecting variant of `resolveCallsInArms`. Appends to a builder where `resolveCallsInArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveCallsInArms__collected(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(arms, [] => { return aver_rt::list_builder_finalize(acc); }, [arm, rest] => { {
@@ -876,11 +876,11 @@ pub fn resolveCallsInArms__collected(
 /// Synthesized collecting variant of `resolveCallsInFields`. Appends to a builder where `resolveCallsInFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveCallsInFields__collected(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fields, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (name, expr) = pair; {

--- a/src/self_host/aver_generated/domain/resolver/core/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/core/mod.rs
@@ -18,7 +18,7 @@ enum __MutualTco1 {
 fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverInt {
     loop {
         __state = match __state {
-            __MutualTco1::MaxSlotInExpr(mut expr, mut acc) => {
+            __MutualTco1::MaxSlotInExpr(mut expr @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprBoolBranch(
@@ -63,7 +63,7 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverInt {
                     _ => __MutualTco1::MaxSlotInExprComposite(expr, acc),
                 }
             }
-            __MutualTco1::MaxSlotInExprComposite(mut expr, mut acc) => {
+            __MutualTco1::MaxSlotInExprComposite(mut expr @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match expr.clone() {
                     crate::aver_generated::domain::ast::Expr::ExprVectorGetOrInt(
@@ -135,7 +135,7 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverInt {
                     _ => __MutualTco1::MaxSlotInExprAggregate(expr, acc),
                 }
             }
-            __MutualTco1::MaxSlotInExprAggregate(mut expr, mut acc) => {
+            __MutualTco1::MaxSlotInExprAggregate(mut expr @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 match expr {
                     crate::aver_generated::domain::ast::Expr::ExprLte(a, b) => {
@@ -213,7 +213,7 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverInt {
                     _ => return acc,
                 }
             }
-            __MutualTco1::MaxSlotInExprPair(mut a, mut b, mut acc) => {
+            __MutualTco1::MaxSlotInExprPair(mut a @ _, mut b @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 __MutualTco1::MaxSlotInExpr(
                     b,
@@ -226,33 +226,33 @@ fn __mutual_tco_trampoline_1(mut __state: __MutualTco1) -> aver_rt::AverInt {
 
 /// Find highest slot index in an expression tree.
 pub fn maxSlotInExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    acc: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     __mutual_tco_trampoline_1(__MutualTco1::MaxSlotInExpr(expr.clone(), acc))
 }
 
 /// Continue max-slot traversal for composite expression forms.
 pub fn maxSlotInExprComposite(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    acc: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     __mutual_tco_trampoline_1(__MutualTco1::MaxSlotInExprComposite(expr.clone(), acc))
 }
 
 /// Finish max-slot traversal for aggregate and call expression forms.
 pub fn maxSlotInExprAggregate(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    acc: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     __mutual_tco_trampoline_1(__MutualTco1::MaxSlotInExprAggregate(expr.clone(), acc))
 }
 
 /// Visit both sides of a binary expression.
 pub fn maxSlotInExprPair(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    acc: aver_rt::AverInt,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     __mutual_tco_trampoline_1(__MutualTco1::MaxSlotInExprPair(a.clone(), b.clone(), acc))
 }
@@ -260,8 +260,8 @@ pub fn maxSlotInExprPair(
 /// Resolve each function definition.
 #[inline(always)]
 pub fn resolveFns(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     loop {
         crate::cancel_checkpoint();
@@ -277,7 +277,7 @@ pub fn resolveFns(
 
 /// Resolve one function: assign slots to params and locals.
 pub fn resolveFn(
-    fd: &crate::aver_generated::domain::ast::FnDef,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     let paramResult @ _ = crate::aver_generated::domain::resolver::core::buildParamSlots(
@@ -294,9 +294,9 @@ pub fn resolveFn(
 /// Assign slot indices 0..n-1 to parameters.
 #[inline(always)]
 pub fn buildParamSlots(
-    mut params: aver_rt::AverList<AverStr>,
-    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
+    mut params @ _: aver_rt::AverList<AverStr>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -317,9 +317,9 @@ pub fn buildParamSlots(
 
 /// Walk body stmts, resolve vars, track new bindings. slotCount = max slot + 1 from body scan.
 pub fn resolveBody(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    nextSlot: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    nextSlot @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     let resolved @ _ = crate::aver_generated::domain::resolver::core::resolveStmts__collected(
@@ -341,10 +341,10 @@ pub fn resolveBody(
 
 /// Compute slotCount as max slot index found in body + 1.
 pub fn computeSlotCount(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    body: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    baseSlot: aver_rt::AverInt,
-    slotMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    baseSlot @ _: aver_rt::AverInt,
+    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     let maxFromBody @ _ = crate::aver_generated::domain::resolver::core::maxSlotInStmts(
@@ -365,8 +365,8 @@ pub fn computeSlotCount(
 /// Find highest slot index in a list of statements.
 #[inline(always)]
 pub fn maxSlotInStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut acc: aver_rt::AverInt,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     loop {
         crate::cancel_checkpoint();
@@ -382,8 +382,8 @@ pub fn maxSlotInStmts(
 
 /// Find highest slot index in a statement.
 pub fn maxSlotInStmt(
-    s: &crate::aver_generated::domain::ast::Stmt,
-    acc: aver_rt::AverInt,
+    s @ _: &crate::aver_generated::domain::ast::Stmt,
+    acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     match s.clone() {
@@ -405,8 +405,8 @@ pub fn maxSlotInStmt(
 /// Find highest slot index in a list of expressions.
 #[inline(always)]
 pub fn maxSlotInExprs(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut acc: aver_rt::AverInt,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     loop {
         crate::cancel_checkpoint();
@@ -423,8 +423,8 @@ pub fn maxSlotInExprs(
 /// Find highest slot index in record fields.
 #[inline(always)]
 pub fn maxSlotInFields(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    mut acc: aver_rt::AverInt,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     loop {
         crate::cancel_checkpoint();
@@ -441,8 +441,8 @@ pub fn maxSlotInFields(
 /// Find highest slot index in match arms.
 #[inline(always)]
 pub fn maxSlotInArms(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    mut acc: aver_rt::AverInt,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut acc @ _: aver_rt::AverInt,
 ) -> aver_rt::AverInt {
     loop {
         crate::cancel_checkpoint();
@@ -458,7 +458,7 @@ pub fn maxSlotInArms(
 
 /// Return the larger of two integers.
 #[inline(always)]
-pub fn maxInt(a: aver_rt::AverInt, b: aver_rt::AverInt) -> aver_rt::AverInt {
+pub fn maxInt(a @ _: aver_rt::AverInt, b @ _: aver_rt::AverInt) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     if (a > b) { a } else { b }
 }
@@ -466,10 +466,10 @@ pub fn maxInt(a: aver_rt::AverInt, b: aver_rt::AverInt) -> aver_rt::AverInt {
 /// Resolve statements, threading slot assignments.
 #[inline(always)]
 pub fn resolveStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     aver_rt::AverInt,
@@ -519,11 +519,11 @@ pub fn resolveStmts(
 
 /// Resolve a single statement and continue.
 pub fn resolveOneStmt(
-    s: &crate::aver_generated::domain::ast::Stmt,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    s @ _: &crate::aver_generated::domain::ast::Stmt,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     aver_rt::AverInt,
@@ -554,11 +554,11 @@ pub fn resolveOneStmt(
 
 /// Resolve an expression statement, collecting pattern slots.
 pub fn resolveStmtExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     aver_rt::AverInt,
@@ -586,12 +586,12 @@ pub fn resolveStmtExpr(
 
 /// Resolve a binding: assign a new slot, replace with StmtBindSlot.
 pub fn resolveStmtBind(
-    name: AverStr,
-    expr: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    name @ _: AverStr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     aver_rt::AverInt,
@@ -609,12 +609,12 @@ pub fn resolveStmtBind(
 
 /// Finish resolving a binding after expr is resolved.
 pub fn resolveStmtBindFinish(
-    name: AverStr,
-    newExpr: &crate::aver_generated::domain::ast::Expr,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    name @ _: AverStr,
+    newExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     aver_rt::AverInt,
@@ -635,8 +635,8 @@ pub fn resolveStmtBindFinish(
 
 /// Resolve an expression. Returns (resolved expr, slots with any new pattern bindings).
 pub fn resolveExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -683,8 +683,8 @@ pub fn resolveExpr(
 
 /// Continue expression resolution after simple leaf forms.
 pub fn resolveExprAfterLeaf(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -818,8 +818,8 @@ pub fn resolveExprAfterLeaf(
 
 /// Continue expression resolution after arithmetic forms.
 pub fn resolveExprAfterArith(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -928,8 +928,8 @@ pub fn resolveExprAfterArith(
 
 /// Finish expression resolution for aggregate forms.
 pub fn resolveExprAfterAggregate(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -958,10 +958,10 @@ pub fn resolveExprAfterAggregate(
 /// Resolve binary expression and rebuild.
 #[inline(always)]
 pub fn resolveBinExpr(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    op: AverStr,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    op @ _: AverStr,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1071,8 +1071,8 @@ pub fn resolveBinExpr(
 
 /// Resolve expression, discarding slots update (for non-match contexts).
 pub fn resolveExprSimple(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     {
@@ -1083,9 +1083,9 @@ pub fn resolveExprSimple(
 
 /// Resolve function call arguments.
 pub fn resolveCallExpr(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1106,9 +1106,9 @@ pub fn resolveCallExpr(
 
 /// Resolve match expression, collecting pattern slots.
 pub fn resolveMatchExpr(
-    subj: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    subj @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1134,8 +1134,8 @@ pub fn resolveMatchExpr(
 
 /// Resolve ? propagation.
 pub fn resolvePropExpr(
-    inner: &crate::aver_generated::domain::ast::Expr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    inner @ _: &crate::aver_generated::domain::ast::Expr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1151,8 +1151,8 @@ pub fn resolvePropExpr(
 
 /// Resolve string concatenation parts.
 pub fn resolveConcatExpr(
-    parts: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    parts @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1172,8 +1172,8 @@ pub fn resolveConcatExpr(
 
 /// Resolve tuple expressions.
 pub fn resolveTupleExpr(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1193,9 +1193,9 @@ pub fn resolveTupleExpr(
 
 /// Resolve independent product expressions.
 pub fn resolveIndependentProductExpr(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    unwrap: bool,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    unwrap @ _: bool,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1216,8 +1216,8 @@ pub fn resolveIndependentProductExpr(
 
 /// Resolve list expressions.
 pub fn resolveListExpr(
-    exprs: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    exprs @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1237,9 +1237,9 @@ pub fn resolveListExpr(
 
 /// Resolve record expressions.
 pub fn resolveRecordExpr(
-    name: AverStr,
-    fields: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    name @ _: AverStr,
+    fields @ _: &aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1260,9 +1260,9 @@ pub fn resolveRecordExpr(
 
 /// Resolve field access.
 pub fn resolveFieldExpr(
-    obj: &crate::aver_generated::domain::ast::Expr,
-    field: AverStr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    obj @ _: &crate::aver_generated::domain::ast::Expr,
+    field @ _: AverStr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::Expr,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1282,8 +1282,8 @@ pub fn resolveFieldExpr(
 /// Resolve a variable: local vars become ExprSlot, others stay ExprVar.
 #[inline(always)]
 pub fn resolveVar(
-    name: AverStr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    name @ _: AverStr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match slots.get(&name).cloned() {
@@ -1295,11 +1295,11 @@ pub fn resolveVar(
 /// Resolve a list of expressions.
 #[inline(always)]
 pub fn resolveExprs(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
-    let slots = std::sync::Arc::new(slots);
+    let slots @ _ = std::sync::Arc::new(slots);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return acc.reverse(); }, [e, rest] => { {
@@ -1315,11 +1315,11 @@ pub fn resolveExprs(
 /// Resolve record field expressions.
 #[inline(always)]
 pub fn resolveFields(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
-    let slots = std::sync::Arc::new(slots);
+    let slots @ _ = std::sync::Arc::new(slots);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fields, [] => { return acc.reverse(); }, [pair, rest] => { { let (name, expr) = pair; {
@@ -1335,14 +1335,14 @@ pub fn resolveFields(
 /// Resolve match arms, collecting all pattern slots.
 #[inline(always)]
 pub fn resolveArms(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
-    let slots = std::sync::Arc::new(slots);
+    let slots @ _ = std::sync::Arc::new(slots);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(arms, [] => { return (acc.reverse(), (*slots).clone()); }, [arm, rest] => { { let (__stp0, _) = crate::aver_generated::domain::resolver::core::resolveArm(&arm, &*slots); {
@@ -1357,10 +1357,10 @@ pub fn resolveArms(
 
 /// Resolve one match arm; continue with the ORIGINAL slots, since an arm's pattern binders are scoped to its own body. Threading the arm-extended map onward leaked binder slots into later arms and past the match, where a wrapping binding aliased them and shadowed names resolved wrong.
 pub fn resolveOneArm(
-    arm: &crate::aver_generated::domain::ast::MatchArm,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    arm @ _: &crate::aver_generated::domain::ast::MatchArm,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1379,8 +1379,8 @@ pub fn resolveOneArm(
 
 /// Resolve a match arm: extend slots with pattern bindings, then resolve body.
 pub fn resolveArm(
-    arm: &crate::aver_generated::domain::ast::MatchArm,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    arm @ _: &crate::aver_generated::domain::ast::MatchArm,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::MatchArm,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1403,9 +1403,9 @@ pub fn resolveArm(
 
 /// Resolve arm body with extended slots.
 pub fn resolveArmBody(
-    arm: &crate::aver_generated::domain::ast::MatchArm,
-    newSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    arm @ _: &crate::aver_generated::domain::ast::MatchArm,
+    newSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::MatchArm,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1427,8 +1427,8 @@ pub fn resolveArmBody(
 
 /// Compute only the slots introduced by one pattern, using the same numbering as addPatternSlots.
 pub fn patternBindingSlots(
-    pat: &crate::aver_generated::domain::ast::Pattern,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> aver_rt::AverMap<AverStr, aver_rt::AverInt> {
     crate::cancel_checkpoint();
     let nextSlot @ _ = crate::aver_generated::domain::resolver::core::mapMaxVal(slots)
@@ -1446,9 +1446,9 @@ pub fn patternBindingSlots(
 
 /// Assign slots to pattern binders without carrying the outer slot map.
 pub fn patternBindingSlotsInner(
-    pat: &crate::aver_generated::domain::ast::Pattern,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1494,10 +1494,10 @@ pub fn patternBindingSlotsInner(
 
 /// Assign slots for cons-pattern binders.
 pub fn patternBindingSlotsCons(
-    h: AverStr,
-    t: AverStr,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
+    h @ _: AverStr,
+    t @ _: AverStr,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1513,9 +1513,9 @@ pub fn patternBindingSlotsCons(
 /// Assign slots for constructor-pattern binders.
 #[inline(always)]
 pub fn patternBindingSlotsConstructor(
-    mut bindings: aver_rt::AverList<AverStr>,
-    mut bindingSlots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
+    mut bindings @ _: aver_rt::AverList<AverStr>,
+    mut bindingSlots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1537,9 +1537,9 @@ pub fn patternBindingSlotsConstructor(
 /// Assign slots for tuple sub-patterns.
 #[inline(always)]
 pub fn patternBindingSlotsTuple(
-    mut pats: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    mut bindingSlots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
+    mut pats @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    mut bindingSlots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1560,8 +1560,8 @@ pub fn patternBindingSlotsTuple(
 
 /// Find the next available slot and add pattern bindings.
 pub fn addPatternSlots(
-    pat: &crate::aver_generated::domain::ast::Pattern,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1574,7 +1574,7 @@ pub fn addPatternSlots(
 
 /// Get maximum value in a map, or -1 if empty.
 #[inline(always)]
-pub fn mapMaxVal(m: &aver_rt::AverMap<AverStr, aver_rt::AverInt>) -> aver_rt::AverInt {
+pub fn mapMaxVal(m @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>) -> aver_rt::AverInt {
     crate::cancel_checkpoint();
     let vals @ _ = {
         let mut es: Vec<_> = m.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
@@ -1586,7 +1586,10 @@ pub fn mapMaxVal(m: &aver_rt::AverMap<AverStr, aver_rt::AverInt>) -> aver_rt::Av
 
 /// Find maximum value in a list.
 #[inline(always)]
-pub fn maxInList(mut vals: aver_rt::AverIntList, mut acc: aver_rt::AverInt) -> aver_rt::AverInt {
+pub fn maxInList(
+    mut vals @ _: aver_rt::AverIntList,
+    mut acc @ _: aver_rt::AverInt,
+) -> aver_rt::AverInt {
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(vals, [] => { return acc; }, [v, rest] => { if (v > acc) { {
@@ -1605,9 +1608,9 @@ pub fn maxInList(mut vals: aver_rt::AverIntList, mut acc: aver_rt::AverInt) -> a
 
 /// Add slots for pattern bindings.
 pub fn addPatternSlotsInner(
-    pat: &crate::aver_generated::domain::ast::Pattern,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1648,10 +1651,10 @@ pub fn addPatternSlotsInner(
 
 /// Add slots for cons pattern [h, ..t].
 pub fn addConsSlots(
-    h: AverStr,
-    t: AverStr,
-    slots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    next: aver_rt::AverInt,
+    h @ _: AverStr,
+    t @ _: AverStr,
+    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1667,9 +1670,9 @@ pub fn addConsSlots(
 /// Add slots for constructor pattern bindings.
 #[inline(always)]
 pub fn addConstructorSlots(
-    mut bindings: aver_rt::AverList<AverStr>,
-    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
+    mut bindings @ _: aver_rt::AverList<AverStr>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1691,9 +1694,9 @@ pub fn addConstructorSlots(
 /// Add slots for tuple sub-patterns.
 #[inline(always)]
 pub fn addTuplePatternSlots(
-    mut pats: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
+    mut pats @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
@@ -1715,10 +1718,10 @@ pub fn addTuplePatternSlots(
 /// Synthesized collecting variant of `resolveStmts`. Appends to a builder where `resolveStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveStmts__collected(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut next: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut next @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     aver_rt::AverInt,
@@ -1769,11 +1772,11 @@ pub fn resolveStmts__collected(
 /// Synthesized collecting variant of `resolveExprs`. Appends to a builder where `resolveExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveExprs__collected(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
-    let slots = std::sync::Arc::new(slots);
+    let slots @ _ = std::sync::Arc::new(slots);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(exprs, [] => { return aver_rt::list_builder_finalize(acc); }, [e, rest] => { {
@@ -1789,11 +1792,11 @@ pub fn resolveExprs__collected(
 /// Synthesized collecting variant of `resolveFields`. Appends to a builder where `resolveFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveFields__collected(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
-    let slots = std::sync::Arc::new(slots);
+    let slots @ _ = std::sync::Arc::new(slots);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fields, [] => { return aver_rt::list_builder_finalize(acc); }, [pair, rest] => { { let (name, expr) = pair; {
@@ -1809,14 +1812,14 @@ pub fn resolveFields__collected(
 /// Synthesized collecting variant of `resolveArms`. Appends to a builder where `resolveArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn resolveArms__collected(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slots: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
-    let slots = std::sync::Arc::new(slots);
+    let slots @ _ = std::sync::Arc::new(slots);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(arms, [] => { return (aver_rt::list_builder_finalize(acc), (*slots).clone()); }, [arm, rest] => { { let (__stp0, _) = crate::aver_generated::domain::resolver::core::resolveArm(&arm, &*slots); {

--- a/src/self_host/aver_generated/domain/resolver/fast/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/fast/mod.rs
@@ -6,11 +6,11 @@ use crate::*;
 /// Tag simple single-expression functions so eval can skip the stmt walker.
 #[inline(always)]
 pub fn annotateFastFns(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    fnMap: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    fnMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
-    let fnMap = std::sync::Arc::new(fnMap);
+    let fnMap @ _ = std::sync::Arc::new(fnMap);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fns, [] => { return acc.reverse(); }, [f, rest] => { {
@@ -25,8 +25,8 @@ pub fn annotateFastFns(
 
 /// Attach a narrow fast-path tag to a function definition.
 pub fn annotateFastFn(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    fnMap: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    fnMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     let selfId @ _ = fnMap
@@ -50,8 +50,8 @@ pub fn annotateFastFn(
 /// Precompute whether the final expression position can self-tail-call directly.
 #[inline(always)]
 pub fn classifyTailLoop(
-    mut selfId: aver_rt::AverInt,
-    mut body: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut selfId @ _: aver_rt::AverInt,
+    mut body @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> bool {
     loop {
         crate::cancel_checkpoint();
@@ -65,8 +65,8 @@ pub fn classifyTailLoop(
 
 /// Only the final expression statement can trigger the tail-loop slot evaluator.
 pub fn stmtNeedsTailLoop(
-    selfId: aver_rt::AverInt,
-    stmt: &crate::aver_generated::domain::ast::Stmt,
+    selfId @ _: aver_rt::AverInt,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
 ) -> bool {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -79,8 +79,8 @@ pub fn stmtNeedsTailLoop(
 
 /// Recognize direct self-calls in tail position, including bool branches and matches.
 pub fn exprNeedsTailLoop(
-    mut selfId: aver_rt::AverInt,
-    mut expr: crate::aver_generated::domain::ast::Expr,
+    mut selfId @ _: aver_rt::AverInt,
+    mut expr @ _: crate::aver_generated::domain::ast::Expr,
 ) -> bool {
     loop {
         crate::cancel_checkpoint();
@@ -119,8 +119,8 @@ pub fn exprNeedsTailLoop(
 /// Return true when any match arm ends in a direct self-tail-call.
 #[inline(always)]
 pub fn armsNeedTailLoop(
-    mut selfId: aver_rt::AverInt,
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut selfId @ _: aver_rt::AverInt,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> bool {
     loop {
         crate::cancel_checkpoint();
@@ -134,7 +134,7 @@ pub fn armsNeedTailLoop(
 
 /// Single expression bodies can bypass evalStmts* and evaluate the expr directly.
 pub fn classifyFastPath(
-    body: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     {
@@ -153,7 +153,7 @@ pub fn classifyFastPath(
 
 /// Only plain expression bodies get a fast expr tag.
 pub fn classifyFastStmt(
-    stmt: &crate::aver_generated::domain::ast::Stmt,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -167,7 +167,7 @@ pub fn classifyFastStmt(
 /// Recognize a few leaf-like and branch-like expr shapes worth running without the full stmt walker.
 #[inline(always)]
 pub fn classifyFastExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(expr) {
@@ -187,7 +187,7 @@ pub fn classifyFastExpr(
 
 /// Recognize a leaf-like expr that can be executed without descending the AST.
 pub fn classifyFastLeafExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -237,7 +237,7 @@ pub fn classifyFastLeafExpr(
 
 /// Finish fast-leaf classification for arithmetic and comparison forms.
 pub fn classifyFastLeafExprTail(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -319,8 +319,8 @@ pub fn classifyFastLeafExprTail(
 
 /// Recognize obj.field when obj is already a resolved slot.
 pub fn classifyFastFieldAccess(
-    obj: &crate::aver_generated::domain::ast::Expr,
-    field: AverStr,
+    obj @ _: &crate::aver_generated::domain::ast::Expr,
+    field @ _: AverStr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match obj.clone() {
@@ -333,9 +333,9 @@ pub fn classifyFastFieldAccess(
 
 /// Recognize slot op slot for arithmetic.
 pub fn classifyFastBinopSlots(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match a.clone() {
@@ -351,9 +351,9 @@ pub fn classifyFastBinopSlots(
 
 /// Recognize slot cmp slot for comparisons.
 pub fn classifyFastCmpSlots(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match a.clone() {
@@ -370,8 +370,8 @@ pub fn classifyFastCmpSlots(
 /// Recognize tiny builtin wrappers that only shuffle slots and integer constants.
 #[inline(always)]
 pub fn classifyFastBuiltinLeaf(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -414,7 +414,7 @@ pub fn classifyFastBuiltinLeaf(
 
 /// Recognize Map.get(slotMap, slotKey).
 pub fn classifyFastMapGet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -438,8 +438,8 @@ pub fn classifyFastMapGet(
 
 /// Encode a direct map lookup when both operands are resolved slots.
 pub fn classifyFastMapGetArgs(
-    mapExpr: &crate::aver_generated::domain::ast::Expr,
-    keyExpr: &crate::aver_generated::domain::ast::Expr,
+    mapExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    keyExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
@@ -455,7 +455,7 @@ pub fn classifyFastMapGetArgs(
 
 /// Recognize Map.set(slotMap, slotKey, slotValue).
 pub fn classifyFastMapSet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -488,9 +488,9 @@ pub fn classifyFastMapSet(
 
 /// Encode a direct map update when all operands are resolved slots.
 pub fn classifyFastMapSetArgs(
-    mapExpr: &crate::aver_generated::domain::ast::Expr,
-    keyExpr: &crate::aver_generated::domain::ast::Expr,
-    valueExpr: &crate::aver_generated::domain::ast::Expr,
+    mapExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    keyExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    valueExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
@@ -513,7 +513,7 @@ pub fn classifyFastMapSetArgs(
 
 /// Recognize Map.has(slotMap, slotKey).
 pub fn classifyFastMapHas(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -537,8 +537,8 @@ pub fn classifyFastMapHas(
 
 /// Encode a direct map membership test when both operands are resolved slots.
 pub fn classifyFastMapHasArgs(
-    mapExpr: &crate::aver_generated::domain::ast::Expr,
-    keyExpr: &crate::aver_generated::domain::ast::Expr,
+    mapExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    keyExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
@@ -554,7 +554,7 @@ pub fn classifyFastMapHasArgs(
 
 /// Recognize Map.remove(slotMap, slotKey).
 pub fn classifyFastMapRemove(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -578,8 +578,8 @@ pub fn classifyFastMapRemove(
 
 /// Encode a direct map key removal when both operands are resolved slots.
 pub fn classifyFastMapRemoveArgs(
-    mapExpr: &crate::aver_generated::domain::ast::Expr,
-    keyExpr: &crate::aver_generated::domain::ast::Expr,
+    mapExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    keyExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match mapExpr.clone() {
@@ -595,7 +595,7 @@ pub fn classifyFastMapRemoveArgs(
 
 /// Recognize Vector.len(slotVec).
 pub fn classifyFastVectorLen(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -615,7 +615,7 @@ pub fn classifyFastVectorLen(
 
 /// Recognize Vector.new(slot, int) wrappers.
 pub fn classifyFastVectorNew(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -639,8 +639,8 @@ pub fn classifyFastVectorNew(
 
 /// Encode Vector.new(slot, int) without keeping the whole AST around.
 pub fn classifyFastVectorNewArgs(
-    sizeExpr: &crate::aver_generated::domain::ast::Expr,
-    fillExpr: &crate::aver_generated::domain::ast::Expr,
+    sizeExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    fillExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match sizeExpr.clone() {
@@ -656,7 +656,7 @@ pub fn classifyFastVectorNewArgs(
 
 /// Recognize Option.withDefault(Vector.get(slot, slot), int).
 pub fn classifyFastOptionWithDefault(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -681,8 +681,8 @@ pub fn classifyFastOptionWithDefault(
 
 /// Encode the common Vector.get-with-default wrapper used in tiny helpers like cellAt.
 pub fn classifyFastOptionWithDefaultArgs(
-    optionExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
+    optionExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match optionExpr.clone() {
@@ -702,8 +702,8 @@ pub fn classifyFastOptionWithDefaultArgs(
 
 /// Recognize Vector.get(slotVec, slotIdx) with an integer default.
 pub fn classifyFastVectorGet(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     {
@@ -729,9 +729,9 @@ pub fn classifyFastVectorGet(
 
 /// Encode Vector.get(slotVec, slotIdx) with an integer fallback.
 pub fn classifyFastVectorGetArgs(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<crate::aver_generated::domain::ast::FastLeaf> {
     crate::cancel_checkpoint();
     match vecExpr.clone() {
@@ -757,8 +757,8 @@ pub fn classifyFastVectorGetArgs(
 /// Recognize a small fixed-shape branch over bools or slot-based comparisons.
 #[inline(always)]
 pub fn classifyFastMatch(
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::resolver::fast::classifyBoolArms(arms) {
@@ -776,8 +776,8 @@ pub fn classifyFastMatch(
 
 /// Recognize a two-arm list match with [] and [h, ..t] leaf bodies.
 pub fn classifyFastListMatch(
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match scrutinee.clone() {
@@ -790,8 +790,8 @@ pub fn classifyFastListMatch(
 
 /// Extract fixed empty/cons list arms regardless of order.
 pub fn classifyFastListArms(
-    slot: aver_rt::AverInt,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    slot @ _: aver_rt::AverInt,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     {
@@ -820,9 +820,9 @@ pub fn classifyFastListArms(
 /// Convert two list-pattern arms into a direct slot branch.
 #[inline(always)]
 pub fn classifyFastListArmPair(
-    slot: aver_rt::AverInt,
-    arm1: &crate::aver_generated::domain::ast::MatchArm,
-    arm2: &crate::aver_generated::domain::ast::MatchArm,
+    slot @ _: aver_rt::AverInt,
+    arm1 @ _: &crate::aver_generated::domain::ast::MatchArm,
+    arm2 @ _: &crate::aver_generated::domain::ast::MatchArm,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     let leaf1 @ _ = crate::aver_generated::domain::resolver::fast::classifyFastLeafExpr(&arm1.body);
@@ -848,13 +848,13 @@ pub fn classifyFastListArmPair(
 
 /// Order empty/cons arms into a direct list branch.
 pub fn classifyFastListPatterns(
-    slot: aver_rt::AverInt,
-    p1: &crate::aver_generated::domain::ast::Pattern,
-    bindingSlots1: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    leaf1: &crate::aver_generated::domain::ast::FastLeaf,
-    p2: &crate::aver_generated::domain::ast::Pattern,
-    bindingSlots2: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    leaf2: &crate::aver_generated::domain::ast::FastLeaf,
+    slot @ _: aver_rt::AverInt,
+    p1 @ _: &crate::aver_generated::domain::ast::Pattern,
+    bindingSlots1 @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    leaf1 @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    p2 @ _: &crate::aver_generated::domain::ast::Pattern,
+    bindingSlots2 @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    leaf2 @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match p1.clone() {
@@ -884,11 +884,11 @@ pub fn classifyFastListPatterns(
 
 /// Finish list fast-path classification when the empty arm is known.
 pub fn classifyFastListOther(
-    slot: aver_rt::AverInt,
-    emptyLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    other: &crate::aver_generated::domain::ast::Pattern,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    otherLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    slot @ _: aver_rt::AverInt,
+    emptyLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    other @ _: &crate::aver_generated::domain::ast::Pattern,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    otherLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match other.clone() {
@@ -908,13 +908,13 @@ pub fn classifyFastListOther(
 
 /// Handle reversed list arms where the cons case appears first.
 pub fn classifyFastListConsFirst(
-    slot: aver_rt::AverInt,
-    head: AverStr,
-    tail: AverStr,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    consLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    other: &crate::aver_generated::domain::ast::Pattern,
-    otherLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    slot @ _: aver_rt::AverInt,
+    head @ _: AverStr,
+    tail @ _: AverStr,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    consLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    other @ _: &crate::aver_generated::domain::ast::Pattern,
+    otherLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match other {
@@ -935,12 +935,12 @@ pub fn classifyFastListConsFirst(
 /// Build the list-slot branch once head/tail binding slots are known.
 #[inline(always)]
 pub fn classifyFastListCons(
-    slot: aver_rt::AverInt,
-    emptyLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    head: AverStr,
-    tail: AverStr,
-    bindingSlots: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
-    consLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    slot @ _: aver_rt::AverInt,
+    emptyLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    head @ _: AverStr,
+    tail @ _: AverStr,
+    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    consLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match bindingSlots.get(&head).cloned() {
@@ -963,8 +963,8 @@ pub fn classifyFastListCons(
 /// Recognize tiny direct-call wrappers that only forward slot arguments.
 #[inline(always)]
 pub fn classifyFastForwardCall(
-    fnId: aver_rt::AverInt,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    fnId @ _: aver_rt::AverInt,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::resolver::fast::classifyFastForwardSlots__collected(
@@ -981,8 +981,8 @@ pub fn classifyFastForwardCall(
 /// Extract slot numbers from a direct call argument list.
 #[inline(always)]
 pub fn classifyFastForwardSlots(
-    mut args: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut acc: aver_rt::AverIntList,
+    mut args @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut acc @ _: aver_rt::AverIntList,
 ) -> Option<aver_rt::AverIntList> {
     loop {
         crate::cancel_checkpoint();
@@ -1005,7 +1005,7 @@ pub fn classifyFastForwardSlots(
 
 /// Extract (then, else) leaves from a two-arm bool match, regardless of arm order.
 pub fn classifyBoolArms(
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> Option<(
     crate::aver_generated::domain::ast::FastLeaf,
     crate::aver_generated::domain::ast::FastLeaf,
@@ -1037,8 +1037,8 @@ pub fn classifyBoolArms(
 /// Convert two bool-pattern arms into ordered leaves.
 #[inline(always)]
 pub fn classifyBoolArmPair(
-    arm1: &crate::aver_generated::domain::ast::MatchArm,
-    arm2: &crate::aver_generated::domain::ast::MatchArm,
+    arm1 @ _: &crate::aver_generated::domain::ast::MatchArm,
+    arm2 @ _: &crate::aver_generated::domain::ast::MatchArm,
 ) -> Option<(
     crate::aver_generated::domain::ast::FastLeaf,
     crate::aver_generated::domain::ast::FastLeaf,
@@ -1062,10 +1062,10 @@ pub fn classifyBoolArmPair(
 
 /// Order bool match arms into (trueLeaf, falseLeaf).
 pub fn classifyBoolArmPatterns(
-    p1: &crate::aver_generated::domain::ast::Pattern,
-    leaf1: &crate::aver_generated::domain::ast::FastLeaf,
-    p2: &crate::aver_generated::domain::ast::Pattern,
-    leaf2: &crate::aver_generated::domain::ast::FastLeaf,
+    p1 @ _: &crate::aver_generated::domain::ast::Pattern,
+    leaf1 @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    p2 @ _: &crate::aver_generated::domain::ast::Pattern,
+    leaf2 @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Option<(
     crate::aver_generated::domain::ast::FastLeaf,
     crate::aver_generated::domain::ast::FastLeaf,
@@ -1083,10 +1083,10 @@ pub fn classifyBoolArmPatterns(
 
 /// Finish ordering bool match arms once the first arm bool is extracted.
 pub fn classifyBoolArmPatternsInner(
-    b1: bool,
-    leaf1: &crate::aver_generated::domain::ast::FastLeaf,
-    p2: &crate::aver_generated::domain::ast::Pattern,
-    leaf2: &crate::aver_generated::domain::ast::FastLeaf,
+    b1 @ _: bool,
+    leaf1 @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    p2 @ _: &crate::aver_generated::domain::ast::Pattern,
+    leaf2 @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Option<(
     crate::aver_generated::domain::ast::FastLeaf,
     crate::aver_generated::domain::ast::FastLeaf,
@@ -1104,10 +1104,10 @@ pub fn classifyBoolArmPatternsInner(
 
 /// Return (trueLeaf, falseLeaf) when the two bool arms are complementary.
 pub fn classifyBoolArmPatternsPair(
-    b1: bool,
-    leaf1: &crate::aver_generated::domain::ast::FastLeaf,
-    b2: bool,
-    leaf2: &crate::aver_generated::domain::ast::FastLeaf,
+    b1 @ _: bool,
+    leaf1 @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    b2 @ _: bool,
+    leaf2 @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> Option<(
     crate::aver_generated::domain::ast::FastLeaf,
     crate::aver_generated::domain::ast::FastLeaf,
@@ -1122,9 +1122,9 @@ pub fn classifyBoolArmPatternsPair(
 
 /// Encode a recognized branch scrutinee with preclassified leaves.
 pub fn classifyFastMatchScrutinee(
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match scrutinee.clone() {
@@ -1162,10 +1162,10 @@ pub fn classifyFastMatchScrutinee(
 
 /// Recognize slot == int/string in either operand order.
 pub fn classifyFastEqScrutinee(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match a.clone() {
@@ -1187,10 +1187,10 @@ pub fn classifyFastEqScrutinee(
 
 /// Encode equality against a constant once the slot side is known.
 pub fn classifyFastEqOther(
-    slot: aver_rt::AverInt,
-    other: &crate::aver_generated::domain::ast::Expr,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    slot @ _: aver_rt::AverInt,
+    other @ _: &crate::aver_generated::domain::ast::Expr,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match other.clone() {
@@ -1216,10 +1216,10 @@ pub fn classifyFastEqOther(
 
 /// Recognize slot < slot branches like minInt.
 pub fn classifyFastLtScrutinee(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    thenLeaf: &crate::aver_generated::domain::ast::FastLeaf,
-    elseLeaf: &crate::aver_generated::domain::ast::FastLeaf,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    thenLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
+    elseLeaf @ _: &crate::aver_generated::domain::ast::FastLeaf,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match a.clone() {
@@ -1241,8 +1241,8 @@ pub fn classifyFastLtScrutinee(
 /// Synthesized collecting variant of `classifyFastForwardSlots`. Appends to a builder where `classifyFastForwardSlots` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn classifyFastForwardSlots__collected(
-    mut args: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut acc: aver_rt::AverIntList,
+    mut args @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut acc @ _: aver_rt::AverIntList,
 ) -> Option<aver_rt::AverIntList> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/resolver/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/mod.rs
@@ -13,7 +13,7 @@ use crate::*;
 
 /// Resolve all functions: slots, direct calls, then attach narrow fast-path tags.
 pub fn resolveProgram(
-    prog: &crate::aver_generated::domain::ast::Program,
+    mut prog @ _: crate::aver_generated::domain::ast::Program,
 ) -> crate::aver_generated::domain::ast::Program {
     crate::cancel_checkpoint();
     let resolvedFns @ _ = crate::aver_generated::domain::resolver::core::resolveFns(

--- a/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/rewrite/mod.rs
@@ -6,8 +6,8 @@ use crate::*;
 /// Rewrite resolved AST into lighter internal expression shapes without changing semantics.
 #[inline(always)]
 pub fn rewriteInternalFns(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     loop {
         crate::cancel_checkpoint();
@@ -23,7 +23,7 @@ pub fn rewriteInternalFns(
 
 /// Rewrite the body of one resolved function into lighter internal expression shapes.
 pub fn rewriteInternalFn(
-    fd: &crate::aver_generated::domain::ast::FnDef,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::FnDef {
@@ -43,8 +43,8 @@ pub fn rewriteInternalFn(
 /// Rewrite statements recursively into lighter internal expression shapes.
 #[inline(always)]
 pub fn rewriteInternalStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Stmt> {
     loop {
         crate::cancel_checkpoint();
@@ -60,7 +60,7 @@ pub fn rewriteInternalStmts(
 
 /// Rewrite one statement recursively into lighter internal expression shapes.
 pub fn rewriteInternalStmt(
-    stmt: &crate::aver_generated::domain::ast::Stmt,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
 ) -> crate::aver_generated::domain::ast::Stmt {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -86,7 +86,7 @@ pub fn rewriteInternalStmt(
 
 /// Rewrite one expression into lighter internal forms after resolve and direct-call linking.
 pub fn rewriteInternalExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -150,7 +150,7 @@ pub fn rewriteInternalExpr(
 
 /// Continue internal rewrite for arithmetic and comparison forms.
 pub fn rewriteInternalExprAfterLeaf(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -256,7 +256,7 @@ pub fn rewriteInternalExprAfterLeaf(
 
 /// Finish internal rewrite for aggregates, calls, and products.
 pub fn rewriteInternalExprAfterArith(
-    expr: &crate::aver_generated::domain::ast::Expr,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -395,8 +395,8 @@ pub fn rewriteInternalExprAfterArith(
 /// Rewrite a list of expressions recursively.
 #[inline(always)]
 pub fn rewriteInternalExprs(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
     loop {
         crate::cancel_checkpoint();
@@ -413,8 +413,8 @@ pub fn rewriteInternalExprs(
 /// Rewrite record field expressions recursively.
 #[inline(always)]
 pub fn rewriteInternalFields(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
     loop {
         crate::cancel_checkpoint();
@@ -431,8 +431,8 @@ pub fn rewriteInternalFields(
 /// Rewrite match arm bodies and resolve PatConstructor to PatConstructorId using constructor tags.
 #[inline(always)]
 pub fn rewriteInternalArms(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm> {
     loop {
         crate::cancel_checkpoint();
@@ -448,7 +448,7 @@ pub fn rewriteInternalArms(
 
 /// Rewrite PatConstructor to PatConstructorId with both tag and full constructor name.
 pub fn rewritePattern(
-    pat: &crate::aver_generated::domain::ast::Pattern,
+    pat @ _: &crate::aver_generated::domain::ast::Pattern,
 ) -> crate::aver_generated::domain::ast::Pattern {
     crate::cancel_checkpoint();
     match pat.clone() {
@@ -471,8 +471,8 @@ pub fn rewritePattern(
 
 /// Convert PatConstructor to PatConstructorId with stable tag and canonical constructor name, so a pattern that names the declaring module matches values the module itself built.
 pub fn rewritePatConstructor(
-    name: AverStr,
-    bindings: &aver_rt::AverList<AverStr>,
+    name @ _: AverStr,
+    bindings @ _: &aver_rt::AverList<AverStr>,
 ) -> crate::aver_generated::domain::ast::Pattern {
     crate::cancel_checkpoint();
     let canonical @ _ = crate::aver_generated::domain::ast::canonicalCtorName(name);
@@ -483,8 +483,8 @@ pub fn rewritePatConstructor(
 /// Rewrite a list of patterns.
 #[inline(always)]
 pub fn rewritePatterns(
-    mut pats: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    mut pats @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Pattern> {
     loop {
         crate::cancel_checkpoint();
@@ -500,9 +500,9 @@ pub fn rewritePatterns(
 
 /// Compress simple resolved arithmetic into slot-based internal nodes.
 pub fn rewriteInternalBinop(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    left: &crate::aver_generated::domain::ast::Expr,
-    right: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match left.clone() {
@@ -526,9 +526,9 @@ pub fn rewriteInternalBinop(
 
 /// Rewrite arithmetic with a slot on the left when the right side is simple.
 pub fn rewriteInternalBinopSlotLeft(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    slot: aver_rt::AverInt,
-    right: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    slot @ _: aver_rt::AverInt,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match right.clone() {
@@ -548,9 +548,9 @@ pub fn rewriteInternalBinopSlotLeft(
 
 /// Rewrite commutative arithmetic when the slot appears on the right.
 pub fn rewriteInternalBinopSlotRight(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    left: &crate::aver_generated::domain::ast::Expr,
-    slot: aver_rt::AverInt,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    slot @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match left.clone() {
@@ -578,9 +578,9 @@ pub fn rewriteInternalBinopSlotRight(
 
 /// Rebuild a generic arithmetic expression when no narrower internal form applies.
 pub fn rebuildInternalBinop(
-    op: &crate::aver_generated::domain::ast::BinOp,
-    left: &crate::aver_generated::domain::ast::Expr,
-    right: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::BinOp,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match op {
@@ -612,7 +612,7 @@ pub fn rebuildInternalBinop(
 }
 
 /// Return whether swapping operand order preserves arithmetic semantics.
-pub fn binopCanFlip(op: &crate::aver_generated::domain::ast::BinOp) -> bool {
+pub fn binopCanFlip(op @ _: &crate::aver_generated::domain::ast::BinOp) -> bool {
     crate::cancel_checkpoint();
     match op {
         crate::aver_generated::domain::ast::BinOp::OpAdd => true,
@@ -624,8 +624,8 @@ pub fn binopCanFlip(op: &crate::aver_generated::domain::ast::BinOp) -> bool {
 /// Recognize fused builtin wrapper patterns after children have already been rewritten.
 #[inline(always)]
 pub fn rewriteInternalBuiltin(
-    name: AverStr,
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    name @ _: AverStr,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     {
@@ -646,7 +646,7 @@ pub fn rewriteInternalBuiltin(
 
 /// Rewrite Option.withDefault(Vector.get(...), int) into one internal node.
 pub fn rewriteInternalOptionWithDefault(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     {
@@ -674,8 +674,8 @@ pub fn rewriteInternalOptionWithDefault(
 
 /// Recognize a fused Vector.get-with-default shape.
 pub fn rewriteInternalOptionWithDefaultArgs(
-    optionExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
+    optionExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match defaultExpr.clone() {
@@ -709,8 +709,8 @@ pub fn rewriteInternalOptionWithDefaultArgs(
 
 /// Fuse Vector.get(vec, idx) with an integer fallback.
 pub fn rewriteInternalVectorGetOrInt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultValue: aver_rt::AverInt,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     {
@@ -751,9 +751,9 @@ pub fn rewriteInternalVectorGetOrInt(
 /// Only fuse Vector.get-with-default when at least one operand is already slot-shaped.
 #[inline(always)]
 pub fn rewriteInternalVectorGetOrIntArgs(
-    vecExpr: &crate::aver_generated::domain::ast::Expr,
-    idxExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultValue: aver_rt::AverInt,
+    vecExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    idxExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::resolver::rewrite::exprHasSlotShape(vecExpr) {
@@ -786,7 +786,7 @@ pub fn rewriteInternalVectorGetOrIntArgs(
 
 /// Rewrite Result.withDefault(Int.mod(...), int) into one internal node.
 pub fn rewriteInternalResultWithDefault(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     {
@@ -814,8 +814,8 @@ pub fn rewriteInternalResultWithDefault(
 
 /// Recognize a fused Int.mod-with-default shape.
 pub fn rewriteInternalResultWithDefaultArgs(
-    resultExpr: &crate::aver_generated::domain::ast::Expr,
-    defaultExpr: &crate::aver_generated::domain::ast::Expr,
+    resultExpr @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultExpr @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match defaultExpr.clone() {
@@ -852,8 +852,8 @@ pub fn rewriteInternalResultWithDefaultArgs(
 
 /// Fuse Int.mod(a, b) with an integer fallback when the operands are slot-shaped.
 pub fn rewriteInternalIntModOrInt(
-    args: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    defaultValue: aver_rt::AverInt,
+    args @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     {
@@ -898,9 +898,9 @@ pub fn rewriteInternalIntModOrInt(
 /// Only fuse Int.mod-with-default when at least one operand is already slot-shaped.
 #[inline(always)]
 pub fn rewriteInternalIntModOrIntArgs(
-    a: &crate::aver_generated::domain::ast::Expr,
-    b: &crate::aver_generated::domain::ast::Expr,
-    defaultValue: aver_rt::AverInt,
+    a @ _: &crate::aver_generated::domain::ast::Expr,
+    b @ _: &crate::aver_generated::domain::ast::Expr,
+    defaultValue @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     if crate::aver_generated::domain::resolver::rewrite::exprHasSlotShape(a) {
@@ -932,7 +932,7 @@ pub fn rewriteInternalIntModOrIntArgs(
 }
 
 /// Return whether an expression is already in a slot-based internal shape worth fusing around.
-pub fn exprHasSlotShape(expr: &crate::aver_generated::domain::ast::Expr) -> bool {
+pub fn exprHasSlotShape(expr @ _: &crate::aver_generated::domain::ast::Expr) -> bool {
     crate::cancel_checkpoint();
     match expr {
         crate::aver_generated::domain::ast::Expr::ExprSlot(_) => true,
@@ -948,9 +948,9 @@ pub fn exprHasSlotShape(expr: &crate::aver_generated::domain::ast::Expr) -> bool
 
 /// Compress simple resolved comparisons into slot-based internal nodes.
 pub fn rewriteInternalCmp(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    left: &crate::aver_generated::domain::ast::Expr,
-    right: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match left.clone() {
@@ -974,9 +974,9 @@ pub fn rewriteInternalCmp(
 
 /// Rewrite comparisons with a slot on the left when the right side is simple.
 pub fn rewriteInternalCmpSlotLeft(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    slot: aver_rt::AverInt,
-    right: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    slot @ _: aver_rt::AverInt,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match right.clone() {
@@ -996,9 +996,9 @@ pub fn rewriteInternalCmpSlotLeft(
 
 /// Rewrite comparisons with a slot on the right when the left side is a simple integer.
 pub fn rewriteInternalCmpSlotRight(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    left: &crate::aver_generated::domain::ast::Expr,
-    slot: aver_rt::AverInt,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    slot @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match left.clone() {
@@ -1022,9 +1022,9 @@ pub fn rewriteInternalCmpSlotRight(
 
 /// Rebuild a generic comparison expression when no narrower internal form applies.
 pub fn rebuildInternalCmp(
-    op: &crate::aver_generated::domain::ast::CmpOp,
-    left: &crate::aver_generated::domain::ast::Expr,
-    right: &crate::aver_generated::domain::ast::Expr,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
+    left @ _: &crate::aver_generated::domain::ast::Expr,
+    right @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match op {
@@ -1069,7 +1069,7 @@ pub fn rebuildInternalCmp(
 
 /// Flip a comparison when swapping operand order.
 pub fn flipCmp(
-    op: &crate::aver_generated::domain::ast::CmpOp,
+    op @ _: &crate::aver_generated::domain::ast::CmpOp,
 ) -> crate::aver_generated::domain::ast::CmpOp {
     crate::cancel_checkpoint();
     match op {
@@ -1097,8 +1097,8 @@ pub fn flipCmp(
 /// Rewrite simple bool matches into a direct branch node.
 #[inline(always)]
 pub fn rewriteInternalMatch(
-    scrutinee: &crate::aver_generated::domain::ast::Expr,
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    scrutinee @ _: &crate::aver_generated::domain::ast::Expr,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match crate::aver_generated::domain::resolver::rewrite::rewriteBoolMatchArms(arms) {
@@ -1119,7 +1119,7 @@ pub fn rewriteInternalMatch(
 
 /// Extract (thenExpr, elseExpr) from a two-arm bool match regardless of arm order.
 pub fn rewriteBoolMatchArms(
-    arms: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    arms @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> Option<(
     crate::aver_generated::domain::ast::Expr,
     crate::aver_generated::domain::ast::Expr,
@@ -1150,8 +1150,8 @@ pub fn rewriteBoolMatchArms(
 
 /// Order two complementary bool arms into (trueExpr, falseExpr).
 pub fn rewriteBoolMatchArmPair(
-    arm1: &crate::aver_generated::domain::ast::MatchArm,
-    arm2: &crate::aver_generated::domain::ast::MatchArm,
+    arm1 @ _: &crate::aver_generated::domain::ast::MatchArm,
+    arm2 @ _: &crate::aver_generated::domain::ast::MatchArm,
 ) -> Option<(
     crate::aver_generated::domain::ast::Expr,
     crate::aver_generated::domain::ast::Expr,
@@ -1172,10 +1172,10 @@ pub fn rewriteBoolMatchArmPair(
 
 /// Finish ordering bool arms once the first pattern bool is known.
 pub fn rewriteBoolMatchArmPairInner(
-    b1: bool,
-    body1: &crate::aver_generated::domain::ast::Expr,
-    p2: &crate::aver_generated::domain::ast::Pattern,
-    body2: &crate::aver_generated::domain::ast::Expr,
+    b1 @ _: bool,
+    body1 @ _: &crate::aver_generated::domain::ast::Expr,
+    p2 @ _: &crate::aver_generated::domain::ast::Pattern,
+    body2 @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<(
     crate::aver_generated::domain::ast::Expr,
     crate::aver_generated::domain::ast::Expr,
@@ -1193,10 +1193,10 @@ pub fn rewriteBoolMatchArmPairInner(
 
 /// Return ordered bool branch bodies when the pair is exactly true/false or false/true.
 pub fn rewriteBoolMatchArmPairBools(
-    b1: bool,
-    body1: &crate::aver_generated::domain::ast::Expr,
-    b2: bool,
-    body2: &crate::aver_generated::domain::ast::Expr,
+    b1 @ _: bool,
+    body1 @ _: &crate::aver_generated::domain::ast::Expr,
+    b2 @ _: bool,
+    body2 @ _: &crate::aver_generated::domain::ast::Expr,
 ) -> Option<(
     crate::aver_generated::domain::ast::Expr,
     crate::aver_generated::domain::ast::Expr,
@@ -1212,8 +1212,8 @@ pub fn rewriteBoolMatchArmPairBools(
 /// Synthesized collecting variant of `rewriteInternalStmts`. Appends to a builder where `rewriteInternalStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn rewriteInternalStmts__collected(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Stmt> {
     loop {
         crate::cancel_checkpoint();
@@ -1230,8 +1230,8 @@ pub fn rewriteInternalStmts__collected(
 /// Synthesized collecting variant of `rewriteInternalExprs`. Appends to a builder where `rewriteInternalExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn rewriteInternalExprs__collected(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
     loop {
         crate::cancel_checkpoint();
@@ -1248,8 +1248,8 @@ pub fn rewriteInternalExprs__collected(
 /// Synthesized collecting variant of `rewriteInternalFields`. Appends to a builder where `rewriteInternalFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn rewriteInternalFields__collected(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
     loop {
         crate::cancel_checkpoint();
@@ -1266,8 +1266,8 @@ pub fn rewriteInternalFields__collected(
 /// Synthesized collecting variant of `rewriteInternalArms`. Appends to a builder where `rewriteInternalArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn rewriteInternalArms__collected(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm> {
     loop {
         crate::cancel_checkpoint();
@@ -1284,8 +1284,8 @@ pub fn rewriteInternalArms__collected(
 /// Synthesized collecting variant of `rewritePatterns`. Appends to a builder where `rewritePatterns` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn rewritePatterns__collected(
-    mut pats: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    mut pats @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Pattern>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Pattern> {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/token/mod.rs
+++ b/src/self_host/aver_generated/domain/token/mod.rs
@@ -516,7 +516,7 @@ impl aver_replay::ReplayValue for Token {
 }
 
 /// Debug representation of a token.
-pub fn tokenRepr(t: &Token) -> AverStr {
+pub fn tokenRepr(t @ _: &Token) -> AverStr {
     crate::cancel_checkpoint();
     match t.clone() {
         crate::aver_generated::domain::token::Token::TkInt(n) => aver_rt::AverStr::from({

--- a/src/self_host/aver_generated/domain/value/mod.rs
+++ b/src/self_host/aver_generated/domain/value/mod.rs
@@ -446,7 +446,7 @@ impl aver_replay::ReplayValue for Val {
 }
 
 /// Render a string key or nested string value with quotes.
-pub fn quoteString(s: AverStr) -> AverStr {
+pub fn quoteString(s @ _: AverStr) -> AverStr {
     crate::cancel_checkpoint();
     ((AverStr::from("\"") + &s) + &AverStr::from("\""))
 }
@@ -454,9 +454,9 @@ pub fn quoteString(s: AverStr) -> AverStr {
 /// Build list repr recursively.
 #[inline(always)]
 pub fn valListRepr(
-    mut items: aver_rt::AverList<Val>,
-    mut acc: AverStr,
-    mut first: bool,
+    mut items @ _: aver_rt::AverList<Val>,
+    mut acc @ _: AverStr,
+    mut first @ _: bool,
 ) -> AverStr {
     loop {
         crate::cancel_checkpoint();
@@ -481,7 +481,7 @@ pub fn valListRepr(
 }
 
 /// Display representation of a runtime value.
-pub fn valRepr(v: &Val) -> AverStr {
+pub fn valRepr(v @ _: &Val) -> AverStr {
     crate::cancel_checkpoint();
     match v.clone() {
         crate::aver_generated::domain::value::Val::ValInt(n) => (n.to_string()).into_aver(),
@@ -635,7 +635,7 @@ pub fn valRepr(v: &Val) -> AverStr {
 }
 
 /// Display representation for nested values. Strings are quoted inside containers and wrappers.
-pub fn valReprInner(v: &Val) -> AverStr {
+pub fn valReprInner(v @ _: &Val) -> AverStr {
     crate::cancel_checkpoint();
     match v.clone() {
         crate::aver_generated::domain::value::Val::ValStr(s) => {
@@ -695,9 +695,9 @@ pub fn valReprInner(v: &Val) -> AverStr {
 /// Build a stable map repr close to the host interpreter output.
 #[inline(always)]
 pub fn valMapRepr(
-    mut entries: aver_rt::AverList<(AverStr, Val)>,
-    mut acc: AverStr,
-    mut first: bool,
+    mut entries @ _: aver_rt::AverList<(AverStr, Val)>,
+    mut acc @ _: AverStr,
+    mut first @ _: bool,
 ) -> AverStr {
     loop {
         crate::cancel_checkpoint();
@@ -722,7 +722,7 @@ pub fn valMapRepr(
 }
 
 /// Stable repr for map keys. Keeps common scalar keys off the general valRepr path.
-pub fn mapKeyRepr(v: &Val) -> AverStr {
+pub fn mapKeyRepr(v @ _: &Val) -> AverStr {
     crate::cancel_checkpoint();
     match v.clone() {
         crate::aver_generated::domain::value::Val::ValInt(n) => (n.to_string()).into_aver(),
@@ -734,7 +734,7 @@ pub fn mapKeyRepr(v: &Val) -> AverStr {
 }
 
 /// Display a variant value using its full name.
-pub fn valVariantReprTagged(fullName: AverStr, fields: &aver_rt::AverList<Val>) -> AverStr {
+pub fn valVariantReprTagged(fullName @ _: AverStr, fields @ _: &aver_rt::AverList<Val>) -> AverStr {
     crate::cancel_checkpoint();
     {
         let __list_subject = fields;
@@ -775,9 +775,9 @@ pub fn valVariantReprTagged(fullName: AverStr, fields: &aver_rt::AverList<Val>) 
 /// Build comma-separated repr of variant fields.
 #[inline(always)]
 pub fn valFieldsRepr(
-    mut items: aver_rt::AverList<Val>,
-    mut acc: AverStr,
-    mut first: bool,
+    mut items @ _: aver_rt::AverList<Val>,
+    mut acc @ _: AverStr,
+    mut first @ _: bool,
 ) -> AverStr {
     loop {
         crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/entry/mod.rs
+++ b/src/self_host/aver_generated/entry/mod.rs
@@ -38,15 +38,20 @@ enum __MutualTco1 {
 
 fn __mutual_tco_trampoline_1(
     mut __state: __MutualTco1,
-    __str_index: &aver_rt::StringIndex,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     loop {
         __state = match __state {
-            __MutualTco1::QualifyFns__indexed(mut fns, mut prefix, mut acc) => {
+            __MutualTco1::QualifyFns__indexed(mut fns @ _, mut prefix @ _, mut acc @ _) => {
                 crate::cancel_checkpoint();
                 aver_list_match!(fns, [] => { return acc.reverse() }, [f, rest] => __MutualTco1::QualifyFnsOne__indexed(f, rest, prefix, acc))
             }
-            __MutualTco1::QualifyFnsOne__indexed(mut f, mut rest, mut prefix, mut acc) => {
+            __MutualTco1::QualifyFnsOne__indexed(
+                mut f @ _,
+                mut rest @ _,
+                mut prefix @ _,
+                mut acc @ _,
+            ) => {
                 crate::cancel_checkpoint();
                 let qualified @ _ = crate::aver_generated::domain::ast::FnDef {
                     name: ((prefix.clone() + &AverStr::from(".")) + &f.name),
@@ -69,10 +74,10 @@ fn __mutual_tco_trampoline_1(
 
 /// Synthesized indexed worker of `qualifyFns`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn qualifyFns__indexed(
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    prefix: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    __str_index: &aver_rt::StringIndex,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prefix @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     __mutual_tco_trampoline_1(
         __MutualTco1::QualifyFns__indexed(fns.clone(), prefix, acc.clone()),
@@ -82,11 +87,11 @@ pub fn qualifyFns__indexed(
 
 /// Synthesized indexed worker of `qualifyFnsOne`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn qualifyFnsOne__indexed(
-    f: &crate::aver_generated::domain::ast::FnDef,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    prefix: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    __str_index: &aver_rt::StringIndex,
+    f @ _: &crate::aver_generated::domain::ast::FnDef,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prefix @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     __mutual_tco_trampoline_1(
         __MutualTco1::QualifyFnsOne__indexed(f.clone(), rest.clone(), prefix, acc.clone()),
@@ -95,11 +100,11 @@ pub fn qualifyFnsOne__indexed(
 }
 
 /// Lex, parse, resolve, and evaluate an Aver source string (no module loading).
-pub fn run(source: AverStr) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
+pub fn run(source @ _: AverStr) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let tokens @ _ = crate::aver_generated::domain::lexer::lex(source);
     let prog @ _ = crate::aver_generated::domain::parser::parse(&tokens)?;
-    let resolved @ _ = crate::aver_generated::domain::resolver::resolveProgram(&prog);
+    let resolved @ _ = crate::aver_generated::domain::resolver::resolveProgram(prog);
     runGuestProgram(
         &resolved,
         &aver_rt::AverList::empty(),
@@ -109,8 +114,8 @@ pub fn run(source: AverStr) -> Result<crate::aver_generated::domain::value::Val,
 
 /// Lex, parse, resolve, load modules, and evaluate.
 pub fn runWithModules(
-    source: AverStr,
-    moduleRoot: AverStr,
+    source @ _: AverStr,
+    moduleRoot @ _: AverStr,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let prepared @ _ = prepareProgramWithModules(source, moduleRoot)?;
@@ -122,8 +127,8 @@ pub fn runWithModules(
 
 /// Lex, parse, resolve, load modules, and return a guest program ready for execution.
 pub fn prepareProgramWithModules(
-    source: AverStr,
-    moduleRoot: AverStr,
+    source @ _: AverStr,
+    moduleRoot @ _: AverStr,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Program,
@@ -134,7 +139,7 @@ pub fn prepareProgramWithModules(
     crate::cancel_checkpoint();
     let tokens @ _ = crate::aver_generated::domain::lexer::lex(source);
     let prog @ _ = crate::aver_generated::domain::parser::parse(&tokens)?;
-    let resolved @ _ = crate::aver_generated::domain::resolver::resolveProgram(&prog);
+    let resolved @ _ = crate::aver_generated::domain::resolver::resolveProgram(prog);
     let r @ _ = loadModules(
         resolved.deps.clone(),
         moduleRoot,
@@ -149,23 +154,26 @@ pub fn prepareProgramWithModules(
 
 /// Execute an already-loaded guest program. guestArgs marks the guest input boundary for scoped replay and policy in generated Rust.
 pub fn runGuestProgram(
-    prog: &crate::aver_generated::domain::ast::Program,
-    moduleFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    guestArgs: &aver_rt::AverList<AverStr>,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    moduleFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    guestArgs @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::evalProgramWithFns(
-        &shiftFnIdsInProgram(prog, aver_rt::AverInt::from_i64(moduleFns.len() as i64)),
+        &shiftFnIdsInProgram(
+            prog.clone(),
+            aver_rt::AverInt::from_i64(moduleFns.len() as i64),
+        ),
         moduleFns,
     )
 }
 
 /// Execute a loaded guest program with CLI-compatible main semantics inside the guest boundary. Returns the user main()'s return Val so the replay scope can serialise it as recording.output (and replay-mode output comparison sees the live value), instead of dropping it to Unit before the wrapping aver_replay scope captures the result.
 pub fn runGuestCliProgram(
-    prog: &crate::aver_generated::domain::ast::Program,
-    moduleFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    localFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    guestArgs: &aver_rt::AverList<AverStr>,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    moduleFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    localFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    guestArgs @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     let __replay_input = aver_replay::ReplayValue::to_replay_json(guestArgs);
     aver_replay::with_guest_scope_args_result(
@@ -190,10 +198,10 @@ pub fn runGuestCliProgram(
 
 /// Load all module dependencies, skipping already-loaded modules.
 pub fn loadModules(
-    mut deps: aver_rt::AverList<AverStr>,
-    mut moduleRoot: AverStr,
-    acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    loaded: aver_rt::AverMap<AverStr, bool>,
+    mut deps @ _: aver_rt::AverList<AverStr>,
+    mut moduleRoot @ _: AverStr,
+    acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    loaded @ _: aver_rt::AverMap<AverStr, bool>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
@@ -201,8 +209,8 @@ pub fn loadModules(
     ),
     AverStr,
 > {
-    let acc = std::sync::Arc::new(acc);
-    let loaded = std::sync::Arc::new(loaded);
+    let acc @ _ = std::sync::Arc::new(acc);
+    let loaded @ _ = std::sync::Arc::new(loaded);
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(deps, [] => { return Ok(((*acc).clone(), (*loaded).clone())); }, [dep, rest] => { if loaded.contains_key(&dep) { {
@@ -215,11 +223,11 @@ pub fn loadModules(
 
 /// Load one module. Tries moduleRoot, then parent dirs up to 3 levels.
 pub fn loadOneModule(
-    dep: AverStr,
-    rest: &aver_rt::AverList<AverStr>,
-    moduleRoot: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    loaded: &aver_rt::AverMap<AverStr, bool>,
+    dep @ _: AverStr,
+    rest @ _: &aver_rt::AverList<AverStr>,
+    moduleRoot @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    loaded @ _: &aver_rt::AverMap<AverStr, bool>,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
@@ -239,14 +247,14 @@ pub fn loadOneModule(
 }
 
 /// Find module file, trying root then parent dirs.
-pub fn findModulePath(dep: AverStr, root: AverStr, depth: aver_rt::AverInt) -> AverStr {
+pub fn findModulePath(dep @ _: AverStr, root @ _: AverStr, depth @ _: aver_rt::AverInt) -> AverStr {
     crate::cancel_checkpoint();
     findModulePath__indexed(dep.clone(), root, depth, aver_rt::string_index_build(&dep))
 }
 
 /// Convert Module.Name to file path: Domain.Foo -> domain/foo.av
 #[inline(always)]
-pub fn modulePathFromName(name: AverStr, moduleRoot: AverStr) -> AverStr {
+pub fn modulePathFromName(name @ _: AverStr, moduleRoot @ _: AverStr) -> AverStr {
     crate::cancel_checkpoint();
     modulePathFromName__indexed(
         name.clone(),
@@ -258,10 +266,10 @@ pub fn modulePathFromName(name: AverStr, moduleRoot: AverStr) -> AverStr {
 /// Replace dots with slashes and lowercase first char of each segment.
 #[inline(always)]
 pub fn dotToSlash(
-    name: AverStr,
-    pos: aver_rt::AverInt,
-    total: aver_rt::AverInt,
-    acc: AverStr,
+    name @ _: AverStr,
+    pos @ _: aver_rt::AverInt,
+    total @ _: aver_rt::AverInt,
+    acc @ _: AverStr,
 ) -> AverStr {
     crate::cancel_checkpoint();
     dotToSlash__indexed(
@@ -276,9 +284,9 @@ pub fn dotToSlash(
 /// Register functions with both qualified (Domain.Foo.bar) and unqualified (bar) names.
 #[inline(always)]
 pub fn qualifyFns(
-    fns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    prefix: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    fns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prefix @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     crate::cancel_checkpoint();
     qualifyFns__indexed(
@@ -292,10 +300,10 @@ pub fn qualifyFns(
 /// Add both qualified and unqualified versions.
 #[inline(always)]
 pub fn qualifyFnsOne(
-    f: &crate::aver_generated::domain::ast::FnDef,
-    rest: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    prefix: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    f @ _: &crate::aver_generated::domain::ast::FnDef,
+    rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prefix @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     crate::cancel_checkpoint();
     qualifyFnsOne__indexed(
@@ -310,8 +318,8 @@ pub fn qualifyFnsOne(
 /// Duplicate module function names first, then resolve locally so direct-call ids are consistent within that module.
 #[inline(always)]
 pub fn resolveQualifiedModuleFns(
-    prog: &crate::aver_generated::domain::ast::Program,
-    dep: AverStr,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    dep @ _: AverStr,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     crate::cancel_checkpoint();
     resolveQualifiedModuleFns__indexed(prog, dep.clone(), &aver_rt::string_index_build(&dep))
@@ -320,9 +328,9 @@ pub fn resolveQualifiedModuleFns(
 /// Shift module-local direct-call ids so they point into the final combined function store.
 #[inline(always)]
 pub fn shiftFnIdsInFns(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     loop {
         crate::cancel_checkpoint();
@@ -338,8 +346,8 @@ pub fn shiftFnIdsInFns(
 
 /// Shift entry-program direct-call ids before prepending loaded module functions.
 pub fn shiftFnIdsInProgram(
-    prog: &crate::aver_generated::domain::ast::Program,
-    offset: aver_rt::AverInt,
+    mut prog @ _: crate::aver_generated::domain::ast::Program,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Program {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::Program {
@@ -359,8 +367,8 @@ pub fn shiftFnIdsInProgram(
 
 /// Shift all embedded direct-call ids in one function definition.
 pub fn shiftFnIdsInFn(
-    fd: &crate::aver_generated::domain::ast::FnDef,
-    offset: aver_rt::AverInt,
+    fd @ _: &crate::aver_generated::domain::ast::FnDef,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::ast::FnDef {
@@ -380,8 +388,8 @@ pub fn shiftFnIdsInFn(
 
 /// Shift fast-path target ids that were resolved against a module-local function list.
 pub fn shiftFnIdsInFastPath(
-    path: &crate::aver_generated::domain::ast::FnFastPath,
-    offset: aver_rt::AverInt,
+    path @ _: &crate::aver_generated::domain::ast::FnFastPath,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::FnFastPath {
     crate::cancel_checkpoint();
     match path.clone() {
@@ -398,9 +406,9 @@ pub fn shiftFnIdsInFastPath(
 /// Shift direct-call ids through a statement list.
 #[inline(always)]
 pub fn shiftFnIdsInStmts(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Stmt> {
     loop {
         crate::cancel_checkpoint();
@@ -416,8 +424,8 @@ pub fn shiftFnIdsInStmts(
 
 /// Shift direct-call ids in one statement.
 pub fn shiftFnIdsInStmt(
-    stmt: &crate::aver_generated::domain::ast::Stmt,
-    offset: aver_rt::AverInt,
+    stmt @ _: &crate::aver_generated::domain::ast::Stmt,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Stmt {
     crate::cancel_checkpoint();
     match stmt.clone() {
@@ -441,8 +449,8 @@ pub fn shiftFnIdsInStmt(
 
 /// Shift direct-call ids in one expression tree.
 pub fn shiftFnIdsInExpr(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    offset: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -532,8 +540,8 @@ pub fn shiftFnIdsInExpr(
 
 /// Finish shifting direct-call ids through the remaining aggregate forms.
 pub fn shiftFnIdsInExprTail(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    offset: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -608,8 +616,8 @@ pub fn shiftFnIdsInExprTail(
 
 /// Finish shifting direct-call ids through access, call, and match forms.
 pub fn shiftFnIdsInExprCalls(
-    expr: &crate::aver_generated::domain::ast::Expr,
-    offset: aver_rt::AverInt,
+    expr @ _: &crate::aver_generated::domain::ast::Expr,
+    offset @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::Expr {
     crate::cancel_checkpoint();
     match expr.clone() {
@@ -706,9 +714,9 @@ pub fn shiftFnIdsInExprCalls(
 /// Shift direct-call ids in a list of expressions.
 #[inline(always)]
 pub fn shiftFnIdsInExprs(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
     loop {
         crate::cancel_checkpoint();
@@ -725,9 +733,9 @@ pub fn shiftFnIdsInExprs(
 /// Shift direct-call ids in record field expressions.
 #[inline(always)]
 pub fn shiftFnIdsInFields(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
     loop {
         crate::cancel_checkpoint();
@@ -744,9 +752,9 @@ pub fn shiftFnIdsInFields(
 /// Shift direct-call ids in match arm bodies.
 #[inline(always)]
 pub fn shiftFnIdsInArms(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm> {
     loop {
         crate::cancel_checkpoint();
@@ -761,7 +769,7 @@ pub fn shiftFnIdsInArms(
 }
 
 /// Run source and return result representation or error.
-pub fn runRepr(source: AverStr) -> AverStr {
+pub fn runRepr(source @ _: AverStr) -> AverStr {
     crate::cancel_checkpoint();
     match run(source) {
         Ok(val @ _) => crate::aver_generated::domain::value::valRepr(&val),
@@ -780,7 +788,7 @@ pub fn runRepr(source: AverStr) -> AverStr {
 }
 
 /// Read a file and run it through the self-hosted pipeline with module loading.
-pub fn runFile(path: AverStr, moduleRoot: AverStr) -> Result<AverStr, AverStr> {
+pub fn runFile(path @ _: AverStr, moduleRoot @ _: AverStr) -> Result<AverStr, AverStr> {
     crate::cancel_checkpoint();
     match loadProgramFromFile(path, moduleRoot) {
         Ok(pair @ _) => {
@@ -793,8 +801,8 @@ pub fn runFile(path: AverStr, moduleRoot: AverStr) -> Result<AverStr, AverStr> {
 
 /// Turn a loaded guest program into a representation string.
 pub fn runFileLoaded(
-    prog: &crate::aver_generated::domain::ast::Program,
-    moduleFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    moduleFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> Result<AverStr, AverStr> {
     crate::cancel_checkpoint();
     match runGuestProgram(prog, moduleFns, &aver_rt::AverList::empty()) {
@@ -805,8 +813,8 @@ pub fn runFileLoaded(
 
 /// Read a file and prepare the guest program plus loaded modules.
 pub fn loadProgramFromFile(
-    path: AverStr,
-    moduleRoot: AverStr,
+    path @ _: AverStr,
+    moduleRoot @ _: AverStr,
 ) -> Result<
     (
         crate::aver_generated::domain::ast::Program,
@@ -840,8 +848,8 @@ pub fn loadProgramFromFile(
 
 /// Dispatch normalized CLI args: path, module root, then guest args. Carries the user main()'s return Val up so the wrapping replay scope serialises it as recording.output.
 pub fn runFromFileWithRest(
-    path: AverStr,
-    rest: &aver_rt::AverList<AverStr>,
+    path @ _: AverStr,
+    rest @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     aver_list_match!(rest.clone(), [] => runCliFile(path, AverStr::from("."), &aver_rt::AverList::empty()), [moduleRoot, guestArgs] => runCliFile(path, moduleRoot, &guestArgs))
@@ -849,9 +857,9 @@ pub fn runFromFileWithRest(
 
 /// Load a guest file outside scope, then execute the guest program inside the guest boundary. Propagates the user main()'s return Val unchanged.
 pub fn runCliFile(
-    path: AverStr,
-    moduleRoot: AverStr,
-    guestArgs: &aver_rt::AverList<AverStr>,
+    path @ _: AverStr,
+    moduleRoot @ _: AverStr,
+    guestArgs @ _: &aver_rt::AverList<AverStr>,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     let prepared @ _ = loadProgramFromFile(path, moduleRoot)?;
@@ -864,8 +872,8 @@ pub fn runCliFile(
 /// Mirror host CLI semantics: surface user main() Result.Err as process failure, but otherwise propagate the live return Val so replay-mode output comparison sees the actual value (recording.output stores the serialised Val, replay re-serialises and compares — dropping to Unit here would force every recording to claim Unit-output, masking real divergence).
 #[inline(always)]
 pub fn finishCliRun(
-    localFns: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    result: &crate::aver_generated::domain::value::Val,
+    localFns @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    result @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     if hasLocalMain(localFns.clone()) {
@@ -877,7 +885,7 @@ pub fn finishCliRun(
 
 /// Convert a guest main() return value into CLI success or failure. Successful returns propagate the live Val so the replay scope can serialise it as recording.output.
 pub fn finishCliMainResult(
-    result: &crate::aver_generated::domain::value::Val,
+    result @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match result.clone() {
@@ -892,7 +900,9 @@ pub fn finishCliMainResult(
 
 /// Check whether the entry program defines its own main().
 #[inline(always)]
-pub fn hasLocalMain(mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>) -> bool {
+pub fn hasLocalMain(
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+) -> bool {
     loop {
         crate::cancel_checkpoint();
         aver_list_match!(fns, [] => { return false; }, [f, rest] => { if (&*f.name == "main") { return true; } else { {
@@ -904,7 +914,7 @@ pub fn hasLocalMain(mut fns: aver_rt::AverList<crate::aver_generated::domain::as
 }
 
 /// Print unless the result is Unit.
-pub fn printIfNotUnit(s: AverStr) -> () {
+pub fn printIfNotUnit(s @ _: AverStr) -> () {
     crate::cancel_checkpoint();
     if (&*s == "()") {
         {
@@ -1160,12 +1170,12 @@ pub fn runDemo() -> Result<(), AverStr> {
 
 /// Synthesized indexed worker of `loadOneModule`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn loadOneModule__indexed(
-    dep: AverStr,
-    rest: &aver_rt::AverList<AverStr>,
-    moduleRoot: AverStr,
-    acc: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    loaded: &aver_rt::AverMap<AverStr, bool>,
-    __str_index: &aver_rt::StringIndex,
+    dep @ _: AverStr,
+    rest @ _: &aver_rt::AverList<AverStr>,
+    moduleRoot @ _: AverStr,
+    acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    loaded @ _: &aver_rt::AverMap<AverStr, bool>,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> Result<
     (
         aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
@@ -1227,12 +1237,12 @@ pub fn loadOneModule__indexed(
 
 /// Synthesized indexed worker of `findModulePath`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn findModulePath__indexed(
-    mut dep: AverStr,
-    mut root: AverStr,
-    mut depth: aver_rt::AverInt,
-    __str_index: aver_rt::StringIndex,
+    mut dep @ _: AverStr,
+    mut root @ _: AverStr,
+    mut depth @ _: aver_rt::AverInt,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> AverStr {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         let path @ _ = modulePathFromName__indexed(dep.clone(), root.clone(), &*__str_index);
@@ -1275,9 +1285,9 @@ pub fn findModulePath__indexed(
 
 /// Synthesized indexed worker of `modulePathFromName`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn modulePathFromName__indexed(
-    name: AverStr,
-    moduleRoot: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    name @ _: AverStr,
+    moduleRoot @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> AverStr {
     crate::cancel_checkpoint();
     (((moduleRoot + &AverStr::from("/"))
@@ -1294,13 +1304,13 @@ pub fn modulePathFromName__indexed(
 /// Synthesized indexed worker of `dotToSlash`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 #[inline(always)]
 pub fn dotToSlash__indexed(
-    mut name: AverStr,
-    mut pos: aver_rt::AverInt,
-    mut total: aver_rt::AverInt,
-    mut acc: AverStr,
-    __str_index: aver_rt::StringIndex,
+    mut name @ _: AverStr,
+    mut pos @ _: aver_rt::AverInt,
+    mut total @ _: aver_rt::AverInt,
+    mut acc @ _: AverStr,
+    __str_index @ _: aver_rt::StringIndex,
 ) -> AverStr {
-    let __str_index = std::sync::Arc::new(__str_index);
+    let __str_index @ _ = std::sync::Arc::new(__str_index);
     loop {
         crate::cancel_checkpoint();
         let nextPos @ _ = pos.add(&aver_rt::AverInt::from_i64(1));
@@ -1337,9 +1347,9 @@ pub fn dotToSlash__indexed(
 
 /// Synthesized indexed worker of `resolveQualifiedModuleFns`. Its hidden String.Index is built by the ABI-preserving wrapper and forwarded through the recursive string-flow component.
 pub fn resolveQualifiedModuleFns__indexed(
-    prog: &crate::aver_generated::domain::ast::Program,
-    dep: AverStr,
-    __str_index: &aver_rt::StringIndex,
+    prog @ _: &crate::aver_generated::domain::ast::Program,
+    dep @ _: AverStr,
+    __str_index @ _: &aver_rt::StringIndex,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     crate::cancel_checkpoint();
     let qualifiedProg @ _ = crate::aver_generated::domain::ast::Program {
@@ -1347,15 +1357,15 @@ pub fn resolveQualifiedModuleFns__indexed(
         fns: qualifyFns__indexed(&prog.fns, dep, &aver_rt::AverList::empty(), __str_index),
         stmts: prog.stmts.clone(),
     };
-    crate::aver_generated::domain::resolver::resolveProgram(&qualifiedProg).fns
+    crate::aver_generated::domain::resolver::resolveProgram(qualifiedProg).fns
 }
 
 /// Synthesized collecting variant of `shiftFnIdsInFns`. Appends to a builder where `shiftFnIdsInFns` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn shiftFnIdsInFns__collected(
-    mut fns: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut fns @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::FnDef>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::FnDef> {
     loop {
         crate::cancel_checkpoint();
@@ -1372,9 +1382,9 @@ pub fn shiftFnIdsInFns__collected(
 /// Synthesized collecting variant of `shiftFnIdsInStmts`. Appends to a builder where `shiftFnIdsInStmts` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn shiftFnIdsInStmts__collected(
-    mut stmts: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut stmts @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Stmt> {
     loop {
         crate::cancel_checkpoint();
@@ -1391,9 +1401,9 @@ pub fn shiftFnIdsInStmts__collected(
 /// Synthesized collecting variant of `shiftFnIdsInExprs`. Appends to a builder where `shiftFnIdsInExprs` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn shiftFnIdsInExprs__collected(
-    mut exprs: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut exprs @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::Expr>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::Expr> {
     loop {
         crate::cancel_checkpoint();
@@ -1410,9 +1420,9 @@ pub fn shiftFnIdsInExprs__collected(
 /// Synthesized collecting variant of `shiftFnIdsInFields`. Appends to a builder where `shiftFnIdsInFields` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn shiftFnIdsInFields__collected(
-    mut fields: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut fields @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)>,
 ) -> aver_rt::AverList<(AverStr, crate::aver_generated::domain::ast::Expr)> {
     loop {
         crate::cancel_checkpoint();
@@ -1429,9 +1439,9 @@ pub fn shiftFnIdsInFields__collected(
 /// Synthesized collecting variant of `shiftFnIdsInArms`. Appends to a builder where `shiftFnIdsInArms` prepends to `acc` and reverses on the way out, which reaches the same list without the cons chain or the reversal. Call sites that start the accumulator at `[]` are moved here.
 #[inline(always)]
 pub fn shiftFnIdsInArms__collected(
-    mut arms: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    mut offset: aver_rt::AverInt,
-    mut acc: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut arms @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
+    mut offset @ _: aver_rt::AverInt,
+    mut acc @ _: aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm> {
     loop {
         crate::cancel_checkpoint();

--- a/src/types/map.rs
+++ b/src/types/map.rs
@@ -320,7 +320,7 @@ pub(crate) fn set_nv_owned(
             // A fresh entry nobody has been handed. The table it carries came
             // out of a slot the caller proved nothing else reaches, so nothing
             // reaches this one either until somebody stores it.
-            held_elsewhere: false,
+            holder_count: 0,
         },
         source,
     );
@@ -366,7 +366,7 @@ pub fn remove_nv_owned(args: &[NanValue], arena: &mut Arena) -> Result<NanValue,
             all_immediate,
             scan_receipt,
             pending_scan_keys,
-            held_elsewhere: false,
+            holder_count: 0,
         },
         source,
     );
@@ -723,7 +723,7 @@ mod tests {
             all_immediate: false,
             scan_receipt: 0,
             pending_scan_keys: Vec::new(),
-            held_elsewhere: false,
+            holder_count: 0,
         }));
         let proof = frame_proof(&arena);
         assert_eq!(

--- a/src/types/vector.rs
+++ b/src/types/vector.rs
@@ -120,7 +120,7 @@ pub fn vec_set_nv_owned(args: &[NanValue], arena: &mut Arena) -> Result<NanValue
     let new_vec_idx = arena.push_inheriting_source_space(
         aver_memory::ArenaEntry::Vector {
             items,
-            held_elsewhere: false,
+            holder_count: 0,
         },
         source,
     );

--- a/src/vm/compiler/mir.rs
+++ b/src/vm/compiler/mir.rs
@@ -500,14 +500,21 @@ pub(super) fn compile_mir_expr(
         // ── Phase 4c: record field access ───────────────────────
         MirExpr::Project(spanned_proj) => {
             let p = &spanned_proj.node;
-            // RECORD_GET_NAMED is the universal path — VM resolves
-            // the field by symbol id at runtime. The HIR walker
-            // sometimes specializes to RECORD_GET when it can
-            // infer field index statically; that's a Phase 6
-            // optimization we skip here.
+            // A direct last read moves the record local onto the operand stack.
+            // RECORD_TAKE_NAMED can then remove the field when runtime alias
+            // checks confirm that the moved handle was unique. Every other
+            // projection stays non-destructive.
+            let take_last_field = matches!(
+                p.base.node,
+                MirExpr::Local(ref local) if local.node.last_use
+            );
             compile_mir_expr(fc, &p.base)?;
             let field_symbol_id = fc.symbols.intern_name(&p.field);
-            fc.emit_op(RECORD_GET_NAMED);
+            fc.emit_op(if take_last_field {
+                RECORD_TAKE_NAMED
+            } else {
+                RECORD_GET_NAMED
+            });
             fc.emit_u32(field_symbol_id);
             Ok(())
         }

--- a/src/vm/execute/dispatch.rs
+++ b/src/vm/execute/dispatch.rs
@@ -1722,18 +1722,26 @@ impl VM {
                     }
                 }
 
-                RECORD_GET_NAMED => {
+                RECORD_GET_NAMED | RECORD_TAKE_NAMED => {
                     let field_symbol_id = read_u32!(code, ip);
 
                     let record = self.stack.pop().ok_or(VmError::StackUnderflow)?;
                     if record.is_record() {
-                        let (type_id, fields) = self.arena.get_record(record.arena_index());
+                        let (type_id, _) = self.arena.get_record(record.arena_index());
                         if let Some(&field_idx) = self
                             .code
                             .record_field_slots
                             .get(&(type_id, field_symbol_id))
                         {
-                            self.stack.push(fields[field_idx as usize]);
+                            let can_take = op == RECORD_TAKE_NAMED
+                                && !self.arena.record_is_held_elsewhere(record)
+                                && self.slot_is_unheld(record);
+                            let value = if can_take {
+                                self.arena.take_record_field(record, field_idx as usize)
+                            } else {
+                                self.arena.get_record(record.arena_index()).1[field_idx as usize]
+                            };
+                            self.stack.push(value);
                         } else {
                             let field_name = self
                                 .code

--- a/src/vm/execute/tests.rs
+++ b/src/vm/execute/tests.rs
@@ -663,6 +663,96 @@ fn map_build_cost(
     }
 }
 
+/// The record-wrapped spelling from issue #1160. The map accumulator is still
+/// linear, but it crosses the helper boundary as one field of `Store` and the
+/// helper returns a fresh `Store` around its successor.
+fn record_map_build_cost(n: i64) -> MapBuildCost {
+    let src = format!(
+        "record Store\n    held: Map<String, String>\n\nfn put(store: Store, key: String) -> Store\n    Store(held = Map.set(store.held, key, \"value-{{key}}\"))\n\nfn build(n: Int, store: Store) -> Store\n    match n > 0\n        true -> build(n - 1, put(store, \"key-{{n}}\"))\n        false -> store\n\nfn main() -> Int\n    Map.len(build({n}, Store(held = {{}})).held)\n"
+    );
+    let mut vm = compile_vm_typechecked(&src);
+    let result = vm
+        .run()
+        .expect("record-wrapped map build program should run");
+    assert_eq!(result.as_int(&vm.arena), n);
+    MapBuildCost {
+        copied: vm.arena.map_entries_copied(),
+        scanned: vm.arena.map_entries_scanned(),
+    }
+}
+
+#[test]
+fn a_map_threaded_through_a_returned_record_is_not_copied_per_insert() {
+    let small = record_map_build_cost(200);
+    let large = record_map_build_cost(400);
+
+    assert_eq!(
+        (small.copied, large.copied),
+        (0, 0),
+        "a linear map hidden in a returned record was preserved rather than consumed: \
+         n=200 copied {}, n=400 copied {} entries",
+        small.copied,
+        large.copied,
+    );
+    assert!(
+        large.scanned <= 3 * small.scanned + 400,
+        "record-wrapped Map.set did not scale linearly: n=200 scanned {}, \
+         n=400 scanned {} entries",
+        small.scanned,
+        large.scanned,
+    );
+}
+
+fn run_record_alias_case(main_body: &str) -> i64 {
+    let src = format!(
+        "record Store\n    held: Map<String, Int>\n\nrecord Holder\n    store: Store\n\nfn put(store: Store, key: String, value: Int) -> Store\n    Store(held = Map.set(store.held, key, value))\n\nfn firstSize(stores: List<Store>) -> Int\n    match stores\n        [] -> 0\n        [head, .._] -> Map.len(head.held)\n\nfn main() -> Int\n{main_body}\n"
+    );
+    let mut vm = compile_vm_typechecked(&src);
+    let value = vm.run().expect("record alias case should run");
+    value.as_int(&vm.arena)
+}
+
+#[test]
+fn taking_a_record_field_preserves_a_separate_map_alias() {
+    let result = run_record_alias_case(
+        "    base = Map.set({}, \"old\", 1)\n    store = Store(held = base)\n    newer = put(store, \"new\", 2)\n    Map.len(base) * 10 + Map.len(newer.held)",
+    );
+    assert_eq!(result, 12, "Map.set mutated the map still named by `base`");
+}
+
+#[test]
+fn taking_a_record_field_preserves_a_separate_record_alias() {
+    let result = run_record_alias_case(
+        "    store = Store(held = Map.set({}, \"old\", 1))\n    alias = store\n    newer = put(store, \"new\", 2)\n    Map.len(alias.held) * 10 + Map.len(newer.held)",
+    );
+    assert_eq!(
+        result, 12,
+        "Map.set mutated the map reachable through `alias`"
+    );
+}
+
+#[test]
+fn taking_a_record_field_preserves_a_record_stored_in_an_aggregate() {
+    let result = run_record_alias_case(
+        "    store = Store(held = Map.set({}, \"old\", 1))\n    holder = Holder(store = store)\n    newer = put(store, \"new\", 2)\n    Map.len(holder.store.held) * 10 + Map.len(newer.held)",
+    );
+    assert_eq!(
+        result, 12,
+        "Map.set mutated the map reachable through an enclosing record"
+    );
+}
+
+#[test]
+fn taking_a_record_field_preserves_a_record_stored_in_a_list() {
+    let result = run_record_alias_case(
+        "    store = Store(held = Map.set({}, \"old\", 1))\n    aliases = [store]\n    newer = put(store, \"new\", 2)\n    firstSize(aliases) * 10 + Map.len(newer.held)",
+    );
+    assert_eq!(
+        result, 12,
+        "Map.set mutated the map reachable through a list-held record"
+    );
+}
+
 /// The string-keyed fold from issue #900 at size `n`, seeded from a `seed` that
 /// already holds `seed_entries` keys none of the fold's own keys collide with.
 fn map_build_copies(n: i64, seed: &str, seed_entries: i64) -> u64 {

--- a/src/vm/opcode.rs
+++ b/src/vm/opcode.rs
@@ -212,6 +212,11 @@ pub const RECORD_GET: u8 = 0x64; // field_idx:u8
 /// Pop record, lookup field by interned field symbol, push value.
 pub const RECORD_GET_NAMED: u8 = 0x67; // field_symbol_id:u32
 
+/// Pop record and push its named field. When the record has no stack or
+/// off-stack aliases, remove the field from the record and release that
+/// holder; otherwise behave exactly like `RECORD_GET_NAMED`.
+pub const RECORD_TAKE_NAMED: u8 = 0x6C; // field_symbol_id:u32
+
 /// Pop `count` field values, push a new variant.
 pub const VARIANT_NEW: u8 = 0x65; // type_id:u16, variant_id:u16, count:u8
 
@@ -245,7 +250,7 @@ pub const PROPAGATE_ERR: u8 = 0x6A;
 /// Pop list, push its length as Int.
 pub const LIST_LEN: u8 = 0x6B;
 
-// 0x6C and 0x6D were LIST_GET and LIST_APPEND — removed.
+// 0x6D was LIST_APPEND — removed.
 
 /// Pop list, pop value, push prepended list.
 pub const LIST_PREPEND: u8 = 0x6E;
@@ -638,6 +643,7 @@ pub fn opcode_name(op: u8) -> &'static str {
         STORE_GLOBAL => "STORE_GLOBAL",
         RECORD_GET => "RECORD_GET",
         RECORD_GET_NAMED => "RECORD_GET_NAMED",
+        RECORD_TAKE_NAMED => "RECORD_TAKE_NAMED",
         VARIANT_NEW => "VARIANT_NEW",
         WRAP => "WRAP",
         TUPLE_NEW => "TUPLE_NEW",
@@ -809,7 +815,7 @@ pub fn opcode_operand_width(op: u8, code: &[u8], ip: usize) -> usize {
         CALL_KNOWN_OWNED | TAIL_CALL_KNOWN => 4, // fn_id:u16 + argc:u8 + owned:u8
 
         // 4-byte
-        MATCH_VARIANT | RECORD_GET_NAMED | LIST_NEW | TUPLE_NEW => 4,
+        MATCH_VARIANT | RECORD_GET_NAMED | RECORD_TAKE_NAMED | LIST_NEW | TUPLE_NEW => 4,
 
         // 5-byte
         CALL_BUILTIN | VARIANT_NEW => 5,

--- a/tests/fixtures/rust_map_helper_return.av
+++ b/tests/fixtures/rust_map_helper_return.av
@@ -35,11 +35,21 @@ fn setStoreOne(key: String, store: Store) -> Result<Store, String>
     ? "Insert one value into the Map carried by Store."
     Result.Ok(Store.update(store, values = Map.set(store.values, key, "v")))
 
+fn setStoreOneCreate(key: String, store: Store) -> Store
+    ? "Insert one value and rebuild Store with its record constructor."
+    Store(values = Map.set(store.values, key, "v"))
+
 fn viaStore(keys: List<String>, store: Store) -> Result<Store, String>
     ? "Build a Store through a Result-returning helper."
     match keys
         [] -> Result.Ok(store)
         [head, ..tail] -> viaStore(tail, setStoreOne(head, store)?)
+
+fn viaStoreCreate(keys: List<String>, store: Store) -> Store
+    ? "Build a Store through a record-constructing helper."
+    match keys
+        [] -> store
+        [head, ..tail] -> viaStoreCreate(tail, setStoreOneCreate(head, store))
 
 fn storeCount() -> Result<Int, String>
     ? "Count the Map built through the Store wrapper."
@@ -51,4 +61,13 @@ fn main() -> Unit
     bare = Map.len(viaHelper(["a", "b", "c"], {}))
     wrapped = Result.withDefault(resultCount(), 0)
     stored = Result.withDefault(storeCount(), 0)
-    Console.print("{bare}/{wrapped}/{stored}")
+    created = Map.len(viaStoreCreate(["a", "b", "c"], Store(values = {})).values)
+    base = Map.set({}, "old", "v")
+    fromMapAlias = setStoreOneCreate("new", Store(values = base))
+    mapAlias = Map.len(base) * 10 + Map.len(fromMapAlias.values)
+    shared = Map.set({}, "old", "v")
+    storeAlias = Store(values = shared)
+    originalStore = Store(values = shared)
+    fromStoreAlias = setStoreOneCreate("new", originalStore)
+    recordAlias = Map.len(storeAlias.values) * 10 + Map.len(fromStoreAlias.values)
+    Console.print("{bare}/{wrapped}/{stored}/{created}/{mapAlias}/{recordAlias}")

--- a/tests/mir_vm_codegen.rs
+++ b/tests/mir_vm_codegen.rs
@@ -371,12 +371,23 @@ fn builtin_ctor_emits_wrap() {
 }
 
 #[test]
-fn record_field_access_emits_record_get_named() {
-    // `MirExpr::Project` → RECORD_GET_NAMED. (Field access on a param,
-    // so no RecordCreate in the body.)
+fn last_use_record_field_access_emits_record_take_named() {
+    // A final projection can transfer the field out of the record. Runtime
+    // ownership checks make the opcode fall back to a non-destructive read
+    // when another alias still exists.
     assert_emits(
         "record P\n  x: Int\n  y: Int\n\nfn px(p: P) -> Int\n    p.x\n",
         "px",
+        opcode::RECORD_TAKE_NAMED,
+        "RECORD_TAKE_NAMED",
+    );
+}
+
+#[test]
+fn nonfinal_record_field_access_keeps_record_get_named() {
+    assert_emits(
+        "record P\n  x: Int\n  y: Int\n\nfn sum(p: P) -> Int\n    p.x + p.y\n",
+        "sum",
         opcode::RECORD_GET_NAMED,
         "RECORD_GET_NAMED",
     );

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -2599,7 +2599,7 @@ fn rust_map_helper_result_preserves_the_owned_move() {
     let _ = fs::remove_dir_all(&ws);
 
     assert!(
-        emitted.contains("pub fn setOne(key: AverStr, mut into: aver_rt::AverMap"),
+        emitted.contains("pub fn setOne(key @ _: AverStr, mut into @ _: aver_rt::AverMap"),
         "setOne must take its Map by value after return-alias analysis:\n{emitted}"
     );
     assert!(
@@ -2611,7 +2611,7 @@ fn rust_map_helper_result_preserves_the_owned_move() {
         "the recursive fold must move its accumulator through setOne:\n{emitted}"
     );
     assert!(
-        emitted.contains("pub fn setOneResult(key: AverStr, mut into: aver_rt::AverMap"),
+        emitted.contains("pub fn setOneResult(key @ _: AverStr, mut into @ _: aver_rt::AverMap"),
         "the Rust-only pass must graduate a Map carried by Result:\n{emitted}"
     );
     assert!(
@@ -2623,7 +2623,7 @@ fn rust_map_helper_result_preserves_the_owned_move() {
         "Result `?` must preserve the owned accumulator move:\n{emitted}"
     );
     assert!(
-        emitted.contains("pub fn setStoreOne(key: AverStr, mut store: Store)"),
+        emitted.contains("pub fn setStoreOne(key @ _: AverStr, mut store @ _: Store)"),
         "a returned Store successor must take the record by value:\n{emitted}"
     );
     assert!(
@@ -2637,6 +2637,22 @@ fn rust_map_helper_result_preserves_the_owned_move() {
     assert!(
         emitted.contains("let __tco1 = setStoreOne(head, store)?;"),
         "the Store fold must move its accumulator through the helper:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("pub fn setStoreOneCreate(key @ _: AverStr, mut store @ _: Store)"),
+        "a constructor-returned Store successor must take the record by value:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("Store { values: store.values.insert_owned(key, AverStr::from(\"v\")) }"),
+        "the constructor must move the Map field out of Store without a forced clone:\n{emitted}"
+    );
+    assert!(
+        !emitted.contains("Store { values: store.values.clone().insert_owned"),
+        "the constructor-wrapped Map path must not force quadratic COW:\n{emitted}"
+    );
+    assert!(
+        emitted.contains("let __tco1 = setStoreOneCreate(head, store);"),
+        "the constructor Store fold must move its accumulator through the helper:\n{emitted}"
     );
 }
 
@@ -4488,7 +4504,7 @@ fn mir_first_class_fn_value_builds_and_matches_vm() {
         compile_rust(&src, &project, name, None, &[])?;
 
         // Structural tripwire: the emitted Rust must carry the fn-pointer
-        // param (`f: fn(aver_rt::AverInt) -> aver_rt::AverInt` — `Int` lowers
+        // param (`f @ _: fn(aver_rt::AverInt) -> aver_rt::AverInt` — `Int` lowers
         // to `AverInt` now), the FnValue passed by bare name
         // (`applyIt(dbl, v)`), and the call-through-slot (`f(v)`). A
         // dropped FnValue or a mis-emitted slot call would erase these.
@@ -4500,10 +4516,10 @@ fn mir_first_class_fn_value_builds_and_matches_vm() {
                 .join("mod.rs"),
         )
         .map_err(|e| format!("read emitted module: {e}"))?;
-        if !emitted.contains("f: fn(aver_rt::AverInt) -> aver_rt::AverInt") {
+        if !emitted.contains("f @ _: fn(aver_rt::AverInt) -> aver_rt::AverInt") {
             return Err(format!(
                 "emitted Rust is missing the fn-pointer param \
-                 `f: fn(aver_rt::AverInt) -> aver_rt::AverInt` — \
+                 `f @ _: fn(aver_rt::AverInt) -> aver_rt::AverInt` — \
                  the LocalSlot param lowering was dropped:\n{emitted}"
             ));
         }
@@ -5116,7 +5132,7 @@ fn main() -> Unit
                 .join("mod.rs"),
         )
         .map_err(|e| format!("read emitted entry module: {e}"))?;
-        if !emitted.contains("f: fn(crate::aver_generated::worker::Shape) -> aver_rt::AverInt")
+        if !emitted.contains("f @ _: fn(crate::aver_generated::worker::Shape) -> aver_rt::AverInt")
             || emitted.contains("Worker_Shape")
         {
             return Err(format!(
@@ -5328,6 +5344,133 @@ fn main() -> Unit
         if rust_stdout != vm_stdout {
             return Err(format!(
                 "dependency-function-let-binder stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
+/// Regression for #1162: a function parameter is a Rust pattern too. Two
+/// dependency glob imports exposing the parameter's name must not make the
+/// signature ambiguous, including signatures synthesized for TCO.
+#[test]
+fn colliding_dependency_function_names_do_not_conflict_with_parameters() {
+    let ws = temp_dir("dependency_function_parameter_collision");
+    for (module, suffix) in [("Alpha", ""), ("Beta", "!")] {
+        fs::write(
+            ws.join(format!("{module}.av")),
+            format!(
+                r#"module {module}
+    exposes [payload]
+    intent = "Expose one of two colliding short function names."
+    effects []
+
+fn payload(value: String) -> String
+    ? "Return this module's payload."
+    "{{value}}{suffix}"
+"#
+            ),
+        )
+        .expect("write dependency module");
+    }
+
+    fs::write(
+        ws.join("Gamma.av"),
+        r#"module Gamma
+    exposes [carried, bounce, ping, pong]
+    depends [Alpha, Beta]
+    intent = "Keep parameter binders distinct from colliding dependency functions."
+    effects []
+
+fn carried(payload: String) -> String
+    ? "Return an ordinary parameter with the colliding name."
+    payload
+
+fn bounce(n: Int, payload: List<Int>) -> List<Int>
+    ? "Carry the colliding parameter through a self tail call."
+    match n > 0
+        true -> bounce(n - 1, payload)
+        false -> payload
+
+fn ping(n: Int, payload: List<Int>) -> List<Int>
+    ? "Carry the colliding parameter through a mutual tail call."
+    match n > 0
+        true -> pong(n - 1, payload)
+        false -> payload
+
+fn pong(n: Int, payload: List<Int>) -> List<Int>
+    ? "Return to ping with the same colliding parameter."
+    match n > 0
+        true -> ping(n - 1, payload)
+        false -> payload
+"#,
+    )
+    .expect("write Gamma module");
+
+    let entry = ws.join("main.av");
+    fs::write(
+        &entry,
+        r#"module Main
+    depends [Gamma]
+    intent = "Reach every parameter-emission shape."
+    effects [Console]
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{Gamma.carried("ok")}/{List.len(Gamma.bounce(1, [1]))}/{List.len(Gamma.ping(1, [1]))}")
+"#,
+    )
+    .expect("write entry module");
+
+    let vm_stdout = run_vm(&entry, Some(&ws)).expect("VM run");
+    assert_eq!(vm_stdout, "ok/1/1", "VM contract changed");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let result = (|| -> Result<(), String> {
+        compile_rust(
+            &entry,
+            &project,
+            "dependency_function_parameter_collision",
+            Some(&ws),
+            &[],
+        )?;
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("gamma")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted Gamma module: {e}"))?;
+        if !emitted.contains("carried(payload @ _: AverStr)") {
+            return Err(format!(
+                "ordinary parameter binder was not made explicit:\n{emitted}"
+            ));
+        }
+        if !emitted.contains("payload @ _: aver_rt::AverIntList") {
+            return Err(format!(
+                "TCO parameter binder was not made explicit:\n{emitted}"
+            ));
+        }
+
+        let bin = cargo_build(&project, "dependency_function_parameter_collision")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("run generated binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "dependency-function-parameter generated binary failed:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "dependency-function-parameter stdout mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
             ));
         }
         Ok(())


### PR DESCRIPTION
Closes #1160.
Closes #1162.

This keeps record-returning collection helpers in the same linear cost class as bare collection helpers. Generated Rust recognizes a record successor whose matching field consumes Map.set/remove, while the VM adds a runtime-checked destructive record projection. Exact arena holder counts and stack-alias checks make that projection fall back to an ordinary read whenever sharing exists.

It also renders every generated Rust function parameter as an explicit binding pattern, including normal, self-TCO, and mutual-TCO paths, so dependency glob imports cannot make parameter names ambiguous.

Measured at 40,000 inserts:
- VM: bare 31.1 ms, record-wrapped 36.1 ms; the issue reproducer was 46.12 s.
- generated Rust: bare 11.8 ms, record-wrapped 8.6 ms; the issue reproducer was 15.66 s.
- deterministic VM counters copy 0 map entries at both 200 and 400 iterations, versus the former 19,900 and 79,800.

Validation:
- cargo test --workspace: 3,645 passed, 26 ignored across 150 suites
- both release clippy lanes, including wasm and wasip2
- self-host regeneration freshness
- cargo fmt and git diff --check