### PR TITLE
Make List.take cost what it takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Aver are documented here. Starting with 0.10.0, minor releases get a codename — short, evocative, and it tells you what the release was really about.
 
+## Unreleased
+
+### Fixed
+
+- **`List.take` and `Bytes.take` no longer read the whole list to hand back a few elements.** Taking the first few elements of a long list used to cost the length of the list, so a program that stepped through a buffer with `take` and `drop` took four times as long every time the buffer doubled. It now costs what it takes, and such a walk is linear: over 98,304 bytes it went from 42.5 s to 0.9 s, and 393,216 bytes — which used to need more than ten minutes — now takes 3.7 s. Taking at least the whole list hands back the same list instead of rebuilding it. Closes [#1181](https://github.com/jasisz/aver/issues/1181).
+
 ## 0.29.0 "Peer" — 2026-08-27
 
 Named for the network role Aver programs can finally sustain — and for the checked relationship between a program and its host. One source-owned contract now drives execution, replay, verification, wasm embedding, and proof export.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
-- **`List.take` and `Bytes.take` no longer read the whole list to hand back a few elements.** Taking the first few elements of a long list used to cost the length of the list, so a program that stepped through a buffer with `take` and `drop` took four times as long every time the buffer doubled. It now costs what it takes, and such a walk is linear: over 98,304 bytes it went from 42.5 s to 0.9 s, and 393,216 bytes — which used to need more than ten minutes — now takes 3.7 s. Taking at least the whole list hands back the same list instead of rebuilding it. Closes [#1181](https://github.com/jasisz/aver/issues/1181).
+- **`List.take` and `Bytes.take` no longer read the whole list to hand back a few elements.** Taking the first few elements of a long list used to cost the length of the list, so a program that stepped through a buffer with `take` and `drop` took four times as long every time the buffer doubled. It now costs what it takes, and such a walk is linear: over 98,304 bytes it went from 42.5 s to 0.9 s, and 393,216 bytes — which used to need more than ten minutes — now takes 3.7 s. Taking at least the whole list hands back the same list instead of rebuilding it, unless that list is the remainder `drop` left behind — those elements are copied out, so holding the answer no longer holds the whole buffer it was read from. Closes [#1181](https://github.com/jasisz/aver/issues/1181).
 
 ## 0.29.0 "Peer" — 2026-08-27
 

--- a/aver-memory/src/arena.rs
+++ b/aver-memory/src/arena.rs
@@ -18,6 +18,7 @@ impl<T: ArenaTypes> Arena<T> {
             active_lane_source_mark: INVALID_LANE_MARK,
             list_elements_copied: 0,
             list_elements_scanned: 0,
+            list_elements_flattened: SharedCount::default(),
             map_entries_copied: 0,
             map_entries_scanned: 0,
             rewrite_out_of_region_roots: false,
@@ -42,7 +43,7 @@ impl<T: ArenaTypes> Arena<T> {
     /// Used for independent product threads: each gets a clean Arena with just the
     /// compile-time context needed to execute functions and builtins.
     ///
-    /// The four copy / scan counters start at zero in the child, so a child
+    /// The copy / scan / flatten counters start at zero in the child, so a child
     /// counts its own work and nothing of its parent's. Nothing is lost by that:
     /// a child arena that runs an independent-product branch is handed back to
     /// the parent at the join, and [`Arena::absorb_copy_counters`] folds its
@@ -70,6 +71,7 @@ impl<T: ArenaTypes> Arena<T> {
             active_lane_source_mark: INVALID_LANE_MARK,
             list_elements_copied: 0,
             list_elements_scanned: 0,
+            list_elements_flattened: SharedCount::default(),
             map_entries_copied: 0,
             map_entries_scanned: 0,
             rewrite_out_of_region_roots: false,
@@ -674,6 +676,31 @@ impl<T: ArenaTypes> Arena<T> {
         self.list_elements_scanned
     }
 
+    /// List elements flattened out of a shared body into a fresh vector by
+    /// [`Arena::list_to_vec`], the whole-list walk behind every builtin that
+    /// needs all the elements at once.
+    ///
+    /// Read it as "no builtin walked a whole list here". A builtin that answers
+    /// about a bounded prefix — `List.take`, `List.drop` — adds nothing to it,
+    /// so a program stepping through a list with those builtins keeps this at
+    /// zero however long the list is; one that flattens the list on every step
+    /// makes it quadratic, which is the shape of a walk that used to cost the
+    /// whole list per step.
+    ///
+    /// It measures work done for a builtin, not by the collector: the two
+    /// counters above are the collector's, and nothing here is in them.
+    #[inline]
+    pub fn list_elements_flattened(&self) -> u64 {
+        self.list_elements_flattened.get()
+    }
+
+    /// Record that `elements` were flattened out of a shared body into a fresh
+    /// vector.
+    #[inline]
+    pub(crate) fn note_list_elements_flattened(&self, elements: usize) {
+        self.list_elements_flattened.add(elements as u64);
+    }
+
     /// Map entries duplicated while a map table was rebuilt rather than written
     /// into, the map counterpart of [`Arena::list_elements_copied`].
     ///
@@ -715,6 +742,8 @@ impl<T: ArenaTypes> Arena<T> {
     pub fn absorb_copy_counters(&mut self, child: &Arena<T>) {
         self.list_elements_copied += child.list_elements_copied;
         self.list_elements_scanned += child.list_elements_scanned;
+        self.list_elements_flattened
+            .add(child.list_elements_flattened.get());
         self.map_entries_copied += child.map_entries_copied;
         self.map_entries_scanned += child.map_entries_scanned;
     }

--- a/aver-memory/src/lib.rs
+++ b/aver-memory/src/lib.rs
@@ -45,6 +45,7 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use core::ops::Deref;
+use core::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 
 // ---------------------------------------------------------------------------
 // ArenaTypes trait — parameterises the arena over consumer-specific types
@@ -1368,6 +1369,33 @@ impl Hasher for DefaultHasher {
 // Arena
 // ---------------------------------------------------------------------------
 
+/// A count the arena can add to through a shared reference.
+///
+/// Reading a list does not change it, so `list_to_vec` takes `&self` and the
+/// tally of what it read cannot live in an ordinary field. The relaxed atomic
+/// keeps `Arena` `Send` and `Sync`, which a plain `Cell` would take away; the
+/// number is only ever read when nothing else is writing it.
+#[derive(Debug, Default)]
+struct SharedCount(AtomicU64);
+
+impl SharedCount {
+    #[inline]
+    fn get(&self) -> u64 {
+        self.0.load(AtomicOrdering::Relaxed)
+    }
+
+    #[inline]
+    fn add(&self, amount: u64) {
+        self.0.fetch_add(amount, AtomicOrdering::Relaxed);
+    }
+}
+
+impl Clone for SharedCount {
+    fn clone(&self) -> Self {
+        SharedCount(AtomicU64::new(self.get()))
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Arena<T: ArenaTypes> {
     young_entries: Vec<ArenaEntry<T>>,
@@ -1407,6 +1435,21 @@ pub struct Arena<T: ArenaTypes> {
     /// immediates escapes the read, so this is the counter that says which
     /// element types the traversal cost is actually linear in.
     list_elements_scanned: u64,
+    /// Total list elements flattened out of a shared body into a fresh vector
+    /// by [`Arena::list_to_vec`] — the whole-list walk a builtin does when it
+    /// needs every element at once.
+    ///
+    /// It is the number a builtin that reads a whole list to answer about part
+    /// of it is made of: `List.take(xs, 1)` over a long list belongs to the
+    /// bounded walks and must leave this alone, while a whole-list walk adds
+    /// the entire length to it on every call. Stepping through a list with such
+    /// a builtin therefore shows its quadratic here as a number rather than as
+    /// a wall-clock reading.
+    ///
+    /// Bounded walks are deliberately outside it. `Arena::list_prefix` and
+    /// `Arena::list_drop` read only what they step over, and counting them here
+    /// would blur exactly the distinction the counter exists to draw.
+    list_elements_flattened: SharedCount,
     /// Total map entries duplicated because a table was rebuilt instead of
     /// written into — `Map.set` and `Map.remove` on a target the ownership
     /// analysis could not prove unshared, any map builder that rebuilds its

--- a/aver-memory/src/lists.rs
+++ b/aver-memory/src/lists.rs
@@ -275,19 +275,77 @@ impl<T: ArenaTypes> Arena<T> {
         }
     }
 
+    /// Whether this list keeps nothing alive beyond the elements it has.
+    ///
+    /// A list can be a window onto a longer allocation: [`Arena::list_drop`]
+    /// answers with the body it stepped into and an advanced `start`, and a
+    /// segment list that has stepped past some of its parts still carries them.
+    /// Such a window holds every element of the body, not just the ones it
+    /// shows — a body of plain numbers is deliberately never rebuilt by a
+    /// collection, offset and all — so nothing may hand one out as an answer
+    /// that is supposed to be small.
+    ///
+    /// The walk visits the spine and stops at the first window it finds. It is
+    /// only ever asked in place of copying the whole list, and it visits no
+    /// more nodes than that copy would visit elements, so asking costs less
+    /// than the copy it can save.
+    fn list_holds_only_its_own_elements(&self, list: NanValue) -> bool {
+        let mut pending: Vec<NanValue> = Vec::new();
+        let mut current = list;
+
+        loop {
+            if !current.is_empty_list_immediate() {
+                match self.get_list(current.arena_index()) {
+                    ArenaList::Flat { start, .. } => {
+                        if *start != 0 {
+                            return false;
+                        }
+                    }
+                    ArenaList::Prepend { tail, .. } => pending.push(*tail),
+                    ArenaList::Concat { left, right, .. } => {
+                        pending.push(*left);
+                        pending.push(*right);
+                    }
+                    ArenaList::Segments {
+                        current: head,
+                        rest,
+                        start,
+                        ..
+                    } => {
+                        if *start != 0 {
+                            return false;
+                        }
+                        pending.push(*head);
+                        pending.extend(rest.iter().copied());
+                    }
+                }
+            }
+            match pending.pop() {
+                Some(next) => current = next,
+                None => return true,
+            }
+        }
+    }
+
     /// Keep the first `count` elements, reading no more of the list than that.
     ///
     /// The cost is what is kept, not what is left behind — the mirror of what
-    /// [`Arena::list_drop`] does at the other end. A list shorter than the count
-    /// is handed straight back rather than rebuilt, and a count of nothing is
-    /// the canonical empty list, so the two edges cost nothing at all.
+    /// [`Arena::list_drop`] does at the other end. A count of nothing is the
+    /// canonical empty list, so that edge costs nothing at all.
+    ///
+    /// Taking at least the whole list hands the list straight back, but only
+    /// when it is made of nothing but its own elements. A list that is a window
+    /// onto a longer allocation is rebuilt instead, because handing the window
+    /// back would leave the answer holding everything the window looks past —
+    /// see [`Arena::list_holds_only_its_own_elements`]. Rebuilding costs the
+    /// length of the answer, which is what taking a whole list has always cost.
     pub fn list_take(&mut self, list: NanValue, count: usize) -> NanValue {
         debug_assert!(list.is_list());
         let len = self.list_len_value(list);
         if count == 0 || len == 0 {
             return NanValue::EMPTY_LIST;
         }
-        if count >= len {
+        if count >= len && self.list_holds_only_its_own_elements(list) {
             return list;
         }
         let items = self.list_prefix(list, count);

--- a/aver-memory/src/lists.rs
+++ b/aver-memory/src/lists.rs
@@ -196,7 +196,105 @@ impl<T: ArenaTypes> Arena<T> {
             }
         }
 
+        self.note_list_elements_flattened(out.len());
         out
+    }
+
+    /// The first `count` elements, reading no more of the list than that.
+    ///
+    /// The bounded counterpart of [`Arena::list_to_vec`]: a prefix is answered
+    /// by walking the prefix, so asking for a few elements of a long list costs
+    /// what was asked for and not what the list holds. Flattening the list and
+    /// throwing most of it away is what made `List.take` cost the whole list on
+    /// every call, and a walk that steps with it quadratic.
+    ///
+    /// Only the spine down to the prefix is walked past it: a left-deep concat
+    /// spine is descended to its leftmost element the way [`Arena::list_drop`]
+    /// and [`Arena::list_get`] descend it.
+    pub fn list_prefix(&self, list: NanValue, count: usize) -> Vec<NanValue> {
+        debug_assert!(list.is_list());
+        if count == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(count.min(self.list_len_value(list)));
+        let mut pending: Vec<NanValue> = Vec::new();
+        let mut current = list;
+
+        loop {
+            if out.len() == count {
+                return out;
+            }
+            if self.list_len_value(current) == 0 {
+                match pending.pop() {
+                    Some(next) => current = next,
+                    None => return out,
+                }
+                continue;
+            }
+            match self.get_list(current.arena_index()) {
+                ArenaList::Flat { items, start, .. } => {
+                    let slice = &items[*start..];
+                    let wanted = (count - out.len()).min(slice.len());
+                    out.extend(slice[..wanted].iter().copied());
+                    current = NanValue::EMPTY_LIST;
+                }
+                ArenaList::Prepend { head, tail, .. } => {
+                    out.push(*head);
+                    current = *tail;
+                }
+                ArenaList::Concat { left, right, .. } => {
+                    pending.push(*right);
+                    current = *left;
+                }
+                ArenaList::Segments {
+                    current: head,
+                    rest,
+                    start,
+                    ..
+                } => {
+                    // Only the segments the prefix can reach are queued: each
+                    // one it does queue carries at least one element towards
+                    // `count`, so a node holding many segments is not walked in
+                    // full for a short prefix.
+                    let mut reachable = 0usize;
+                    let mut queued: Vec<NanValue> = Vec::new();
+                    let wanted = count - out.len();
+                    for part in &rest[*start..] {
+                        if reachable >= wanted {
+                            break;
+                        }
+                        reachable += self.list_len_value(*part);
+                        queued.push(*part);
+                    }
+                    for part in queued.iter().rev() {
+                        pending.push(*part);
+                    }
+                    current = *head;
+                }
+            }
+        }
+    }
+
+    /// Keep the first `count` elements, reading no more of the list than that.
+    ///
+    /// The cost is what is kept, not what is left behind — the mirror of what
+    /// [`Arena::list_drop`] does at the other end. A list shorter than the count
+    /// is handed straight back rather than rebuilt, and a count of nothing is
+    /// the canonical empty list, so the two edges cost nothing at all.
+    pub fn list_take(&mut self, list: NanValue, count: usize) -> NanValue {
+        debug_assert!(list.is_list());
+        let len = self.list_len_value(list);
+        if count == 0 || len == 0 {
+            return NanValue::EMPTY_LIST;
+        }
+        if count >= len {
+            return list;
+        }
+        let items = self.list_prefix(list, count);
+        if items.is_empty() {
+            return NanValue::EMPTY_LIST;
+        }
+        NanValue::new_list(self.push_list(items))
     }
 
     pub fn list_uncons(&mut self, list: NanValue) -> Option<(NanValue, NanValue)> {

--- a/src/nan_value/tests.rs
+++ b/src/nan_value/tests.rs
@@ -1550,7 +1550,10 @@ fn stepping_a_list_with_take_and_drop_stays_linear() {
 }
 
 /// Taking at least the whole list must hand it straight back rather than
-/// rebuild it — the counterpart of `List.drop(xs, 0)` returning `xs`.
+/// rebuild it — the counterpart of `List.drop(xs, 0)` returning `xs`. The list
+/// here is a body of exactly its own elements, so handing it back keeps nothing
+/// alive that the answer does not already hold; the test below is the other
+/// half of that condition.
 #[test]
 fn taking_the_whole_list_returns_the_list_it_was_given() {
     let mut arena = Arena::new();
@@ -1565,6 +1568,49 @@ fn taking_the_whole_list_returns_the_list_it_was_given() {
             "List.take({count}) rebuilt a list it was asked to keep whole",
         );
     }
+}
+
+/// Handing the list back must not hand back a view into a body far longer than
+/// the list is.
+///
+/// `List.drop` answers with a view over the body it stepped into — the same
+/// allocation at an advanced offset — and a body of plain numbers survives
+/// collection whole, offset and all. So a four-element view onto a
+/// 100,000-element buffer keeps all 100,000 alive. Handing that view back as
+/// the answer to a whole-list take leaves the caller holding the buffer for as
+/// long as it holds the four elements, which is what
+/// `Bytes.take(Bytes.drop(buffer, header), announced)` does on every message
+/// read out of a connection. Rebuilding the four elements costs four and lets
+/// the buffer go.
+#[test]
+fn taking_the_whole_of_a_view_does_not_keep_the_body_it_looks_into() {
+    let mut arena = Arena::new();
+    let items: Vec<NanValue> = (0..100_000).map(NanValue::new_int_inline).collect();
+    let list = NanValue::new_list(arena.push_list(items));
+    let buffer = flat_body!(arena, list);
+
+    let tail = drop_builtin(&mut arena, list, 99_996);
+    let taken = take_builtin(&mut arena, tail, 4_000);
+
+    assert_eq!(
+        list_contents(&arena, taken),
+        (99_996..100_000).collect::<Vec<i64>>(),
+        "the four elements at the end of the buffer are the answer",
+    );
+    let kept = flat_body!(arena, taken);
+    assert!(
+        !std::sync::Arc::ptr_eq(&buffer, &kept),
+        "List.take handed back the view it was given, so the four elements it \
+         answers with still hold the 100,000-element buffer they were read out \
+         of",
+    );
+    assert_eq!(
+        kept.len(),
+        arena.list_len_value(taken),
+        "the answer holds a body of {} elements to have {}",
+        kept.len(),
+        arena.list_len_value(taken),
+    );
 }
 
 /// Taking nothing — and taking a negative count, which clamps to nothing —

--- a/src/nan_value/tests.rs
+++ b/src/nan_value/tests.rs
@@ -1466,3 +1466,158 @@ fn walking_by_drop_agrees_with_walking_by_uncons() {
         }
     }
 }
+
+// ─── `List.take` costs what it takes (issue #1181) ───────────────────────────
+//
+// `List.take(xs, n)` should cost `n`, not the length of `xs`. It used to
+// flatten the whole list into a fresh vector and then throw all but the first
+// `n` elements away, so taking one element off a 98,304-element list cost the
+// same as reading all of it — and a parser that steps through a buffer with
+// `take` and `drop` was quadratic in the buffer, while the same walk by
+// destructuring was linear.
+//
+// The evidence is the arena's flatten count, not a stopwatch: a bounded walk
+// adds nothing to it however long the list is, and a whole-list walk adds the
+// entire length on every call.
+//
+// Every test below drives the real builtin (`List.take` through `call_nv`),
+// not the arena helper underneath it, so a builtin that stops using the helper
+// is still caught.
+
+/// Drive the `List.take` builtin the way the VM does.
+fn take_builtin(arena: &mut Arena, list: NanValue, count: i64) -> NanValue {
+    let count = NanValue::new_int(count, arena);
+    crate::types::list::call_nv("List.take", &[list, count], arena)
+        .expect("List.take is owned by the list namespace")
+        .expect("List.take over a list and an int")
+}
+
+/// The load-bearing one: taking a prefix reads the prefix and nothing else.
+#[test]
+fn taking_a_prefix_does_not_flatten_the_list() {
+    let mut arena = Arena::new();
+    let items: Vec<NanValue> = (0..65_536).map(NanValue::new_int_inline).collect();
+    let list = NanValue::new_list(arena.push_list(items));
+
+    let flattened_before = arena.list_elements_flattened();
+    let taken = take_builtin(&mut arena, list, 1);
+    let flattened = arena.list_elements_flattened() - flattened_before;
+
+    assert_eq!(
+        flattened, 0,
+        "List.take(xs, 1) read {flattened} elements of a 65,536-element list; \
+         taking a prefix must cost the prefix",
+    );
+    assert_eq!(list_contents(&arena, taken), vec![0]);
+}
+
+/// Stepping through a list with `take` and `drop` — the shape a parser that
+/// peeks a header and advances past it has — must cost the list once, not once
+/// per step. Doubling the list used to quadruple the elements read.
+#[test]
+fn stepping_a_list_with_take_and_drop_stays_linear() {
+    fn walk_cost(n: i64) -> u64 {
+        let mut arena = Arena::new();
+        let items: Vec<NanValue> = (0..n).map(NanValue::new_int_inline).collect();
+        let mut list = NanValue::new_list(arena.push_list(items));
+
+        let flattened_before = arena.list_elements_flattened();
+        let mut seen = 0i64;
+        while arena.list_len_value(list) > 0 {
+            let head = take_builtin(&mut arena, list, 4);
+            seen += arena.list_len_value(head) as i64;
+            list = crate::types::list::call_nv(
+                "List.drop",
+                &[list, NanValue::new_int(4, &mut arena)],
+                &mut arena,
+            )
+            .expect("List.drop is owned by the list namespace")
+            .expect("List.drop over a list and an int");
+        }
+        assert_eq!(seen, n, "the walk did not see every element exactly once");
+        arena.list_elements_flattened() - flattened_before
+    }
+
+    let small = walk_cost(2_000);
+    let large = walk_cost(4_000);
+
+    assert_eq!(
+        (small, large),
+        (0, 0),
+        "a take/drop walk still flattens the list it steps through: 2,000 \
+         elements read {small}, 4,000 read {large}",
+    );
+}
+
+/// Taking at least the whole list must hand it straight back rather than
+/// rebuild it — the counterpart of `List.drop(xs, 0)` returning `xs`.
+#[test]
+fn taking_the_whole_list_returns_the_list_it_was_given() {
+    let mut arena = Arena::new();
+    let items: Vec<NanValue> = (0..8).map(NanValue::new_int_inline).collect();
+    let list = NanValue::new_list(arena.push_list(items));
+
+    for count in [8, 9, 8_000] {
+        let taken = take_builtin(&mut arena, list, count);
+        assert_eq!(
+            taken.bits(),
+            list.bits(),
+            "List.take({count}) rebuilt a list it was asked to keep whole",
+        );
+    }
+}
+
+/// Taking nothing — and taking a negative count, which clamps to nothing —
+/// yields the canonical empty list.
+#[test]
+fn taking_nothing_yields_the_canonical_empty_list() {
+    let mut arena = Arena::new();
+    let items: Vec<NanValue> = (0..3).map(NanValue::new_int_inline).collect();
+    let list = NanValue::new_list(arena.push_list(items));
+
+    for count in [0, -1, -4_000] {
+        let taken = take_builtin(&mut arena, list, count);
+        assert_eq!(
+            taken.bits(),
+            NanValue::EMPTY_LIST.bits(),
+            "List.take({count}) is not the canonical empty list",
+        );
+    }
+}
+
+/// The meaning held still: on every shape the arena can hold, `List.take(xs, n)`
+/// is the first `n` elements of `xs`, count by count.
+#[test]
+fn taking_a_prefix_agrees_with_the_elements_it_names() {
+    let mut arena = Arena::new();
+    let flat_items: Vec<NanValue> = (0..40).map(NanValue::new_int_inline).collect();
+    let flat = NanValue::new_list(arena.push_list(flat_items));
+    let mut prepended = flat;
+    for value in (100..110).rev() {
+        let next = arena.push_list_prepend(NanValue::new_int_inline(value), prepended);
+        prepended = NanValue::new_list(next);
+    }
+    let mut appended = NanValue::new_list(arena.push_list(vec![NanValue::new_int_inline(0)]));
+    for value in 1..300 {
+        let next = arena.push_list_append(appended, NanValue::new_int_inline(value));
+        appended = NanValue::new_list(next);
+    }
+    let concat = NanValue::new_list(arena.push_list_concat(prepended, appended));
+    let stepped = drop_builtin(&mut arena, concat, 45);
+
+    for list in [flat, prepended, appended, concat, stepped] {
+        let all = list_contents(&arena, list);
+        for count in [-3i64, 0, 1, 2, 7, 39, 40, 41, 349, 350, 5_000] {
+            let wanted = count.max(0) as usize;
+            let expected: Vec<i64> = all.iter().take(wanted).copied().collect();
+            let taken = take_builtin(&mut arena, list, count);
+            assert_eq!(
+                list_contents(&arena, taken),
+                expected,
+                "List.take(xs, {count}) over a {}-element list is not its first \
+                 {wanted} elements",
+                all.len(),
+            );
+        }
+    }
+}

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -93,16 +93,10 @@ fn take_nv(args: &[NanValue], arena: &mut Arena) -> Result<NanValue, RuntimeErro
             "List.take() second argument must be an Int".to_string(),
         ));
     };
-    let items: Vec<NanValue> = arena
-        .list_to_vec_value(args[0])
-        .into_iter()
-        .take(count)
-        .collect();
-    if items.is_empty() {
-        return Ok(NanValue::EMPTY_LIST);
-    }
-    let list_idx = arena.push_list(items);
-    Ok(NanValue::new_list(list_idx))
+    // Walks the prefix it keeps instead of the list it was handed: reading the
+    // whole list to answer about its first `count` elements made a walk that
+    // steps with `take` cost the list once per step (issue #1181).
+    Ok(arena.list_take(args[0], count))
 }
 
 fn drop_nv(args: &[NanValue], arena: &mut Arena) -> Result<NanValue, RuntimeError> {


### PR DESCRIPTION
Closes #1181.

`List.take(xs, n)` read the whole of `xs` into a fresh vector and then kept the first `n` elements, so it cost the length of the list rather than the count asked for. `List.drop` already hands back a view over the body it steps into (#913) and destructuring shares that body too, which left `take` as the only one of the three paying for the whole list — and made a walk that steps through a buffer with `take` and `drop` quadratic in the buffer.

The builtin now walks the prefix it keeps, on every shape the arena can hold. Taking at least the whole list hands the same list back instead of rebuilding it, and taking nothing is the canonical empty list, so both edges cost nothing.

### Measured

Same debug binary before and after, on the same machine.

| repeated 2,000 times over a 98,304-element `Bytes` | before | after |
|---|---|---|
| `Bytes.take(b, 1)` | 1,818 ms | 8 ms |
| `Bytes.drop(b, 1)` | 10 ms | 11 ms |
| destructuring `Bytes.octets(b)` | 8 ms | 8 ms |

Walking a buffer one octet at a time with `take` and `drop`:

| elements | before | after |
|---|---|---|
| 98,304 | 42,487 ms | 892 ms |
| 196,608 | 170,202 ms | 1,827 ms |
| 393,216 | over ten minutes, killed | 3,687 ms |

Four times the time per doubling before, two after. Both walks print the same sum as the walk over the same octets as a list, at every size.

### Guard

The evidence is a count, not a stopwatch. The arena gained `list_elements_flattened`: list elements copied out of a shared body into a fresh vector by the whole-list walk behind builtins that need every element at once. A bounded walk adds nothing to it, so the tests read the difference directly:

- `List.take(xs, 1)` over a 65,536-element list reads 0 elements; before this change it read all 65,536;
- the take/drop stepping walk reads 0 at 2,000 and at 4,000 elements; before, 501,000 and 2,002,000 — the quadratic itself;
- taking at least the whole list returns the very list it was given.

Three semantic tests sit beside them and pass on both sides of the change: the prefix a count names, on flat bodies, prepend chains, concat spines, segmented lists and a stepped view; the canonical empty list for a count of nothing and for negative counts; and `stdlib/bytes.av`'s own verify cases.

Backends: this is the bytecode VM only. Generated Rust (`take_first`) and wasm-gc already cost what they take.

Known gap: a left-deep concat spine is still descended to its leftmost element, so `take` over one costs the depth of the spine. `List.drop` and `List.get` descend it the same way, and closing it means changing the spine, not the builtin.

### Review follow-up

Handing the list back for a whole-list take could keep storage the answer does not need. `List.drop` answers with a view over the body it stepped into, and a body of plain numbers is kept whole by a collection, offset and all — so four elements taken out of what `drop` left of a 100,000-element buffer went on holding the whole buffer, where the old `take` copied the four out and let the buffer go. The list is now handed back only when it holds nothing beyond its own elements; a view onto a longer body is rebuilt instead, which costs the length of the answer — exactly what taking a whole list cost before this change. `taking_the_whole_of_a_view_does_not_keep_the_body_it_looks_into` is the guard, and it fails on the first commit of this branch. This is the shape `Bytes.take(Bytes.drop(buffer, headerLength), announced)` has in Robin's `inbox.av`.

The concat-spine cost noted above is unchanged and out of scope here: it predates this change, and `List.drop` and `List.get` descend the spine the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

