### PR TITLE
test(rust): validate emitted projects in CI and fuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,9 @@ name: Fuzz
 #     resolve. Catches panics in any post-parse pass — the surface a
 #     real user touches every time they run `aver check`.
 #   * `fuzz_replay_codec`       — JSON record codec roundtrip.
+#   * `fuzz_codegen_rust`       — source → resolved Rust ProjectOutput;
+#     a bounded post-campaign sample goes through real `rustc` via
+#     `aver compile --check`.
 #   * `fuzz_codegen_wasm_gc`    — source → compile → wasmparser validate.
 #   * `fuzz_codegen_wasip2`     — source → wasip2 core + component → component-model validate.
 #   * `fuzz_verify_runner`      — source → run_verify_for_items_vm.
@@ -115,6 +118,9 @@ jobs:
             corpus: corpus/replay
             dict: dicts/replay_json.dict
           - target: fuzz_codegen_wasm_gc
+            corpus: corpus/parser
+            dict: dicts/aver.dict
+          - target: fuzz_codegen_rust
             corpus: corpus/parser
             dict: dicts/aver.dict
           - target: fuzz_verify_runner
@@ -366,6 +372,24 @@ jobs:
             echo "no metrics snapshot (target ran < 10k execs)"
           fi
           echo "::endgroup::"
+
+      - name: Rust codegen oracle (bounded real rustc)
+        if: matrix.target == 'fuzz_codegen_rust'
+        # AFL's hot loop emits projects in-process. Spawning Cargo for every
+        # mutation would collapse throughput, so ask the public `--check`
+        # gate about a deterministic sample of accepted queue entries after
+        # the campaign. The committed corpus is a fallback that guarantees
+        # the oracle still has valid seeds if AFL exits before writing a
+        # usable queue. One shared target amortises aver-rt and dependencies.
+        run: |
+          cargo build --locked --bin aver
+          python3 tools/validate_rust_fuzz_corpus.py \
+            --aver target/debug/aver \
+            --corpus fuzz/corpus/parser \
+            --corpus fuzz/out/fuzz_codegen_rust/default/queue \
+            --limit 24 \
+            --max-candidates 256 \
+            --target-dir target/rust-fuzz-oracle
 
       - name: Summarise findings
         working-directory: fuzz

--- a/.github/workflows/rust-codegen.yml
+++ b/.github/workflows/rust-codegen.yml
@@ -1,11 +1,11 @@
 name: Rust codegen
 
-# Nightly Rust codegen regression. For a hand-picked corpus of
-# single-file `examples/core/*.av` programs, run
-# `aver compile <file> --target rust -o <tmp>` then
-# `cargo check --manifest-path <tmp>/Cargo.toml`. Asserts the
-# emitted Rust project actually type-checks under the real
-# compiler.
+# Nightly Rust codegen regression. The first job checks a hand-picked corpus
+# of single-file `examples/core/*.av` programs; the second checks the pinned
+# btc-listener revision from #1172 with current Aver. The corpus job
+# materialises each project and invokes Cargo explicitly; the downstream job
+# exercises the public `aver compile --target rust --check` gate. Both assert
+# that emitted Rust type-checks under the real compiler.
 #
 # Catches the bug class where `compile_to_rust` emits syntactically
 # valid but semantically broken source: missing imports, mistyped
@@ -71,3 +71,58 @@ jobs:
         # named example + the cargo check output in the failure
         # message.
         run: cargo test --test rust_codegen_regression -- --nocapture
