### PR TITLE
Move last-use Maps across Rust call boundaries

### DIFF
--- a/src/codegen/rust/expr.rs
+++ b/src/codegen/rust/expr.rs
@@ -192,7 +192,7 @@ pub(super) fn callee_borrow_mask(name: &str, arg_count: usize, ctx: &CodegenCont
     };
 
     // own_param graduation: a NON-TCO collection param the `own_param`
-    // pass PROVED uniquely owned is emitted owned-by-value (`mut p: T`,
+    // pass proved can use the owned Rust ABI is emitted by value (`mut p: T`,
     // see `MirFnEmitPolicy::apply_own_param` / `emit_fn_params_with_owned`),
     // so the CALLER must pass it BY VALUE, not `&T`. Clear the borrow bit
     // at every graduated param position so the call site matches the

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -128,14 +128,13 @@ pub struct MirEmitCtx<'a> {
     /// argument is not a real move point. Owning positions clone these
     /// params; non-owning reads remain allocation-free.
     pub loop_carried_params: &'a HashSet<String>,
-    /// Collection (`Vector`/`Map`) params that the `own_param` MIR pass
-    /// PROVED uniquely owned (cleared their `aliased_slots` bit). These
-    /// are emitted owned-by-value (`mut p: T`, NOT `&T`) and, at a
-    /// last-use read, skip the `.clone()` so an in-place `Rc::make_mut`
-    /// runs on a refcount-1 backing (native O(n) mutate instead of the
-    /// O(n²) borrow+clone COW). SOUNDNESS: a name is in this set only
-    /// when `own_param` cleared its bit — never broadened past what the
-    /// pass proved. Disjoint from `borrowed_params` by construction.
+    /// Collection (`Vector`/`Map`) params whose `own_param` MIR fact proves
+    /// every visible caller can provide an owned carrier (cleared
+    /// `aliased_slots` bit). These emit owned-by-value (`mut p: T`, not `&T`)
+    /// and move at a last-use read. A genuinely shared backing remains safe
+    /// through the runtime COW gate; the linear case reaches it with one fewer
+    /// handle and avoids the borrow+clone full-table copy. Disjoint from
+    /// `borrowed_params` by construction.
     pub owned_params: &'a HashSet<String>,
     /// Owning module prefix for the fn whose body this ctx emits.
     pub current_module_scope: Option<&'a str>,
