### PR TITLE
refactor(rust): model representation capabilities

### DIFF
--- a/docs/rust.md
+++ b/docs/rust.md
@@ -94,6 +94,29 @@ The generated Rust keeps:
 
 Generated Cargo projects now target Rust edition 2024.
 
+## Representation capabilities
+
+The Rust backend derives representation traits from an explicit capability
+contract for each fully qualified Aver type. Two modules may therefore expose
+types with the same bare name without sharing `Clone`, equality, hashing, or
+display decisions. Composite types receive each trait independently, and only
+when every field's selected Rust representation supports it.
+
+| Aver representation | Generated capabilities |
+|---|---|
+| `Int`, `Bool`, `Unit`, `String` | `Clone`, `PartialEq`, `Eq`, `Hash`, Aver display |
+| `Float` | `Clone`, `PartialEq`, Aver display |
+| `List<T>`, `Vector<T>`, `Map<K, V>` | inherited from the selected runtime carrier and its element/key/value types |
+| packed byte refinement | the same equality, hashing, and display contract as ordinary `List<Int>` |
+| capability resource | cloneable opaque handle and opaque Aver display; no Aver equality or hashing |
+
+`Hash` and ordering are separate capabilities: a representation may be
+hashable without being an admissible ordered map key. Provider resource
+carriers retain the host-side comparison needed to move and clone composites,
+but that implementation detail does not make resource identity observable in
+Aver; source equality, hashing, and resource-containing operations that would
+expose it are rejected before Rust emission.
+
 ## Runtime dependency
 
 `Cargo.toml` is generated around the shared `aver-rt` runtime crate. Service-specific runtime features are enabled only when needed:

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -13,6 +13,7 @@ mod policy;
 mod project;
 mod provider;
 mod replay;
+mod representation;
 mod runtime;
 mod self_host;
 mod syntax;

