### PR TITLE
Make release validation exact and parallel

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -1,6 +1,11 @@
 name: Certification
 
 on:
+  # Release candidates get the complete matrix on their exact commit. Ordinary
+  # pushes to main remain on the six-hour cadence below, avoiding 330 lane-min
+  # for every merge while making the release gate explicit and reproducible.
+  push:
+    branches: ['release/**']
   pull_request:
     branches: [main]
   # The full matrix runs on a timer rather than on every push to main. It is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
     branches: [main]
   # Nightly deep sweep against main with the heavy proptest budget: the
@@ -37,7 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Release tooling
-        run: python3 tools/tests/test_release.py
+        run: python3 -m unittest discover -s tools/tests -p 'test_*.py'
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -123,6 +123,10 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install nextest
+        if: startsWith(matrix.name, 'integrations')
+        uses: taiki-e/install-action@nextest
 
       - uses: Swatinem/rust-cache@v2
 
@@ -295,15 +299,42 @@ jobs:
     # practice. If a release-mode regression slips in, a hot follow-up
     # PR fixes it from main; PR review unblocks immediately.
     name: WASM release build (main)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-latest
     needs: [check, wasm]
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Cache wasm-tools
+        id: cache-wasm-tools-release
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/wasm-tools
+          key: wasm-tools-${{ runner.os }}-1.246.2
+      - name: Install wasm-tools
+        if: steps.cache-wasm-tools-release.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSfL --retry 6 --retry-all-errors --retry-delay 15 --connect-timeout 30 -o /tmp/wasm-tools.tar.gz \
+            https://github.com/bytecodealliance/wasm-tools/releases/download/v1.246.2/wasm-tools-1.246.2-x86_64-linux.tar.gz
+          tar -xzf /tmp/wasm-tools.tar.gz -C /tmp
+          mv /tmp/wasm-tools-1.246.2-x86_64-linux/wasm-tools "$HOME/.local/bin/wasm-tools"
       - name: Build (wasm release)
         run: cargo build -p aver-lang --features wasm --release
+      - name: Validate the exact release-candidate edge artifact
+        if: startsWith(github.ref, 'refs/heads/release/')
+        run: |
+          mkdir -p target/release-edge-smoke
+          ./target/release/aver compile tools/edge/app.av \
+            --preset cloudflare \
+            --handler handler \
+            --module-root tools/edge \
+            -o target/release-edge-smoke
+          "$HOME/.local/bin/wasm-tools" validate --features all \
+            target/release-edge-smoke/app.wasm
 
   bench:
     # Post-merge bench gate. PR-time CI doesn't run this — perf
@@ -315,7 +346,9 @@ jobs:
     # --target=vm` against their branch before opening a PR if they
     # touched a perf-sensitive path.
     name: Bench Gate
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -20,7 +20,7 @@ on:
   # Per-PR + main-push so a proof-codegen / proof-metric drift is
   # caught at PR time, same convention as `ci.yml`.
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
     branches: [main]
   schedule:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,19 +324,31 @@ To create a new pure namespace, follow the pattern in `src/types/char.rs` or `sr
 
 ## Releases: `tools/release.py` is the only path
 
-Run `python3 tools/release.py X.Y.Z` (add `--dry-run` first for a sanity pass). The script is the single source of truth for the full release flow — it covers everything below in the right order, idempotently:
+Use the two-phase path (add `--dry-run` first for a sanity pass):
+
+```bash
+python3 tools/release.py X.Y.Z --prepare
+# wait for CI, Proof, and Certification on release/X.Y.Z
+python3 tools/release.py X.Y.Z --deploy-edge
+```
+
+The prepare phase commits the exact release tree and pushes only `release/X.Y.Z`. Expensive gates run in parallel on that exact SHA. The resume phase refuses to publish unless the candidate is byte-identical, all three workflows are green, and `origin/main` still equals the candidate's recorded base; it then fast-forwards main, publishes, tags, deploys if requested, carries dev versions, and removes the candidate branch. The saved plan makes both phases idempotent.
+
+If candidate CI fails, fix the candidate locally and rerun `python3 tools/release.py X.Y.Z --prepare`. Before any publication the script may reopen the sealed plan, recompute crate bumps/cascades from the changed publish inputs, and push a fast-forward repair commit for a fresh exact-SHA CI pass.
+
+The script is the single source of truth for the full release flow — it covers everything below in the right order:
 
 0. Editor grammar sync check (`editors/sync.py --check`)
 1. Cascade-bump `aver-rt` / `aver-memory` / `aver-cert` / `aver-lang` / `aver-lsp` Cargo.toml + cross-crate dep pins; `aver-cert` keeps its independent 0.1.x line (first public release `0.1.0`, later source changes patch-bump it), and the cascade logic honours `PUBLISH_BLOCKERS` so `cargo publish` doesn't hit a resolution conflict
 2. Bump the `tools/website/index.html` hero version badge
 3. Regenerate self-host (`self_hosted/main.av` → `src/self_host/`)
 4. Regenerate playground WASM artifacts (`tools/website/rebuild_playground.py`)
-5. Verify (fmt + workspace clippy + aver-lang+wasm clippy + cargo test + bench scenarios + edge `--preset cloudflare` compile + `wasm-tools validate`)
-5.5. Stamp the CHANGELOG header (`## X.Y.Z "Codename" (unreleased)` → `## X.Y.Z "Codename" — YYYY-MM-DD`)
-6. `cargo publish` each changed crate in CRATE_ORDER
-7. Git add + commit + tag + push + `gh release create` with notes from the CHANGELOG section
+5. Stamp the CHANGELOG header (`## X.Y.Z "Codename" (unreleased)` → `## X.Y.Z "Codename" — YYYY-MM-DD`) and commit the candidate
+6. Push `release/X.Y.Z`; CI runs fmt, clippy, package, every native/wasm/wasip2 test, bench scenarios, release wasm build, edge `--preset cloudflare` + `wasm-tools validate`; Proof and the complete Certification matrix run beside it
+7. On resume, require the exact green SHA and unchanged main, then `cargo publish` each changed crate in `CRATE_ORDER`
+8. Fast-forward main, tag, push, and `gh release create` with notes from the CHANGELOG section; optionally deploy edge, then carry dev versions
 
