### PR TITLE
Update JSON certificate KPI after Bytes expansion

### DIFF
--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2087,9 +2087,13 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
     // The denominator counts every function in json.wasm that carries no
     // claim. It rose from 90 to 133 when the string-index pass started
     // synthesizing index workers for the parser's recursive `String.charAt`
-    // walks; those workers are compiler-made and have no source-level claim.
+    // walks. The Bytes API expansion then added five ordinary stdlib helpers
+    // (`empty`, `len`, `concat`, `take`, `drop`), while lowering the JSON
+    // parser's `String.firstCodePoint` calls added four `__code` workers. None
+    // of those nine functions carries an artifact claim, so the denominator is
+    // now 142 while the certified numerator remains 12.
     assert!(
-        compile_report.contains("(12 certified, 133 source-level-only)"),
+        compile_report.contains("(12 certified, 142 source-level-only)"),
         "json certificate KPI denominator changed:
 {compile_report}"
     );


### PR DESCRIPTION
Certification's JSON tamper tripwire still expected the pre-#1109 source-level-only denominator.

The increase from 133 to 142 is accounted for exactly: five new Bytes stdlib helpers and four code-point lowering workers. The certified numerator remains 12.

This updates the explicit KPI and documents the nine additions; it does not relax certificate verification or the tamper assertions.

Test: cargo test --locked --features wasm --test cert_verify_spec cert_verify_declines_tampered_array_new_data_operands -- --nocapture (1 passed, 371.69s)