### PR TITLE
fix(rust): preserve borrowed TCO captures in products

### DIFF
--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -71,7 +71,8 @@ use super::expr::{
     has_string_literal_patterns,
 };
 use super::ownership::{
-    align_equality_operands, emits_direct_borrow, local_of, materialize_borrowed, materialize_owned,
+    align_equality_operands, emits_direct_borrow, local_of, materialize_borrowed,
+    materialize_owned, materialize_scoped_thread_capture,
 };
 use super::pattern::emit_pattern;
 use super::syntax::{aver_name_to_rust, generated_ident};
@@ -2418,14 +2419,7 @@ fn emit_parallel_capture_bindings(
     for local in captures.values() {
         let source_name = local.name.as_str();
         let rust_name = aver_name_to_rust(source_name);
-        let capture = if ctx.is_borrowed_param(source_name)
-            || ctx.is_copy(source_name)
-            || ctx.bare.is_bare(local.slot)
-        {
-            rust_name.clone()
-        } else {
-            format!("{rust_name}.clone()")
-        };
+        let capture = materialize_scoped_thread_capture(rust_name.clone(), local, ctx);
         code.push_str(&format!("let {rust_name} = {capture}; "));
     }
     code.push_str(&format!("{thread_scope}.spawn(move || "));
@@ -6296,6 +6290,48 @@ mod tests {
         assert!(
             emit.contains("let __h1 = { let height = height.clone(); __s.spawn(move ||"),
             "branch 1 capture must be scoped to its spawn: {emit}"
+        );
+    }
+
+    #[test]
+    fn scoped_thread_capture_uses_the_actual_tco_carrier() {
+        let local = MirLocal {
+            slot: LocalId(0),
+            last_use: false,
+            name: "network".to_string(),
+        };
+        let local_types = HashMap::from([("network".to_string(), Type::named("Network"))]);
+        let borrowed = HashSet::from(["network".to_string()]);
+        let wrapped = HashSet::from(["network".to_string()]);
+
+        let mut ctx = empty_ctx();
+        ctx.local_types = &local_types;
+        assert_eq!(
+            materialize_scoped_thread_capture("network".to_string(), &local, &ctx),
+            "network.clone()",
+            "an owned value needs one clone per branch"
+        );
+
+        ctx.borrowed_params = &borrowed;
+        assert_eq!(
+            materialize_scoped_thread_capture("network".to_string(), &local, &ctx),
+            "network",
+            "an ordinary &T parameter is copied into the branch"
+        );
+
+        ctx.borrowed_params = empty_string_set();
+        ctx.rc_wrapped = &wrapped;
+        assert_eq!(
+            materialize_scoped_thread_capture("network".to_string(), &local, &ctx),
+            "network.clone()",
+            "a self-TCO Arc<T> carrier is cloned"
+        );
+
+        ctx.rc_wrapped_are_borrowed_refs = true;
+        assert_eq!(
+            materialize_scoped_thread_capture("network".to_string(), &local, &ctx),
+            "network",
+            "a mutual-TCO &T invariant is copied, not cloned into an owned T"
         );
     }
 

--- a/src/codegen/rust/ownership.rs
+++ b/src/codegen/rust/ownership.rs
@@ -66,34 +66,7 @@ pub(super) fn local_of(expr: &MirExpr) -> Option<&MirLocal> {
 /// or borrows the value.
 pub(super) fn value_facts(expr: &MirExpr, ctx: &MirEmitCtx<'_>) -> RustValueFacts {
     if let Some(local) = local_of(expr) {
-        let name = local.name.as_str();
-        let copy =
-            ctx.bare.is_bare(local.slot) || ctx.local_types.get(name).is_some_and(is_copy_type);
-        let wrapped = ctx.rc_wrapped.contains(name);
-        let borrowed = ctx.borrowed_params.contains(name) || wrapped;
-        let mode = if copy {
-            RustValueMode::Copy
-        } else if borrowed {
-            RustValueMode::Borrowed
-        } else {
-            RustValueMode::Owned
-        };
-        return RustValueFacts {
-            mode,
-            borrow_shape: if wrapped {
-                BorrowShape::DerefWrapper
-            } else {
-                BorrowShape::Direct
-            },
-            can_move: mode == RustValueMode::Copy
-                || (mode == RustValueMode::Owned
-                    && local.last_use
-                    && !ctx.loop_carried_params.contains(name)),
-            provider_resource: ctx
-                .local_types
-                .get(name)
-                .is_some_and(|ty| is_provider_resource_type(ty, ctx)),
-        };
+        return local_value_facts(local, ctx);
     }
 
     if let MirExpr::Project(project) = expr {
@@ -124,6 +97,36 @@ pub(super) fn value_facts(expr: &MirExpr, ctx: &MirEmitCtx<'_>) -> RustValueFact
     }
 }
 
+fn local_value_facts(local: &MirLocal, ctx: &MirEmitCtx<'_>) -> RustValueFacts {
+    let name = local.name.as_str();
+    let copy = ctx.bare.is_bare(local.slot) || ctx.local_types.get(name).is_some_and(is_copy_type);
+    let wrapped = ctx.rc_wrapped.contains(name);
+    let borrowed = ctx.borrowed_params.contains(name) || wrapped;
+    let mode = if copy {
+        RustValueMode::Copy
+    } else if borrowed {
+        RustValueMode::Borrowed
+    } else {
+        RustValueMode::Owned
+    };
+    RustValueFacts {
+        mode,
+        borrow_shape: if wrapped {
+            BorrowShape::DerefWrapper
+        } else {
+            BorrowShape::Direct
+        },
+        can_move: mode == RustValueMode::Copy
+            || (mode == RustValueMode::Owned
+                && local.last_use
+                && !ctx.loop_carried_params.contains(name)),
+        provider_resource: ctx
+            .local_types
+            .get(name)
+            .is_some_and(|ty| is_provider_resource_type(ty, ctx)),
+    }
+}
+
 /// Materialise `expr` for a Rust position that consumes an owned `T`.
 pub(super) fn materialize_owned(code: String, expr: &MirExpr, ctx: &MirEmitCtx<'_>) -> String {
     let facts = value_facts(expr, ctx);
@@ -151,6 +154,29 @@ pub(super) fn materialize_borrowed(code: String, expr: &MirExpr, ctx: &MirEmitCt
         RustValueMode::Borrowed if facts.borrow_shape == BorrowShape::Direct => code,
         RustValueMode::Borrowed => format!("&*{}", code),
         RustValueMode::Owned => format!("&{}", code),
+    }
+}
+
+/// Materialise a source local before moving it into one scoped-thread branch.
+/// Every branch needs an independent carrier, but that carrier is not always
+/// an owned `T`: ordinary borrowed params and mutual-TCO invariants are `&T`
+/// and can be copied, while self-TCO invariants are `Arc<T>` and must clone the
+/// wrapper. Owned values are cloned because sibling branches may capture the
+/// same local regardless of this occurrence's `last_use` annotation.
+pub(super) fn materialize_scoped_thread_capture(
+    code: String,
+    local: &MirLocal,
+    ctx: &MirEmitCtx<'_>,
+) -> String {
+    let facts = local_value_facts(local, ctx);
+    match facts.mode {
+        RustValueMode::Copy => code,
+        RustValueMode::Borrowed
+            if facts.borrow_shape == BorrowShape::Direct || ctx.rc_wrapped_are_borrowed_refs =>
+        {
+            code
+        }
+        RustValueMode::Borrowed | RustValueMode::Owned => format!("{code}.clone()"),
     }
 }
 

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -4431,6 +4431,106 @@ fn recursive_independent_product_owns_each_shared_capture() {
     result.unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Regression for #1191: a mutual-TCO invariant is represented as `&T` in
+/// the trampoline. Capturing it for a `?!` branch must copy that reference;
+/// calling `.clone()` at the capture boundary clones the enum referent into
+/// an owned `T`, while call emission still treats the local as the invariant
+/// wrapper and produces `&*network` (E0614).
+#[test]
+fn mutual_tco_enum_invariant_builds_inside_independent_product() {
+    let ws = temp_dir("mutual_tco_ip_enum_capture");
+    let source = ws.join("main.av");
+    fs::write(
+        &source,
+        r#"module Repro
+    intent = "A mutual-TCO invariant is captured by two independent-product branches."
+    effects [Console]
+
+type Network
+    Mainnet
+    Signet
+
+fn observed(network: Network) -> Result<Int, String>
+    ? "Turn the selected network into a small result."
+    match network
+        Network.Mainnet -> Result.Ok(1)
+        Network.Signet -> Result.Ok(2)
+
+fn first(network: Network, remaining: Int) -> Result<Int, String>
+    ? "Stop at zero or hand the invariant network to the partner."
+    match remaining == 0
+        true -> Result.Ok(0)
+        false -> second(network, remaining)
+
+fn second(network: Network, remaining: Int) -> Result<Int, String>
+    ? "Read the invariant in both branches before returning to first."
+    both = (observed(network), observed(network))?!
+    match both
+        (left, right) -> first(network, remaining - left - right)
+
+fn main() -> Unit
+    ! [Console.print]
+    match first(Network.Mainnet, 4)
+        Result.Ok(value) -> Console.print("{value}")
+        Result.Err(error) -> Console.print(error)
+"#,
+    )
+    .expect("write #1191 regression source");
+
+    let vm_stdout = run_vm(&source, None).unwrap_or_else(|e| panic!("VM run failed: {e}"));
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+
+    let result = (|| -> Result<(), String> {
+        compile_rust(&source, &project, "mutual_tco_ip_enum_capture", None, &[])?;
+        let emitted = fs::read_to_string(
+            project
+                .join("src")
+                .join("aver_generated")
+                .join("entry")
+                .join("mod.rs"),
+        )
+        .map_err(|e| format!("read emitted entry module: {e}"))?;
+        if !emitted.contains("enum __MutualTco")
+            || !emitted.contains("fn __mutual_tco_trampoline_")
+            || !emitted.contains("std::thread::scope")
+        {
+            return Err(format!(
+                "probe did not exercise mutual TCO plus independent-product emission:\n{emitted}"
+            ));
+        }
+        if emitted.matches("let network = network;").count() < 2
+            || emitted.contains("let network = network.clone();")
+        {
+            return Err(format!(
+                "mutual-TCO &Network was not copied into every branch:\n{emitted}"
+            ));
+        }
+
+        // Load-bearing gate: before the fix rustc reports two E0614 errors.
+        let bin = cargo_build(&project, "mutual_tco_ip_enum_capture")?;
+        let out = Command::new(&bin)
+            .output()
+            .map_err(|e| format!("failed to run #1191 regression binary: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "#1191 regression binary exited non-zero:\n{}",
+                format_output(&out)
+            ));
+        }
+        let rust_stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if rust_stdout != vm_stdout {
+            return Err(format!(
+                "#1191 output mismatch\n--- VM ---\n{vm_stdout}\n--- Rust ---\n{rust_stdout}"
+            ));
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|e| panic!("{e}"));
+}
+
 // ─── Mode (g): MIR-emitted first-class fn values ──────────────────────────
 //
 // W6/Stage-0 (the final construct gap): the MIR walker now emits


### PR DESCRIPTION
Closes #1191

## Summary
- route scoped-thread captures through the centralized Rust ownership model
- copy mutual-TCO &T invariants into each branch while retaining clones for self-TCO Arc<T> carriers and owned values
- add a focused carrier-policy test and an end-to-end mutual-TCO enum + ?! regression that builds and matches the VM

## Validation
- cargo test --lib (1463 passed)
- cargo test --test rust_codegen_differential (64 passed, 10 ignored)
- cargo test --test rust_codegen_regression (4 passed)
- cargo test --test compile_spec (5 passed)
- cargo clippy --lib --test rust_codegen_differential -- -D warnings
- cargo fmt --all -- --check
- python3 tools/regenerate_self_host.py --check
- current n1bor/btc-listener with the Ahead.network workaround reverted: aver compile plus cargo check passes all 140 modules