--- a/src/codegen/rust/representation.rs
+++ b/src/codegen/rust/representation.rs
@@ -1,0 +1,320 @@
+//! Trait capabilities of values after lowering to the Rust backend.
+//!
+//! Surface types do not map one-to-one to Rust carriers: `List<Int>` may be
+//! `AverIntList`, an opaque refinement may be `AverPackedU8`, and capability
+//! resources are provider-owned handles. Generated composite derives must ask
+//! what the selected carrier promises instead of inferring traits from a bare
+//! Aver type name or attaching a blanket derive and waiting for rustc.
+
+use std::collections::HashSet;
+
+use crate::ast::TypeDef;
+use crate::codegen::CodegenContext;
+use crate::types::{Type, parse_type_str};
+
+/// Operations a lowered Rust value promises to generated composite types.
+///
+/// This is deliberately a conservative promise, not a reflection of every
+/// implementation detail on the carrier. In particular a provider resource's
+/// host wrapper may implement `Eq`/`Hash` for registry bookkeeping, while its
+/// Aver-facing capability set withholds both because provider token identity
+/// is unobservable. The typechecker enforces that surface rule before codegen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RepresentationCapabilities {
+    pub clone: bool,
+    pub partial_eq: bool,
+    pub eq: bool,
+    pub hash: bool,
+    pub aver_display: bool,
+}
+
+/// Complete structural contract consumed by a generated record or sum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct RepresentationContract {
+    pub capabilities: RepresentationCapabilities,
+    pub orderable: bool,
+}
+
+impl RepresentationCapabilities {
+    const ALL: Self = Self {
+        clone: true,
+        partial_eq: true,
+        eq: true,
+        hash: true,
+        aver_display: true,
+    };
+
+    const NONE: Self = Self {
+        clone: false,
+        partial_eq: false,
+        eq: false,
+        hash: false,
+        aver_display: false,
+    };
+
+    /// Carrier-level equality keeps generated resource holders usable from a
+    /// Rust host (and preserves #994), but it is not an Aver equality grant.
+    /// The checker rejects `==`, equality-bearing helpers and Map keys for a
+    /// resource or any represented wrapper that reaches one.
+    const PROVIDER_RESOURCE: Self = Self {
+        clone: true,
+        partial_eq: true,
+        eq: false,
+        hash: false,
+        aver_display: true,
+    };
+
+    fn intersect(self, other: Self) -> Self {
+        Self {
+            clone: self.clone && other.clone,
+            partial_eq: self.partial_eq && other.partial_eq,
+            eq: self.eq && other.eq,
+            hash: self.hash && other.hash,
+            aver_display: self.aver_display && other.aver_display,
+        }
+    }
+}
+
+/// Contract of one declaration's actual emitted representation.
+pub(super) fn type_def_contract(td: &TypeDef, ctx: &CodegenContext) -> RepresentationContract {
+    RepresentationContract {
+        capabilities: capabilities_for_def(td, ctx, &mut HashSet::new()),
+        // Keep order beside the five requested traits so Hash bounds for
+        // AverMap and generated Ord impls resolve named fields identically.
+        orderable: orderable_def(td, ctx, &mut HashSet::new()),
+    }
+}
+
+fn capabilities_for_def(
+    td: &TypeDef,
+    ctx: &CodegenContext,
+    visiting: &mut HashSet<String>,
+) -> RepresentationCapabilities {
+    let key = crate::codegen::common::backend_type_def_key(ctx, td);
+    if !visiting.insert(key.clone()) {
+        // Recursive fields are emitted through Arc<Self>. Assume the cycle's
+        // own promise and let every non-recursive field narrow it.
+        return RepresentationCapabilities::ALL;
+    }
+
+    let capabilities = if super::uses_packed_u8(ctx, crate::codegen::common::type_def_name(td)) {
+        // `AverPackedU8` explicitly implements all five operations, with
+        // equality/hash compatible with the ordinary `List<Int>` carrier.
+        RepresentationCapabilities::ALL
+    } else {
+        fields_of(td).fold(RepresentationCapabilities::ALL, |caps, field| {
+            caps.intersect(capabilities_for_type(
+                &parse_type_str(field),
+                ctx,
+                crate::codegen::common::type_key_for_decl(ctx, td).scope_str(),
+                visiting,
+            ))
+        })
+    };
+
+    visiting.remove(&key);
+    capabilities
+}
+
+fn capabilities_for_type(
+    ty: &Type,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+    visiting: &mut HashSet<String>,
+) -> RepresentationCapabilities {
+    match ty {
+        Type::Int | Type::Bool | Type::Unit | Type::Str => RepresentationCapabilities::ALL,
+        Type::Float => RepresentationCapabilities {
+            clone: true,
+            partial_eq: true,
+            eq: false,
+            hash: false,
+            aver_display: true,
+        },
+        Type::Result(ok, err) => capabilities_for_type(ok, ctx, scope, visiting)
+            .intersect(capabilities_for_type(err, ctx, scope, visiting)),
+        Type::Option(inner) => capabilities_for_type(inner, ctx, scope, visiting),
+        Type::Tuple(inner) => inner
+            .iter()
+            .fold(RepresentationCapabilities::ALL, |caps, item| {
+                caps.intersect(capabilities_for_type(item, ctx, scope, visiting))
+            }),
+        Type::List(inner) => {
+            let inner = capabilities_for_type(inner, ctx, scope, visiting);
+            RepresentationCapabilities {
+                // AverList and AverIntList clone their shared carrier.
+                clone: true,
+                partial_eq: inner.partial_eq,
+                eq: inner.eq,
+                hash: inner.hash,
+                aver_display: inner.aver_display,
+            }
+        }
+        Type::Vector(inner) => {
+            let inner = capabilities_for_type(inner, ctx, scope, visiting);
+            RepresentationCapabilities {
+                // AverVector clones its Rc independently of T.
+                clone: true,
+                partial_eq: inner.partial_eq,
+                eq: inner.eq,
+                hash: inner.hash,
+                // Its display iterator needs cloned elements.
+                aver_display: inner.clone && inner.aver_display,
+            }
+        }
+        Type::Map(key, value) => {
+            let key_caps = capabilities_for_type(key, ctx, scope, visiting);
+            let value_caps = capabilities_for_type(value, ctx, scope, visiting);
+            let key_base = key_caps.clone && key_caps.eq && key_caps.hash;
+            RepresentationCapabilities {
+                // AverMap clones its Rc independently of K/V.
+                clone: true,
+                partial_eq: key_base
+                    && key_caps.partial_eq
+                    && value_caps.clone
+                    && value_caps.partial_eq,
+                eq: key_base && value_caps.clone && value_caps.eq,
+                hash: key_base
+                    && orderable_type(key, ctx, scope, &mut HashSet::new())
+                    && value_caps.clone
+                    && value_caps.hash,
+                aver_display: key_base
+                    && key_caps.aver_display
+                    && orderable_type(key, ctx, scope, &mut HashSet::new())
+                    && value_caps.clone
+                    && value_caps.aver_display,
+            }
+        }
+        Type::Named { id, name } => {
+            if is_provider_resource(*id, name, ctx, scope) {
+                return RepresentationCapabilities::PROVIDER_RESOURCE;
+            }
+            let Some(td) = named_type_def(*id, name, ctx, scope) else {
+                // String.Index is compiler plumbing and never a surface field;
+                // every other miss is fail-closed instead of borrowing traits
+                // from an unrelated same-named declaration.
+                return if name == "String.Index" {
+                    RepresentationCapabilities {
+                        clone: true,
+                        ..RepresentationCapabilities::NONE
+                    }
+                } else {
+                    RepresentationCapabilities::NONE
+                };
+            };
+            capabilities_for_def(td, ctx, visiting)
+        }
+        // Function values cannot inhabit records/sums (the checker restricts
+        // Fn to direct parameters). Keep only the carrier's cheap clone fact;
+        // a leaked Fn field therefore loses every generated structural trait.
+        Type::Fn(..) => RepresentationCapabilities {
+            clone: true,
+            ..RepresentationCapabilities::NONE
+        },
+        Type::Var(_) | Type::Invalid => RepresentationCapabilities::NONE,
+    }
+}
+
+fn orderable_def(td: &TypeDef, ctx: &CodegenContext, visiting: &mut HashSet<String>) -> bool {
+    let key = crate::codegen::common::backend_type_def_key(ctx, td);
+    if !visiting.insert(key.clone()) {
+        return true;
+    }
+    let orderable = if super::uses_packed_u8(ctx, crate::codegen::common::type_def_name(td)) {
+        true
+    } else {
+        fields_of(td).all(|field| {
+            orderable_type(
+                &parse_type_str(field),
+                ctx,
+                crate::codegen::common::type_key_for_decl(ctx, td).scope_str(),
+                visiting,
+            )
+        })
+    };
+    visiting.remove(&key);
+    orderable
+}
+
+fn orderable_type(
+    ty: &Type,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+    visiting: &mut HashSet<String>,
+) -> bool {
+    match ty {
+        Type::Int | Type::Bool | Type::Unit | Type::Str => true,
+        Type::Option(inner) | Type::List(inner) => orderable_type(inner, ctx, scope, visiting),
+        Type::Result(ok, err) => {
+            orderable_type(ok, ctx, scope, visiting) && orderable_type(err, ctx, scope, visiting)
+        }
+        Type::Tuple(items) => items
+            .iter()
+            .all(|item| orderable_type(item, ctx, scope, visiting)),
+        Type::Named { id, name } => {
+            if is_provider_resource(*id, name, ctx, scope) {
+                return false;
+            }
+            named_type_def(*id, name, ctx, scope).is_some_and(|td| orderable_def(td, ctx, visiting))
+        }
+        Type::Float
+        | Type::Map(_, _)
+        | Type::Vector(_)
+        | Type::Fn(..)
+        | Type::Var(_)
+        | Type::Invalid => false,
+    }
+}
+
+fn named_type_def<'a>(
+    id: Option<crate::ir::TypeId>,
+    name: &str,
+    ctx: &'a CodegenContext,
+    scope: Option<&str>,
+) -> Option<&'a TypeDef> {
+    let key = id
+        .map(|id| ctx.symbol_table.type_entry(id).key.clone())
+        .unwrap_or_else(|| crate::codegen::common::type_key_for_name(ctx, name, scope));
+    match key.scope_str() {
+        None => ctx
+            .type_defs
+            .iter()
+            .find(|td| crate::codegen::common::type_def_name(td) == key.name),
+        Some(owner) => ctx
+            .modules
+            .iter()
+            .find(|module| module.prefix == owner)?
+            .type_defs
+            .iter()
+            .find(|td| crate::codegen::common::type_def_name(td) == key.name),
+    }
+}
+
+fn is_provider_resource(
+    id: Option<crate::ir::TypeId>,
+    name: &str,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> bool {
+    let id = id.or_else(|| {
+        let key = crate::codegen::common::type_key_for_name(ctx, name, scope);
+        ctx.symbol_table.type_id_of(&key)
+    });
+    if id.is_some_and(|id| ctx.symbol_table.type_entry(id).is_capability_resource) {
+        return true;
+    }
+    ctx.capabilities
+        .resource_types()
+        .any(|canonical| canonical == name)
+}
+
+fn fields_of(td: &TypeDef) -> impl Iterator<Item = &String> {
+    let fields: Vec<&String> = match td {
+        TypeDef::Sum { variants, .. } => variants
+            .iter()
+            .flat_map(|variant| variant.fields.iter())
+            .collect(),
+        TypeDef::Product { fields, .. } => fields.iter().map(|(_, ty)| ty).collect(),
+    };
+    fields.into_iter()
+}

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -3,6 +3,9 @@ use super::expr::{
     aver_name_to_rust, classify_thin_fn_def_for_rust, explicit_binding_pattern,
     explicit_parameter_pattern,
 };
+use super::representation::{
+    RepresentationCapabilities, RepresentationContract, type_def_contract,
+};
 use super::types::type_annotation_to_rust_scoped;
 use crate::ast::*;
 use crate::codegen::CodegenContext;
@@ -79,10 +82,10 @@ fn emit_type_def_with_visibility(td: &TypeDef, public: bool, ctx: &CodegenContex
     // name, which put the question through `find_type_def` — first-match-wins
     // for a bare name — so a same-named type in another module answered
     // instead. jasisz/aver#1134.
-    let hash_eq = type_can_derive_hash_eq(td, ctx, scope);
+    let representation = type_def_contract(td, ctx);
     match td {
         TypeDef::Sum { name, variants, .. } => {
-            emit_sum_type(name, variants, public, ctx, scope, hash_eq)
+            emit_sum_type(name, variants, public, ctx, scope, representation)
         }
         TypeDef::Product { name, fields, .. } => emit_product_type(
             name,
@@ -91,189 +94,27 @@ fn emit_type_def_with_visibility(td: &TypeDef, public: bool, ctx: &CodegenContex
             ctx,
             scope,
             super::uses_packed_u8(ctx, name),
-            hash_eq,
+            representation,
         ),
     }
 }
 
-use crate::codegen::common::type_def_name;
-
-/// Locate a `TypeDef` by canonical or bare name.
-///
-/// Epic #180 Phase 6 — accepts dotted canonical keys
-/// (`"A.Shape"` for module-owned types) routed to the matching
-/// module's `type_defs` list, so cross-module same-bare-name
-/// types resolve to the correct declaration instead of the
-/// first-match-wins bare lookup. Bare keys still resolve via
-/// the entry → module-walk fallback chain.
-fn find_type_def<'a>(name: &str, ctx: &'a CodegenContext) -> Option<&'a TypeDef> {
-    if let Some((prefix, bare)) = name.rsplit_once('.') {
-        for module in &ctx.modules {
-            if module.prefix == prefix {
-                return module.type_defs.iter().find(|td| type_def_name(td) == bare);
-            }
-        }
+fn derive_line(capabilities: RepresentationCapabilities) -> String {
+    let mut traits = Vec::new();
+    if capabilities.clone {
+        traits.push("Clone");
     }
-    ctx.type_defs
-        .iter()
-        .find(|td| type_def_name(td) == name)
-        .or_else(|| {
-            ctx.modules
-                .iter()
-                .flat_map(|module| module.type_defs.iter())
-                .find(|td| type_def_name(td) == name)
-        })
-}
-
-/// The key the field EMITTER would resolve this reference to.
-///
-/// The derives have to describe the struct that is actually emitted, so a
-/// field's type name has to resolve here exactly as it does in
-/// [`crate::codegen::rust::types::type_to_rust_scoped`] — a bare name in the
-/// scope of the module that declares the field. Resolving it first-match-wins
-/// across modules picked a same-named type from somewhere else, and the
-/// derives then described a struct nobody emitted. jasisz/aver#1134.
-///
-/// `None` keeps the previous bare-name behaviour for compiler-owned named
-/// types, which carry no `TypeId` to disambiguate with.
-fn scoped_named_key(
-    ctx: &CodegenContext,
-    ty: &crate::types::Type,
-    scope: Option<&str>,
-) -> Option<String> {
-    let crate::types::Type::Named { id, name } = ty else {
-        return None;
-    };
-    if let Some(id) = id {
-        return Some(ctx.symbol_table.type_entry(*id).key.canonical());
+    traits.push("Debug");
+    if capabilities.partial_eq {
+        traits.push("PartialEq");
     }
-    let key = crate::codegen::common::type_key_for_name(ctx, name, scope);
-    ctx.symbol_table
-        .type_id_of(&key)
-        .map(|_| key.canonical())
-        .or_else(|| Some(name.clone()))
-}
-
-fn rust_hash_eq_safe_type(
-    ty: &crate::types::Type,
-    ctx: &CodegenContext,
-    scope: Option<&str>,
-    visiting: &mut HashSet<String>,
-) -> bool {
-    use crate::types::Type;
-
-    match ty {
-        Type::Int | Type::Bool | Type::Unit | Type::Str => true,
-        Type::Float => false,
-        Type::Result(ok, err) => {
-            rust_hash_eq_safe_type(ok, ctx, scope, visiting)
-                && rust_hash_eq_safe_type(err, ctx, scope, visiting)
-        }
-        Type::Option(inner) => rust_hash_eq_safe_type(inner, ctx, scope, visiting),
-        // `AverList<T>` and `AverIntList` implement Eq and Hash whenever their
-        // element does, so a list is only unsafe for what it holds. `Vector`
-        // stays out: the runtime's key comparator has no order for it, and the
-        // checker refuses a key that reaches one.
-        Type::List(inner) => rust_hash_eq_safe_type(inner, ctx, scope, visiting),
-        Type::Vector(_) => false,
-        Type::Tuple(items) => items
-            .iter()
-            .all(|item| rust_hash_eq_safe_type(item, ctx, scope, visiting)),
-        Type::Map(_, _) | Type::Fn(_, _, _) | Type::Var(_) | Type::Invalid => false,
-        Type::Named { .. } => {
-            let Some(key) = scoped_named_key(ctx, ty, scope) else {
-                return false;
-            };
-            rust_hash_eq_safe_named(&key, ctx, visiting)
-        }
+    if capabilities.eq {
+        traits.push("Eq");
     }
-}
-
-/// Whether THIS declaration's own fields can carry `Eq` and `Hash`.
-///
-/// Takes the `TypeDef` rather than looking one up, because a bare name does
-/// not identify a declaration: two modules may each declare `Progress`, and
-/// [`find_type_def`] answers a bare name first-match-wins. Asking by name
-/// stamped one twin's answer onto the other — a record holding a value that
-/// can never be `Eq` came out `#[derive(.., Eq, Hash)]` and only `cargo build`
-/// saw it. jasisz/aver#1134.
-///
-/// `key` is the cycle-guard identity only; it never selects the declaration.
-fn rust_hash_eq_safe_def(
-    td: &TypeDef,
-    key: &str,
-    ctx: &CodegenContext,
-    scope: Option<&str>,
-    visiting: &mut HashSet<String>,
-) -> bool {
-    if !visiting.insert(key.to_string()) {
-        return true;
+    if capabilities.hash {
+        traits.push("Hash");
     }
-
-    // A packed byte sequence is carried by `aver_rt::AverPackedU8`, which
-    // implements Eq, Hash and Ord, so the source-level `List<Int>` below
-    // describes a field this struct does not hold. Answering from the
-    // source type is what kept `Map<Bytes, T>` — and anything holding a
-    // `Bytes` — from deriving what the map needs on this backend.
-    let safe = if super::uses_packed_u8(ctx, crate::codegen::common::type_def_name(td)) {
-        true
-    } else {
-        match td {
-            TypeDef::Sum { variants, .. } => variants.iter().all(|variant| {
-                variant.fields.iter().all(|field_ty| {
-                    let parsed = crate::types::parse_type_str(field_ty);
-                    rust_hash_eq_safe_type(&parsed, ctx, scope, visiting)
-                })
-            }),
-            TypeDef::Product { fields, .. } => fields.iter().all(|(_, field_ty)| {
-                let parsed = crate::types::parse_type_str(field_ty);
-                rust_hash_eq_safe_type(&parsed, ctx, scope, visiting)
-            }),
-        }
-    };
-
-    visiting.remove(key);
-    safe
-}
-
-/// Field-reference entry point: a field names a type, so this one has to
-/// resolve. An unresolvable name is not safe.
-fn rust_hash_eq_safe_named(
-    name: &str,
-    ctx: &CodegenContext,
-    visiting: &mut HashSet<String>,
-) -> bool {
-    match find_type_def(name, ctx) {
-        Some(td) => {
-            // A dependency's own fields are written in ITS scope, not in the
-            // scope of whoever named it, so the descent re-scopes here.
-            let owner = crate::codegen::common::type_key_for_decl(ctx, td);
-            rust_hash_eq_safe_def(td, name, ctx, owner.scope_str(), visiting)
-        }
-        None => false,
-    }
-}
-
-fn type_can_derive_hash_eq(td: &TypeDef, ctx: &CodegenContext, scope: Option<&str>) -> bool {
-    let mut visiting = HashSet::new();
-    let key = crate::codegen::common::backend_type_def_key(ctx, td);
-    rust_hash_eq_safe_def(td, &key, ctx, scope, &mut visiting)
-}
-
-/// Whether the generated type can carry the canonical key order.
-///
-/// A map keyed on this type sorts by it, so every part has to order the same
-/// way on every backend. `Float` has no order the proof model can state, and
-/// `Map` and `Vector` have none in the runtime's key comparator either — the
-/// checker refuses a key that reaches any of them, and this is the other half
-/// of that agreement.
-fn type_parts_are_orderable<'a>(parts: impl Iterator<Item = &'a String>) -> bool {
-    parts.into_iter().all(|ty| {
-        !ty.contains("Float")
-            && !ty.contains("Map<")
-            && !ty.contains("Vector<")
-            && !ty.contains("Fn(")
-    })
+    format!("#[derive({})]", traits.join(", "))
 }
 
 fn emit_sum_type(
@@ -282,16 +123,12 @@ fn emit_sum_type(
     public: bool,
     ctx: &CodegenContext,
     scope: Option<&str>,
-    hash_eq: bool,
+    representation: RepresentationContract,
 ) -> String {
     let mut out = String::new();
     let visibility = visibility_prefix(public);
-    let derives = if hash_eq {
-        "#[derive(Clone, Debug, PartialEq, Eq, Hash)]"
-    } else {
-        "#[derive(Clone, Debug, PartialEq)]"
-    };
-    writeln!(out, "{}", derives).unwrap();
+    let capabilities = representation.capabilities;
+    writeln!(out, "{}", derive_line(capabilities)).unwrap();
     writeln!(out, "{}enum {} {{", visibility, name).unwrap();
     for v in variants {
         if v.fields.is_empty() {
@@ -321,7 +158,7 @@ fn emit_sum_type(
     // field name: declaration order is not observable anywhere else, so
     // ordering by it would make reordering two constructors change how every
     // map on this key iterates.
-    if hash_eq && type_parts_are_orderable(variants.iter().flat_map(|v| v.fields.iter())) {
+    if capabilities.eq && capabilities.hash && representation.orderable {
         let mut by_name: Vec<&TypeVariant> = variants.iter().collect();
         by_name.sort_by(|a, b| a.name.cmp(&b.name));
         writeln!(out).unwrap();
@@ -390,55 +227,57 @@ fn emit_sum_type(
         writeln!(out, "}}").unwrap();
     }
 
-    // Generate AverDisplay impl
-    writeln!(out).unwrap();
-    writeln!(out, "impl aver_rt::AverDisplay for {} {{", name).unwrap();
-    writeln!(out, "    fn aver_display(&self) -> String {{").unwrap();
-    writeln!(out, "        match self {{").unwrap();
-    for v in variants {
-        if v.fields.is_empty() {
-            writeln!(
-                out,
-                "            {}::{} => \"{}\".to_string(),",
-                name, v.name, v.name
-            )
-            .unwrap();
-        } else {
-            let bindings: Vec<String> = (0..v.fields.len()).map(|i| format!("f{}", i)).collect();
-            let display_parts: Vec<String> = bindings
-                .iter()
-                .map(|b| format!("{}.aver_display_inner()", b))
-                .collect();
-            if v.fields.len() == 1 {
-                // Single field: direct format without vec![].join() allocation
+    if capabilities.aver_display {
+        writeln!(out).unwrap();
+        writeln!(out, "impl aver_rt::AverDisplay for {} {{", name).unwrap();
+        writeln!(out, "    fn aver_display(&self) -> String {{").unwrap();
+        writeln!(out, "        match self {{").unwrap();
+        for v in variants {
+            if v.fields.is_empty() {
                 writeln!(
                     out,
-                    "            {}::{}({}) => format!(\"{}({{}})\", {}),",
-                    name, v.name, bindings[0], v.name, display_parts[0]
+                    "            {}::{} => \"{}\".to_string(),",
+                    name, v.name, v.name
                 )
                 .unwrap();
             } else {
-                writeln!(
-                    out,
-                    "            {}::{}({}) => format!(\"{}({{}})\", vec![{}].join(\", \")),",
-                    name,
-                    v.name,
-                    bindings.join(", "),
-                    v.name,
-                    display_parts.join(", ")
-                )
-                .unwrap();
+                let bindings: Vec<String> =
+                    (0..v.fields.len()).map(|i| format!("f{}", i)).collect();
+                let display_parts: Vec<String> = bindings
+                    .iter()
+                    .map(|b| format!("{}.aver_display_inner()", b))
+                    .collect();
+                if v.fields.len() == 1 {
+                    // Single field: direct format without vec![].join() allocation
+                    writeln!(
+                        out,
+                        "            {}::{}({}) => format!(\"{}({{}})\", {}),",
+                        name, v.name, bindings[0], v.name, display_parts[0]
+                    )
+                    .unwrap();
+                } else {
+                    writeln!(
+                        out,
+                        "            {}::{}({}) => format!(\"{}({{}})\", vec![{}].join(\", \")),",
+                        name,
+                        v.name,
+                        bindings.join(", "),
+                        v.name,
+                        display_parts.join(", ")
+                    )
+                    .unwrap();
+                }
             }
         }
+        writeln!(out, "        }}").unwrap();
+        writeln!(out, "    }}").unwrap();
+        writeln!(
+            out,
+            "    fn aver_display_inner(&self) -> String {{ self.aver_display() }}"
+        )
+        .unwrap();
+        writeln!(out, "}}").unwrap();
     }
-    writeln!(out, "        }}").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(
-        out,
-        "    fn aver_display_inner(&self) -> String {{ self.aver_display() }}"
-    )
-    .unwrap();
-    writeln!(out, "}}").unwrap();
 
     out.trim_end().to_string()
 }
@@ -450,16 +289,12 @@ fn emit_product_type(
     ctx: &CodegenContext,
     scope: Option<&str>,
     packed_u8: bool,
-    hash_eq: bool,
+    representation: RepresentationContract,
 ) -> String {
     let mut out = String::new();
     let visibility = visibility_prefix(public);
-    let derives = if hash_eq {
-        "#[derive(Clone, Debug, PartialEq, Eq, Hash)]"
-    } else {
-        "#[derive(Clone, Debug, PartialEq)]"
-    };
-    writeln!(out, "{}", derives).unwrap();
+    let capabilities = representation.capabilities;
+    writeln!(out, "{}", derive_line(capabilities)).unwrap();
     writeln!(out, "{}struct {} {{", visibility, name).unwrap();
     for (field_name, field_type) in fields {
         let rust_type = if packed_u8 {
@@ -487,7 +322,7 @@ fn emit_product_type(
     // anywhere else in Aver — a record is built and read by name, and there is
     // no positional pattern — so ordering by it would make reordering two
     // fields change how every map on this key iterates.
-    if hash_eq && type_parts_are_orderable(fields.iter().map(|(_, ty)| ty)) {
+    if capabilities.eq && capabilities.hash && representation.orderable {
         let mut by_name: Vec<&(String, String)> = fields.iter().collect();
         by_name.sort_by(|a, b| a.0.cmp(&b.0));
         writeln!(out).unwrap();
@@ -520,39 +355,40 @@ fn emit_product_type(
         writeln!(out, "}}").unwrap();
     }
 
-    // Generate AverDisplay impl
-    writeln!(out).unwrap();
-    writeln!(out, "impl aver_rt::AverDisplay for {} {{", name).unwrap();
-    writeln!(out, "    fn aver_display(&self) -> String {{").unwrap();
-    let parts: Vec<String> = fields
-        .iter()
-        .map(|(field_name, _)| {
-            format!(
-                "format!(\"{}: {{}}\", self.{}.aver_display_inner())",
-                field_name,
-                aver_name_to_rust(field_name)
+    if capabilities.aver_display {
+        writeln!(out).unwrap();
+        writeln!(out, "impl aver_rt::AverDisplay for {} {{", name).unwrap();
+        writeln!(out, "    fn aver_display(&self) -> String {{").unwrap();
+        let parts: Vec<String> = fields
+            .iter()
+            .map(|(field_name, _)| {
+                format!(
+                    "format!(\"{}: {{}}\", self.{}.aver_display_inner())",
+                    field_name,
+                    aver_name_to_rust(field_name)
+                )
+            })
+            .collect();
+        if fields.len() == 1 {
+            // Single field: direct format without vec![].join() allocation
+            writeln!(out, "        format!(\"{}({{}})\", {})", name, parts[0]).unwrap();
+        } else {
+            writeln!(
+                out,
+                "        format!(\"{}({{}})\", vec![{}].join(\", \"))",
+                name,
+                parts.join(", ")
             )
-        })
-        .collect();
-    if fields.len() == 1 {
-        // Single field: direct format without vec![].join() allocation
-        writeln!(out, "        format!(\"{}({{}})\", {})", name, parts[0]).unwrap();
-    } else {
+            .unwrap();
+        }
+        writeln!(out, "    }}").unwrap();
         writeln!(
             out,
-            "        format!(\"{}({{}})\", vec![{}].join(\", \"))",
-            name,
-            parts.join(", ")
+            "    fn aver_display_inner(&self) -> String {{ self.aver_display() }}"
         )
         .unwrap();
+        writeln!(out, "}}").unwrap();
     }
-    writeln!(out, "    }}").unwrap();
-    writeln!(
-        out,
-        "    fn aver_display_inner(&self) -> String {{ self.aver_display() }}"
-    )
-    .unwrap();
-    writeln!(out, "}}").unwrap();
 
     out.trim_end().to_string()
 }
@@ -1918,6 +1754,43 @@ mod tests {
     }
 
     #[test]
+    fn derives_each_supported_representation_trait_independently() {
+        let vector_key = TypeDef::Product {
+            name: "VectorHolder".to_string(),
+            fields: vec![("values".to_string(), "Vector<Int>".to_string())],
+            line: 1,
+        };
+        let float_value = TypeDef::Product {
+            name: "Measurement".to_string(),
+            fields: vec![("value".to_string(), "Float".to_string())],
+            line: 2,
+        };
+        let mut ctx = empty_ctx();
+        ctx.type_defs.push(vector_key.clone());
+        ctx.type_defs.push(float_value.clone());
+
+        let vector = emit_public_type_def(&vector_key, &ctx);
+        assert!(
+            vector.contains("#[derive(Clone, Debug, PartialEq, Eq, Hash)]"),
+            "AverVector<Int> implements all requested structural traits:\n{vector}"
+        );
+        assert!(
+            !vector.contains("impl Ord for VectorHolder"),
+            "Hash support must not be confused with canonical Map-key order:\n{vector}"
+        );
+        assert!(vector.contains("impl aver_rt::AverDisplay for VectorHolder"));
+
+        let float = emit_public_type_def(&float_value, &ctx);
+        assert!(
+            float.contains("#[derive(Clone, Debug, PartialEq)]"),
+            "f64 supports clone/equality/display but deliberately not Eq/Hash:\n{float}"
+        );
+        assert!(!float.lines().next().unwrap_or_default().contains(", Eq"));
+        assert!(!float.lines().next().unwrap_or_default().contains("Hash"));
+        assert!(float.contains("impl aver_rt::AverDisplay for Measurement"));
+    }
+
+    #[test]
     fn packed_byte_sequence_derives_eq_hash() {
         // `Bytes` declares `values: List<Int>`, but this backend emits
         // `aver_rt::AverPackedU8`, which implements Eq, Hash and Ord. Deciding
@@ -1930,9 +1803,13 @@ mod tests {
             fields: vec![("values".to_string(), "List<Int>".to_string())],
             line: 1,
         };
-        let mut ctx = empty_ctx();
-        ctx.type_defs.push(td.clone());
-        ctx.packed_sequence_layouts.insert(
+        let mut ordinary_ctx = empty_ctx();
+        ordinary_ctx.type_defs.push(td.clone());
+        let ordinary = emit_public_type_def(&td, &ordinary_ctx);
+
+        let mut packed_ctx = empty_ctx();
+        packed_ctx.type_defs.push(td.clone());
+        packed_ctx.packed_sequence_layouts.insert(
             "Bytes".to_string(),
             crate::codegen::proof_lower::PackedSequenceLayout {
                 element_interval: crate::ir::interval::Interval::unbounded(),
@@ -1940,7 +1817,7 @@ mod tests {
             },
         );
 
-        let emitted = emit_public_type_def(&td, &ctx);
+        let emitted = emit_public_type_def(&td, &packed_ctx);
         assert!(
             emitted.contains("aver_rt::AverPackedU8"),
             "expected the packed carrier, got:\n{emitted}"
@@ -1948,6 +1825,11 @@ mod tests {
         assert!(
             emitted.contains("#[derive(Clone, Debug, PartialEq, Eq, Hash)]"),
             "a packed byte sequence must derive what a Map key needs, got:\n{emitted}"
+        );
+        assert_eq!(
+            ordinary.lines().next(),
+            emitted.lines().next(),
+            "ordinary List<Int> and packed U8 carriers must promise the same equality/hash traits"
         );
     }
 

--- a/src/self_host/aver_generated/http/mod.rs
+++ b/src/self_host/aver_generated/http/mod.rs
@@ -1,7 +1,7 @@
 #[allow(unused_imports)]
 use crate::*;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Response {
     pub status: aver_rt::AverInt,
     pub body: AverStr,


### PR DESCRIPTION
Closes #1176.

## Summary
- model Clone, PartialEq, Eq, Hash, Aver display, and ordering as an explicit Rust representation contract
- resolve named field capabilities through TypeId/TypeKey-qualified declarations, including recursive composites
- derive each supported trait independently and emit AverDisplay only when the selected carrier supports it
- make packed byte carriers agree with ordinary List<Int>, while provider resources remain cloneable/displayable without exposing Aver equality or hashing
- document the contract and refresh the checked-in self-host output

## Validation
- cargo test --lib (1464 passed)
- cargo test --test compile_spec -- --nocapture (5 passed)
- cargo test --test rust_codegen_differential (64 passed, 10 ignored)
- cargo test --test native_provider_rust_spec (7 passed)
- cargo test --test rust_codegen_regression (4 passed)
- targeted regressions for #994, #1065, and #1134
- cargo clippy --lib --test rust_codegen_differential --test native_provider_rust_spec -- -D warnings
- python3 tools/regenerate_self_host.py --check
- current n1bor/btc-listener: 140-module compile plus downstream cargo check