+
+  btc-listener-canary:
+    name: Rust codegen downstream (btc-listener)
+    runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository == 'jasisz/aver'
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      # Pin the public project at the exact revision that reported #1172.
+      # Upstream application changes must not turn an Aver regression canary
+      # red; update this SHA deliberately when adopting a newer corpus.
+      - uses: actions/checkout@v5
+        with:
+          repository: n1bor/btc-listener
+          ref: a28f19de1d85d506cc75b0a52a9466b2e9607af8
+          path: btc-listener
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install libclang for the pinned RocksDB provider
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libclang-dev
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-codegen-btc-listener
+
+      - name: Place current Aver at btc-listener's pinned dev path
+        # Both downstream provider crates intentionally depend on aver-rt at
+        # this absolute path; btc-listener's own CI checks out its pinned Aver
+        # revision there. Clone this workflow's exact checkout locally so the
+        # canary tests current Aver under the same source identity without
+        # rewriting the downstream manifests.
+        run: |
+          sudo mkdir -p /home/owensr/aver
+          sudo chown "$USER" /home/owensr/aver
+          git clone --quiet --local "$GITHUB_WORKSPACE" /home/owensr/aver/aver
+          git -C /home/owensr/aver/aver checkout --quiet "$GITHUB_SHA"
+
+      - name: Build current Aver
+        working-directory: /home/owensr/aver/aver
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target/btc-listener-aver
+        run: cargo build --locked --bin aver
+
+      - name: Check the emitted downstream project
+        env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target/btc-listener-canary
+        run: |
+          target/btc-listener-aver/debug/aver compile \
+            btc-listener/main.av \
+            --module-root btc-listener \
+            --target rust \
+            --check \
+            -o "$RUNNER_TEMP/btc-listener-generated"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -64,6 +64,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "fuzz_codegen_rust"
+path = "fuzz_targets/codegen_rust.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_verify_runner"
 path = "fuzz_targets/verify_runner.rs"
 test = false

--- a/fuzz/fuzz_targets/codegen_rust.rs
+++ b/fuzz/fuzz_targets/codegen_rust.rs
@@ -1,0 +1,126 @@
+// Coverage-guided fuzz target: arbitrary bytes -> emitted Rust project.
+//
+// This is the high-throughput half of the Rust validity oracle. It drives
+// accepted programs through the production dependency preparation, runtime
+// lowering, resolved-identity context, and Rust emitter without spawning
+// rustc on every AFL iteration. Any type-correct Aver program must reach a
+// complete ProjectOutput without panicking or asking the emitter to insert a
+// compile_error! placeholder.
+//
+// Rust's type checker remains the authority for whether those files form a
+// valid crate. The nightly workflow therefore takes a bounded, deterministic
+// sample of this target's evolved queue and replays it through
+// `aver compile --target rust --check`. Splitting the two loops preserves AFL
+// throughput while retaining a real rustc oracle.
+
+#[path = "common.rs"]
+mod common;
+
+use aver::ir::{PipelineConfig, TypecheckMode};
+
+const MAX_INPUT_SIZE: usize = 8 * 1024;
+
+fn main() {
+    afl::fuzz!(|data: &[u8]| {
+        if data.len() > MAX_INPUT_SIZE {
+            return;
+        }
+        let counters = common::counters();
+        counters.record_exec();
+
+        let setup = common::try_multimodule_input(data);
+        let single_root;
+        let (source, module_root): (&str, &str) = match &setup {
+            Some(setup) => {
+                let Some(root) = setup.module_root.to_str() else {
+                    return;
+                };
+                (setup.entry_source.as_str(), root)
+            }
+            None => {
+                let Ok(source) = std::str::from_utf8(data) else {
+                    return;
+                };
+                // `load_compile_deps` also supplies embedded standard-library
+                // modules. Give single-file inputs an empty, stable project
+                // root so arbitrary dependency names cannot resolve against
+                // files from the fuzz crate's working directory.
+                single_root = std::env::temp_dir().join("aver-fuzz-rust-single-root");
+                if std::fs::create_dir_all(&single_root).is_err() {
+                    return;
+                }
+                let Some(root) = single_root.to_str() else {
+                    return;
+                };
+                (source, root)
+            }
+        };
+
+        let mut lexer = aver::lexer::Lexer::new(source);
+        let Ok(tokens) = lexer.tokenize() else {
+            return;
+        };
+        counters.record_lex_ok();
+        let mut parser = aver::parser::Parser::new(tokens);
+        let Ok(mut items) = parser.parse() else {
+            return;
+        };
+        let (nodes, depth) = common::ast_metrics(&items);
+        counters.record_parse_ok(nodes, depth);
+
+        let Ok(prepared) = aver::source::load_compile_deps(&items, module_root) else {
+            return;
+        };
+        let aver::source::PreparedCompileDeps { modules, loaded } = prepared;
+        let mut result = aver::ir::pipeline::run(
+            &mut items,
+            PipelineConfig {
+                typecheck: Some(TypecheckMode::WithCheckedLoaded(&loaded)),
+                run_interp_lower: true,
+                run_buffer_build: true,
+                run_chars_fusion: true,
+                run_string_index: true,
+                run_list_build: true,
+                run_build_symbols: true,
+                dep_modules: &modules,
+                ..Default::default()
+            },
+        );
+        let Some(typecheck) = result.typecheck.as_ref() else {
+            return;
+        };
+        if !typecheck.errors.is_empty() {
+            return;
+        }
+        counters.record_typecheck_clean();
+
+        let typecheck = result
+            .typecheck
+            .take()
+            .expect("Rust fuzz pipeline requested typechecking");
+        let view = result.codegen_view(items);
+        let mut ctx = aver::codegen::build_context(
+            view.items,
+            &typecheck,
+            view.analysis.as_ref(),
+            "aver_fuzz_rust".to_string(),
+            modules,
+            view.symbol_table,
+            view.resolved_items,
+        );
+        let output = aver::codegen::rust::transpile(&mut ctx);
+
+        if !output.generated_compile_errors().is_empty() {
+            std::process::abort();
+        }
+        let has_manifest = output.files.iter().any(|(path, _)| path == "Cargo.toml");
+        let has_entry = output
+            .files
+            .iter()
+            .any(|(path, _)| path == "src/aver_generated/entry/mod.rs");
+        if !has_manifest || !has_entry {
+            std::process::abort();
+        }
+    });
+    common::counters().flush();
+}

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -183,11 +183,7 @@ fn expr_metrics(root: &aver::ast::Spanned<aver::ast::Expr>, base_depth: u64) -> 
                     stack.push((a, d + 1));
                 }
             }
