### PR TITLE
perf(runtime): use keyed aHash for AverMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +213,7 @@ dependencies = [
 name = "aver-rt"
 version = "0.4.12-dev"
 dependencies = [
+ "ahash",
  "criterion",
  "crossterm",
  "ctrlc",

--- a/aver-rt/Cargo.toml
+++ b/aver-rt/Cargo.toml
@@ -26,6 +26,7 @@ terminal = ["dep:crossterm"]
 all-features = true
 
 [dependencies]
+ahash = { version = "0.8", default-features = false, features = ["std", "runtime-rng"] }
 crossterm = { version = "0.28", optional = true }
 num-bigint = "0.4"
 num-integer = "0.1"

--- a/aver-rt/src/lib.rs
+++ b/aver-rt/src/lib.rs
@@ -62,7 +62,8 @@ pub use terminal::{
     show_cursor as terminal_show_cursor, size as terminal_size,
 };
 
-use std::collections::HashMap as StdHashMap;
+use ahash::RandomState as AHashRandomState;
+use std::collections::HashMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::FusedIterator;
@@ -216,8 +217,15 @@ pub fn par_execute_with_cancel<T: Send, E: Send>(
 // owner we mutate in place — turning O(log n) persistent-set into O(1)
 // amortized insert.
 
+/// Native backing table for an Aver `Map`.
+///
+/// Generated programs can put network-derived values into a map, so retain a
+/// per-table random key while avoiding SipHash13's cost on structural and byte
+/// keys. The hash is internal only: every observable map walk is sorted.
+type AverHashMap<K, V> = HashMap<K, V, AHashRandomState>;
+
 pub struct AverMap<K, V> {
-    inner: Rc<StdHashMap<K, V>>,
+    inner: Rc<AverHashMap<K, V>>,
 }
 
 impl<K, V> Clone for AverMap<K, V> {
@@ -235,7 +243,7 @@ where
 {
     pub fn new() -> Self {
         Self {
-            inner: Rc::new(StdHashMap::new()),
+            inner: Rc::new(AverHashMap::with_hasher(AHashRandomState::new())),
         }
     }
 
@@ -1505,8 +1513,19 @@ pub fn string_join<S: AsRef<str>>(parts: &AverList<S>, sep: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        AverList, AverListInner, LIST_APPEND_CHUNK_LIMIT, aver_display, env_set, string_slice,
+        AverList, AverListInner, AverMap, LIST_APPEND_CHUNK_LIMIT, aver_display, env_set,
+        string_slice,
     };
+
+    /// `AverMap` is exposed to generated programs, including programs that put
+    /// network-derived values into a map. Keep the fast hasher keyed per map
+    /// instead of silently falling back to deterministic `FxHash` or Rust's
+    /// slower default SipHash13.
+    #[test]
+    fn aver_map_uses_keyed_ahash_state() {
+        let map = AverMap::<u64, u64>::new();
+        let _: &ahash::RandomState = map.inner.hasher();
+    }
 
     /// One step off a flat list allocates nothing: the tail is the node it was
     /// taken from, read from one element further in. A fresh node per step is


### PR DESCRIPTION
## Summary

- back `aver_rt::AverMap` with `HashMap<K, V, ahash::RandomState>`
- request runtime randomness explicitly, retaining a per-table key for maps that contain network-derived values
- pin the backing hasher with a compile-time regression test
- leave Aver semantics unchanged: observable map walks remain canonically sorted

## Measurement

Synthetic UTXO-window workload using the real `AverPackedU8::Hash`: 200,000 resident 37-byte keys and 2,000,000 randomized lookups. These are medians across three process runs, each taking eleven samples.

| operation | SipHash13 | aHash | change |
|---|---:|---:|---:|
| hash 2m keys | 383.5 ms | 67.7 ms | 5.7x faster |
| insert 200k | 59.0 ms | 15.2 ms | 3.9x faster |
| hit 2m | 740.6 ms | 387.6 ms | 1.9x faster |
| miss 2m | 697.4 ms | 327.5 ms | 2.1x faster |

The machine does not hold n1bor's chainstate snapshot, so this does not claim a measured end-to-end node speedup. Applying the issue's 2.9–3.5% hashing self-time to the isolated ratio predicts roughly 2.4–3.0% for that walk.

wasm-gc already emits its own open-addressing map and needs a different optimization. #1203 tracks a V8 measurement gate plus cached bucket hashes/fingerprints rather than coupling that work to this runtime change.

## Verification

- `cargo test -p aver-rt --all-features` — 107 passed
- `cargo clippy -p aver-rt --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check -p aver-rt --target wasm32-unknown-unknown`
- `cargo check -p aver-rt --target wasm32-wasip1`

Closes #1197.
