### PR TITLE
Reuse checked modules across audit verification

### DIFF
--- a/examples/games/eggcatch/core.av
+++ b/examples/games/eggcatch/core.av
@@ -890,6 +890,10 @@ fn bodyGap(l: String, mid: String, r: String, gap: Int) -> String
       "evenly (left half rounded down) around the middle segment."
     "║" + l + spaces(Int.div(gap, 2)) + mid + spaces(gap - Int.div(gap, 2)) + r + "║"
 
+verify bodyGap
+    bodyGap("L", "M", "R", 4) => "║L  M  R║"
+    bodyGap("", "x", "", 3) => "║ x  ║"
+
 fn basketMark(fox: Chute, c: Chute) -> String
     ? "The basket sits under exactly one chute lip: a cup at the fox's"
       "position, a space elsewhere. Always one column wide."
@@ -924,11 +928,19 @@ fn beamL(egg: Option<Int>, i: Int) -> String
         "●" -> "●"
         _ -> "\\"
 
+verify beamL
+    beamL(Option.Some(2), 2) => "●"
+    beamL(Option.None, 2) => "\\"
+
 fn beamR(egg: Option<Int>, i: Int) -> String
     ? "Right ramp beam for row i, mirrored."
     match cell(egg, i)
         "●" -> "●"
         _ -> "/"
+
+verify beamR
+    beamR(Option.Some(2), 2) => "●"
+    beamR(Option.None, 2) => "/"
 
 fn upL(egg: Option<Int>, i: Int) -> String
     ? "Upper-left ramp segment for row i: indent, then the beam (or the egg"
@@ -942,6 +954,10 @@ verify upL
 fn upR(egg: Option<Int>, i: Int) -> String
     ? "Upper-right ramp segment for row i, mirrored."
     beamR(egg, i) + spaces(4 + 2 * i)