-            Expr::Constructor(_, payload) => {
-                if let Some(arg) = payload {
-                    stack.push((arg, d + 1));
-                }
-            }
+            Expr::Constructor(_, Some(arg)) => stack.push((arg, d + 1)),
             Expr::Match { subject, arms } => {
                 stack.push((subject, d + 1));
                 for arm in arms {
@@ -274,8 +270,9 @@ pub fn counters() -> &'static Counters {
 //   <entry_idx: u8 in 0..n_files>
 //
 // Anything malformed → `None`, target falls back to single-file.
-// Names are lowercased and rendered as `<name>.av` files under a
-// deterministically-named directory keyed on `hash(data)`. Same input
+// Names are lowercased and rendered with the production module mapping
+// (`Domain.User` -> `domain/user.av`) under a deterministically-named
+// directory keyed on `hash(data)`. Same input
 // → same directory path → AFL's coverage map stays stable. A fresh
 // random tempdir would mean every exec sees different paths inside
 // `LoadedModule.path` / Aver error messages, which AFL reads as
@@ -288,8 +285,7 @@ pub struct MultiModuleSetup {
     /// Path to the entry .av file inside the deterministic dir.
     pub entry_path: std::path::PathBuf,
     /// Module root for `--module-root` / `find_module_file` lookups
-    /// — same directory as the entry, since all synthetic files
-    /// land flat at the dir root.
+    /// — the common ancestor of every synthetic module path.
     pub module_root: std::path::PathBuf,
     /// Raw entry source — handed to targets that only need the
     /// bytes (e.g. `parse_bytes`, `replay_codec`).
@@ -357,7 +353,23 @@ pub fn try_multimodule_input(data: &[u8]) -> Option<MultiModuleSetup> {
         let body = std::str::from_utf8(&data[pos..pos + body_len]).ok()?;
         pos += body_len;
 
-        let file_path = dir.join(format!("{name}.av"));
+        // Dotted module identities map to directories in the real loader:
+        // `Domain.User` lives at `domain/user.av`, not
+        // `domain.user.av`. Keeping that mapping here matters because a
+        // synthetic input that only works in the fuzz filesystem never
+        // exercises the production cross-module path it claims to cover.
+        let mut file_path = dir.clone();
+        let mut parts = name.split('.').peekable();
+        while let Some(part) = parts.next() {
+            if parts.peek().is_some() {
+                file_path.push(part);
+            } else {
+                file_path.push(format!("{part}.av"));
+            }
+        }
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).ok()?;
+        }
         std::fs::write(&file_path, body).ok()?;
         file_paths.push(file_path);
     }

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -5480,6 +5480,85 @@ fn main() -> Unit
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Regression for #1134: derive requirements belong to a declaration, not
+/// its bare type name. `Snapshot.Progress` can carry Eq + Hash, while the
+/// same-named `Bodies.Progress` contains a Float and cannot. The emitter unit
+/// test pins the chosen derive text; this test asks rustc about the complete
+/// multi-module project through the public `compile --check` gate.
+#[test]
+fn same_named_records_keep_declaration_scoped_derives_under_compile_check() {
+    let ws = temp_dir("same_named_record_derives");
+    fs::write(
+        ws.join("Snapshot.av"),
+        r#"module Snapshot
+    exposes [Progress, done]
+    intent = "Own the equality-safe progress record."
+    effects []
+
+record Progress
+    done: Int
+
+fn done(progress: Progress) -> Int
+    ? "Read the completed count."
+    progress.done
+"#,
+    )
+    .expect("write Snapshot module");
+    fs::write(
+        ws.join("Bodies.av"),
+        r#"module Bodies
+    exposes [Progress, Walk, count]
+    intent = "Own a same-named progress record that cannot be Eq."
+    effects []
+
+record Progress
+    ratio: Float
+
+record Walk
+    step: Progress
+
+fn count(walk: Walk) -> Int
+    ? "Ignore the floating-point walk state."
+    0
+"#,
+    )
+    .expect("write Bodies module");
+    let entry = ws.join("main.av");
+    fs::write(
+        &entry,
+        r#"module Main
+    depends [Snapshot, Bodies]
+    intent = "Reach both same-named records in one generated Rust crate."
+    effects []
+
+fn main() -> Int
+    Snapshot.done(Snapshot.Progress(done = 1)) + Bodies.count(Bodies.Walk(step = Bodies.Progress(ratio = 0.5)))
+"#,
+    )
+    .expect("write entry module");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let shared_target = shared_target_dir();
+    let shared_target = shared_target
+        .to_str()
+        .expect("shared Cargo target path should be UTF-8");
+    let result = compile_rust_env(
+        &entry,
+        &project,
+        "same_named_record_derives",
+        Some(&ws),
+        &["--check"],
+        &[
+            ("CARGO_TARGET_DIR", shared_target),
+            ("CARGO_NET_OFFLINE", "true"),
+        ],
+    );
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|error| panic!("{error}"));
+}
+
 // ─── Mode (h): Int.fromString / Float.fromString Err-message bytes ────────
 //
 // `Int.fromString` / `Float.fromString` return a `Result<_, String>`.

