### PR TITLE
Add an opt-in cargo check gate to Rust compilation

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -20,6 +20,18 @@ Compiled examples/core/hello.av → /tmp/hello-rs/ [Rust]
   cd /tmp/hello-rs && cargo build && cargo run
 ```
 
+To validate the generated crate immediately, add `--check`:
+
+```bash
+aver compile examples/core/hello.av -o /tmp/hello-rs --check
+```
+
+For the Rust target, `--check` runs `cargo check` against the generated
+manifest, forwards Cargo's diagnostics, and exits non-zero when Cargo or rustc
+rejects the project. The generated files remain available for inspection after
+a failure. Without the flag, `aver compile` only emits the project and does not
+invoke Cargo.
+
 ## What it generates
 
 Generates a complete Cargo project:

--- a/src/cli_entry.rs
+++ b/src/cli_entry.rs
@@ -29,6 +29,8 @@ mod replay_cmd;
 mod run_wasip2;
 #[path = "main/run_wasm_gc.rs"]
 mod run_wasm_gc;
+#[path = "main/rust_check.rs"]
+mod rust_check;
 #[path = "main/shape_cmd.rs"]
 mod shape_cmd;
 #[path = "main/shared.rs"]
@@ -329,6 +331,7 @@ fn main_impl(
             name,
             module_root,
             target,
+            check,
             with_replay,
             policy,
             guest_entry,
@@ -367,6 +370,11 @@ fn main_impl(
                 ),
                 None => (*target, *pack),
             };
+            if let Some(error) = cli::compile_check_target_rejection(*check, effective_target) {
+                use colored::Colorize;
+                eprintln!("{}", error.red());
+                std::process::exit(1);
+            }
             if let Some(error) =
                 cli::boxed_sequences_target_rejection(*test_boxed_sequences, effective_target)
             {
@@ -433,6 +441,7 @@ fn main_impl(
                 project_name: name.as_deref(),
                 module_root_override: module_root.as_deref(),
                 target: effective_target,
+                check: *check,
                 with_replay: *with_replay,
                 policy_mode: &policy_mode,
                 guest_entry: guest_entry.as_deref(),

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -119,6 +119,15 @@ pub(super) fn boxed_sequences_target_rejection(
     )
 }
 
+pub(super) fn compile_check_target_rejection(
+    enabled: bool,
+    target: CompileTarget,
+) -> Option<&'static str> {
+    (enabled && !matches!(target, CompileTarget::Rust)).then_some(
+        "--check requires --target rust (it validates the generated Cargo project with `cargo check`)",
+    )
+}
+
 /// WASI 0.2 world the component targets. Used only by
 /// `--target wasip2`; ignored by every other target. Defaults to
 /// `wasi:cli/command` (a long-lived process exporting `wasi:cli/run`).
@@ -424,6 +433,15 @@ pub(super) enum Commands {
         /// Compile target: rust (default), wasm-gc, wasip2
         #[arg(long, default_value = "rust")]
         target: CompileTarget,
+        /// After emitting a Rust project, run `cargo check` against its
+        /// manifest and propagate Cargo's exit status and diagnostics.
+        /// The generated project remains in place when validation fails.
+        #[arg(
+            long,
+            default_value_t = false,
+            conflicts_with_all = ["emit_ir_after", "explain_passes", "explain_mir_coverage"]
+        )]
+        check: bool,
         /// Emit optional record/replay runtime support into the generated project
         #[arg(long)]
         with_replay: bool,
@@ -951,6 +969,26 @@ mod tests {
             }
             _ => panic!("expected compile command"),
         }
+    }
+
+    #[test]
+    fn compile_accepts_check_for_default_rust_target() {
+        let cli = Cli::parse_from(["aver", "compile", "examples/core/hello.av", "--check"]);
+        match cli.command {
+            Commands::Compile { target, check, .. } => {
+                assert_eq!(target, CompileTarget::Rust);
+                assert!(check);
+            }
+            _ => panic!("expected compile command"),
+        }
+    }
+
+    #[test]
+    fn compile_check_rejects_non_rust_targets() {
+        assert!(compile_check_target_rejection(true, CompileTarget::Rust).is_none());
+        assert!(compile_check_target_rejection(true, CompileTarget::WasmGc).is_some());
+        assert!(compile_check_target_rejection(true, CompileTarget::Wasip2).is_some());
+        assert!(compile_check_target_rejection(false, CompileTarget::WasmGc).is_none());
     }
 
     #[test]

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4029,11 +4029,10 @@ fn build_codegen_context(
     (ctx, module_root)
 }
 
-fn write_codegen_output(
+fn prepare_codegen_output(
     file: &str,
     output_dir: &str,
     target_label: &str,
-    build_hint: &str,
     output: &codegen::ProjectOutput,
 ) {
     let out_path = Path::new(output_dir);
@@ -4071,11 +4070,23 @@ fn write_codegen_output(
         );
         process::exit(1);
     }
+}
 
+fn report_codegen_output(
+    file: &str,
+    output_dir: &str,
+    target_label: &str,
+    build_hint: &str,
+    output: &codegen::ProjectOutput,
+    cargo_checked: bool,
+) {
     println!(
         "{}",
         format!("Compiled {} → {}/ [{}]", file, output_dir, target_label).green()
     );
+    if cargo_checked {
+        println!("  {}", "cargo check passed".green());
+    }
     // A verify case the backend could not render is left out of the
     // generated test module. That is not a build failure, but it is a case
     // the crate does not run, so it is named here rather than vanishing.
@@ -4089,6 +4100,17 @@ fn write_codegen_output(
         }
     }
     println!("  {}", build_hint.cyan());
+}
+
+fn write_codegen_output(
+    file: &str,
+    output_dir: &str,
+    target_label: &str,
+    build_hint: &str,
+    output: &codegen::ProjectOutput,
+) {
+    prepare_codegen_output(file, output_dir, target_label, output);
+    report_codegen_output(file, output_dir, target_label, build_hint, output, false);
 }
 
 pub(super) struct BenchOptions<'a> {
@@ -6330,6 +6352,7 @@ pub(super) fn cmd_compile(opts: CompileOptions<'_>) {
         project_name,
         module_root_override,
         target,
+        check,
         with_replay,
         policy_mode,
         guest_entry,
@@ -6482,7 +6505,13 @@ pub(super) fn cmd_compile(opts: CompileOptions<'_>) {
         }
     };
     let build_hint = format!("cd {} && cargo build && cargo run", output_dir);
-    write_codegen_output(file, output_dir, "Rust", &build_hint, &output);
+    prepare_codegen_output(file, output_dir, "Rust", &output);
+    if check && let Err(error) = super::rust_check::run(Path::new(output_dir)) {
+        let exit_code = error.exit_code();
+        eprintln!("{}", error.to_string().red());
+        process::exit(exit_code);
+    }
+    report_codegen_output(file, output_dir, "Rust", &build_hint, &output, check);
     print_capability_target_accounting(
         &ctx.items,
         &ctx.modules,
@@ -7301,6 +7330,7 @@ pub(super) struct CompileOptions<'a> {
     pub(super) project_name: Option<&'a str>,
     pub(super) module_root_override: Option<&'a str>,
     pub(super) target: super::cli::CompileTarget,
+    pub(super) check: bool,
     pub(super) with_replay: bool,
     pub(super) policy_mode: &'a super::cli::CompilePolicyMode,
     pub(super) guest_entry: Option<&'a str>,

--- a/src/main/rust_check.rs
+++ b/src/main/rust_check.rs
@@ -1,0 +1,155 @@
+use std::ffi::OsStr;
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+
+#[derive(Debug)]
+pub(super) enum CargoCheckError {
+    Spawn {
+        manifest: PathBuf,
+        source: io::Error,
+    },
+    Failed {
+        manifest: PathBuf,
+        status: ExitStatus,
+    },
+}
+
+impl CargoCheckError {
+    pub(super) fn exit_code(&self) -> i32 {
+        match self {
+            Self::Spawn { .. } => 1,
+            Self::Failed { status, .. } => status.code().unwrap_or(1),
+        }
+    }
+}
+
+impl fmt::Display for CargoCheckError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Spawn { manifest, source } => write!(
+                formatter,
+                "Generated Rust project remains at '{}', but `cargo check` could not start: {}",
+                manifest
+                    .parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .display(),
+                source
+            ),
+            Self::Failed { manifest, status } => write!(
+                formatter,
+                "Generated Rust project remains at '{}', but `cargo check` failed with {}",
+                manifest
+                    .parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .display(),
+                status
+            ),
+        }
+    }
+}
+
+pub(super) fn run(output_dir: &Path) -> Result<(), CargoCheckError> {
+    run_with_program(OsStr::new("cargo"), output_dir)
+}
+
+fn run_with_program(cargo: &OsStr, output_dir: &Path) -> Result<(), CargoCheckError> {
+    let manifest = output_dir.join("Cargo.toml");
+    let status = Command::new(cargo)
+        .arg("check")
+        .arg("--manifest-path")
+        .arg(&manifest)
+        .status()
+        .map_err(|source| CargoCheckError::Spawn {
+            manifest: manifest.clone(),
+            source,
+        })?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CargoCheckError::Failed { manifest, status })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[cfg(unix)]
+    fn shell_quote(path: &Path) -> String {
+        format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
+    }
+
+    #[cfg(unix)]
+    fn fake_cargo(dir: &Path, exit_code: i32) -> (PathBuf, PathBuf) {
+        let program = dir.join("cargo");
+        let args_log = dir.join("args.log");
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > {}\nexit {}\n",
+            shell_quote(&args_log),
+            exit_code
+        );
+        fs::write(&program, script).expect("write fake cargo");
+        let mut permissions = fs::metadata(&program)
+            .expect("stat fake cargo")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).expect("make fake cargo executable");
+        (program, args_log)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invokes_cargo_check_with_generated_manifest() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let project = temp.path().join("generated");
+        fs::create_dir_all(&project).expect("create generated project");
+        let (cargo, args_log) = fake_cargo(temp.path(), 0);
+
+        run_with_program(cargo.as_os_str(), &project).expect("fake cargo check should pass");
+
+        let args = fs::read_to_string(args_log).expect("read fake cargo args");
+        assert_eq!(
+            args.lines().collect::<Vec<_>>(),
+            vec![
+                "check",
+                "--manifest-path",
+                project.join("Cargo.toml").to_string_lossy().as_ref()
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_cargo_failure_exit_code() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let project = temp.path().join("generated");
+        fs::create_dir_all(&project).expect("create generated project");
+        let (cargo, _) = fake_cargo(temp.path(), 37);
+
+        let error = run_with_program(cargo.as_os_str(), &project)
+            .expect_err("fake cargo check should fail");
+
+        assert_eq!(error.exit_code(), 37);
+        assert!(error.to_string().contains("project remains at"));
+    }
+
+    #[test]
+    fn spawn_failure_uses_nonzero_exit_code() {
+        let temp = tempfile::tempdir().expect("create temp dir");
+        let missing = temp.path().join("definitely-not-cargo");
+
+        let error = run_with_program(missing.as_os_str(), temp.path())
+            .expect_err("missing cargo program should fail");
+
+        assert_eq!(error.exit_code(), 1);
+        assert!(error.to_string().contains("could not start"));
+    }
+}

--- a/tests/compile_spec.rs
+++ b/tests/compile_spec.rs
@@ -3,6 +3,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 fn temp_output_dir(prefix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -41,6 +44,162 @@ fn marker_count(path: &Path) -> usize {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => 0,
         Err(err) => panic!("failed to read {}: {}", path.display(), err),
     }
+}
+
+#[cfg(unix)]
+fn write_fake_cargo(dir: &Path) -> PathBuf {
+    let cargo = dir.join("cargo");
+    fs::write(
+        &cargo,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$AVER_TEST_CARGO_ARGS\"\nexit \"$AVER_TEST_CARGO_STATUS\"\n",
+    )
+    .expect("write fake cargo");
+    let mut permissions = fs::metadata(&cargo).expect("stat fake cargo").permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&cargo, permissions).expect("make fake cargo executable");
+    cargo
+}
+
+#[cfg(unix)]
+fn write_compile_check_probe(workspace: &Path) -> PathBuf {
+    fs::create_dir_all(workspace).expect("create compile-check workspace");
+    let source = workspace.join("main.av");
+    fs::write(
+        &source,
+        r#"module Main
+    intent = "Exercise the Rust compile check boundary."
+    exposes [main]
+
+fn main() -> Int
+    1
+"#,
+    )
+    .expect("write compile-check source");
+    source
+}
+
+#[cfg(unix)]
+#[test]
+fn compile_check_runs_cargo_and_reports_success_only_after_it_passes() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = temp_output_dir("aver-compile-check-success");
+    let fake_bin = workspace.join("bin");
+    let output_dir = workspace.join("out");
+    let args_log = workspace.join("cargo-args.txt");
+    let source = write_compile_check_probe(&workspace);
+    fs::create_dir_all(&fake_bin).expect("create fake bin dir");
+    write_fake_cargo(&fake_bin);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg(&source)
+        .arg("--target")
+        .arg("rust")
+        .arg("--check")
+        .arg("-o")
+        .arg(&output_dir)
+        .env("PATH", &fake_bin)
+        .env("AVER_TEST_CARGO_ARGS", &args_log)
+        .env("AVER_TEST_CARGO_STATUS", "0")
+        .output()
+        .expect("run aver compile --check");
+
+    assert!(
+        output.status.success(),
+        "compile --check should pass when Cargo passes:\n{}",
+        format_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Compiled"),
+        "missing compile success:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("cargo check passed"),
+        "missing Cargo success:\n{stdout}"
+    );
+    let cargo_args = fs::read_to_string(&args_log).expect("read fake Cargo args");
+    assert_eq!(
+        cargo_args.lines().collect::<Vec<_>>(),
+        vec![
+            "check",
+            "--manifest-path",
+            output_dir.join("Cargo.toml").to_string_lossy().as_ref()
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&workspace);
+}
+
+#[cfg(unix)]
+#[test]
+fn compile_check_propagates_cargo_failure_and_keeps_generated_project() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = temp_output_dir("aver-compile-check-failure");
+    let fake_bin = workspace.join("bin");
+    let output_dir = workspace.join("out");
+    let args_log = workspace.join("cargo-args.txt");
+    let source = write_compile_check_probe(&workspace);
+    fs::create_dir_all(&fake_bin).expect("create fake bin dir");
+    write_fake_cargo(&fake_bin);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg(&source)
+        .arg("--check")
+        .arg("-o")
+        .arg(&output_dir)
+        .env("PATH", &fake_bin)
+        .env("AVER_TEST_CARGO_ARGS", &args_log)
+        .env("AVER_TEST_CARGO_STATUS", "37")
+        .output()
+        .expect("run failing aver compile --check");
+
+    assert_eq!(
+        output.status.code(),
+        Some(37),
+        "compile --check should preserve Cargo's exit code:\n{}",
+        format_output(&output)
+    );
+    assert!(
+        output_dir.join("Cargo.toml").is_file(),
+        "generated project should remain after Cargo failure"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Compiled"),
+        "compile success must wait for Cargo:\n{stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`cargo check` failed"),
+        "missing Cargo failure context:\n{stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&workspace);
+}
+
+#[test]
+fn compile_check_rejects_non_rust_target_before_codegen() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("examples/core/hello.av")
+        .arg("--target")
+        .arg("wasm-gc")
+        .arg("--check")
+        .output()
+        .expect("run aver compile --target wasm-gc --check");
+
+    assert_eq!(output.status.code(), Some(1), "{}", format_output(&output));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--check requires --target rust"),
+        "{}",
+        format_output(&output)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add opt-in `aver compile --target rust --check`
- run `cargo check --manifest-path <output>/Cargo.toml` after materialising the generated project
- forward Cargo diagnostics and preserve its non-zero exit code
- keep the generated project after failure and delay Aver's success message until Cargo passes
- reject `--check` for non-Rust targets and codegen-observability short-circuit modes
- document the validation boundary and cover success, failure, target rejection, argument forwarding, and missing-Cargo behaviour

Plain `aver compile` remains a pure emitter. Source mapping and the broader Rust-backend hardening remain tracked separately in #1173–#1177.

## Verification

- `cargo test -p aver-lang --lib --bins` — 1451 passed
- `cargo test --test compile_spec -- --nocapture` — 4 passed
- `cargo clippy -p aver-lang --lib --bin aver -- -D warnings`
- `cargo fmt --all -- --check`
- real generated-project smoke test: `aver compile examples/core/hello.av --target rust --check`

Closes #1172.