@@ -386,7 +385,7 @@ pub(super) struct MirFnEmitPolicy {
     pub local_types: HashMap<String, Type>,
     pub rc_wrapped: HashSet<String>,
     pub borrowed_params: HashSet<String>,
-    /// Collection params `own_param` proved uniquely owned — see the
+    /// Collection params `own_param` proved can use the owned Rust ABI — see the
     /// `MirEmitCtx::owned_params` doc. Default empty (no own_param facts
     /// applied); populated by [`Self::apply_own_param`].
     pub owned_params: HashSet<String>,
@@ -491,16 +490,12 @@ impl MirFnEmitPolicy {
     /// that param: Rust can move the record and its replaced field while the
     /// caller still clones at a non-last-use call site.
     ///
-    /// SOUNDNESS (the #383 corruption class): a collection param is
-    /// graduated ONLY when `own_param` cleared its bit. `own_param`'s
-    /// RULE 1 flags EVERY `Vector`/`Map` param `true` up front and only
-    /// clears the bit on a whole-program proof of unique ownership
-    /// (every visible call site passes a fresh / linearly-threaded
-    /// value, captured-into-aggregate slots stay flagged, multi-module
-    /// returns early leaving every bit set). So a cleared bit on a
-    /// collection param is exactly the pass's proof — never a heuristic.
-    /// A missing bit defaults to flagged (`true`) → not graduated
-    /// (conservative). Params still flagged keep borrow-by-default.
+    /// SOUNDNESS (the #383 corruption class): a collection param graduates
+    /// only when `own_param` clears its bit after seeing every call site.
+    /// Shared-arena backends require unique backing. This Rust-only second
+    /// refinement requires an owned carrier instead: non-final uses clone,
+    /// final uses move, and Map/Vector mutators preserve retained aliases via
+    /// COW. Missing facts remain flagged and keep borrow-by-default.
     pub(super) fn apply_own_param(&mut self, mir_fn: &crate::ir::mir::MirFn) {
         for (i, param) in mir_fn.params.iter().enumerate() {
             // Only collection params are candidates (the only thing
@@ -520,7 +515,8 @@ impl MirFnEmitPolicy {
             // by PARAM POSITION `i` (its `(0..nparams).filter(|&i| …)`),
             // matching `MirParam.local = LocalId(i)`; match that exactly.
             //
-            // Cleared bit ⟺ own_param proved unique ownership. Missing →
+            // Cleared bit ⟺ own_param proved the selected model's ownership
+            // condition (unique arena backing or owned Rust carrier). Missing →
             // treat as flagged (conservative). Still-flagged → keep the
             // existing borrow-by-default decision (do not graduate).
             let collection_graduated = is_owned_collection_candidate(ty)
@@ -603,7 +599,7 @@ fn result_contains_record_successor_of(expr: &MirExpr, slot: LocalId) -> bool {
 }
 
 /// The Rust-mangled names of a fn's `Vector`/`Map` params that
-/// `own_param` PROVED uniquely owned (cleared `aliased_slots` bit) — the
+/// `own_param` proved can use the owned Rust ABI (cleared `aliased_slots` bit) — the
 /// set the non-TCO SIGNATURE emits owned-by-value (`mut p: T`). The
 /// `param_types` are the `ResolvedFnDef` param `(name, Type)` pairs (real
 /// `Type`, not the `MirParam.ty` Debug string); the `mir_fn` supplies the

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -1825,8 +1825,8 @@ fn deep(n: Int, _: Int) -> Int
 ";
         // Not recursive at all — but the parameter is a COLLECTION, and
         // that is the other thing that can put a `mut` in front of it.
-        // `own_param` proves a `Vector` parameter uniquely owned when every
-        // call site passes a fresh value, and the owned spelling is `mut p:
+        // `own_param` proves a `Vector` parameter can use the owned Rust ABI
+        // when every call site passes a fresh value, and the spelling is `mut p:
         // T`. The proof is by parameter POSITION and never reads the name,
         // so it reaches the wildcard too.
         const OWNED_COLLECTION_WILDCARD_PARAM: &str = "\

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -869,9 +869,9 @@ fn emit_fn_params_inner(
             } else if mutable {
                 format!("{}: {}", explicit_parameter_pattern(name, true), rust_type)
             } else if owned_params.contains(&rust_name) {
-                // own_param proved this collection param uniquely owned:
-                // take it by value (`mut p: T`) so the body's in-place
-                // mutate runs on a refcount-1 backing. `mut` because the
+                // own_param proved every caller can provide an owned carrier:
+                // take it by value (`mut p: T`) so a linear caller reaches the
+                // COW gate without an extra handle. `mut` because the
                 // owned-mutate builtins (`Vector.set` → `set_owned`,
                 // `Map.set` → `insert_owned`) consume `self` by value.
                 format!("{}: {}", explicit_parameter_pattern(name, true), rust_type)

--- a/src/ir/mir/optimize/own_param.rs
+++ b/src/ir/mir/optimize/own_param.rs
@@ -23,11 +23,11 @@
 //! escape sites is unsound by omission: any unforeseen site is a silent
 //! corruption (a backend mutates shared data in place).
 //!
-//! So the polarity is flipped. The default for every collection param is
-//! **flagged** (kept aliased — never mutated in place). The bit is
-//! cleared only when a *positive proof* succeeds, i.e. when **every**
-//! occurrence of the param `P` — and of every let-local that may share
-//! `P`'s backing (its alias closure) — is one of these RECOGNIZED
+//! For shared-arena backends the polarity is flipped. The default for every
+//! collection param is **flagged** (kept aliased — never mutated in place).
+//! The bit is cleared only when a *positive proof* succeeds, i.e. when
+//! **every** occurrence of the param `P` — and of every let-local that may
+//! share `P`'s backing (its alias closure) — is one of these RECOGNIZED
 //! non-retaining-linear uses:
 //!
 //! - `P` (or an alias) as the TARGET/receiver arg (arg 0) of a
@@ -52,13 +52,14 @@
 //! scan defaults every *unrecognized* position to retaining, so it
 //! cannot miss an escape — the audits converge.
 //!
-//! The body-local proof above is one half; the other is the
-//! interprocedural call-site proof: even a body-locally-linear param
-//! graduates only when **every** visible call site of its fn passes it a
-//! uniquely-owned argument (a fresh constructor, an owned set-chain, a
-//! `last_use` non-aliased local with no live caller-side alias),
-//! computed as a monotone-descending fixpoint. Default is keep-flagged;
-//! un-flagging is the gated exception.
+//! The body-local proof above is one half; the other is the interprocedural
+//! call-site proof, computed as a monotone-descending fixpoint. An arena param
+//! graduates only when every visible call site passes uniquely-owned storage.
+//! The Rust refinement asks the narrower ABI question instead: can every call
+//! site provide an owned `T`? Rust's emitter clones a non-final owning use,
+//! moves a final one, and its collection mutators enforce COW, so a retained
+//! sibling handle may cost a real copy but cannot make the move incorrect.
+//! Default is keep-flagged; un-flagging is the gated exception in both models.
 //!
 //! ## Soundness gates
 //!
@@ -71,10 +72,18 @@
 //! - A call site reached through `MirCallee::LocalSlot` (a fn value) has
 //!   no statically-known target, so it never counts as a visible caller;
 //!   such fns are already pinned via the address-taken set.
-//! - An argument is uniquely-owned only when proven so. A named user-fn
+//! - An arena argument is uniquely-owned only when proven so. A named user-fn
 //!   result qualifies only through a return-alias summary that identifies
-//!   every parameter backing it may carry; a fn-value result stays unknown,
-//!   and a local with a live caller-side alias is never owned.
+//!   every parameter backing it may carry; a fn-value result stays unknown.
+//!   Arena backends also reject a local with a live caller-side alias. Rust
+//!   may still move that local: its owned mutators enforce COW at runtime, so
+//!   an actual sibling handle remains correct without the borrowed ABI adding
+//!   yet another handle.
+//! - On generated Rust, a last-use pattern binding is movable by construction:
+//!   matches with bindings materialize their subject by value, and the binding
+//!   owns the extracted value. Its collection backing may still be shared,
+//!   but the Rust runtime preserves COW semantics; moving the binding avoids
+//!   adding the extra owner that a borrowed callee parameter would create.
 //! - Two alias-prone params receiving the same slot at one call site are
 //!   both rejected (the value is shared between them inside the callee).
 //!
@@ -90,7 +99,7 @@ use crate::ast::Spanned;
 use crate::ir::FnId;
 use crate::ir::hir::BuiltinIntrinsic;
 
-use super::super::expr::{MirCallee, MirExpr, walk_children};
+use super::super::expr::{MirCallee, MirExpr, MirPattern, walk_children};
 use super::super::program::MirProgram;
 
 mod return_alias;
@@ -147,6 +156,10 @@ enum OwnershipModel {
 
 impl OwnershipModel {
     fn returned_aggregates_are_consumed(self) -> bool {
+        self == Self::RustDropAware
+    }
+
+    fn owned_carriers_are_cow_protected(self) -> bool {
         self == Self::RustDropAware
     }
 }
@@ -210,6 +223,24 @@ fn own_param_refine_for_model(mut program: MirProgram, model: OwnershipModel) ->
         provenance.insert(*id, m);
     }
 
+    // Rust match emission materializes every subject that has bindings by
+    // value (`mir_clone_arg`) before destructuring it. Consequently each
+    // pattern local is an owned Rust value, even when its `Rc` backing still
+    // aliases another aggregate component. A last-use read of such a local is
+    // movable into an owned callee parameter without manufacturing the extra
+    // handle that today's borrowed ABI creates. Arena backends cannot use this
+    // fact: their destructured wrapper/tuple entries remain observable holders.
+    let mut rust_owned_pattern_slots: HashMap<FnId, HashSet<u32>> = HashMap::new();
+    if model.owned_carriers_are_cow_protected() {
+        for (id, f) in program.iter() {
+            let mut slots = HashSet::new();
+            collect_pattern_bound_slots(&f.body.node, &mut slots);
+            if !slots.is_empty() {
+                rust_owned_pattern_slots.insert(*id, slots);
+            }
+        }
+    }
+
     // Interprocedural capture summary: `captures_param[f] = { i | param
     // i of f is NOT proven non-retaining in f's body — i.e. some
     // occurrence of param i is not a recognized linear use, OR it is
@@ -222,11 +253,15 @@ fn own_param_refine_for_model(mut program: MirProgram, model: OwnershipModel) ->
     // capturing callee param escapes in the caller too).
     let builtins = program.builtins.clone();
     let return_aliases = compute_return_alias_summary(&program, &provenance, &builtins, model);
-    let captures_param = compute_capture_summary(&program, &provenance, &builtins, model);
+    let captures_param = if model.owned_carriers_are_cow_protected() {
+        HashMap::new()
+    } else {
+        compute_capture_summary(&program, &provenance, &builtins, model)
+    };
 
     // --- BODY-LOCAL PROOF -------------------------------------------------
     //
-    // For each fn, compute the set of slots that LEAK in its body: slots
+    // For each arena-backend fn, compute the set of slots that LEAK in its body: slots
     // that appear (directly or through an alias chain) in any position
     // the whitelist does NOT recognize as non-retaining-linear. The scan
     // is positive — it walks every operand position, marks the
@@ -234,7 +269,7 @@ fn own_param_refine_for_model(mut program: MirProgram, model: OwnershipModel) ->
     // it does not explicitly recognize) as retaining. A bare `Local` in
     // a retaining position contributes its alias roots to the leak set.
     //
-    // A param slot in the leak set MUST stay flagged: some occurrence of
+    // An arena param slot in the leak set MUST stay flagged: some occurrence of
     // it (or of a value sharing its backing) is retained beyond a linear
     // consume, so an in-place mutation would corrupt the retained handle.
     // This single scan subsumes the old `collect_escaping_slots`
@@ -245,22 +280,32 @@ fn own_param_refine_for_model(mut program: MirProgram, model: OwnershipModel) ->
     // distinct shape: the param appears only in recognized-safe
     // positions, yet a still-live RENAME alias observes the pre-mutation
     // backing. `collect_live_aliased_params` pins those separately.
+    //
+    // Generated Rust deliberately skips both pins. Graduation there means
+    // "every call site can provide an owned `T`", not "the backing has no
+    // other handle". MIR liveness makes non-final owning uses clone, final
+    // uses move, and Map/Vector mutation crosses a COW gate. A retained alias
+    // can therefore force a real copy but cannot observe in-place corruption;
+    // keeping the borrowed ABI would only add another handle and can never
+    // improve that outcome. This distinction is the core of issue #1196.
     let mut leaking: HashMap<FnId, HashSet<u32>> = HashMap::new();
-    for (id, f) in program.iter() {
-        let prov = provenance.get(id).cloned().unwrap_or_default();
-        let mut leak: HashSet<u32> = HashSet::new();
-        scan_body_leaks(
-            model,
-            &f.body.node,
-            &prov,
-            &captures_param,
-            &builtins,
-            &mut leak,
-        );
-        let nparams = f.params.len();
-        collect_live_aliased_params(&f.body.node, &prov, &builtins, nparams, &mut leak);
-        if !leak.is_empty() {
-            leaking.insert(*id, leak);
+    if !model.owned_carriers_are_cow_protected() {
+        for (id, f) in program.iter() {
+            let prov = provenance.get(id).cloned().unwrap_or_default();
+            let mut leak: HashSet<u32> = HashSet::new();
+            scan_body_leaks(
+                model,
+                &f.body.node,
+                &prov,
+                &captures_param,
+                &builtins,
+                &mut leak,
+            );
+            let nparams = f.params.len();
+            collect_live_aliased_params(&f.body.node, &prov, &builtins, nparams, &mut leak);
+            if !leak.is_empty() {
+                leaking.insert(*id, leak);
+            }
         }
     }
 
@@ -384,26 +429,29 @@ fn own_param_refine_for_model(mut program: MirProgram, model: OwnershipModel) ->
                     }
                 };
                 let dup = matches!(&arg.node, MirExpr::Local(l) if slot_counts.get(&l.node.slot.0).copied().unwrap_or(0) > 1);
-                // Live-alias-at-callsite: an owned local passed here is
-                // NOT uniquely owned if the CALLER still observes its
-                // slot through a live rename alias (`alias = base;
-                // mutate(base); read alias`). The callee graduates and
-                // mutates in place, corrupting the caller's alias.
-                let caller_aliased = matches!(&arg.node, MirExpr::Local(l)
-                    if caller_live_aliased.is_some_and(|s| s.contains(&l.node.slot.0)));
-                let ok = !dup
-                    && !caller_aliased
-                    && uniquely_owned(
-                        &arg.node,
-                        cs.caller,
-                        &program,
-                        &owned,
-                        &provenance,
-                        &return_aliases,
-                        model,
-                        &builtins,
-                        0,
-                    );
+                // Live-alias-at-callsite: arena backends must reject an owned
+                // local if the caller still observes it through a rename
+                // alias (`alias = base; mutate(base); read alias`) because
+                // their fast path mutates shared storage directly. Generated
+                // Rust may move the last-use handle: `Rc::make_mut` / the
+                // collection's equivalent COW gate preserves the caller's
+                // alias and the move avoids adding one gratuitous handle.
+                let caller_aliased = !model.owned_carriers_are_cow_protected()
+                    && matches!(&arg.node, MirExpr::Local(l)
+                        if caller_live_aliased.is_some_and(|s| s.contains(&l.node.slot.0)));
+                let argument_owned = uniquely_owned(
+                    &arg.node,
+                    cs.caller,
+                    &program,
+                    &owned,
+                    &provenance,
+                    &rust_owned_pattern_slots,
+                    &return_aliases,
+                    model,
+                    &builtins,
+                    0,
+                );
+                let ok = !dup && !caller_aliased && argument_owned;
                 if !ok && owned.insert(key, false) != Some(false) {
                     changed = true;
                 }
@@ -432,8 +480,9 @@ fn own_param_refine_for_model(mut program: MirProgram, model: OwnershipModel) ->
     program
 }
 
-/// Is `e`, evaluated in `caller`, a uniquely-owned value (does not
-/// create / carry an alias of a still-live binding)? Default false.
+/// Can `e`, evaluated in `caller`, supply the model's owned argument?
+/// Arena storage must be unique; generated Rust needs a movable owned carrier
+/// because its mutators retain COW protection. Default false.
 #[allow(clippy::too_many_arguments)]
 fn uniquely_owned(
     e: &MirExpr,
@@ -441,6 +490,7 @@ fn uniquely_owned(
     program: &MirProgram,
     owned: &HashMap<(FnId, usize), bool>,
     provenance: &HashMap<FnId, HashMap<u32, Spanned<MirExpr>>>,
+    rust_owned_pattern_slots: &HashMap<FnId, HashSet<u32>>,
     return_aliases: &ReturnAliasSummary,
     model: OwnershipModel,
     builtins: &[String],
@@ -493,6 +543,7 @@ fn uniquely_owned(
                                 program,
                                 owned,
                                 provenance,
+                                rust_owned_pattern_slots,
                                 return_aliases,
                                 model,
                                 builtins,
@@ -531,6 +582,7 @@ fn uniquely_owned(
                                     program,
                                     owned,
                                     provenance,
+                                    rust_owned_pattern_slots,
                                     return_aliases,
                                     model,
                                     builtins,
@@ -545,6 +597,7 @@ fn uniquely_owned(
                             program,
                             owned,
                             provenance,
+                            rust_owned_pattern_slots,
                             return_aliases,
                             model,
                             builtins,
@@ -555,6 +608,7 @@ fn uniquely_owned(
                             program,
                             owned,
                             provenance,
+                            rust_owned_pattern_slots,
                             return_aliases,
                             model,
                             builtins,
@@ -580,6 +634,7 @@ fn uniquely_owned(
                             program,
                             owned,
                             provenance,
+                            rust_owned_pattern_slots,
                             return_aliases,
                             model,
                             builtins,
@@ -610,6 +665,7 @@ fn uniquely_owned(
                     program,
                     owned,
                     provenance,
+                    rust_owned_pattern_slots,
                     return_aliases,
                     model,
                     builtins,
@@ -622,6 +678,7 @@ fn uniquely_owned(
             program,
             owned,
             provenance,
+            rust_owned_pattern_slots,
             return_aliases,
             model,
             builtins,
@@ -631,7 +688,7 @@ fn uniquely_owned(
     }
 }
 
-/// Is slot `s` (in `caller`) a uniquely-owned binding, IGNORING the
+/// Can slot `s` (in `caller`) supply the model's owned binding, IGNORING the
 /// per-occurrence `last_use` flag? Factored out of the `Local` arm so
 /// the self-keep shape can decide liveness by OR-ing its two
 /// occurrences' last-use bits while sharing the same ownership logic.
@@ -642,6 +699,7 @@ fn slot_owned(
     program: &MirProgram,
     owned: &HashMap<(FnId, usize), bool>,
     provenance: &HashMap<FnId, HashMap<u32, Spanned<MirExpr>>>,
+    rust_owned_pattern_slots: &HashMap<FnId, HashSet<u32>>,
     return_aliases: &ReturnAliasSummary,
     model: OwnershipModel,
     builtins: &[String],
@@ -655,6 +713,14 @@ fn slot_owned(
         None => return false,
     };
     let is_param = (slot as usize) < caller_fn.params.len();
+    if !is_param
+        && model.owned_carriers_are_cow_protected()
+        && rust_owned_pattern_slots
+            .get(&caller)
+            .is_some_and(|slots| slots.contains(&slot))
+    {
+        return true;
+    }
     // Flagged in the caller's table (RULE 1 param or RULE 2 intra-proc
     // alias such as a Vector.get handle).
     if caller_fn
@@ -686,6 +752,7 @@ fn slot_owned(
             program,
             owned,
             provenance,
+            rust_owned_pattern_slots,
             return_aliases,
             model,
             builtins,
@@ -700,6 +767,40 @@ fn collect_fn_values(e: &MirExpr, out: &mut HashSet<String>) {
     walk_children(e, &mut |c| collect_fn_values(c, out));
     if let MirExpr::FnValue(name) = e {
         out.insert(name.clone());
+    }
+}
+
+/// Collect every local introduced by a match pattern. Generated Rust matches
+/// by value whenever a pattern binds, so these slots contain owned values.
+/// Nested tuple patterns and constructor payloads are flattened recursively;
+/// list patterns expose both their owned head and owned tail locals.
+fn collect_pattern_bound_slots(e: &MirExpr, out: &mut HashSet<u32>) {
+    if let MirExpr::Match(m) = e {
+        for arm in &m.node.arms {
+            collect_pattern_slots(&arm.pattern, out);
+        }
+    }
+    walk_children(e, &mut |child| collect_pattern_bound_slots(child, out));
+}
+
+fn collect_pattern_slots(pattern: &MirPattern, out: &mut HashSet<u32>) {
+    match pattern {
+        MirPattern::Bind(local, _) => {
+            out.insert(local.0);
+        }
+        MirPattern::Cons { head, tail, .. } => {
+            out.insert(head.0);
+            out.insert(tail.0);
+        }
+        MirPattern::Tuple(items) => {
+            for item in items {
+                collect_pattern_slots(item, out);
+            }
+        }
+        MirPattern::Ctor { bindings, .. } => {
+            out.extend(bindings.iter().map(|local| local.0));
+        }
+        MirPattern::Wildcard | MirPattern::Literal(_) | MirPattern::EmptyList => {}
     }
 }
 
@@ -1411,7 +1512,9 @@ fn compute_capture_summary(
             // live-alias pins. A param leaking ⇒ it captures its arg.
             let mut leak: HashSet<u32> = HashSet::new();
             scan_body_leaks(model, &f.body.node, &prov, &captures, builtins, &mut leak);
-            collect_live_aliased_params(&f.body.node, &prov, builtins, nparams, &mut leak);
+            if !model.owned_carriers_are_cow_protected() {
+                collect_live_aliased_params(&f.body.node, &prov, builtins, nparams, &mut leak);
+            }
             let idx_map = &param_slot_to_idx[id];
             let entry = captures.entry(*id).or_default();
             for &s in &leak {

--- a/src/self_host/aver_generated/domain/builtins/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/mod.rs
@@ -2630,7 +2630,7 @@ pub fn builtinTcpPoll(
         let (socketsV, timeoutV) = pair;
         match socketsV {
             crate::aver_generated::domain::value::Val::ValMap(sockets) => {
-                crate::aver_generated::domain::builtins::builtinTcpPollInner(&sockets, &timeoutV)
+                crate::aver_generated::domain::builtins::builtinTcpPollInner(sockets, &timeoutV)
             }
             _ => Err(AverStr::from(
                 "Tcp.poll requires a Map as its first argument",
@@ -2641,7 +2641,7 @@ pub fn builtinTcpPoll(
 
 /// Inner Tcp.poll.
 pub fn builtinTcpPollInner(
-    sockets @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    mut sockets @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
     timeoutV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();

--- a/src/self_host/aver_generated/domain/builtins/vector/mod.rs
+++ b/src/self_host/aver_generated/domain/builtins/vector/mod.rs
@@ -142,7 +142,7 @@ pub fn builtinVectorSetInner(
                         Ok(crate::aver_generated::domain::value::Val::ValNone)
                     } else {
                         if (idx < aver_rt::AverInt::from_i64(vec.len() as i64)) {
-                            crate::aver_generated::domain::builtins::vector::builtinVectorSetInBounds(&vec, idx, valV)
+                            crate::aver_generated::domain::builtins::vector::builtinVectorSetInBounds(vec, idx, valV)
                         } else {
                             Ok(crate::aver_generated::domain::value::Val::ValNone)
                         }
@@ -158,14 +158,14 @@ pub fn builtinVectorSetInner(
 /// Set a vector element when bounds have already been checked.
 #[inline(always)]
 pub fn builtinVectorSetInBounds(
-    vec @ _: &aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
+    mut vec @ _: aver_rt::AverVector<crate::aver_generated::domain::value::Val>,
     idx @ _: aver_rt::AverInt,
     valV @ _: &crate::aver_generated::domain::value::Val,
 ) -> Result<crate::aver_generated::domain::value::Val, AverStr> {
     crate::cancel_checkpoint();
     match (idx)
         .to_usize()
-        .and_then(|__i| vec.clone().set_owned(__i, valV.clone()))
+        .and_then(|__i| vec.set_owned(__i, valV.clone()))
     {
         Some(newVec @ _) => Ok(crate::aver_generated::domain::value::Val::ValSome(
             std::sync::Arc::new(crate::aver_generated::domain::value::Val::ValVector(newVec)),

--- a/src/self_host/aver_generated/domain/eval/core/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/core/mod.rs
@@ -4220,7 +4220,7 @@ pub fn evalTopLevelStmts(
     let fns @ _ = std::sync::Arc::new(fns);
     loop {
         crate::cancel_checkpoint();
-        aver_list_match!(stmts, [] => { return Ok((last, env)); }, [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env, &crate::aver_generated::domain::eval::store::withGlobals(&*fns, &env)) { Err(e @ _) => { return Err(e); }, Ok(pair @ _) => { { let (v, newEnv) = pair; {
+        aver_list_match!(stmts, [] => { return Ok((last, env)); }, [s, rest] => { match crate::aver_generated::domain::eval::core::evalStmt(&s, &env.clone(), &crate::aver_generated::domain::eval::store::withGlobals(&*fns, env)) { Err(e @ _) => { return Err(e); }, Ok(pair @ _) => { { let (v, newEnv) = pair; {
             let __tco0 = rest;
             let __tco1 = newEnv;
             let __tco2 = v;
@@ -4247,7 +4247,7 @@ pub fn evalProgram(
     {
         let (v, globals) = top;
         crate::aver_generated::domain::eval::core::maybeCallMain(
-            &crate::aver_generated::domain::eval::store::withGlobals(&fnsStore, &globals),
+            &crate::aver_generated::domain::eval::store::withGlobals(&fnsStore, globals),
             &v,
         )
     }
@@ -4271,7 +4271,7 @@ pub fn evalProgramWithFns(
     {
         let (v, globals) = top;
         crate::aver_generated::domain::eval::core::maybeCallMain(
-            &crate::aver_generated::domain::eval::store::withGlobals(&allFns, &globals),
+            &crate::aver_generated::domain::eval::store::withGlobals(&allFns, globals),
             &v,
         )
     }

--- a/src/self_host/aver_generated/domain/eval/store/mod.rs
+++ b/src/self_host/aver_generated/domain/eval/store/mod.rs
@@ -99,13 +99,13 @@ pub fn emptyFnStore() -> FnStore {
 /// Attach evaluated top-level bindings so function bodies can read them.
 pub fn withGlobals(
     fns @ _: &FnStore,
-    globals @ _: &aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
+    mut globals @ _: aver_rt::AverMap<AverStr, crate::aver_generated::domain::value::Val>,
 ) -> FnStore {
     crate::cancel_checkpoint();
     crate::aver_generated::domain::eval::store::FnStore {
         nameToId: fns.nameToId.clone(),
         byId: fns.byId.clone(),
-        globals: globals.clone(),
+        globals: globals,
     }
 }
 

--- a/src/self_host/aver_generated/domain/resolver/core/mod.rs
+++ b/src/self_host/aver_generated/domain/resolver/core/mod.rs
@@ -285,7 +285,7 @@ pub fn resolveFn(
     );
     {
         let (slotMap, nextSlot) = paramResult;
-        crate::aver_generated::domain::resolver::core::resolveBody(fd, &slotMap, nextSlot)
+        crate::aver_generated::domain::resolver::core::resolveBody(fd, slotMap, nextSlot)
     }
 }
 
@@ -316,13 +316,13 @@ pub fn buildParamSlots(
 /// Walk body stmts, resolve vars, track new bindings. slotCount = max slot + 1 from body scan.
 pub fn resolveBody(
     fd @ _: &crate::aver_generated::domain::ast::FnDef,
-    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     nextSlot @ _: aver_rt::AverInt,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     let resolved @ _ = crate::aver_generated::domain::resolver::core::resolveStmts__collected(
         fd.body.clone(),
-        slots.clone(),
+        slots,
         nextSlot,
         aver_rt::list_builder_new((aver_rt::AverInt::from_i64(0)).to_usize().unwrap_or(0)),
     );
@@ -332,7 +332,7 @@ pub fn resolveBody(
             fd,
             &newBody,
             finalSlot,
-            &finalSlotMap,
+            finalSlotMap,
         )
     }
 }
@@ -342,7 +342,7 @@ pub fn computeSlotCount(
     fd @ _: &crate::aver_generated::domain::ast::FnDef,
     body @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
     baseSlot @ _: aver_rt::AverInt,
-    slotMap @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slotMap @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> crate::aver_generated::domain::ast::FnDef {
     crate::cancel_checkpoint();
     let maxFromBody @ _ = crate::aver_generated::domain::resolver::core::maxSlotInStmts(
@@ -354,7 +354,7 @@ pub fn computeSlotCount(
         params: fd.params.clone(),
         body: body.clone(),
         slotCount: maxFromBody.add(&aver_rt::AverInt::from_i64(1)),
-        slotMap: slotMap.clone(),
+        slotMap: slotMap,
         fastPath: crate::aver_generated::domain::ast::FnFastPath::FastNone,
         tailLoop: false,
     }
@@ -519,7 +519,7 @@ pub fn resolveStmts(
 pub fn resolveOneStmt(
     s @ _: &crate::aver_generated::domain::ast::Stmt,
     rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     next @ _: aver_rt::AverInt,
     acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
@@ -542,7 +542,7 @@ pub fn resolveOneStmt(
         crate::aver_generated::domain::ast::Stmt::StmtBindSlot(_, _) => {
             crate::aver_generated::domain::resolver::core::resolveStmts(
                 rest.clone(),
-                slots.clone(),
+                slots,
                 next,
                 aver_rt::AverList::prepend(s.clone(), &acc.clone()),
             )
@@ -554,7 +554,7 @@ pub fn resolveOneStmt(
 pub fn resolveStmtExpr(
     expr @ _: &crate::aver_generated::domain::ast::Expr,
     rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     next @ _: aver_rt::AverInt,
     acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
@@ -565,7 +565,7 @@ pub fn resolveStmtExpr(
     crate::cancel_checkpoint();
     {
         let (re, newSlots) =
-            crate::aver_generated::domain::resolver::core::resolveExpr(expr, slots);
+            crate::aver_generated::domain::resolver::core::resolveExpr(expr, &slots);
         crate::aver_generated::domain::resolver::core::resolveStmts(
             rest.clone(),
             newSlots.clone(),
@@ -587,7 +587,7 @@ pub fn resolveStmtBind(
     name @ _: AverStr,
     expr @ _: &crate::aver_generated::domain::ast::Expr,
     rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     next @ _: aver_rt::AverInt,
     acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
@@ -598,9 +598,9 @@ pub fn resolveStmtBind(
     crate::cancel_checkpoint();
     {
         let (newExpr, exprSlots) =
-            crate::aver_generated::domain::resolver::core::resolveExpr(expr, slots);
+            crate::aver_generated::domain::resolver::core::resolveExpr(expr, &slots);
         crate::aver_generated::domain::resolver::core::resolveStmtBindFinish(
-            name, &newExpr, rest, &exprSlots, next, acc,
+            name, &newExpr, rest, exprSlots, next, acc,
         )
     }
 }
@@ -610,7 +610,7 @@ pub fn resolveStmtBindFinish(
     name @ _: AverStr,
     newExpr @ _: &crate::aver_generated::domain::ast::Expr,
     rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
-    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     next @ _: aver_rt::AverInt,
     acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::Stmt>,
 ) -> (
@@ -619,7 +619,7 @@ pub fn resolveStmtBindFinish(
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) {
     crate::cancel_checkpoint();
-    let newSlots @ _ = slots.clone().insert_owned(name, next.clone());
+    let newSlots @ _ = slots.insert_owned(name, next.clone());
     crate::aver_generated::domain::resolver::core::resolveStmts(
         rest.clone(),
         newSlots,
@@ -1357,7 +1357,7 @@ pub fn resolveArms(
 pub fn resolveOneArm(
     arm @ _: &crate::aver_generated::domain::ast::MatchArm,
     rest @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
-    slots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut slots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     acc @ _: &aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
 ) -> (
     aver_rt::AverList<crate::aver_generated::domain::ast::MatchArm>,
@@ -1366,10 +1366,10 @@ pub fn resolveOneArm(
     crate::cancel_checkpoint();
     {
         let (resolvedArm, _) =
-            crate::aver_generated::domain::resolver::core::resolveArm(arm, slots);
+            crate::aver_generated::domain::resolver::core::resolveArm(arm, &slots);
         crate::aver_generated::domain::resolver::core::resolveArms(
             rest.clone(),
-            slots.clone(),
+            slots,
             aver_rt::AverList::prepend(resolvedArm, &acc.clone()),
         )
     }
@@ -1390,7 +1390,7 @@ pub fn resolveArm(
         let (newSlots, _) = armSlotResult;
         crate::aver_generated::domain::resolver::core::resolveArmBody(
             arm,
-            &newSlots,
+            newSlots,
             &crate::aver_generated::domain::resolver::core::patternBindingSlots(
                 &arm.pattern,
                 slots,
@@ -1402,7 +1402,7 @@ pub fn resolveArm(
 /// Resolve arm body with extended slots.
 pub fn resolveArmBody(
     arm @ _: &crate::aver_generated::domain::ast::MatchArm,
-    newSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut newSlots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
 ) -> (
     crate::aver_generated::domain::ast::MatchArm,
@@ -1411,7 +1411,7 @@ pub fn resolveArmBody(
     crate::cancel_checkpoint();
     {
         let (re, finalSlots) =
-            crate::aver_generated::domain::resolver::core::resolveExpr(&arm.body, newSlots);
+            crate::aver_generated::domain::resolver::core::resolveExpr(&arm.body, &newSlots);
         (
             crate::aver_generated::domain::ast::MatchArm {
                 pattern: arm.pattern.clone(),
@@ -1435,7 +1435,7 @@ pub fn patternBindingSlots(
         let (bindingSlots, _) =
             crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(
                 pat,
-                &HashMap::new(),
+                HashMap::new(),
                 nextSlot,
             );
         bindingSlots
@@ -1445,7 +1445,7 @@ pub fn patternBindingSlots(
 /// Assign slots to pattern binders without carrying the outer slot map.
 pub fn patternBindingSlotsInner(
     pat @ _: &crate::aver_generated::domain::ast::Pattern,
-    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut bindingSlots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
@@ -1454,7 +1454,7 @@ pub fn patternBindingSlotsInner(
     crate::cancel_checkpoint();
     match pat.clone() {
         crate::aver_generated::domain::ast::Pattern::PatVar(name) => (
-            bindingSlots.clone().insert_owned(name, next.clone()),
+            bindingSlots.insert_owned(name, next.clone()),
             next.add(&aver_rt::AverInt::from_i64(1)),
         ),
         crate::aver_generated::domain::ast::Pattern::PatCons(h, t) => {
@@ -1468,25 +1468,25 @@ pub fn patternBindingSlotsInner(
         crate::aver_generated::domain::ast::Pattern::PatConstructor(_, bindings) => {
             crate::aver_generated::domain::resolver::core::patternBindingSlotsConstructor(
                 bindings,
-                bindingSlots.clone(),
+                bindingSlots,
                 next,
             )
         }
         crate::aver_generated::domain::ast::Pattern::PatConstructorId(_, _, bindings) => {
             crate::aver_generated::domain::resolver::core::patternBindingSlotsConstructor(
                 bindings,
-                bindingSlots.clone(),
+                bindingSlots,
                 next,
             )
         }
         crate::aver_generated::domain::ast::Pattern::PatTuple(pats) => {
             crate::aver_generated::domain::resolver::core::patternBindingSlotsTuple(
                 pats,
-                bindingSlots.clone(),
+                bindingSlots,
                 next,
             )
         }
-        _ => (bindingSlots.clone(), next),
+        _ => (bindingSlots, next),
     }
 }
 
@@ -1494,14 +1494,14 @@ pub fn patternBindingSlotsInner(
 pub fn patternBindingSlotsCons(
     h @ _: AverStr,
     t @ _: AverStr,
-    bindingSlots @ _: &aver_rt::AverMap<AverStr, aver_rt::AverInt>,
+    mut bindingSlots @ _: aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     next @ _: aver_rt::AverInt,
 ) -> (
     aver_rt::AverMap<AverStr, aver_rt::AverInt>,
     aver_rt::AverInt,
 ) {
     crate::cancel_checkpoint();
-    let bindingSlots2 @ _ = bindingSlots.clone().insert_owned(h, next.clone());
+    let bindingSlots2 @ _ = bindingSlots.insert_owned(h, next.clone());
     (
         bindingSlots2.insert_owned(t, next.add(&aver_rt::AverInt::from_i64(1))),
         next.add(&aver_rt::AverInt::from_i64(2)),
@@ -1544,7 +1544,7 @@ pub fn patternBindingSlotsTuple(
 ) {
     loop {
         crate::cancel_checkpoint();
-        aver_list_match!(pats, [] => { return (bindingSlots, next); }, [p, rest] => { { let (newBindingSlots, newNext) = crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(&p, &bindingSlots, next); {
+        aver_list_match!(pats, [] => { return (bindingSlots, next); }, [p, rest] => { { let (newBindingSlots, newNext) = crate::aver_generated::domain::resolver::core::patternBindingSlotsInner(&p, bindingSlots, next); {
             let __tco0 = rest;
             let __tco1 = newBindingSlots;
             let __tco2 = newNext;

--- a/tests/own_param_graduation.rs
+++ b/tests/own_param_graduation.rs
@@ -187,6 +187,68 @@ fn main() -> Result<Int, String>
     );
 }
 
+/// Regression for #1196: a mutually-tail-recursive dispatcher owns its
+/// accumulator at the point where it hands that accumulator to a normal
+/// helper. The helper returns the successor inside `Result<Tuple<...>>`.
+/// Generated Rust consumes the wrapper and tuple, so the normal helper may
+/// take the last-use Map by value; borrowing it here makes the helper's first
+/// `Map.set` copy the complete backing table once per dispatcher round.
+#[test]
+fn map_crossing_from_mutual_tco_into_result_tuple_helper_graduates_for_rust() {
+    let src = r#"module CrossCallMap
+    intent = "move a Map from a mutual-TCO dispatcher through a normal helper"
+    depends []
+    effects []
+
+fn changed(into: Map<String, Int>) -> Result<Tuple<Map<String, Int>, Int>, String>
+    ? "return the map successor in the aggregate consumed by the dispatcher"
+    Result.Ok((Map.set(into, "key", 1), 1))
+
+fn kept(into: Map<String, Int>) -> Map<String, Int>
+    ? "model a read helper whose conservative result may alias its input"
+    into
+
+fn absorbing(left: Int, into: Map<String, Int>) -> Result<Map<String, Int>, String>
+    ? "hand the last-use map to changed before tail-calling continued"
+    snapshot = kept(into)
+    observedLen = Map.len(snapshot)
+    match changed(into)
+        Result.Err(why) -> Result.Err(why)
+        Result.Ok(parts) -> match parts
+            (next, _) -> continued(left, next)
+
+fn continued(left: Int, into: Map<String, Int>) -> Result<Map<String, Int>, String>
+    ? "mutually tail-call absorbing until the requested rounds are complete"
+    match left
+        0 -> Result.Ok(into)
+        _ -> absorbing(left - 1, into)
+
+fn main() -> Result<Int, String>
+    built = absorbing(3, {})?
+    Result.Ok(Map.len(built))
+"#;
+
+    let shared = refine(src);
+    assert!(
+        param_flagged(&shared, "changed", 0),
+        "arena backends must not infer ownership through destructured wrapper entries"
+    );
+
+    let rust = own_param_refine_for_rust(shared);
+    assert!(
+        !param_flagged(&rust, "changed", 0),
+        "the normal helper must own the dispatcher's last-use Map argument"
+    );
+    assert!(
+        !param_flagged(&rust, "absorbing", 1),
+        "the first mutual-TCO state must preserve ownership through the helper result"
+    );
+    assert!(
+        !param_flagged(&rust, "continued", 1),
+        "the next mutual-TCO state must receive the destructured Map by value"
+    );
+}
+
 /// Precision dual of the escape soundness suite: the aliased params from
 /// the three corruption classes must STAY flagged after the refinement.
 /// (Their observable correctness is covered in `own_param_soundness`;

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -2656,6 +2656,115 @@ fn rust_map_helper_result_preserves_the_owned_move() {
     );
 }
 
+/// Issue #1196 end to end: a Map owned by a mutual-TCO trampoline crosses a
+/// module boundary into a normal helper, returns inside `Result<Tuple<...>>`,
+/// and is destructured before the next trampoline state. The pattern-bound
+/// successor is an owned Rust value; losing that fact makes `changed` borrow
+/// the Map and its first `insert_owned` copy the complete table every round.
+#[test]
+fn rust_mutual_tco_moves_last_use_map_into_cross_module_helper() {
+    let ws = temp_dir("mutual_tco_cross_module_map");
+    let worker = ws.join("worker.av");
+    let entry = ws.join("main.av");
+    fs::write(
+        &worker,
+        r#"module Worker
+    intent = "change an owned map and return it through a consumed aggregate"
+    depends []
+    exposes [changed, forked, inserted]
+    effects []
+
+fn changed(into: Map<String, Int>) -> Result<Tuple<Map<String, Int>, Int>, String>
+    ? "return the map successor in the aggregate consumed by the dispatcher"
+    Result.Ok((Map.set(into, "key", 1), 1))
+
+fn forked(into: Map<String, Int>) -> Tuple<Map<String, Int>, Map<String, Int>>
+    ? "return two COW handles so the Rust-only ownership fact is tested safely"
+    (into, into)
+
+fn inserted(into: Map<String, Int>, key: String) -> Map<String, Int>
+    ? "mutate one extracted handle while its sibling remains observable"
+    Map.set(into, key, 1)
+"#,
+    )
+    .expect("write worker module");
+    fs::write(
+        &entry,
+        r#"module Entry
+    intent = "thread a map through mutual TCO and a cross-module helper"
+    depends [Worker]
+    effects [Console.print]
+
+fn absorbing(left: Int, into: Map<String, Int>) -> Result<Map<String, Int>, String>
+    ? "hand the last-use map to Worker.changed before tail-calling continued"
+    match Worker.changed(into)
+        Result.Err(why) -> Result.Err(why)
+        Result.Ok(parts) -> match parts
+            (next, _) -> continued(left, next)
+
+fn continued(left: Int, into: Map<String, Int>) -> Result<Map<String, Int>, String>
+    ? "mutually tail-call absorbing until the requested rounds are complete"
+    match left
+        0 -> Result.Ok(into)
+        _ -> absorbing(left - 1, into)
+
+fn renderedFork(pair: Tuple<Map<String, Int>, Map<String, Int>>) -> String
+    ? "prove that moving a pattern local preserves a still-live COW sibling"
+    match pair
+        (moving, kept) -> "{Map.len(Worker.inserted(moving, "other"))}/{Map.len(kept)}"
+
+fn main() -> Unit
+    ! [Console.print]
+    built = Result.withDefault(absorbing(3, {}), {})
+    Console.print(renderedFork(Worker.forked(built)))
+"#,
+    )
+    .expect("write entry module");
+
+    let vm = run_vm(&entry, Some(&ws)).expect("VM run");
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("project dir");
+    let name = "mutual_tco_cross_module_map";
+    compile_rust(&entry, &project, name, Some(&ws), &[]).expect("compile Rust project");
+
+    let entry_rust = fs::read_to_string(project.join("src/aver_generated/entry/mod.rs"))
+        .expect("read generated entry module");
+    let worker_rust = fs::read_to_string(project.join("src/aver_generated/worker/mod.rs"))
+        .expect("read generated worker module");
+    assert!(
+        worker_rust.contains("pub fn changed(mut into @ _: aver_rt::AverMap"),
+        "the cross-module helper must take its Map by value:\n{worker_rust}"
+    );
+    assert!(
+        entry_rust.contains("worker::changed(into)"),
+        "the trampoline must move its last-use Map across the module call:\n{entry_rust}"
+    );
+    assert!(
+        !entry_rust.contains("worker::changed(&into)"),
+        "the old borrowed call recreates an Rc owner and forces full-table COW:\n{entry_rust}"
+    );
+    assert!(
+        worker_rust.contains("into.insert_owned"),
+        "the owned helper parameter must flow directly into Map.set:\n{worker_rust}"
+    );
+    assert!(
+        entry_rust.contains("worker::inserted(moving"),
+        "a last-use pattern local must move into an owned helper parameter:\n{entry_rust}"
+    );
+
+    let bin = cargo_build(&project, name).expect("build generated project");
+    let output = Command::new(bin).output().expect("run generated binary");
+    assert!(
+        output.status.success(),
+        "generated binary failed:\n{}",
+        format_output(&output)
+    );
+    let rust = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let _ = fs::remove_dir_all(&ws);
+    assert_eq!(vm, "2/1", "VM result and retained COW sibling");
+    assert_eq!(rust, vm, "generated Rust diverged from the VM");
+}
+
 // ─── fn-result alias summaries preserve caller aliases ─────────────────
 //
 // A named function result may grant ownership only through the complete


### PR DESCRIPTION
## Summary

- distinguish the shared-arena uniqueness proof from the Rust owned-carrier ABI proof
- let last-use pattern bindings move through Result/tuple destructuring and mutual-TCO state
- preserve Rust COW semantics when another handle really remains, while avoiding the extra handle created by a borrowed callee ABI
- keep the VM/wasm arena-safe ownership rules unchanged
- regenerate the checked-in self-host output

On the reported btc-listener tree this changes Infra.Utxo.absorbed(&created, &spent, ...) to absorbed(created, spent, ...), and both Map parameters are emitted by value.

## Verification

- own_param_graduation: 13 passed
- own_param_soundness: 27 passed
- cross-module Rust differential: VM/Rust parity plus retained COW sibling, passed
- actual 140-module n1bor/btc-listener emitted project: cargo check passed
- repository test run: every functional suite passed; the self-host freshness gate requested regeneration, then its focused check passed
- self-host regeneration check passed
- native and wasm/wasip2 clippy commands from CI passed

Closes #1196