+
+verify upR
+    upR(Option.Some(0), 0) => "●    "
+    upR(Option.None, 2) => "/        "
 
 fn rowHeader(b: Board) -> String
     ? "Header row: title, mode tag, score and miss pips."

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -4847,7 +4847,14 @@ fn try_emit_mir_fusion(
                         let b_str = emit_literal(&crate::ast::Literal::Int(*n));
                         Some(format!("({}).rem_euclid(&({})).unwrap()", a_str, b_str))
                     } else {
-                        let b_str = emit_mir_expr(b, ctx)?;
+                        // `__b` owns the divisor so the zero and remainder
+                        // branches can share it. Preserve an outer local that
+                        // remains live after this fused expression (notably a
+                        // loop-carried TCO parameter) instead of moving it
+                        // into the temporary. The unfused `Int.mod` path only
+                        // borrows its divisor, so the fusion owes the source
+                        // program the same ownership behaviour.
+                        let b_str = mir_clone_arg(emit_mir_expr(b, ctx)?, &b.node, ctx);
                         Some(format!(
                             "{{ let __b = {}; if __b.is_zero() {{ {} }} else {{ ({}).rem_euclid(&__b).unwrap() }} }}",
                             b_str, default, a_str
@@ -5959,6 +5966,36 @@ mod tests {
         assert_eq!(
             emit,
             "(match (aver_rt::AverInt::from_i64(7)).rem_euclid(&(aver_rt::AverInt::from_i64(3))) { Some(__r) => Ok(__r), None => Err(\"division by zero\".to_string()) }).into_aver()"
+        );
+    }
+
+    #[test]
+    fn fused_int_mod_with_default_preserves_live_divisor() {
+        let divisor = span_ty(
+            MirExpr::Local(span(MirLocal {
+                slot: LocalId(0),
+                last_use: false,
+                name: "divisor".to_string(),
+            })),
+            Type::Int,
+        );
+        let inner = span(MirExpr::Call(span(MirCall {
+            callee: MirCallee::Builtin(crate::ir::BuiltinId(1)),
+            args: vec![int_lit(7), divisor],
+        })));
+        let outer = span(MirExpr::Call(span(MirCall {
+            callee: MirCallee::Builtin(crate::ir::BuiltinId(0)),
+            args: vec![inner, int_lit(0)],
+        })));
+        let mut ctx = ctx_with_builtin("Result.withDefault");
+        ctx.mir_builtins = Box::leak(
+            vec!["Result.withDefault".to_string(), "Int.mod".to_string()].into_boxed_slice(),
+        );
+
+        let emit = emit_mir_expr(&outer, &ctx).expect("fused Int.mod should emit");
+        assert!(
+            emit.contains("let __b = divisor.clone()"),
+            "a live divisor must survive the owning fusion temporary: {emit}"
         );
     }
 

--- a/src/diagnostics/analyze.rs
+++ b/src/diagnostics/analyze.rs
@@ -15,6 +15,7 @@ use super::factories::{
     from_check_finding_with_index, from_type_error_with_index, unused_binding_diagnostic_with_index,
 };
 use super::model::{AnalysisReport, Diagnostic, Severity, Span};
+use crate::ast::TopLevel;
 use crate::checker::{
     CheckFinding, check_module_intent_with_sigs_in, collect_cse_warnings_in,
     collect_independence_warnings_in, collect_module_effects_warnings_in,
@@ -26,6 +27,7 @@ use crate::checker::{FindingSpan, collect_verify_law_dependency_warnings_in};
 use crate::source::{LoadedModule, parse_source_with_verify_ceiling};
 #[cfg(feature = "runtime")]
 use crate::tail_check::collect_non_tail_recursion_warnings_with_sigs;
+use crate::types::checker::TypeCheckResult;
 
 /// Options for `analyze_source`. Defaults enable every available collector.
 #[derive(Clone, Debug)]
@@ -196,6 +198,55 @@ fn analyze_source_impl(
     // program.
     let tc_result = crate::ir::pipeline::typecheck_gate(&items, &mode, &items);
 
+    analyze_prechecked_items_impl(
+        source,
+        options,
+        &items,
+        &transformed,
+        &tc_result,
+        #[cfg(feature = "runtime")]
+        provider_bindings,
+    )
+}
+
+/// Render canonical diagnostics from a program the caller has already parsed,
+/// TCO-transformed, and type-checked.
+///
+/// Whole-program commands use this seam when the same checked module is also
+/// going to verification or code generation. Keeping execution out of this
+/// function is deliberate: the caller can feed the same typecheck result into
+/// a prepared backend instead of making analysis silently check the program a
+/// second time.
+pub fn analyze_prechecked_items(
+    source: &str,
+    options: &AnalyzeOptions,
+    items: &[TopLevel],
+    transformed: &[TopLevel],
+    tc_result: &TypeCheckResult,
+) -> AnalysisReport {
+    assert!(
+        !options.include_verify_run,
+        "prechecked analysis leaves verify execution to the prepared caller"
+    );
+    analyze_prechecked_items_impl(
+        source,
+        options,
+        items,
+        transformed,
+        tc_result,
+        #[cfg(feature = "runtime")]
+        &[],
+    )
+}
+
+fn analyze_prechecked_items_impl(
+    source: &str,
+    options: &AnalyzeOptions,
+    items: &[TopLevel],
+    transformed: &[TopLevel],
+    tc_result: &TypeCheckResult,
+    #[cfg(feature = "runtime")] provider_bindings: &[crate::provider::ProviderBinding],
+) -> AnalysisReport {
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     let source_index = SourceIndex::new(source);
 
@@ -210,7 +261,7 @@ fn analyze_source_impl(
 
     let findings = if options.include_intent_warnings {
         Some(check_module_intent_with_sigs_in(
-            &items,
+            items,
             Some(&tc_result.fn_sigs),
             None,
         ))
@@ -253,7 +304,7 @@ fn analyze_source_impl(
     }
 
     if options.include_coverage_warnings {
-        for w in collect_verify_coverage_warnings_in(&items, None) {
+        for w in collect_verify_coverage_warnings_in(items, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -269,7 +320,7 @@ fn analyze_source_impl(
     // the project file says. Anchored on the module declaration line (the
     // `depends [...]` list lives in its indented block).
     if !options.stdlib_shadowed.is_empty() {
-        let (module_name, module_line) = crate::visibility::module_decl(&items)
+        let (module_name, module_line) = crate::visibility::module_decl(items)
             .map(|m| (Some(m.name.clone()), m.line))
             .unwrap_or((None, 1));
         for (dep_name, shadowed_path) in &options.stdlib_shadowed {
@@ -295,7 +346,7 @@ fn analyze_source_impl(
     // surfaced via `tc_result.errors`. Overdeclared (boundary lists
     // effects no fn uses) is a softer hint — still worth surfacing so
     // the module header documents what the code actually does.
-    for w in collect_module_effects_warnings_in(&items, None) {
+    for w in collect_module_effects_warnings_in(items, None) {
         diagnostics.push(from_check_finding_with_index(
             Severity::Warning,
             &w,
@@ -306,7 +357,7 @@ fn analyze_source_impl(
 
     #[cfg(feature = "runtime")]
     if options.include_law_dependency_warnings {
-        for w in collect_verify_law_dependency_warnings_in(&items, &tc_result.fn_sigs, None) {
+        for w in collect_verify_law_dependency_warnings_in(items, &tc_result.fn_sigs, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -317,7 +368,7 @@ fn analyze_source_impl(
     }
 
     if options.include_cse_warnings {
-        for w in collect_cse_warnings_in(&transformed, None) {
+        for w in collect_cse_warnings_in(transformed, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -328,7 +379,7 @@ fn analyze_source_impl(
     }
 
     if options.include_perf_warnings {
-        for w in collect_perf_warnings_in(&transformed, None) {
+        for w in collect_perf_warnings_in(transformed, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -339,7 +390,7 @@ fn analyze_source_impl(
     }
 
     if options.include_traversal_warnings {
-        for w in collect_traversal_warnings_in(&transformed, None) {
+        for w in collect_traversal_warnings_in(transformed, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -350,7 +401,7 @@ fn analyze_source_impl(
     }
 
     if options.include_independence_warnings {
-        for w in collect_independence_warnings_in(&transformed, &tc_result.fn_sigs, None) {
+        for w in collect_independence_warnings_in(transformed, &tc_result.fn_sigs, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -361,7 +412,7 @@ fn analyze_source_impl(
     }
 
     if options.include_naming_warnings {
-        for w in collect_naming_warnings_in(&items, None) {
+        for w in collect_naming_warnings_in(items, None) {
             diagnostics.push(from_check_finding_with_index(
                 Severity::Warning,
                 &w,
@@ -377,7 +428,7 @@ fn analyze_source_impl(
         // the compiled VM would crash on missing symbols. Multi-file
         // now works through the same VM path via loaded_modules →
         // compile_program_with_loaded_modules.
-        let runnable_items = items.clone();
+        let runnable_items = items.to_vec();
         let mode = if options.verify_run_hostile {
             crate::verify_law::expand::ExpansionMode::Hostile
         } else {
@@ -426,7 +477,7 @@ fn analyze_source_impl(
     #[cfg(feature = "runtime")]
     if options.include_non_tail_warnings {
         let non_tail =
-            collect_non_tail_recursion_warnings_with_sigs(&transformed, &tc_result.fn_sigs);
+            collect_non_tail_recursion_warnings_with_sigs(transformed, &tc_result.fn_sigs);
         for w in &non_tail {
             let mut line_counts: Vec<(usize, usize)> = Vec::new();
             for &ln in &w.callsite_lines {
@@ -476,7 +527,7 @@ fn analyze_source_impl(
 
     if options.include_why_summary {
         report.why_summary = Some(super::why::summarize(
-            &items,
+            items,
             source,
             options.file_label.clone(),
         ));
@@ -484,7 +535,7 @@ fn analyze_source_impl(
 
     if options.include_context_summary {
         let ctx = super::context::build_context_for_items(
-            &items,
+            items,
             source,
             options.file_label.clone(),
             options.module_base_dir.as_deref(),

--- a/src/diagnostics/factories.rs
+++ b/src/diagnostics/factories.rs
@@ -36,6 +36,30 @@ pub fn verify_provider_setup_diagnostic(file: &str, error: &str) -> Diagnostic {
     }
 }
 
+/// Verification could not prepare or execute its backend before producing
+/// case outcomes. This is a failed audit axis, not a source type error and not
+/// an empty successful verify run.
+pub fn verify_engine_error_diagnostic(file: &str, error: &str) -> Diagnostic {
+    Diagnostic {
+        severity: Severity::Fail,
+        slug: "verify-engine",
+        summary: format!("verify engine could not run: {error}"),
+        span: Span {
+            file: file.to_string(),
+            line: 1,
+            col: 1,
+        },
+        fn_name: None,
+        intent: None,
+        fields: vec![("engine_error", error.to_string())],
+        conflict: None,
+        repair: Repair::default(),
+        regions: Vec::new(),
+        related: Vec::new(),
+        from_hostile: false,
+    }
+}
+
 /// Build a `Diagnostic` from a `TypeError` (from the typechecker).
 pub fn from_type_error(te: &TypeError, source: &str, file: &str) -> Diagnostic {
     let source_index = SourceIndex::new(source);

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -24,12 +24,12 @@ pub mod why;
 
 #[cfg(feature = "runtime")]
 pub use analyze::analyze_source_with_verify_provider_bindings;
-pub use analyze::{AnalyzeOptions, analyze_source};
+pub use analyze::{AnalyzeOptions, analyze_prechecked_items, analyze_source};
 pub use factories::{
     from_check_finding, from_type_error, needs_format_diagnostic, replay_effect_error_diagnostic,
     replay_output_mismatch_diagnostic, unused_binding_diagnostic, verify_declined_diagnostic,
-    verify_mismatch_diagnostic, verify_provider_setup_diagnostic, verify_runtime_error_diagnostic,
-    verify_unexpected_err_diagnostic,
+    verify_engine_error_diagnostic, verify_mismatch_diagnostic, verify_provider_setup_diagnostic,
+    verify_runtime_error_diagnostic, verify_unexpected_err_diagnostic,
 };
 pub use model::{
     AnalysisReport, AnnotatedRegion, Diagnostic, RelatedSpan, Repair, SCHEMA_VERSION, Severity,

--- a/src/diagnostics/verify_run.rs
+++ b/src/diagnostics/verify_run.rs
@@ -170,7 +170,9 @@ fn load_project_config(base_dir: &str) -> Option<crate::config::ProjectConfig> {
         .flatten()
 }
 
-fn map_results_to_diagnostics(
+/// Convert backend-neutral verify case results into the canonical diagnostic
+/// bundle used by audit, the playground, and editor integrations.
+pub fn map_results_to_diagnostics(
     results: Vec<VerifyResult>,
     file_label: &str,
     source: &str,

--- a/src/diagnostics/vm_verify.rs
+++ b/src/diagnostics/vm_verify.rs
@@ -745,13 +745,35 @@ fn prepare_verify_for_items_vm_with_loaded(
         return Err(format_type_errors(&typecheck.errors));
     }
 
+    prepare_verify_for_prechecked_items_vm_with_loaded(
+        items,
+        loaded,
+        source_file,
+        typecheck.capabilities,
+    )
+}
+
+/// Build the immutable verify VM from TCO-transformed items whose typecheck
+/// gate has already passed.
+///
+/// `aver audit` uses this after its static collectors have consumed the same
+/// typecheck result. The ordinary verify front door remains wrapped by
+/// [`prepare_verify_for_items_vm_with_checked_loaded`], so callers cannot
+/// accidentally skip checking unless they explicitly hold the checked state.
+#[cfg(feature = "runtime")]
+pub fn prepare_verify_for_prechecked_items_vm_with_loaded(
+    mut items: Vec<TopLevel>,
+    loaded: Vec<crate::source::LoadedModule>,
+    source_file: &str,
+    capabilities: crate::capability::CapabilityRegistry,
+) -> Result<PreparedVmVerify, String> {
     let verify_blocks = merge_verify_blocks(&items);
     let plans = build_verify_vm_plans(&mut items, &verify_blocks);
     crate::ir::pipeline::resolve(&mut items);
     if plans.is_empty() {
         return Ok(PreparedVmVerify {
             machine: None,
-            capabilities: typecheck.capabilities,
+            capabilities,
             plans,
         });
     }
@@ -767,7 +789,7 @@ fn prepare_verify_for_items_vm_with_loaded(
     let mut arena = Arena::new();
     vm::register_service_types(&mut arena);
     let mut symbol_table = crate::ir::SymbolTable::build(&items, &dep_modules);
-    symbol_table.merge_capability_registry(&typecheck.capabilities);
+    symbol_table.merge_capability_registry(&capabilities);
     let resolved_items = crate::ir::hir::resolve_program(&symbol_table, &items);
     let (code, globals) = vm::compile_program_with_loaded_modules(
         &resolved_items,
@@ -780,7 +802,7 @@ fn prepare_verify_for_items_vm_with_loaded(
     .map_err(|error| format!("VM compile error: {error}"))?;
     Ok(PreparedVmVerify {
         machine: Some(vm::VM::new(code, globals, arena)),
-        capabilities: typecheck.capabilities,
+        capabilities,
         plans,
     })
 }
@@ -1178,12 +1200,56 @@ pub fn run_verify_for_items_vm_with_loaded_and_mode(
 }
 
 pub fn run_verify_for_items_vm_with_loaded_and_mode_and_bindings(
+    items: Vec<TopLevel>,
+    loaded: Vec<crate::source::LoadedModule>,
+    config: Option<ProjectConfig>,
+    source_file: &str,
+    mode: ExpansionMode,
+    provider_bindings: &[crate::provider::ProviderBinding],
+) -> Result<Vec<VerifyResult>, String> {
+    run_verify_for_items_vm_with_loaded_impl(
+        items,
+        loaded,
+        config,
+        source_file,
+        mode,
+        provider_bindings,
+        false,
+    )
+}
+
+/// Verify against dependency surfaces whose bodies already passed their own
+/// leaves-first typecheck. Hostile mode still checks the current module after
+/// injecting its adversarial stubs; it only avoids walking every dependency
+/// body again.
+pub fn run_verify_for_items_vm_with_checked_loaded_and_mode_and_bindings(
+    items: Vec<TopLevel>,
+    loaded: Vec<crate::source::LoadedModule>,
+    config: Option<ProjectConfig>,
+    source_file: &str,
+    mode: ExpansionMode,
+    provider_bindings: &[crate::provider::ProviderBinding],
+) -> Result<Vec<VerifyResult>, String> {
+    run_verify_for_items_vm_with_loaded_impl(
+        items,
+        loaded,
+        config,
+        source_file,
+        mode,
+        provider_bindings,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_verify_for_items_vm_with_loaded_impl(
     mut items: Vec<TopLevel>,
     loaded: Vec<crate::source::LoadedModule>,
     config: Option<ProjectConfig>,
     source_file: &str,
     mode: ExpansionMode,
     provider_bindings: &[crate::provider::ProviderBinding],
+    dependencies_checked: bool,
 ) -> Result<Vec<VerifyResult>, String> {
     crate::ir::pipeline::tco(&mut items);
 
@@ -1197,11 +1263,13 @@ pub fn run_verify_for_items_vm_with_loaded_and_mode_and_bindings(
 
     // Same gate as the disk-loader path above, so the playground and
     // the LSP refuse a shadowing program exactly as the CLI does.
-    let tc_result = crate::ir::pipeline::typecheck_gate(
-        &items,
-        &crate::ir::TypecheckMode::WithLoaded(&loaded),
-        &items[..user_program_len],
-    );
+    let typecheck_mode = if dependencies_checked {
+        crate::ir::TypecheckMode::WithCheckedLoaded(&loaded)
+    } else {
+        crate::ir::TypecheckMode::WithLoaded(&loaded)
+    };
+    let tc_result =
+        crate::ir::pipeline::typecheck_gate(&items, &typecheck_mode, &items[..user_program_len]);
     if !tc_result.errors.is_empty() {
         return Err(format_type_errors(&tc_result.errors));
     }

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -1866,7 +1866,7 @@ pub(super) fn cmd_audit(
         .map(|file| {
             (
                 file,
-                collect_program_units_with_cache(
+                collect_verify_program_units_with_cache(
                     file,
                     &module_root,
                     &mut reported,
@@ -1883,7 +1883,7 @@ pub(super) fn cmd_audit(
         .iter()
         .filter_map(|(_, units)| units.as_ref().ok())
         .flatten()
-        .map(|(path, _, _)| canonical_path_key(path))
+        .map(|unit| canonical_path_key(&unit.path))
         .collect::<HashSet<_>>();
     let context = AuditContext {
         module_root: &module_root,
@@ -1898,6 +1898,11 @@ pub(super) fn cmd_audit(
     let mut audited_modules = 0usize;
     let mut totals = AuditTotals::default();
     let mut printed_any = false;
+    // A checked-loaded typecheck is sound only after every project dependency
+    // passed its own leaves-first preparation. Remember failures across
+    // overlapping directory programs so an importer never compiles through a
+    // dependency that an earlier unit already rejected.
+    let mut failed_preparations = HashSet::new();
 
     for (file, units) in programs {
         // An input whose every module was audited under an earlier input
@@ -1935,11 +1940,16 @@ pub(super) fn cmd_audit(
                 continue;
             }
         };
-        for (idx, (unit_path, source, _items)) in units.iter().enumerate() {
+        for (idx, unit) in units.iter().enumerate() {
             if !json && idx > 0 {
                 println!();
             }
-            totals.add(audit_unit(unit_path, source, &context, &mut tracker));
+            totals.add(audit_unit(
+                unit,
+                &context,
+                &mut tracker,
+                &mut failed_preparations,
+            ));
             audited_modules += 1;
         }
     }
@@ -2035,16 +2045,20 @@ impl AuditTotals {
 /// Audit one module: its static diagnostics (minus those another audited
 /// module owns), its verify run, and its format check, rendered in place.
 fn audit_unit(
-    path: &str,
-    source: &str,
+    unit: &VerifyReportUnit,
     context: &AuditContext<'_>,
     tracker: &mut SuppressionTracker,
+    failed_preparations: &mut HashSet<PathBuf>,
 ) -> AuditTotals {
     use super::format_cmd::try_format_project_source;
     use aver::diagnostics::{
-        AnalyzeOptions, analyze_source_with_verify_provider_bindings, needs_format_diagnostic,
+        AnalyzeOptions, analyze_prechecked_items, analyze_source, needs_format_diagnostic,
+        verify_engine_error_diagnostic, verify_provider_setup_diagnostic,
     };
+    use aver::verify_law::expand::ExpansionMode;
 
+    let path = &unit.path;
+    let source = &unit.source;
     let module_root = context.module_root;
     let shown_path = display_check_path(path, module_root);
     let own_key = canonical_path_key(path);
@@ -2052,10 +2066,94 @@ fn audit_unit(
     let mut opts = AnalyzeOptions::new(shown_path.clone());
     opts.module_base_dir = Some(module_root.to_string());
     opts.source_path = Some(path.to_string());
-    opts.include_verify_run = true;
-    opts.verify_run_hostile = context.hostile;
-    let mut report =
-        analyze_source_with_verify_provider_bindings(source, &opts, context.provider_bindings);
+    opts.include_verify_run = false;
+
+    let dependency_failed = unit.project_dependencies.iter().any(|(dep_path, _)| {
+        failed_preparations.contains(&aver::source::canonicalize_path(dep_path))
+    });
+    let mut preparation_failed = dependency_failed || unit.fault.is_some();
+
+    // Tolerant program loading keeps malformed modules as report units. Let
+    // canonical source analysis recreate their parse/module diagnostic. Clean
+    // units take the prepared seam: one TCO + one checked-loaded typecheck feed
+    // both static collectors and the declared verify VM.
+    let mut report = if unit.fault.is_some() || unit.items.is_empty() {
+        analyze_source(source, &opts)
+    } else {
+        let mut transformed = unit.items.clone();
+        aver::ir::pipeline::tco(&mut transformed);
+        let tc_result = aver::ir::pipeline::typecheck_gate(
+            &transformed,
+            &aver::ir::TypecheckMode::WithCheckedLoaded(&unit.loaded),
+            &unit.items,
+        );
+        preparation_failed |= !tc_result.errors.is_empty();
+        let mut report =
+            analyze_prechecked_items(source, &opts, &unit.items, &transformed, &tc_result);
+
+        if !preparation_failed && tc_result.errors.is_empty() {
+            let verify_result = if context.hostile {
+                // Hostile verification is a genuinely different checked
+                // program: it appends adversarial provider stubs. Recheck this
+                // module once after injection, but trust the already-audited
+                // dependency bodies.
+                aver::diagnostics::vm_verify::run_verify_for_items_vm_with_checked_loaded_and_mode_and_bindings(
+                    unit.items.clone(),
+                    unit.loaded.clone(),
+                    context.config.cloned(),
+                    path,
+                    ExpansionMode::Hostile,
+                    context.provider_bindings,
+                )
+            } else {
+                aver::diagnostics::vm_verify::prepare_verify_for_prechecked_items_vm_with_loaded(
+                    transformed,
+                    unit.loaded.clone(),
+                    path,
+                    tc_result.capabilities.clone(),
+                )
+                .and_then(|prepared| {
+                    aver::diagnostics::vm_verify::run_prepared_verify_vm_with_bindings(
+                        prepared,
+                        context.config.cloned(),
+                        Some(module_root),
+                        path,
+                        context.provider_bindings,
+                        false,
+                    )
+                })
+            };
+
+            match verify_result {
+                Ok(results) => {
+                    let (verify_diagnostics, verify_summary) =
+                        aver::diagnostics::verify_run::map_results_to_diagnostics(
+                            results,
+                            &shown_path,
+                            source,
+                        );
+                    report.diagnostics.extend(verify_diagnostics);
+                    report.verify_summary = Some(verify_summary);
+                }
+                Err(error) => {
+                    preparation_failed = true;
+                    let diagnostic = if aver::provider::is_provider_setup_error(&error) {
+                        verify_provider_setup_diagnostic(&shown_path, &error)
+                    } else {
+                        verify_engine_error_diagnostic(&shown_path, &error)
+                    };
+                    report.diagnostics.push(diagnostic);
+                    report.verify_summary =
+                        Some(aver::diagnostics::model::VerifySummary { blocks: Vec::new() });
+                }
+            }
+        }
+        report
+    };
+
+    if preparation_failed {
+        failed_preparations.insert(aver::source::canonicalize_path(Path::new(path)));
+    }
     report.diagnostics.retain(|d| {
         let key = span_file_key(&d.span.file, module_root);
         key == own_key || !context.unit_keys.contains(&key)
@@ -2078,7 +2176,7 @@ fn audit_unit(
     // per-rule violations (capped at the factory's MAX_VIOLATION_REGIONS).
     let (needs_format, format_violations) =
         match try_format_project_source(source, module_root, path) {
-            Ok((formatted, violations)) if formatted != source => (true, violations),
+            Ok((formatted, violations)) if formatted != *source => (true, violations),
             _ => (false, Vec::new()),
         };
     if needs_format {
@@ -2107,7 +2205,7 @@ fn audit_unit(
     let verify_setup_failures = report
         .diagnostics
         .iter()
-        .filter(|diagnostic| diagnostic.slug == "verify-provider-setup")
+        .filter(|diagnostic| matches!(diagnostic.slug, "verify-provider-setup" | "verify-engine"))
         .count();
     let verify_failures = verify_setup_failures
         + report


### PR DESCRIPTION
## Summary\n- Reuse one TCO/typecheck result for audit diagnostics and declared VM verification.\n- Keep hostile verification honest by rechecking only the current stub-augmented module while trusting already-checked dependencies.\n- Fail closed when the verify engine cannot prepare instead of presenting an empty successful verify run.\n- Fix generated Rust fusion moving a live Int.mod divisor into Result.withDefault.\n- Add the four missing Eggcatch rendering verify blocks found by the example sweep.\n\n## Performance\nIndicative warm local release timings:\n- examples/core: 0.04-0.05s, previously about 0.09s\n- Checkers: 0.08-0.09s, previously about 0.15s\n- examples/data: 0.13s, previously about 0.15s\n\n## Validation\n- cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings\n- cargo clippy -p aver-lang --lib --bin aver --features wasm,wasip2 -- -D warnings\n- cargo test --test proof_spec (308 passed)\n- audit dependency-fold, error-count, suppression, verify-budget, and provider-host regression suites\n- all games through VM audit and hostile audit; zero counterexamples\n- all games compile and validate as wasm-gc; wasm-gc verify has zero failures\n- generated Rust cargo-check matrix, including the formerly failing Life case\n- wasip2 success for Wumpus and precise expected Terminal rejection for terminal games\n- self-host parity on the supported common subset: 27/27 deterministic core/data runs match the VM\n