-Flags worth knowing: `--dry-run`, `--skip-publish`, `--skip-playground`, `--skip-self-host`, `--deploy-edge` (the last one rebuilds + deploys `tools/edge` to Cloudflare and curl-smokes `/`, `/api`, `/fractal`).
+Flags worth knowing: `--prepare`, `--dry-run`, `--skip-publish`, `--skip-playground`, `--skip-self-host`, `--deploy-edge` (the last one rebuilds + deploys `tools/edge` from a temporary tree, then curl-smokes `/`, `/api`, `/fractal` without dirtying the repository).
 
 **Don't bump versions or tag by hand.** The 0.19.0 "Echo" release was attempted manually first, which skipped the cascade bump, website badge, self-host regen, playground regen, the verify gates beyond unit tests, `cargo publish`, and `gh release create`. The lesson: even when individual steps feel obvious in isolation, the script's idempotent design + correct ordering is the only thing that catches the dependency chain at the right place.
 

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -123,7 +123,7 @@ aver bench bench/scenarios/ \
 
 `--baseline-dir DIR` auto-picks `<host.os>-<host.arch>-<backend.name>.json` from `DIR` based on the current machine. When no matching file exists, the gate is silently skipped — one CI workflow gates wherever a baseline is pinned, runs cleanly on hosts without one. Repo currently ships `bench/baselines/macos-aarch64-vm.json`; Linux baseline gets captured automatically on first CI run, commit `bench/baselines/linux-x86_64-vm.json` from that artifact to enable gating there.
 
-The CI `Bench Gate` job in `.github/workflows/ci.yml` runs `aver bench bench/scenarios/ --target=vm --baseline-dir bench/baselines/ --fail-on-regression --json` on every PR; results upload as a 30-day-retention artifact.
+The CI `Bench Gate` job in `.github/workflows/ci.yml` runs `aver bench bench/scenarios/ --target=vm --baseline-dir bench/baselines/ --fail-on-regression --json` on pushes to main and exact release-candidate branches; results upload as a 30-day-retention artifact.
 
 ### NDJSON output for streaming
 
@@ -135,7 +135,7 @@ Directory mode emits one report per line when `--json` is set. Trivially streama
 
 ### Release script integration
 
