### PR TITLE
Fix wasm32 arena layout guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 
@@ -69,16 +70,16 @@ jobs:
       - name: Compile gate — isolated certificate feature sets
         # The certificate-producer split leaves feature combinations that no
         # test step compiles on its own: the slim aver-cert plan surface
-        # (what non-certify compiler builds link), the playground build
-        # (library target only — the aver_self_host_cli bin has never built
-        # under playground features, a pre-existing gap outside this gate's
-        # scope), and a bare `certify` build. Cheap `cargo check`s keep every
-        # nameable combination compiling without adding test time. The
-        # remaining combination, wasip2-only, is checked in the WASM job,
-        # whose cache already holds the heavy component-model dependencies.
+        # (what non-certify compiler builds link), the actual wasm32 playground
+        # library (the aver_self_host_cli bin has never built under playground
+        # features, a pre-existing gap outside this gate's scope), and a bare
+        # `certify` build. Cheap `cargo check`s keep every nameable combination
+        # compiling without adding test time. The remaining combination,
+        # wasip2-only, is checked in the WASM job, whose cache already holds the
+        # heavy component-model dependencies.
         run: |
           cargo check -p aver-cert --no-default-features --features plans
-          cargo check -p aver-lang --lib --no-default-features --features playground
+          cargo check -p aver-lang --lib --target wasm32-unknown-unknown --no-default-features --features playground
           cargo check -p aver-lang --features certify
 
       - name: Prefetch provider-host feature graph

--- a/src/nan_value.rs
+++ b/src/nan_value.rs
@@ -90,13 +90,20 @@ pub type ArenaEntry = aver_memory::ArenaEntry<AverTypes>;
 pub type ArenaSymbol = aver_memory::ArenaSymbol<AverTypes>;
 
 /// Every arena slot is one of these, so the widest variant sets what a slot
-/// costs whatever it holds. The widest payload remains 40 bytes after adding
-/// the Map and flat-list lane receipts; segmented lists deliberately stay on
-/// their conservative scan path because adding a receipt there would grow the
-/// payload. A variant wider than 40 would increase every slot in the arena,
-/// which is why both boundaries are pinned.
+/// costs whatever it holds. On 64-bit targets the widest payload remains 40
+/// bytes after adding the Map and flat-list lane receipts; segmented lists
+/// deliberately stay on their conservative scan path because adding a receipt
+/// there would grow the payload. A variant wider than 40 would increase every
+/// slot in the arena. The wasm32 playground compiler has smaller pointer-sized
+/// fields, so its corresponding 24/32-byte boundaries are pinned separately.
+#[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::size_of::<ArenaList>() == 40);
+#[cfg(target_pointer_width = "64")]
 const _: () = assert!(core::mem::size_of::<ArenaEntry>() == 48);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<ArenaList>() == 24);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(core::mem::size_of::<ArenaEntry>() == 32);
 
 // ---------------------------------------------------------------------------
 // Extension trait for Value <-> NanValue conversion


### PR DESCRIPTION
Release 0.29.0 stopped before publishing while rebuilding the playground compiler: the arena size guards pinned 64-bit host sizes while wasm32 legitimately uses smaller pointer-sized layouts.

This pins both supported layouts explicitly: ArenaList/ArenaEntry stay 40/48 bytes on 64-bit and 24/32 bytes on 32-bit. It also moves the existing playground compile gate onto the actual wasm32 target, so PR CI catches the release-only failure.

Verified locally:
- cargo fmt --check
- cargo check -p aver-lang --lib
- cargo check -p aver-lang --lib --target wasm32-unknown-unknown --no-default-features --features playground
- wasm-pack build --target web --features playground --no-default-features