### PR TITLE
Repair nightly fuzz harnesses after dependency preparation refactor

### DIFF
--- a/fuzz/fuzz_targets/codegen_wasip2.rs
+++ b/fuzz/fuzz_targets/codegen_wasip2.rs
@@ -86,7 +86,7 @@ fn main() {
             if let Ok(dep_modules) = aver::source::load_compile_deps(&items, root) {
                 type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
                     &mut items,
-                    &dep_modules,
+                    &dep_modules.modules,
                     &result
                         .typecheck
                         .as_ref()

--- a/fuzz/fuzz_targets/codegen_wasm_gc.rs
+++ b/fuzz/fuzz_targets/codegen_wasm_gc.rs
@@ -105,7 +105,7 @@ fn main() {
             if let Ok(dep_modules) = aver::source::load_compile_deps(&items, root) {
                 type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
                     &mut items,
-                    &dep_modules,
+                    &dep_modules.modules,
                     &result
                         .typecheck
                         .as_ref()

--- a/fuzz/fuzz_targets/parity_vm_vs_wasm_gc.rs
+++ b/fuzz/fuzz_targets/parity_vm_vs_wasm_gc.rs
@@ -259,7 +259,7 @@ fn run_wasm_gc(
             if let Ok(dep_modules) = aver::source::load_compile_deps(items, root) {
                 type_aliases = aver::codegen::wasm_gc::flatten_multimodule(
                     &mut items_flat,
-                    &dep_modules,
+                    &dep_modules.modules,
                     capabilities,
                     aver::codegen::wasm_gc::CapabilityFunctionSurface::Runtime,
                 );
@@ -275,6 +275,7 @@ fn run_wasm_gc(
                     entry_info: None,
                     mode: aver::runtime::wasm_gc::EffectMode::Normal,
                     type_aliases: type_aliases.clone(),
+                    ..Default::default()
                 },
             )
         });


### PR DESCRIPTION
Fixes the three fuzz jobs that failed to compile on main after PreparedCompileDeps replaced the raw module vector. The wasm-gc and wasip2 harnesses now pass prepared.modules to flatten_multimodule, and the parity harness inherits new RunConfig fields through Default.

Verified with cargo check for fuzz_codegen_wasm_gc, fuzz_codegen_wasip2, and fuzz_parity_vm_vs_wasm_gc, plus the fuzz crate format check.