-`tools/release.py verify()` runs the full scenario suite in directory mode as a smoke gate before publishing:
+The two-phase release requires this CI gate on the exact `release/X.Y.Z` commit before publishing. The one-shot compatibility path in `tools/release.py verify()` runs the same scenario suite locally:
 
 ```python
 run([str(REPO_ROOT / "target" / "release" / "aver"), "bench",

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -69,8 +69,10 @@ replacement for strict `verify`.
 
 ## Releases
 
-Release `aver-cert` through `python3 tools/release.py X.Y.Z`, never with a
-separate manual `cargo publish`. The verifier keeps its own `0.1.x` version
+Release `aver-cert` through `python3 tools/release.py X.Y.Z --prepare`, wait for
+the exact candidate's CI/Proof/Certification runs, then resume with
+`python3 tools/release.py X.Y.Z`; never use a separate manual `cargo publish`.
+The verifier keeps its own `0.1.x` version
 line, but the release tool coordinates it with Aver: it publishes the first
 `0.1.0`, patch-bumps it only when its source changes, updates `aver-lang`'s
 exact producer dependency pin, and publishes `aver-cert` before `aver-lang`.

--- a/tools/ci_test_schedule.json
+++ b/tools/ci_test_schedule.json
@@ -1,0 +1,29 @@
+{
+  "schema": 1,
+  "source": {
+    "workflow_run": "https://github.com/jasisz/aver/actions/runs/33095728752",
+    "measured_at": "2026-08-27",
+    "default_weight_seconds": 1.0
+  },
+  "split_targets": [
+    "provider_vm_host_spec",
+    "verify_step_budget_spec"
+  ],
+  "weights_seconds": {
+    "compile_spec": 13.93,
+    "eval_spec": 1.97,
+    "map_iteration_order": 2.95,
+    "map_key_order": 5.97,
+    "native_provider_rust_spec": 53.53,
+    "proof_spec": 2.08,
+    "provider_package_workflow_spec": 33.88,
+    "provider_vm_host_spec": 998.43,
+    "rust_codegen_differential": 64.01,
+    "rust_codegen_regression": 12.14,
+    "rust_self_host_regen": 9.08,
+    "typechecker_spec": 1.53,
+    "verify_runner_regressions": 1.08,
+    "verify_step_budget_spec": 826.34,
+    "vm_pattern_shadow_matrix": 8.58
+  }
+}

--- a/tools/ci_test_shard.py
+++ b/tools/ci_test_shard.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
-"""Run one deterministic shard of aver-lang integration-test targets."""
+"""Run one measured shard of aver-lang integration tests.
+
+Most integration targets are assigned whole to one runner with longest-first
+bin packing.  A very small set of targets whose individual test cases dominate
+the wall clock are partitioned across every runner with nextest instead.  The
+measured schedule lives beside this script so a CI run can be reproduced and a
+new target still lands safely at the conservative default weight.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
 import subprocess
+from pathlib import Path
+from typing import Mapping
+
+
+SCHEDULE_PATH = Path(__file__).with_name("ci_test_schedule.json")
+DEFAULT_WEIGHT_SECONDS = 1.0
 
 
 def integration_targets(metadata: dict[str, object]) -> list[str]:
@@ -21,10 +34,80 @@ def integration_targets(metadata: dict[str, object]) -> list[str]:
     raise SystemExit("cargo metadata did not contain the aver-lang package")
 
 
+def load_schedule(path: Path = SCHEDULE_PATH) -> tuple[dict[str, float], set[str]]:
+    payload = json.loads(path.read_text())
+    if payload.get("schema") != 1:
+        raise SystemExit(f"unsupported CI test schedule schema in {path}")
+    raw_weights = payload.get("weights_seconds")
+    raw_split = payload.get("split_targets")
+    if not isinstance(raw_weights, dict) or not isinstance(raw_split, list):
+        raise SystemExit(f"invalid CI test schedule in {path}")
+    weights: dict[str, float] = {}
+    for target, weight in raw_weights.items():
+        if not isinstance(target, str) or not isinstance(weight, (int, float)):
+            raise SystemExit(f"invalid target weight in {path}")
+        if weight <= 0:
+            raise SystemExit(f"weight for {target} must be positive")
+        weights[target] = float(weight)
+    if any(not isinstance(target, str) for target in raw_split):
+        raise SystemExit(f"invalid split target in {path}")
+    return weights, set(raw_split)
+
+
+def weighted_shards(
+    targets: list[str],
+    count: int,
+    weights: Mapping[str, float],
+    split_targets: set[str],
+) -> tuple[list[list[str]], list[float]]:
+    known = set(targets)
+    stale = (set(weights) | split_targets) - known
+    if stale:
+        raise SystemExit(
+            "CI test schedule names missing targets: " + ", ".join(sorted(stale))
+        )
+
+    shards: list[list[str]] = [[] for _ in range(count)]
+    loads = [0.0] * count
+    regular = [target for target in targets if target not in split_targets]
+    ordered = sorted(
+        regular,
+        key=lambda target: (-weights.get(target, DEFAULT_WEIGHT_SECONDS), target),
+    )
+    for target in ordered:
+        shard = min(range(count), key=lambda index: (loads[index], index))
+        shards[shard].append(target)
+        loads[shard] += weights.get(target, DEFAULT_WEIGHT_SECONDS)
+    for shard in shards:
+        shard.sort()
+    return shards, loads
+
+
+def cargo_test_command(targets: list[str]) -> list[str]:
+    command = ["cargo", "test", "-p", "aver-lang"]
+    for target in targets:
+        command.extend(["--test", target])
+    return command
+
+
+def nextest_command(split_targets: set[str], index: int, count: int) -> list[str]:
+    command = ["cargo", "nextest", "run", "-p", "aver-lang"]
+    for target in sorted(split_targets):
+        command.extend(["--test", target])
+    # Slice partitioning is round-robin over nextest's stable sorted test IDs.
+    # In particular the three provider-host cases cannot randomly collide on
+    # one runner, while the 31 verify-budget cases spread across all four.
+    command.extend(["--partition", f"slice:{index + 1}/{count}"])
+    return command
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("index", type=int, help="zero-based shard index")
     parser.add_argument("count", type=int, help="total shard count")
+    parser.add_argument(
+        "--plan", action="store_true", help="print the shard without running tests"
+    )
     args = parser.parse_args()
     if args.count < 1:
         parser.error("count must be positive")
@@ -41,19 +124,43 @@ def main() -> int:
             text=True,
         )
     )
-    selected = integration_targets(metadata)[args.index :: args.count]
-    if not selected:
+    targets = integration_targets(metadata)
+    weights, split_targets = load_schedule()
+    shards, loads = weighted_shards(targets, args.count, weights, split_targets)
+    selected = shards[args.index]
+    if not selected and not split_targets:
         raise SystemExit(f"integration-test shard {args.index}/{args.count} is empty")
 
     print(
-        f"integration-test shard {args.index + 1}/{args.count}: "
+        f"integration-test shard {args.index + 1}/{args.count} "
+        f"(~{loads[args.index]:.1f}s measured whole-target load): "
         + ", ".join(selected),
         flush=True,
     )
-    command = ["cargo", "test", "-p", "aver-lang"]
-    for target in selected:
-        command.extend(["--test", target])
-    return subprocess.run(command, check=False).returncode
+    if args.plan:
+        if split_targets:
+            print(
+                "test-case partition "
+                f"{args.index + 1}/{args.count}: " + ", ".join(sorted(split_targets)),
+                flush=True,
+            )
+        return 0
+    if selected:
+        result = subprocess.run(cargo_test_command(selected), check=False)
+        if result.returncode != 0:
+            return result.returncode
+
+    if split_targets:
+        print(
+            "test-case partition "
+            f"{args.index + 1}/{args.count}: " + ", ".join(sorted(split_targets)),
+            flush=True,
+        )
+        return subprocess.run(
+            nextest_command(split_targets, args.index, args.count),
+            check=False,
+        ).returncode
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/release.py
+++ b/tools/release.py
@@ -3,6 +3,8 @@
 Aver release script.
 
 Usage:
+    python3 tools/release.py 0.9.7 --prepare
+    # wait for exact-commit CI, Proof, and Certification
     python3 tools/release.py 0.9.7
     python3 tools/release.py 0.9.7 --dry-run
     python3 tools/release.py 0.9.7 --skip-publish
@@ -45,7 +47,8 @@ VERSION_FILES = {
 }
 
 RELEASE_PLAN_PATH = REPO_ROOT / "target" / ".aver-release-plan.json"
-RELEASE_PLAN_SCHEMA = 2
+RELEASE_PLAN_SCHEMA = 3
+RELEASE_CI_WORKFLOWS = {"CI", "Proof", "Certification"}
 
 
 class ReleaseError(RuntimeError):
@@ -95,6 +98,8 @@ class ReleasePlan:
     publish_states: dict[str, str]
     package_checksums: dict[str, str] = field(default_factory=dict)
     release_commit: str | None = None
+    base_commit: str | None = None
+    candidate_ref: str | None = None
 
 
 def run(
@@ -116,8 +121,59 @@ def run(
     return subprocess.run(cmd, cwd=cwd, check=check, env=env)
 
 
+def ci_verified_commit(commit: str) -> tuple[bool, str]:
+    """Whether every release workflow passed on exactly ``commit``."""
+    try:
+        raw = run(
+            [
+                "gh",
+                "run",
+                "list",
+                "--commit",
+                commit,
+                "--limit",
+                "50",
+                "--json",
+                "name,conclusion,status",
+            ],
+            capture=True,
+            check=True,
+        ).stdout
+        runs = json.loads(raw)
+    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+        return False, "cannot read CI results for this commit"
+    if not isinstance(runs, list):
+        return False, "CI returned an invalid workflow list"
+
+    # `gh run list` is newest-first. A manual rerun may leave an older failed
+    # row for the same workflow and SHA; only the newest attempt decides the
+    # gate, while unrelated workflows cannot hold a release hostage.
+    latest: dict[str, dict[str, object]] = {}
+    for result in runs:
+        if not isinstance(result, dict):
+            continue
+        name = result.get("name")
+        if isinstance(name, str) and name in RELEASE_CI_WORKFLOWS:
+            latest.setdefault(name, result)
+
+    missing = RELEASE_CI_WORKFLOWS - set(latest)
+    if missing:
+        return False, f"no run of {', '.join(sorted(missing))} on {commit[:8]}"
+    running = sorted(
+        name for name, result in latest.items() if result.get("status") != "completed"
+    )
+    if running:
+        return False, f"CI still running on {commit[:8]}: {', '.join(running)}"
+    failed = sorted(
+        name for name, result in latest.items() if result.get("conclusion") != "success"
+    )
+    if failed:
+        return False, f"CI failed on {commit[:8]}: {', '.join(failed)}"
+    return True, f"release CI green on {commit[:8]}"
+
+
 def ci_verified_head() -> tuple[bool, str]:
-    """Whether CI already ran the test suite on exactly this commit.
+    """Whether release CI already passed on the settled main HEAD.
 
     Only the full `cargo test` run below is skippable this way, and only when
     every workflow that gates `main` reported success for this exact SHA. The
@@ -131,7 +187,6 @@ def ci_verified_head() -> tuple[bool, str]:
     rather than `success` and the tests run. Releasing from a settled `main`
     is what makes it fire.
     """
-    required = {"CI", "Proof", "Certification"}
     try:
         head = run(
             ["git", "rev-parse", "HEAD"], capture=True, check=True
@@ -143,34 +198,7 @@ def ci_verified_head() -> tuple[bool, str]:
         return False, "cannot read git refs"
     if head != upstream:
         return False, "HEAD is not origin/main"
-    try:
-        raw = run(
-            [
-                "gh",
-                "run",
-                "list",
-                "--commit",
-                head,
-                "--limit",
-                "50",
-                "--json",
-                "name,conclusion,status",
-            ],
-            capture=True,
-            check=True,
-        ).stdout
-        runs = json.loads(raw)
-    except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
-        return False, "cannot read CI results for this commit"
-    if any(r.get("status") != "completed" for r in runs):
-        return False, "CI is still running on this commit"
-    if any(r.get("conclusion") == "failure" for r in runs):
-        return False, "CI failed on this commit"
-    succeeded = {r["name"] for r in runs if r.get("conclusion") == "success"}
-    missing = required - succeeded
-    if missing:
-        return False, f"no successful run of {', '.join(sorted(missing))}"
-    return True, f"CI green on {head[:8]}"
+    return ci_verified_commit(head)
 
 
 def current_version() -> str:
@@ -533,9 +561,7 @@ def compute_new_versions(
     published_baselines = dict(old_versions)
     for crate in CRATE_ORDER:
         if crate != "aver-lang":
-            published_baselines[crate] = published_baseline_for_dev(
-                old_versions[crate]
-            )
+            published_baselines[crate] = published_baseline_for_dev(old_versions[crate])
 
     new = dict(published_baselines)
     new["aver-lang"] = new_main
@@ -568,9 +594,7 @@ def compute_new_versions(
     # Pass 3: occupied targets are collisions, never an invitation to mutate the
     # planned version behind CHANGELOG/tag/GitHub release metadata.
     for crate in CRATE_ORDER:
-        if new[crate] != published_baselines[crate] and registry[crate].has(
-            new[crate]
-        ):
+        if new[crate] != published_baselines[crate] and registry[crate].has(new[crate]):
             raise ReleaseError(
                 f"planned {crate} {new[crate]} already exists on crates.io; "
                 "choose the version explicitly and rerun"
@@ -638,6 +662,8 @@ def save_release_plan(plan: ReleasePlan, path: Path | None = None) -> None:
         "publish_states": plan.publish_states,
         "package_checksums": plan.package_checksums,
         "release_commit": plan.release_commit,
+        "base_commit": plan.base_commit,
+        "candidate_ref": plan.candidate_ref,
     }
     temporary = path.with_suffix(path.suffix + ".tmp")
     temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
@@ -742,6 +768,20 @@ def load_release_plan(
         or re.fullmatch(r"[0-9a-f]{40,64}", release_commit) is None
     ):
         raise ReleaseError("saved release plan has an invalid release_commit")
+    base_commit = payload.get("base_commit")
+    if base_commit is not None and (
+        not isinstance(base_commit, str)
+        or re.fullmatch(r"[0-9a-f]{40,64}", base_commit) is None
+    ):
+        raise ReleaseError("saved release plan has an invalid base_commit")
+    candidate_ref = payload.get("candidate_ref")
+    if candidate_ref is not None and (
+        not isinstance(candidate_ref, str)
+        or re.fullmatch(r"release/[0-9A-Za-z._-]+", candidate_ref) is None
+    ):
+        raise ReleaseError("saved release plan has an invalid candidate_ref")
+    if release_commit is not None and (base_commit is None or candidate_ref is None):
+        raise ReleaseError("saved release candidate is missing its base commit or ref")
 
     return ReleasePlan(
         requested_main=requested_main,
@@ -752,6 +792,8 @@ def load_release_plan(
         publish_states=dict(states),
         package_checksums=dict(package_checksums),
         release_commit=release_commit,
+        base_commit=base_commit,
+        candidate_ref=candidate_ref,
     )
 
 
@@ -842,9 +884,7 @@ def refresh_unsealed_release_plan(
     current_fingerprints = {crate: fingerprint(crate) for crate in CRATE_ORDER}
 
     def changed(crate: str, _version: str, _baseline: str | None) -> bool:
-        published_baseline = published_baseline_for_dev(
-            plan.base_versions[crate]
-        )
+        published_baseline = published_baseline_for_dev(plan.base_versions[crate])
         return (
             plan.target_versions[crate] != published_baseline
             or current_fingerprints[crate] != plan.planning_fingerprints[crate]
@@ -1033,9 +1073,7 @@ def bump_website_version(new_version: str, dry_run: bool) -> None:
 def regenerate_self_host(dry_run: bool) -> None:
     print("Regenerating self-host...")
     if dry_run:
-        print(
-            "  [dry-run] would run: python3 tools/regenerate_self_host.py"
-        )
+        print("  [dry-run] would run: python3 tools/regenerate_self_host.py")
         return
     run([sys.executable, str(REPO_ROOT / "tools" / "regenerate_self_host.py")])
 
@@ -1070,7 +1108,18 @@ def verify(dry_run: bool) -> None:
         return
 
     print("  verify: release tooling unit tests", flush=True)
-    run([sys.executable, "tools/tests/test_release.py"])
+    run(
+        [
+            sys.executable,
+            "-m",
+            "unittest",
+            "discover",
+            "-s",
+            "tools/tests",
+            "-p",
+            "test_*.py",
+        ]
+    )
     print("  verify: cargo package -p aver-cert --all-features", flush=True)
     run(["cargo", "package", "-p", "aver-cert", "--all-features", "--allow-dirty"])
     print("  verify: cargo fmt", flush=True)
@@ -1502,6 +1551,173 @@ def git_commit_release(
     seal_release_plan(plan)
 
 
+def release_candidate_ref(version: str) -> str:
+    if re.fullmatch(r"[0-9A-Za-z][0-9A-Za-z._-]*", version) is None:
+        raise ReleaseError(f"version {version!r} cannot form a release branch name")
+    return f"release/{version}"
+
+
+def initialize_release_candidate(plan: ReleasePlan, version: str) -> None:
+    """Pin the candidate to the settled main commit it is based on."""
+    expected_ref = release_candidate_ref(version)
+    if plan.base_commit is not None or plan.candidate_ref is not None:
+        if plan.base_commit is None or plan.candidate_ref != expected_ref:
+            raise ReleaseError("saved release candidate identity is incomplete")
+        return
+
+    head = run(["git", "rev-parse", "HEAD"], capture=True).stdout.strip()
+    upstream = run(["git", "rev-parse", "origin/main"], capture=True).stdout.strip()
+    if head != upstream:
+        raise ReleaseError(
+            "release preparation must start from origin/main; "
+            f"HEAD is {head[:8]}, origin/main is {upstream[:8]}"
+        )
+    plan.base_commit = head
+    plan.candidate_ref = expected_ref
+    save_release_plan(plan)
+
+
+def candidate_has_local_changes(plan: ReleasePlan) -> bool:
+    if plan.release_commit is None:
+        return False
+    head = run(["git", "rev-parse", "HEAD"], capture=True).stdout.strip()
+    dirty = bool(run(["git", "status", "--porcelain"], capture=True).stdout.strip())
+    return head != plan.release_commit or dirty
+
+
+def reopen_release_candidate(
+    plan: ReleasePlan,
+    registry: Mapping[str, RegistryState],
+) -> None:
+    """Replan a changed candidate before any irreversible publication."""
+    if plan.release_commit is None or not plan.fingerprints:
+        raise ReleaseError("release candidate is not sealed")
+    if plan.package_checksums or any(
+        state in {"publishing", "published"} for state in plan.publish_states.values()
+    ):
+        raise ReleaseError("cannot repair a release candidate after publication began")
+    head = run(["git", "rev-parse", "HEAD"], capture=True).stdout.strip()
+    ancestor = run(
+        ["git", "merge-base", "--is-ancestor", plan.release_commit, head],
+        check=False,
+        capture=True,
+    )
+    if ancestor.returncode != 0:
+        raise ReleaseError(
+            "current HEAD does not descend from the prepared release candidate"
+        )
+    upstream = run(["git", "rev-parse", "origin/main"], capture=True).stdout.strip()
+    if plan.base_commit is None or upstream != plan.base_commit:
+        raise ReleaseError("origin/main moved; this candidate must be prepared anew")
+
+    current_fingerprints = {
+        crate: publish_inputs_fingerprint(crate) for crate in CRATE_ORDER
+    }
+
+    def changed(crate: str, _version: str, _baseline: str | None) -> bool:
+        published_baseline = published_baseline_for_dev(plan.base_versions[crate])
+        return (
+            plan.target_versions[crate] != published_baseline
+            or current_fingerprints[crate] != plan.fingerprints[crate]
+        )
+
+    plan.target_versions = compute_new_versions(
+        plan.base_versions,
+        plan.requested_main,
+        registry,
+        changed=changed,
+    )
+    plan.planning_fingerprints = {
+        crate: planning_inputs_fingerprint(crate) for crate in CRATE_ORDER
+    }
+    plan.publish_states = {
+        crate: (
+            "existing"
+            if registry[crate].has(plan.target_versions[crate])
+            else "pending"
+        )
+        for crate in CRATE_ORDER
+    }
+    plan.fingerprints = {}
+    plan.release_commit = None
+    save_release_plan(plan)
+
+
+def push_release_candidate(plan: ReleasePlan, dry_run: bool) -> None:
+    """Publish the exact release tree on a non-main branch for CI."""
+    if dry_run:
+        print(f"  [dry-run] git push origin HEAD:refs/heads/{plan.candidate_ref}")
+        return
+    if plan.release_commit is None or plan.base_commit is None:
+        raise ReleaseError("release candidate is not committed")
+    if plan.candidate_ref is None:
+        raise ReleaseError("release candidate has no remote ref")
+    require_clean_release_tree(plan)
+    upstream = run(["git", "rev-parse", "origin/main"], capture=True).stdout.strip()
+    if upstream != plan.base_commit:
+        raise ReleaseError(
+            "origin/main moved while preparing the release candidate: "
+            f"expected {plan.base_commit[:8]}, got {upstream[:8]}"
+        )
+    run(
+        [
+            "git",
+            "push",
+            "origin",
+            f"HEAD:refs/heads/{plan.candidate_ref}",
+        ]
+    )
+
+
+def require_prepared_release(plan: ReleasePlan) -> None:
+    """Require an unchanged candidate, unchanged main, and exact green CI."""
+    if (
+        plan.release_commit is None
+        or plan.base_commit is None
+        or plan.candidate_ref is None
+    ):
+        raise ReleaseError("release candidate has not been fully prepared")
+    run(["git", "fetch", "origin"])
+    require_clean_release_tree(plan)
+    upstream = run(["git", "rev-parse", "origin/main"], capture=True).stdout.strip()
+    if upstream not in {plan.base_commit, plan.release_commit}:
+        raise ReleaseError(
+            "origin/main moved after release preparation; prepare a new candidate "
+            f"on the new tip (expected {plan.base_commit[:8]} or the release "
+            f"commit {plan.release_commit[:8]}, got {upstream[:8]})"
+        )
+    remote_candidate = run(
+        ["git", "rev-parse", f"origin/{plan.candidate_ref}"],
+        capture=True,
+        check=False,
+    ).stdout.strip()
+    if remote_candidate != plan.release_commit:
+        raise ReleaseError(
+            f"origin/{plan.candidate_ref} is {remote_candidate or 'missing'}, "
+            f"expected {plan.release_commit}"
+        )
+    green, detail = ci_verified_commit(plan.release_commit)
+    if not green:
+        raise ReleaseError(detail)
+    print(f"  {detail}")
+
+
+def delete_release_candidate(plan: ReleasePlan) -> None:
+    """Best-effort cleanup after the tag and dev-version commit are durable."""
+    if plan.candidate_ref is None:
+        return
+    result = run(
+        ["git", "push", "origin", "--delete", plan.candidate_ref],
+        check=False,
+        capture=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"  warning: could not delete {plan.candidate_ref}: "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+
+
 def git_commit_tag_push(
     version: str,
     dry_run: bool,
@@ -1590,6 +1806,12 @@ def parse_args() -> argparse.Namespace:
         help="Show what would be done without executing",
     )
     parser.add_argument(
+        "--prepare",
+        action="store_true",
+        help="Build and push an exact release candidate branch, then stop for CI. "
+        "Rerun without --prepare after CI is green to publish/tag/deploy.",
+    )
+    parser.add_argument(
         "--skip-publish", action="store_true", help="Skip crates.io publish"
     )
     parser.add_argument(
@@ -1668,53 +1890,103 @@ def main() -> int:
             )
             save_release_plan(plan)
             print(f"  saved release plan to {RELEASE_PLAN_PATH}")
+    if not dry_run:
+        if plan is None:
+            raise ReleaseError("real release lost its saved plan")
+        initialize_release_candidate(plan, new_version)
+        if (
+            args.prepare
+            and plan.release_commit is not None
+            and candidate_has_local_changes(plan)
+        ):
+            print("  reopening changed release candidate for a new CI pass")
+            reopen_release_candidate(plan, registry)
+            new_versions = plan.target_versions
     print("\nTarget versions:")
     for crate, ver in new_versions.items():
         changed = " (changed)" if ver != old_versions[crate] else ""
         print(f"  {crate}: {ver}{changed}")
-    print("\nBumping versions...")
-    bump_all_versions(old_versions, new_versions, dry_run)
-    print()
-
-    # 2.5 Bump landing-page version badge
-    print("Bumping website badge...")
-    bump_website_version(new_version, dry_run)
-    print()
-
-    # 3. Regenerate self-host
-    if not args.skip_self_host:
-        regenerate_self_host(dry_run)
+    prepared_resume = plan is not None and plan.release_commit is not None
+    if prepared_resume:
+        if args.prepare:
+            green, detail = ci_verified_commit(plan.release_commit or "")
+            print(f"\nRelease candidate already prepared: {detail}")
+            print(
+                f"Rerun without --prepare after CI is green: "
+                f"python3 tools/release.py {new_version}"
+            )
+            return 0 if green else 1
+        print("\nChecking the exact prepared release candidate...")
+        if dry_run:
+            print("  [dry-run] would require candidate ref + CI/Proof/Certification")
+        else:
+            require_prepared_release(plan)
+        print()
+    else:
+        print("\nBumping versions...")
+        bump_all_versions(old_versions, new_versions, dry_run)
         print()
 
-    # 4. Regenerate playground
-    if not args.skip_playground:
-        regenerate_playground(dry_run)
+        # 2.5 Bump landing-page version badge
+        print("Bumping website badge...")
+        bump_website_version(new_version, dry_run)
         print()
 
-    # 5. Verify
-    verify(dry_run)
-    print()
+        # 3. Regenerate self-host
+        if not args.skip_self_host:
+            regenerate_self_host(dry_run)
+            print()
 
-    # 5.5 Stamp the CHANGELOG header for this release with today's date.
-    #     Done after verify so a failed verification doesn't dirty the
-    #     working tree with a half-finished release commit.
-    print("Stamping CHANGELOG release date...")
-    stamp_changelog_release_date(new_version, dry_run)
-    print()
+        # 4. Regenerate playground
+        if not args.skip_playground:
+            regenerate_playground(dry_run)
+            print()
 
-    if not dry_run:
-        if plan is None:
-            raise ReleaseError("real release lost its saved plan")
-        print("Sealing release input fingerprints...")
-        seal_release_plan(plan)
+        # In the two-phase path, CI verifies the exact committed tree. The
+        # one-shot compatibility path keeps the local release gates.
+        if not args.prepare:
+            verify(dry_run)
+            print()
+
+        # Stamp before committing the candidate so CI and the eventual tag see
+        # byte-for-byte identical release notes.
+        print("Stamping CHANGELOG release date...")
+        stamp_changelog_release_date(new_version, dry_run)
         print()
 
-    # 6. Commit the exact tree Cargo will package. This makes
-    # `.cargo_vcs_info.json` point at the eventual release tag instead of a
-    # stale dirty parent commit.
-    print("Committing release tree...")
-    git_commit_release(new_version, dry_run, plan)
-    print()
+        if not dry_run:
+            if plan is None:
+                raise ReleaseError("real release lost its saved plan")
+            print("Sealing release input fingerprints...")
+            seal_release_plan(plan)
+            print()
+
+        # Commit the exact tree Cargo will package. This makes
+        # `.cargo_vcs_info.json` point at the eventual release tag instead of a
+        # stale dirty parent commit.
+        print("Committing release tree...")
+        git_commit_release(new_version, dry_run, plan)
+        print()
+
+        if args.prepare:
+            print("Pushing release candidate for exact-commit CI...")
+            if dry_run:
+                print(
+                    "  [dry-run] git push origin "
+                    f"HEAD:refs/heads/{release_candidate_ref(new_version)}"
+                )
+            else:
+                if plan is None:
+                    raise ReleaseError("real release lost its saved plan")
+                push_release_candidate(plan, False)
+            print()
+            print(f"Prepared {new_version}. CI now owns the expensive gates.")
+            print(
+                "After CI, resume without --prepare: "
+                f"python3 tools/release.py {new_version}"
+                + (" --deploy-edge" if args.deploy_edge else "")
+            )
+            return 0
 
     # 7. Publish
     if not args.skip_publish:
@@ -1731,16 +2003,17 @@ def main() -> int:
     )
     print()
 
-    # 9. Move main off the versions just published. A released number is
-    #    immutable on the registry; main must not keep claiming it.
-    carry_dev_versions(new_versions, dry_run)
-    print()
-
-    # 9. Optional: rebuild + deploy `tools/edge` (Cloudflare Workers
-    #    Mandelbrot demo). Live deploy of a public endpoint, so opt-in.
+    # 9. Optional deployment still runs on the committed release tree. If the
+    # public smoke fails, the saved plan remains resumable at target versions;
+    # carrying dev versions first would strand a retry between two version sets.
     if args.deploy_edge:
         deploy_edge(dry_run)
         print()
+
+    # 10. Move main off the versions just published. A released number is
+    #     immutable on the registry; main must not keep claiming it.
+    carry_dev_versions(new_versions, dry_run)
+    print()
 
     if not dry_run:
         if plan is None or any(
@@ -1748,6 +2021,8 @@ def main() -> int:
             for state in plan.publish_states.values()
         ):
             raise ReleaseError("refusing to clear an incomplete release plan")
+        if prepared_resume:
+            delete_release_candidate(plan)
         clear_release_plan()
 
     print(f"{'[dry-run] ' if dry_run else ''}Done! Released {new_version}")
@@ -1830,55 +2105,66 @@ def deploy_edge(dry_run: bool) -> None:
 
     aver_bin = REPO_ROOT / "target" / "release" / "aver"
     edge_dir = REPO_ROOT / "tools" / "edge"
-    dist_dir = edge_dir / "dist"
+    shipped_dist = edge_dir / "dist"
+    dist_dir = REPO_ROOT / "target" / "release-edge-deploy"
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    # Compile beside the repository tree. The existing production Wrangler
+    # configuration is the template, but a successful deploy must not leave a
+    # newly encoded app.wasm dirty after the release and carry-dev commits.
+    shutil.copytree(shipped_dist, dist_dir)
 
     print("  rebuild dist/ from app.av...")
-    run(
-        [
-            str(aver_bin),
-            "compile",
-            str(edge_dir / "app.av"),
-            "--preset",
-            "cloudflare",
-            "--handler",
-            "handler",
-            "--module-root",
-            str(edge_dir),
-            "-o",
-            str(dist_dir),
-        ]
-    )
+    try:
+        run(
+            [
+                str(aver_bin),
+                "compile",
+                str(edge_dir / "app.av"),
+                "--preset",
+                "cloudflare",
+                "--handler",
+                "handler",
+                "--module-root",
+                str(edge_dir),
+                "-o",
+                str(dist_dir),
+            ]
+        )
 
-    print("  wrangler deploy...")
-    # wrangler 4.x needs Node >=22; if the default node is too old, prefer
-    # `~/.nvm/versions/node/v22.*/bin` if present. Fall back to PATH `wrangler`.
-    env_path = os.environ.get("PATH", "")
-    nvm_dir = Path.home() / ".nvm" / "versions" / "node"
-    if nvm_dir.exists():
-        v22 = sorted([p for p in nvm_dir.iterdir() if p.name.startswith("v22.")])
-        if v22:
-            env_path = f"{v22[-1] / 'bin'}:{env_path}"
-    deploy_env = {**os.environ, "PATH": env_path}
-    subprocess.run(
-        ["npx", "wrangler@latest", "deploy"],
-        cwd=dist_dir,
-        env=deploy_env,
-        check=True,
-    )
+        print("  wrangler deploy...")
+        # wrangler 4.x needs Node >=22; if the default node is too old, prefer
+        # `~/.nvm/versions/node/v22.*/bin` if present. Fall back to PATH `wrangler`.
+        env_path = os.environ.get("PATH", "")
+        nvm_dir = Path.home() / ".nvm" / "versions" / "node"
+        if nvm_dir.exists():
+            v22 = sorted([p for p in nvm_dir.iterdir() if p.name.startswith("v22.")])
+            if v22:
+                env_path = f"{v22[-1] / 'bin'}:{env_path}"
+        deploy_env = {**os.environ, "PATH": env_path}
+        subprocess.run(
+            ["npx", "wrangler@latest", "deploy"],
+            cwd=dist_dir,
+            env=deploy_env,
+            check=True,
+        )
 
-    # Smoke the public production domain declared by the shipped Wrangler
-    # configuration. The workers.dev and preview routes stay disabled.
-    base = "https://edge.averlang.dev"
-    for path in ("/", "/api", "/fractal"):
-        url = base + path
-        with urllib.request.urlopen(url, timeout=10) as resp:
-            if resp.status != 200:
-                raise SystemExit(
-                    f"edge smoke: {url} returned HTTP {resp.status} (expected 200)"
+        # Smoke the public production domain declared by the shipped Wrangler
+        # configuration. The workers.dev and preview routes stay disabled.
+        base = "https://edge.averlang.dev"
+        for path in ("/", "/api", "/fractal"):
+            url = base + path
+            with urllib.request.urlopen(url, timeout=10) as resp:
+                if resp.status != 200:
+                    raise SystemExit(
+                        f"edge smoke: {url} returned HTTP {resp.status} (expected 200)"
+                    )
+                print(
+                    f"  {url} HTTP {resp.status} "
+                    f"({resp.headers.get('content-length', '?')} bytes)"
                 )
-            print(
-                f"  {url} HTTP {resp.status} ({resp.headers.get('content-length', '?')} bytes)"
-            )
+    finally:
+        shutil.rmtree(dist_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_ci_test_shard.py
+++ b/tools/tests/test_ci_test_shard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression tests for deterministic measured CI test sharding."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    "ci_test_shard", REPO_ROOT / "tools" / "ci_test_shard.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+sharding = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = sharding
+SPEC.loader.exec_module(sharding)
+
+
+class WeightedShardTests(unittest.TestCase):
+    def test_longest_targets_land_on_different_shards(self) -> None:
+        targets = ["slow_a", "slow_b", "small_a", "small_b"]
+        shards, loads = sharding.weighted_shards(
+            targets,
+            2,
+            {"slow_a": 100.0, "slow_b": 90.0},
+            set(),
+        )
+
+        self.assertNotEqual(
+            next(i for i, shard in enumerate(shards) if "slow_a" in shard),
+            next(i for i, shard in enumerate(shards) if "slow_b" in shard),
+        )
+        self.assertEqual(sorted(sum(shards, [])), sorted(targets))
+        self.assertEqual(loads, [100.0, 92.0])
+
+    def test_split_targets_are_removed_from_whole_target_bins(self) -> None:
+        shards, _loads = sharding.weighted_shards(
+            ["huge", "ordinary"],
+            2,
+            {"huge": 500.0},
+            {"huge"},
+        )
+
+        self.assertEqual(sum(shards, []), ["ordinary"])
+        self.assertEqual(
+            sharding.nextest_command({"huge"}, 1, 4)[-2:],
+            ["--partition", "slice:2/4"],
+        )
+
+    def test_stale_schedule_entry_fails_closed(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "missing targets: old_name"):
+            sharding.weighted_shards(
+                ["current"],
+                1,
+                {"old_name": 10.0},
+                set(),
+            )
+
+    def test_repository_schedule_covers_real_split_targets(self) -> None:
+        weights, split_targets = sharding.load_schedule()
+        self.assertEqual(
+            split_targets,
+            {"provider_vm_host_spec", "verify_step_budget_spec"},
+        )
+        self.assertGreater(weights["provider_vm_host_spec"], 900)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import json
 import subprocess
 import sys
 import tempfile
@@ -769,6 +770,204 @@ class RetryTests(unittest.TestCase):
         self.assertIn("--registry", commands[0])
         self.assertIn("crates-io", commands[0])
         self.assertNotIn("--allow-dirty", commands[0])
+
+
+class ReleaseCiTests(unittest.TestCase):
+    def test_exact_commit_requires_all_three_release_workflows(self) -> None:
+        rows = [
+            {"name": name, "status": "completed", "conclusion": "success"}
+            for name in ("CI", "Proof", "Certification")
+        ]
+        result = subprocess.CompletedProcess(
+            ["gh", "run", "list"], 0, stdout=json.dumps(rows), stderr=""
+        )
+        with mock.patch.object(release, "run", return_value=result):
+            green, detail = release.ci_verified_commit("a" * 40)
+
+        self.assertTrue(green)
+        self.assertIn("release CI green", detail)
+
+        rows.pop()
+        result.stdout = json.dumps(rows)
+        with mock.patch.object(release, "run", return_value=result):
+            green, detail = release.ci_verified_commit("a" * 40)
+        self.assertFalse(green)
+        self.assertIn("Certification", detail)
+
+    def test_newest_workflow_attempt_decides_the_gate(self) -> None:
+        rows = [
+            {"name": "CI", "status": "completed", "conclusion": "success"},
+            {"name": "CI", "status": "completed", "conclusion": "failure"},
+            {"name": "Proof", "status": "completed", "conclusion": "success"},
+            {
+                "name": "Certification",
+                "status": "completed",
+                "conclusion": "success",
+            },
+            {"name": "Fuzz", "status": "in_progress", "conclusion": None},
+        ]
+        result = subprocess.CompletedProcess(
+            ["gh", "run", "list"], 0, stdout=json.dumps(rows), stderr=""
+        )
+        with mock.patch.object(release, "run", return_value=result):
+            green, _detail = release.ci_verified_commit("b" * 40)
+        self.assertTrue(green)
+
+    def test_candidate_records_the_exact_main_base(self) -> None:
+        plan = release.create_release_plan(
+            "0.27.0", versions(), versions(main="0.27.0"), registry()
+        )
+        head = "c" * 40
+        results = [
+            subprocess.CompletedProcess(["git"], 0, stdout=head + "\n", stderr=""),
+            subprocess.CompletedProcess(["git"], 0, stdout=head + "\n", stderr=""),
+        ]
+        with (
+            mock.patch.object(release, "run", side_effect=results),
+            mock.patch.object(release, "save_release_plan") as saver,
+        ):
+            release.initialize_release_candidate(plan, "0.27.0")
+
+        self.assertEqual(plan.base_commit, head)
+        self.assertEqual(plan.candidate_ref, "release/0.27.0")
+        saver.assert_called_once_with(plan)
+
+    def test_finalize_refuses_when_main_moved_after_preparation(self) -> None:
+        plan = release.create_release_plan(
+            "0.27.0", versions(), versions(main="0.27.0"), registry()
+        )
+        plan.base_commit = "d" * 40
+        plan.release_commit = "e" * 40
+        plan.candidate_ref = "release/0.27.0"
+        results = [
+            subprocess.CompletedProcess(["git", "fetch"], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                ["git", "rev-parse"], 0, stdout="f" * 40 + "\n", stderr=""
+            ),
+        ]
+        with (
+            mock.patch.object(release, "run", side_effect=results),
+            mock.patch.object(release, "require_clean_release_tree"),
+            mock.patch.object(release, "ci_verified_commit") as ci,
+        ):
+            with self.assertRaisesRegex(release.ReleaseError, "origin/main moved"):
+                release.require_prepared_release(plan)
+        ci.assert_not_called()
+
+    def test_saved_release_commit_requires_candidate_identity(self) -> None:
+        plan = release.create_release_plan(
+            "0.27.0", versions(), versions(main="0.27.0"), registry()
+        )
+        plan.release_commit = "a" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "plan.json"
+            release.save_release_plan(plan, path)
+            with self.assertRaisesRegex(release.ReleaseError, "missing its base"):
+                release.load_release_plan("0.27.0", versions(main="0.27.0"), path)
+
+    def test_repair_pass_replans_a_newly_changed_runtime_crate(self) -> None:
+        base = versions()
+        target = versions(main="0.27.0")
+        target["aver-lsp"] = "0.6.16"
+        state = registry(
+            aver_rt={"0.4.9"},
+            aver_memory={"0.2.11"},
+            aver_cert={"0.1.0"},
+            aver_lang={"0.26.0"},
+            aver_lsp={"0.6.15"},
+        )
+        plan = release.create_release_plan(
+            "0.27.0",
+            base,
+            target,
+            state,
+            fingerprint=lambda crate: f"planning-{crate}",
+        )
+        plan.fingerprints = {crate: f"sealed-{crate}" for crate in release.CRATE_ORDER}
+        plan.release_commit = "a" * 40
+        plan.base_commit = "b" * 40
+        plan.candidate_ref = "release/0.27.0"
+        results = [
+            subprocess.CompletedProcess(
+                ["git", "rev-parse", "HEAD"],
+                0,
+                stdout=plan.release_commit + "\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(["git", "merge-base"], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                ["git", "rev-parse", "origin/main"],
+                0,
+                stdout=plan.base_commit + "\n",
+                stderr="",
+            ),
+        ]
+
+        with (
+            mock.patch.object(release, "run", side_effect=results),
+            mock.patch.object(
+                release,
+                "publish_inputs_fingerprint",
+                side_effect=lambda crate: (
+                    "changed-aver-rt" if crate == "aver-rt" else f"sealed-{crate}"
+                ),
+            ),
+            mock.patch.object(
+                release,
+                "planning_inputs_fingerprint",
+                side_effect=lambda crate: f"replanned-{crate}",
+            ),
+            mock.patch.object(release, "save_release_plan"),
+        ):
+            release.reopen_release_candidate(plan, state)
+
+        self.assertEqual(plan.target_versions["aver-rt"], "0.4.10")
+        self.assertEqual(plan.target_versions["aver-memory"], "0.2.12")
+        self.assertEqual(plan.publish_states["aver-rt"], "pending")
+        self.assertEqual(plan.fingerprints, {})
+        self.assertIsNone(plan.release_commit)
+
+
+class DeploymentTests(unittest.TestCase):
+    def test_edge_deploy_builds_in_target_without_dirtying_shipped_dist(self) -> None:
+        class Response:
+            status = 200
+            headers = {"content-length": "2"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            shipped = root / "tools" / "edge" / "dist"
+            shipped.mkdir(parents=True)
+            (shipped / "app.wasm").write_bytes(b"committed")
+            (shipped / "wrangler.toml").write_text('name = "demo"\n')
+            (root / "tools" / "edge" / "app.av").write_text("fn main() = 0\n")
+            aver_bin = root / "target" / "release" / "aver"
+            aver_bin.parent.mkdir(parents=True)
+            aver_bin.write_text("")
+
+            def runner(command, **_kwargs):
+                output = Path(command[-1])
+                (output / "app.wasm").write_bytes(b"deployed")
+                return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+            with (
+                mock.patch.object(release, "REPO_ROOT", root),
+                mock.patch.object(release, "run", side_effect=runner),
+                mock.patch.object(release.subprocess, "run"),
+                mock.patch.object(
+                    release.urllib.request, "urlopen", return_value=Response()
+                ),
+            ):
+                release.deploy_edge(False)
+
+            self.assertEqual((shipped / "app.wasm").read_bytes(), b"committed")
+            self.assertFalse((root / "target" / "release-edge-deploy").exists())
 
 
 class FinalizationTests(unittest.TestCase):

--- a/tools/tests/test_release.py
+++ b/tools/tests/test_release.py
@@ -872,10 +872,13 @@ class ReleaseCiTests(unittest.TestCase):
         state = registry(
             aver_rt={"0.4.9"},
             aver_memory={"0.2.11"},
-            aver_cert={"0.1.0"},
             aver_lang={"0.26.0"},
             aver_lsp={"0.6.15"},
         )
+        # This test exercises candidate repair, not recovery of aver-cert's
+        # independently versioned baseline from the repository's tag history.
+        # Keep it hermetic under CI's deliberately shallow checkout.
+        state["aver-cert"] = release.RegistryState(release.RegistryKind.MISSING)
         plan = release.create_release_plan(
             "0.27.0",
             base,


### PR DESCRIPTION
## What changed

- Replace alphabetical integration-target round-robin with a measured longest-first schedule. The two targets that dominated the last run (998 s and 826 s) are partitioned by test case across all four runners with nextest; ordinary measured load is 82.0 / 81.5 / 81.1 / 81.1 s.
- Add a two-phase release flow. --prepare commits and pushes release/X.Y.Z; CI, Proof, and the complete Certification matrix gate that exact SHA. Resume refuses changed bytes, a moved main, missing workflows, or failed workflows before publishing.
- Permit a failed candidate to be repaired and re-prepared before publication, with crate bumps and dependency cascades recomputed from changed publish inputs.
- Compile/deploy edge from a temporary target tree so a successful release no longer leaves tools/edge/dist/app.wasm dirty.
- Run the release-tool test directory as one discovered suite and document the new workflow.

## Evidence

- 48 release/sharding unit tests pass.
- Ruff check and format check pass.
- cargo fmt --all -- --check passes.
- All three workflow files parse as YAML.
- nextest successfully builds and discovers the 3 provider-host plus 31 verify-budget cases selected for case-level partitioning.
- All four generated shard plans cover 128 whole targets plus both split targets, with balanced measured loads.