### PR TITLE
A [[verify.costly]] entry for a file this run did not verify is not reported as a stale path

### DIFF
--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -2503,8 +2503,31 @@ fn report_stale_verify_costly(
             }
         }
     }
+    // A run over one file, or one program graph, legitimately leaves entries
+    // for other paths untouched — the same rule `[[check.suppress]]` follows.
+    // "The path may be stale" is only true of a path the project has not
+    // got, so an entry no verified file matched is settled against the disk
+    // before it is scolded: if its globs cover an .av file under the module
+    // root, this run simply did not reach it. Listed once, and only when an
+    // entry needs it.
+    let on_disk: Vec<String> = if covered.iter().all(|c| *c) {
+        Vec::new()
+    } else {
+        resolve_av_inputs(module_root)
+            .unwrap_or_default()
+            .iter()
+            .map(|file| aver::diagnostics::vm_verify::costly_glob_key(file, Some(module_root)))
+            .collect()
+    };
     for (idx, entry) in cfg.verify.costly.iter().enumerate() {
         if matched[idx] {
+            continue;
+        }
+        if !covered[idx]
+            && on_disk
+                .iter()
+                .any(|key| cfg.verify_costly_covers_file(idx, key))
+        {
             continue;
         }
         let scope = if entry.files.is_empty() {

--- a/tests/verify_step_budget_spec.rs
+++ b/tests/verify_step_budget_spec.rs
@@ -240,6 +240,47 @@ fn a_costly_entry_without_fn_reason_or_a_dial_is_a_config_error() {
     }
 }
 
+// ── d′. an entry for a file this run did not verify is not stale ────────
+
+/// `aver verify main.av` verifies one program graph, and an entry scoped to
+/// a file outside it raises nothing in that run — which says nothing about
+/// whether the path is stale. A path the project has on disk is not scolded;
+/// only one it has not got is (the case above).
+#[test]
+fn a_costly_entry_for_a_file_outside_this_run_is_not_reported_stale() {
+    let dir = project(
+        "budget-elsewhere",
+        "costly.av",
+        r#"
+[[verify.costly]]
+fn         = "countdown"
+step-limit = 50000000
+reason     = "the case counts down from 400,000; that is the case, not a runaway"
+
+[[verify.costly]]
+fn         = "case"
+files      = ["corpus/elsewhere*.av"]
+step-limit = 50000000
+reason     = "a corpus verified as its own job, not from main.av"
+"#,
+    );
+    std::fs::create_dir_all(dir.join("corpus")).expect("make the corpus directory");
+    std::fs::write(
+        dir.join("corpus/elsewhere1.av"),
+        "module Elsewhere1\n\nfn case() -> Int\n    ? \"Not reached from main.av.\"\n    1\n\nverify case\n    case() => 1\n",
+    )
+    .expect("stage the file outside the graph");
+    let out = verify(&dir, &[]);
+    let stderr = String::from_utf8_lossy(&out.stderr).to_string();
+
+    assert!(
+        !stderr.contains("[[verify.costly]]"),
+        "an entry whose files exist but were not in this run is not stale:\n{}",
+        format_output(&out)
+    );
+    assert_eq!(out.status.code(), Some(0), "{}", format_output(&out));
+}
+
 // ── d. an entry that raised nothing is reported ─────────────────────────
 
 #[test]


### PR DESCRIPTION
`aver verify main.av` verifies one program graph. A `[[verify.costly]]` entry scoped to files outside that graph raises nothing in the run, and `report_stale_verify_costly` then says

```
warning: aver.toml [[verify.costly]] fn = "case" (files: corpus/assetcases*.av) matched no verified file — the path may be stale
```

— on every single-file run, for a path the project has. n1bor/btc-listener keeps its Core corpus in `corpus/` and verifies it as its own CI job (n1bor/btc-listener#219), so `aver verify main.av` warns three times per run about entries that are correct and live, and the warning becomes noise a reader learns to skip.

`report_dead_suppressions` already records the rule: a run over one file legitimately leaves waivers for other paths untouched. This applies it to the verify side without the whole-tree gate, because the gate would also silence the entry that *is* stale under a single-file run (the case `a_costly_entry_that_raised_nothing_is_reported_as_stale` pins): an entry no verified file matched is settled against the disk first — if its globs cover any `.av` file under the module root, this run simply did not reach it and nothing is said; if they cover none, the path may be stale, as before. The directory is listed once, and only when some entry needs it.

One new spec case, `a_costly_entry_for_a_file_outside_this_run_is_not_reported_stale`; the other 31 in `verify_step_budget_spec` are unchanged and pass.