### PR TITLE
Keep exhaustive record ownership audits off the VM hot path

### DIFF
--- a/aver-memory/src/arena.rs
+++ b/aver-memory/src/arena.rs
@@ -1052,10 +1052,11 @@ impl<T: ArenaTypes> Arena<T> {
 
     /// Remove and return one field from a record whose uniqueness the caller
     /// has already established. Removing the direct reference releases exactly
-    /// one registered holder on a nested map, vector, or record.
+    /// one registered holder on a nested map, vector, or record. The hot path
+    /// checks the incremental holder count only; the exhaustive heap-scan
+    /// counterpart belongs in tests because it is `O(live heap)`.
     pub fn take_record_field(&mut self, record: NanValue, field_idx: usize) -> NanValue {
         debug_assert!(!self.record_is_held_elsewhere(record));
-        debug_assert!(!self.any_entry_holds_slot(record.arena_index()));
         let value = match self.get_mut(record.arena_index()) {
             ArenaEntry::Record { fields, .. } => {
                 std::mem::replace(&mut fields[field_idx], NanValue::UNIT)

--- a/aver-memory/src/arena/tests.rs
+++ b/aver-memory/src/arena/tests.rs
@@ -39,6 +39,20 @@ fn taking_record_fields_releases_exactly_the_removed_holders() {
 }
 
 #[test]
+fn record_holder_count_matches_the_exhaustive_audit_after_a_field_take() {
+    let mut arena = TestArena::new();
+    let inner = NanValue::new_record(arena.push_record(1, Vec::new()));
+    let outer = NanValue::new_record(arena.push_record(2, vec![inner]));
+
+    assert!(arena.record_is_held_elsewhere(inner));
+    assert!(arena.any_entry_holds_slot(inner.arena_index()));
+
+    assert_eq!(arena.take_record_field(outer, 0).bits(), inner.bits());
+    assert!(!arena.record_is_held_elsewhere(inner));
+    assert!(!arena.any_entry_holds_slot(inner.arena_index()));
+}
+
+#[test]
 fn lane_receipts_must_not_be_newer_than_the_frame_serial() {
     let mut arena = TestArena::new();
     let early_receipt = arena.lane_mark();


### PR DESCRIPTION
Record field extraction already has an incremental O(1) holder_count check, but also ran the independent any_entry_holds_slot audit on every take under debug assertions. That audit is O(live heap) and its own contract says it must not run in the hot path. Custom-provider verify hosts are debug builds, so record-heavy downstream verification paid a full arena scan per field take.

This keeps the O(1) ownership fence in the runtime path and moves the independent exhaustive comparison into an arena regression test. The new test checks that the recorded count and from-scratch audit agree before and after a destructive field take.

Validation:
- cargo test -p aver-memory: 12 passed
- record alias VM tests: 4 passed
- record-threaded map scaling test: passed
- full btc-listener verify: 137 modules, 2189 blocks, 11752/11752 cases; 66.46 s after the fix versus about 30 minutes before on the same machine. The after measurement includes rebuilding the custom provider host.