--- a/tools/ci_test_schedule.json
+++ b/tools/ci_test_schedule.json
@@ -18,7 +18,7 @@
     "proof_spec": 2.08,
     "provider_package_workflow_spec": 33.88,
     "provider_vm_host_spec": 998.43,
-    "rust_codegen_differential": 64.01,
+    "rust_codegen_differential": 72.55,
     "rust_codegen_regression": 12.14,
     "rust_self_host_regen": 9.08,
     "typechecker_spec": 1.53,

--- a/tools/tests/test_validate_rust_fuzz_corpus.py
+++ b/tools/tests/test_validate_rust_fuzz_corpus.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "validate_rust_fuzz_corpus.py"
+SPEC = importlib.util.spec_from_file_location("validate_rust_fuzz_corpus", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+oracle = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = oracle
+SPEC.loader.exec_module(oracle)
+
+
+def encoded_project(files: list[tuple[str, str]], entry_index: int) -> bytes:
+    data = bytearray(oracle.MULTIMODULE_MAGIC)
+    data.append(len(files))
+    for name, body in files:
+        name_bytes = name.encode()
+        body_bytes = body.encode()
+        data.append(len(name_bytes))
+        data.extend(name_bytes)
+        data.extend(len(body_bytes).to_bytes(2, "little"))
+        data.extend(body_bytes)
+    data.append(entry_index)
+    return bytes(data)
+
+
+class RustFuzzCorpusOracleTests(unittest.TestCase):
+    def test_decodes_dotted_modules_to_loader_paths(self) -> None:
+        data = encoded_project(
+            [
+                ("Domain.Helper", "module Domain.Helper\n"),
+                (
+                    "Main",
+                    "module Main\n    intent = \"entry\"\n    depends [Domain.Helper]\n",
+                ),
+            ],
+            1,
+        )
+        with tempfile.TemporaryDirectory() as temp:
+            decoded = oracle.decode_input(data, Path(temp))
+            self.assertIsNotNone(decoded)
+            assert decoded is not None
+            self.assertEqual(decoded.entry, Path(temp) / "main.av")
+            self.assertEqual(
+                (Path(temp) / "domain" / "helper.av").read_text(),
+                "module Domain.Helper\n",
+            )
+
+    def test_candidate_order_is_deterministic_and_deduplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            corpus = Path(temp)
+            (corpus / "z").write_bytes(b"same")
+            (corpus / "a").write_bytes(b"same")
+            (corpus / "b").write_bytes(b"different")
+            (corpus / "multi").write_bytes(encoded_project([("Main", "module Main\n")], 0))
+            first = oracle.stable_candidates([corpus], 10)
+            second = oracle.stable_candidates([corpus], 10)
+            self.assertEqual(first, second)
+            self.assertEqual(len(first), 3)
+            self.assertTrue(first[0][1].startswith(oracle.MULTIMODULE_MAGIC))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_rust_fuzz_corpus.py
+++ b/tools/validate_rust_fuzz_corpus.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Replay a bounded AFL corpus through `aver compile --target rust --check`.
+
+The AFL target keeps rustc out of its hot loop. This companion selects inputs
+deterministically, skips programs rejected before codegen, and asks the real
+Rust toolchain about up to ``--limit`` accepted programs. All checks share one
+Cargo target directory so the runtime dependency graph is paid for once.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+MULTIMODULE_MAGIC = bytes((0xA7, 0xE2, 0x40, 0x01))
+
+
+@dataclass(frozen=True)
+class DecodedInput:
+    entry: Path
+    module_root: Path
+
+
+def decode_input(data: bytes, destination: Path) -> DecodedInput | None:
+    """Materialize one raw or multi-module fuzz input under ``destination``."""
+    destination.mkdir(parents=True, exist_ok=True)
+    if not data.startswith(MULTIMODULE_MAGIC):
+        try:
+            source = data.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        entry = destination / "main.av"
+        entry.write_text(source)
+        return DecodedInput(entry=entry, module_root=destination)
+
+    position = len(MULTIMODULE_MAGIC)
+    if position >= len(data):
+        return None
+    file_count = data[position]
+    position += 1
+    if not 1 <= file_count <= 4:
+        return None
+
+    paths: list[Path] = []
+    for _ in range(file_count):
+        if position >= len(data):
+            return None
+        name_length = data[position]
+        position += 1
+        if not 1 <= name_length <= 20 or position + name_length > len(data):
+            return None
+        name_bytes = data[position : position + name_length]
+        position += name_length
+        if (
+            not all(
+                ord("0") <= byte <= ord("9")
+                or ord("A") <= byte <= ord("Z")
+                or ord("a") <= byte <= ord("z")
+                or byte == ord(".")
+                for byte in name_bytes
+            )
+            or name_bytes[0] == ord(".")
+            or name_bytes[-1] == ord(".")
+        ):
+            return None
+        try:
+            name = name_bytes.decode("ascii").lower()
+        except UnicodeDecodeError:
+            return None
+
+        if position + 2 > len(data):
+            return None
+        body_length = int.from_bytes(data[position : position + 2], "little")
+        position += 2
+        if position + body_length > len(data):
+            return None
+        try:
+            body = data[position : position + body_length].decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+        position += body_length
+
+        parts = name.split(".")
+        path = destination.joinpath(*parts[:-1], f"{parts[-1]}.av")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+        paths.append(path)
+
+    if position >= len(data):
+        return None
+    entry_index = data[position]
+    if entry_index >= len(paths):
+        return None
+    return DecodedInput(entry=paths[entry_index], module_root=destination)
+
+
+def stable_candidates(corpus_dirs: list[Path], maximum: int) -> list[tuple[str, bytes]]:
+    """Return stable, deduplicated candidates with multi-module seeds first."""
+    by_digest: dict[str, tuple[int, bytes]] = {}
+    for directory_index, directory in enumerate(corpus_dirs):
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.iterdir()):
+            if not path.is_file() or path.name.startswith("README"):
+                continue
+            data = path.read_bytes()
+            digest = hashlib.sha256(data).hexdigest()
+            by_digest.setdefault(digest, (directory_index, data))
+    ordered = sorted(
+        by_digest,
+        key=lambda digest: (
+            not by_digest[digest][1].startswith(MULTIMODULE_MAGIC),
+            by_digest[digest][0],
+            digest,
+        ),
+    )
+    return [(digest, by_digest[digest][1]) for digest in ordered[:maximum]]
+
+
+def command_output(result: subprocess.CompletedProcess[str]) -> str:
+    return (
+        f"status: {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def run(args: argparse.Namespace) -> int:
+    aver = args.aver.resolve()
+    candidates = stable_candidates(args.corpus, args.max_candidates)
+    if not candidates:
+        raise SystemExit("Rust fuzz oracle found no corpus inputs")
+
+    checked = 0
+    multimodule_checked = 0
+    rejected = 0
+    has_multimodule_candidate = any(
+        data.startswith(MULTIMODULE_MAGIC) for _, data in candidates
+    )
+    with tempfile.TemporaryDirectory(prefix="aver-rust-fuzz-oracle-") as temp_text:
+        temp = Path(temp_text)
+        cargo_target = args.target_dir.resolve() if args.target_dir else temp / "cargo-target"
+        cargo_target.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        env["CARGO_TARGET_DIR"] = str(cargo_target)
+        # The oracle is about rustc, not a developer-machine compiler cache.
+        # A stale or sandboxed wrapper can otherwise turn a valid emitted
+        # crate into an infrastructure failure before rustc starts.
+        env["RUSTC_WRAPPER"] = ""
+        env["RUSTC_WORKSPACE_WRAPPER"] = ""
+        env["CARGO_BUILD_RUSTC_WRAPPER"] = ""
+        # The workflow builds Aver immediately before this step, so the
+        # complete runtime graph is already cached. Keep corpus validity
+        # independent of registry availability during the oracle pass.
+        env["CARGO_NET_OFFLINE"] = "true"
+
+        for digest, data in candidates:
+            case = decode_input(data, temp / f"case-{digest[:16]}" / "source")
+            if case is None:
+                rejected += 1
+                continue
+
+            output = temp / f"case-{digest[:16]}" / "generated"
+            compile_check = subprocess.run(
+                [
+                    str(aver),
+                    "compile",
+                    str(case.entry),
+                    "--module-root",
+                    str(case.module_root),
+                    "--target",
+                    "rust",
+                    "--check",
+                    "--name",
+                    f"fuzz_oracle_{digest[:16]}",
+                    "-o",
+                    str(output),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=env,
+            )
+            if compile_check.returncode != 0:
+                # Parse/type errors and target refusals happen before a
+                # project exists; they are ordinary invalid fuzz inputs. A
+                # failure after materialisation is exactly the gap this
+                # oracle exists to expose (emitter refusal or rustc error).
+                if not (output / "Cargo.toml").is_file():
+                    rejected += 1
+                    continue
+                print(
+                    f"Rust fuzz oracle failed for sha256:{digest}\n"
+                    f"{command_output(compile_check)}"
+                )
+                return 1
+            checked += 1
+            if data.startswith(MULTIMODULE_MAGIC):
+                multimodule_checked += 1
+            if checked >= args.limit:
+                break
+
+    if checked == 0:
+        raise SystemExit(
+            f"Rust fuzz oracle checked no type-correct inputs ({rejected} rejected)"
+        )
+    if has_multimodule_candidate and multimodule_checked == 0:
+        raise SystemExit(
+            "Rust fuzz oracle had multi-module seeds but none reached compile --check"
+        )
+    print(
+        f"Rust fuzz oracle: {checked} emitted project(s) passed --check; "
+        f"{multimodule_checked} multi-module; "
+        f"{rejected} candidate(s) rejected before codegen"
+    )
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--aver", type=Path, required=True, help="path to the aver binary")
+    parser.add_argument(
+        "--corpus",
+        type=Path,
+        action="append",
+        required=True,
+        help="AFL queue or fallback corpus directory; repeatable",
+    )
+    parser.add_argument("--limit", type=int, default=24, help="maximum accepted programs")
+    parser.add_argument(
+        "--max-candidates",
+        type=int,
+        default=256,
+        help="maximum raw inputs considered before filtering",
+    )
+    parser.add_argument(
+        "--target-dir",
+        type=Path,
+        help="shared CARGO_TARGET_DIR (temporary when omitted)",
+    )
+    args = parser.parse_args()
+    if args.limit < 1 or args.max_candidates < args.limit:
+        parser.error("require 1 <= --limit <= --max-candidates")
+    return args
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(parse_args()))


### PR DESCRIPTION
Closes #1173.

## What changed

- Audited the nine failures from #1172 against ordinary PR CI. Eight already had real generated-project build or run coverage; this adds the missing end-to-end #1134 duplicate-type regression through `aver compile --target rust --check`, sharing the differential Cargo target.
- Adds `fuzz_codegen_rust`: parse, dependency preparation, runtime lowering, resolved identity, and Rust project emission stay in the AFL hot loop. Backend `compile_error!` substitutions and incomplete projects are crashes.
- Adds a bounded post-campaign oracle. It deterministically samples up to 24 accepted queue entries, requires multi-module coverage, and sends them through the public `--check` path with one offline shared Cargo target.
- Fixes the fuzz multi-module filesystem mapping so `Domain.User` is materialized as `domain/user.av`, matching the production loader.
- Adds a nightly canary for n1bor/btc-listener pinned at the exact #1172 revision. Current Aver is placed at the downstream dev path, then its complete 140-module Rust project and providers are checked through `--check`.

## Validation

- `cargo test --test rust_codegen_differential -- --nocapture` — 62 passed, 10 ignored
- `cargo clippy --test rust_codegen_differential -- -D warnings`
- `cargo clippy --manifest-path fuzz/Cargo.toml --bin fuzz_codegen_rust --no-deps -- -D warnings`
- `python3 -m unittest discover -s tools/tests -p test_*.py` — 50 passed
- bounded local oracle — 3 projects passed, including 2 multi-module inputs
- pinned btc-listener `compile --check` — passed the complete generated project, including both native providers
- Rust formatting, workflow YAML parsing, and `git diff --check`