### PR TITLE
Fix wasm-gc String.trim Unicode whitespace

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -223,7 +223,7 @@ Source: `src/types/string.rs`
 | `String.endsWith` | `(String, String) -> Bool` | |
 | `String.contains` | `(String, String) -> Bool` | |
 | `String.slice` | `(String, Int, Int) -> String` | Character indices; out-of-range ends clamp |
-| `String.trim` | `String -> String` | |
+| `String.trim` | `String -> String` | Trims Unicode `White_Space` from both ends (same set as Rust `str::trim`) |
 | `String.split` | `(String, String) -> List<String>` | |
 | `String.replace` | `(String, String, String) -> String` | |
 | `String.join` | `(List<String>, String) -> String` | |

--- a/src/codegen/wasm_gc/README.md
+++ b/src/codegen/wasm_gc/README.md
@@ -218,7 +218,7 @@ Audited 2026-05-02 against `src/codegen/wasm/abi.rs` + `src/types/checker/builti
 | Bool      | and/or/not ✅ |
 | Int       | toString/toFloat/abs/min/max/mod ✅, fromString ✅ |
 | Float     | toString/floor/ceil/round/abs/sqrt/min/max/pi/fromInt ✅, fromString ✅ |
-| String    | len/length/byteLength/startsWith/endsWith/contains/slice/toUpper/toLower/split/join/fromInt/fromFloat/fromBool/charAt/chars/replace ✅ (`toUpper`/`toLower` are full Unicode — expansions such as `ß` → `SS` and the final-sigma rule included — from the tables in `builtins/case_tables.rs`; `startsWith` compares bytes, which is what the VM's `str::starts_with` does too). **`trim` ⚠️ diverges from the VM**: it strips only space, tab, CR and LF, while the VM calls Rust `str::trim`, which strips every Unicode whitespace character — measured, `String.trim("\u{00A0}x\u{00A0}")` keeps both no-break spaces here and drops them on the VM, and the same holds for U+3000 and for ASCII vertical tab and form feed |
+| String    | len/length/byteLength/startsWith/endsWith/contains/slice/toUpper/toLower/trim/split/join/fromInt/fromFloat/fromBool/charAt/chars/replace ✅ (`toUpper`/`toLower` are full Unicode — expansions such as `ß` → `SS` and the final-sigma rule included — from the tables in `builtins/case_tables.rs`; `trim` strips the same Unicode `White_Space` scalar values as Rust `str::trim`; `startsWith` compares bytes, which is what the VM's `str::starts_with` does too) |
 | Char      | toCode/fromCode ✅ |
 | Option    | Some/None/withDefault/toResult ✅ |
 | Result    | Ok/Err/withDefault ✅ |

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -1458,10 +1458,306 @@ fn emit_string_slice(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     wat_helper::compile_wat_helper(&wat)
 }
 
-/// `String.trim`. Trims ASCII whitespace (space, tab, LF, CR) from
-/// both ends; allocates a fresh string sized to the inner slice.
+/// `String.trim`. Trims Rust/Unicode `White_Space` scalar values from
+/// both ends; allocates a fresh string sized to the inner byte slice.
 fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let (_, preamble) = string_module_preamble(registry)?;
+    let decode_at_start = r#"
+                ;; Decode the UTF-8 scalar at byte offset `$start` into `$cp`
+                ;; and its byte width into `$step`. String arrays are always
+                ;; valid UTF-8, so this helper can decode without a fallback
+                ;; validation path.
+                local.get $s
+                local.get $start
+                array.get_u $string
+                local.set $ch
+
+                local.get $ch
+                i32.const 0x80
+                i32.lt_u
+                (if
+                  (then
+                    local.get $ch
+                    local.set $cp
+                    i32.const 1
+                    local.set $step)
+                  (else
+                    local.get $ch
+                    i32.const 0xE0
+                    i32.lt_u
+                    (if
+                      (then
+                        local.get $ch
+                        i32.const 0x1F
+                        i32.and
+                        i32.const 6
+                        i32.shl
+                        local.get $s
+                        local.get $start
+                        i32.const 1
+                        i32.add
+                        array.get_u $string
+                        i32.const 0x3F
+                        i32.and
+                        i32.or
+                        local.set $cp
+                        i32.const 2
+                        local.set $step)
+                      (else
+                        local.get $ch
+                        i32.const 0xF0
+                        i32.lt_u
+                        (if
+                          (then
+                            local.get $ch
+                            i32.const 0x0F
+                            i32.and
+                            i32.const 12
+                            i32.shl
+                            local.get $s
+                            local.get $start
+                            i32.const 1
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.const 6
+                            i32.shl
+                            i32.or
+                            local.get $s
+                            local.get $start
+                            i32.const 2
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.or
+                            local.set $cp
+                            i32.const 3
+                            local.set $step)
+                          (else
+                            local.get $ch
+                            i32.const 0x07
+                            i32.and
+                            i32.const 18
+                            i32.shl
+                            local.get $s
+                            local.get $start
+                            i32.const 1
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.const 12
+                            i32.shl
+                            i32.or
+                            local.get $s
+                            local.get $start
+                            i32.const 2
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.const 6
+                            i32.shl
+                            i32.or
+                            local.get $s
+                            local.get $start
+                            i32.const 3
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.or
+                            local.set $cp
+                            i32.const 4
+                            local.set $step))))))
+    "#;
+    let decode_at_prev = r#"
+                ;; `$end` is the first byte after the candidate scalar. Walk
+                ;; back over UTF-8 continuation bytes to find that scalar's
+                ;; start byte, then decode it into `$cp`.
+                local.get $end
+                i32.const 1
+                i32.sub
+                local.set $prev
+                (block $bd
+                  (loop $bt
+                    local.get $prev
+                    local.get $start
+                    i32.le_u
+                    br_if $bd
+
+                    local.get $s
+                    local.get $prev
+                    array.get_u $string
+                    i32.const 0xC0
+                    i32.and
+                    i32.const 0x80
+                    i32.ne
+                    br_if $bd
+
+                    local.get $prev
+                    i32.const 1
+                    i32.sub
+                    local.set $prev
+                    br $bt))
+
+                local.get $s
+                local.get $prev
+                array.get_u $string
+                local.set $ch
+
+                local.get $ch
+                i32.const 0x80
+                i32.lt_u
+                (if
+                  (then
+                    local.get $ch
+                    local.set $cp)
+                  (else
+                    local.get $ch
+                    i32.const 0xE0
+                    i32.lt_u
+                    (if
+                      (then
+                        local.get $ch
+                        i32.const 0x1F
+                        i32.and
+                        i32.const 6
+                        i32.shl
+                        local.get $s
+                        local.get $prev
+                        i32.const 1
+                        i32.add
+                        array.get_u $string
+                        i32.const 0x3F
+                        i32.and
+                        i32.or
+                        local.set $cp)
+                      (else
+                        local.get $ch
+                        i32.const 0xF0
+                        i32.lt_u
+                        (if
+                          (then
+                            local.get $ch
+                            i32.const 0x0F
+                            i32.and
+                            i32.const 12
+                            i32.shl
+                            local.get $s
+                            local.get $prev
+                            i32.const 1
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.const 6
+                            i32.shl
+                            i32.or
+                            local.get $s
+                            local.get $prev
+                            i32.const 2
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.or
+                            local.set $cp)
+                          (else
+                            local.get $ch
+                            i32.const 0x07
+                            i32.and
+                            i32.const 18
+                            i32.shl
+                            local.get $s
+                            local.get $prev
+                            i32.const 1
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.const 12
+                            i32.shl
+                            i32.or
+                            local.get $s
+                            local.get $prev
+                            i32.const 2
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.const 6
+                            i32.shl
+                            i32.or
+                            local.get $s
+                            local.get $prev
+                            i32.const 3
+                            i32.add
+                            array.get_u $string
+                            i32.const 0x3F
+                            i32.and
+                            i32.or
+                            local.set $cp))))))
+    "#;
+    let unicode_whitespace_predicate = r#"
+                ;; Unicode White_Space, matching Rust `char::is_whitespace`
+                ;; and therefore `str::trim`: U+0009..U+000D, U+0020,
+                ;; U+0085, U+00A0, U+1680, U+2000..U+200A, U+2028,
+                ;; U+2029, U+202F, U+205F and U+3000.
+                local.get $cp
+                i32.const 0x09
+                i32.ge_u
+                local.get $cp
+                i32.const 0x0D
+                i32.le_u
+                i32.and
+                local.get $cp
+                i32.const 0x20
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x85
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0xA0
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x1680
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x2000
+                i32.ge_u
+                local.get $cp
+                i32.const 0x200A
+                i32.le_u
+                i32.and
+                i32.or
+                local.get $cp
+                i32.const 0x2028
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x2029
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x202F
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x205F
+                i32.eq
+                i32.or
+                local.get $cp
+                i32.const 0x3000
+                i32.eq
+                i32.or
+    "#;
     let wat = format!(
         r#"
         (module
@@ -1472,7 +1768,10 @@ fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
             (local $len i32)
             (local $start i32)
             (local $end i32)
+            (local $prev i32)
             (local $ch i32)
+            (local $cp i32)
+            (local $step i32)
             (local $new_len i32)
             (local $out (ref null $string))
 
@@ -1486,20 +1785,14 @@ fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
                 i32.ge_u
                 br_if $sd
 
-                local.get $s
-                local.get $start
-                array.get_u $string
-                local.set $ch
+                {decode_at_start}
 
-                local.get $ch i32.const 0x20 i32.eq
-                local.get $ch i32.const 0x09 i32.eq i32.or
-                local.get $ch i32.const 0x0A i32.eq i32.or
-                local.get $ch i32.const 0x0D i32.eq i32.or
+                {unicode_whitespace_predicate}
                 i32.eqz
                 br_if $sd
 
                 local.get $start
-                i32.const 1
+                local.get $step
                 i32.add
                 local.set $start
                 br $st))
@@ -1512,23 +1805,13 @@ fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
                 i32.le_u
                 br_if $ed
 
-                local.get $s
-                local.get $end
-                i32.const 1
-                i32.sub
-                array.get_u $string
-                local.set $ch
+                {decode_at_prev}
 
-                local.get $ch i32.const 0x20 i32.eq
-                local.get $ch i32.const 0x09 i32.eq i32.or
-                local.get $ch i32.const 0x0A i32.eq i32.or
-                local.get $ch i32.const 0x0D i32.eq i32.or
+                {unicode_whitespace_predicate}
                 i32.eqz
                 br_if $ed
 
-                local.get $end
-                i32.const 1
-                i32.sub
+                local.get $prev
                 local.set $end
                 br $et))
 

--- a/src/codegen/wasm_gc/builtins/mod.rs
+++ b/src/codegen/wasm_gc/builtins/mod.rs
@@ -1462,121 +1462,10 @@ fn emit_string_slice(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
 /// both ends; allocates a fresh string sized to the inner byte slice.
 fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
     let (_, preamble) = string_module_preamble(registry)?;
-    let decode_at_start = r#"
-                ;; Decode the UTF-8 scalar at byte offset `$start` into `$cp`
-                ;; and its byte width into `$step`. String arrays are always
-                ;; valid UTF-8, so this helper can decode without a fallback
-                ;; validation path.
-                local.get $s
-                local.get $start
-                array.get_u $string
-                local.set $ch
-
-                local.get $ch
-                i32.const 0x80
-                i32.lt_u
-                (if
-                  (then
-                    local.get $ch
-                    local.set $cp
-                    i32.const 1
-                    local.set $step)
-                  (else
-                    local.get $ch
-                    i32.const 0xE0
-                    i32.lt_u
-                    (if
-                      (then
-                        local.get $ch
-                        i32.const 0x1F
-                        i32.and
-                        i32.const 6
-                        i32.shl
-                        local.get $s
-                        local.get $start
-                        i32.const 1
-                        i32.add
-                        array.get_u $string
-                        i32.const 0x3F
-                        i32.and
-                        i32.or
-                        local.set $cp
-                        i32.const 2
-                        local.set $step)
-                      (else
-                        local.get $ch
-                        i32.const 0xF0
-                        i32.lt_u
-                        (if
-                          (then
-                            local.get $ch
-                            i32.const 0x0F
-                            i32.and
-                            i32.const 12
-                            i32.shl
-                            local.get $s
-                            local.get $start
-                            i32.const 1
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.const 6
-                            i32.shl
-                            i32.or
-                            local.get $s
-                            local.get $start
-                            i32.const 2
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.or
-                            local.set $cp
-                            i32.const 3
-                            local.set $step)
-                          (else
-                            local.get $ch
-                            i32.const 0x07
-                            i32.and
-                            i32.const 18
-                            i32.shl
-                            local.get $s
-                            local.get $start
-                            i32.const 1
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.const 12
-                            i32.shl
-                            i32.or
-                            local.get $s
-                            local.get $start
-                            i32.const 2
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.const 6
-                            i32.shl
-                            i32.or
-                            local.get $s
-                            local.get $start
-                            i32.const 3
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.or
-                            local.set $cp
-                            i32.const 4
-                            local.set $step))))))
-    "#;
-    let decode_at_prev = r#"
+    let decode_at_start = string_case::decode("$start", "$ch", "$cp", "$step");
+    let find_prev = r#"
                 ;; `$end` is the first byte after the candidate scalar. Walk
-                ;; back over UTF-8 continuation bytes to find that scalar's
-                ;; start byte, then decode it into `$cp`.
+                ;; back over UTF-8 continuation bytes to find its start.
                 local.get $end
                 i32.const 1
                 i32.sub
@@ -1602,105 +1491,8 @@ fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
                     i32.sub
                     local.set $prev
                     br $bt))
-
-                local.get $s
-                local.get $prev
-                array.get_u $string
-                local.set $ch
-
-                local.get $ch
-                i32.const 0x80
-                i32.lt_u
-                (if
-                  (then
-                    local.get $ch
-                    local.set $cp)
-                  (else
-                    local.get $ch
-                    i32.const 0xE0
-                    i32.lt_u
-                    (if
-                      (then
-                        local.get $ch
-                        i32.const 0x1F
-                        i32.and
-                        i32.const 6
-                        i32.shl
-                        local.get $s
-                        local.get $prev
-                        i32.const 1
-                        i32.add
-                        array.get_u $string
-                        i32.const 0x3F
-                        i32.and
-                        i32.or
-                        local.set $cp)
-                      (else
-                        local.get $ch
-                        i32.const 0xF0
-                        i32.lt_u
-                        (if
-                          (then
-                            local.get $ch
-                            i32.const 0x0F
-                            i32.and
-                            i32.const 12
-                            i32.shl
-                            local.get $s
-                            local.get $prev
-                            i32.const 1
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.const 6
-                            i32.shl
-                            i32.or
-                            local.get $s
-                            local.get $prev
-                            i32.const 2
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.or
-                            local.set $cp)
-                          (else
-                            local.get $ch
-                            i32.const 0x07
-                            i32.and
-                            i32.const 18
-                            i32.shl
-                            local.get $s
-                            local.get $prev
-                            i32.const 1
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.const 12
-                            i32.shl
-                            i32.or
-                            local.get $s
-                            local.get $prev
-                            i32.const 2
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.const 6
-                            i32.shl
-                            i32.or
-                            local.get $s
-                            local.get $prev
-                            i32.const 3
-                            i32.add
-                            array.get_u $string
-                            i32.const 0x3F
-                            i32.and
-                            i32.or
-                            local.set $cp))))))
     "#;
+    let decode_at_prev = string_case::decode("$prev", "$ch", "$cp", "$step");
     let unicode_whitespace_predicate = r#"
                 ;; Unicode White_Space, matching Rust `char::is_whitespace`
                 ;; and therefore `str::trim`: U+0009..U+000D, U+0020,
@@ -1805,6 +1597,7 @@ fn emit_string_trim(registry: &TypeRegistry) -> Result<Function, WasmGcError> {
                 i32.le_u
                 br_if $ed
 
+                {find_prev}
                 {decode_at_prev}
 
                 {unicode_whitespace_predicate}

--- a/src/codegen/wasm_gc/builtins/string_case.rs
+++ b/src/codegen/wasm_gc/builtins/string_case.rs
@@ -92,7 +92,7 @@ fn search(span: TableSpan, record: u32, point: bool, key: &str, id: &str) -> Str
 /// Input is always well-formed UTF-8 — String values come from
 /// literals, concatenation, scalar-boundary slicing, or the validating
 /// `String.fromUtf8` — so there is no error arm.
-fn decode(idx: &str, byte: &str, code: &str, clen: &str) -> String {
+pub(super) fn decode(idx: &str, byte: &str, code: &str, clen: &str) -> String {
     format!(
         r#"
             local.get $s local.get {idx} array.get_u $string local.set {byte}

--- a/tests/wasip2_unicode_case.rs
+++ b/tests/wasip2_unicode_case.rs
@@ -23,6 +23,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// case-ignorable, and an astral pair (Deseret).
 const SAMPLE: &str = "ĄĆĘ ŁÓŚ ß ÀÉÎ ΩΔ ΑΣ ΑΣΒ ΣΣ aΣ aΣb ΑΣ'Β ΑΣ' aΣ\u{02B0}b İ ı ﬀ 𐐀𐐨 abcXYZ";
 
+/// All Unicode `White_Space` scalar values used by Rust `str::trim`.
+const TRIM_WHITE_SPACE: &str = "\u{0009}\u{000A}\u{000B}\u{000C}\u{000D}\u{0020}\u{0085}\u{00A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}\u{3000}";
+
 fn tempdir(prefix: &str) -> PathBuf {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -63,6 +66,7 @@ fn escape_aver(s: &str) -> String {
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),
+            '\u{000C}' => out.push_str("\\f"),
             _ => out.push(c),
         }
     }
@@ -94,5 +98,33 @@ fn main() -> Unit
     let got = String::from_utf8_lossy(&out.stdout).into_owned();
     let want = format!("{}|{}\n", SAMPLE.to_lowercase(), SAMPLE.to_uppercase());
     assert_eq!(got, want, "wasip2 case mapping diverged from Rust std");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn wasip2_trim_matches_rust_unicode_whitespace() {
+    let dir = tempdir("trim");
+    let sample = format!("{TRIM_WHITE_SPACE}x{TRIM_WHITE_SPACE}");
+    let literal = escape_aver(&sample);
+    let src = format!(
+        r#"
+fn main() -> Unit
+    ! [Console.print]
+    text = "{literal}"
+    Console.print("[{{String.trim(text)}}]")
+"#
+    );
+    let fixture = write_fixture(&dir, "trim.av", &src);
+    let out = run_wasip2(&dir, &fixture);
+    assert!(
+        out.status.success(),
+        "trim.av failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let got = String::from_utf8_lossy(&out.stdout).into_owned();
+    let want = format!("[{}]\n", sample.trim());
+    assert_eq!(got, want, "wasip2 trim diverged from Rust std");
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/wasm_gc_unicode_trim_regression.rs
+++ b/tests/wasm_gc_unicode_trim_regression.rs
@@ -102,6 +102,9 @@ fn trim_strips_the_full_unicode_white_space_set() {
     // scalars (U+200B ZERO WIDTH SPACE) are not stripped.
     inputs.push(format!("a{}b", '\u{3000}'));
     inputs.push("\u{200B}x\u{200B}".to_string());
+    // Exercise the four-byte UTF-8 decode path when trimming stops at a
+    // non-whitespace scalar.
+    inputs.push("\u{3000}😀\u{3000}".to_string());
     inputs.push("plain".to_string());
 
     let source = trim_program(&inputs);

--- a/tests/wasm_gc_unicode_trim_regression.rs
+++ b/tests/wasm_gc_unicode_trim_regression.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "wasm")]
+
+//! Regression — `String.trim` on wasm-gc must match the VM and Rust
+//! `str::trim`: trim every Unicode `White_Space` scalar value, not only
+//! space/tab/LF/CR bytes. The concrete failures from #1189 included
+//! NBSP (U+00A0), ideographic space (U+3000), vertical tab and form feed.
+
+use aver::checker::VerifyResult;
+use aver::diagnostics::vm_verify::run_verify_for_items_vm;
+use aver::diagnostics::wasm_gc_verify::run_verify_for_items_wasm_gc;
+use aver::source::parse_source;
+
+const WHITE_SPACE: &[char] = &[
+    '\u{0009}', '\u{000A}', '\u{000B}', '\u{000C}', '\u{000D}', '\u{0020}', '\u{0085}', '\u{00A0}',
+    '\u{1680}', '\u{2000}', '\u{2001}', '\u{2002}', '\u{2003}', '\u{2004}', '\u{2005}', '\u{2006}',
+    '\u{2007}', '\u{2008}', '\u{2009}', '\u{200A}', '\u{2028}', '\u{2029}', '\u{202F}', '\u{205F}',
+    '\u{3000}',
+];
+
+fn run_both_backends(source: &str) -> [(&'static str, Vec<VerifyResult>); 2] {
+    let items = parse_source(source).unwrap_or_else(|e| {
+        panic!("parse failed: {e}\n--- source ---\n{source}");
+    });
+    let vm = run_verify_for_items_vm(
+        items.clone(),
+        None,
+        None,
+        "wasm_gc_unicode_trim_regression.av",
+    )
+    .unwrap_or_else(|e| panic!("VM verify failed: {e}\n--- source ---\n{source}"));
+    let gc = run_verify_for_items_wasm_gc(items, None, None, "wasm_gc_unicode_trim_regression.av")
+        .unwrap_or_else(|e| panic!("wasm-gc verify failed: {e}\n--- source ---\n{source}"));
+    [("vm", vm), ("wasm-gc", gc)]
+}
+
+fn assert_all_pass_on_both(source: &str, expected_passed: usize) {
+    for (backend, results) in run_both_backends(source) {
+        let passed: usize = results.iter().map(|r| r.passed).sum();
+        let failed: usize = results.iter().map(|r| r.failed).sum();
+        let skipped: usize = results.iter().map(|r| r.skipped).sum();
+        let declined: usize = results.iter().map(|r| r.declined).sum();
+        assert_eq!(
+            (passed, failed, skipped, declined),
+            (expected_passed, 0, 0, 0),
+            "[{backend}] expected {expected_passed}/0/0/0 passed/failed/skipped/declined, \
+             got {passed}/{failed}/{skipped}/{declined}\n--- source ---\n{source}"
+        );
+    }
+}
+
+/// Escape one arbitrary scalar sequence into an Aver string literal.
+/// Aver has no `\u` escape, so non-ASCII whitespace enters the fixture as
+/// raw UTF-8; the lexer-supported ASCII controls use named escapes where
+/// possible so the source stays readable.
+fn escape_aver(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 8);
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '{' => out.push_str("\\{"),
+            '}' => out.push_str("\\}"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{000C}' => out.push_str("\\f"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn trim_program(inputs: &[String]) -> String {
+    let mut src = String::from(
+        r#"
+fn trimmed(s: String) -> String
+    ? "Trim whitespace from both ends."
+    String.trim(s)
+
+verify trimmed
+"#,
+    );
+    for input in inputs {
+        src.push_str("    trimmed(\"");
+        src.push_str(&escape_aver(input));
+        src.push_str("\") => \"");
+        src.push_str(&escape_aver(input.trim()));
+        src.push_str("\"\n");
+    }
+    src
+}
+
+#[test]
+fn trim_strips_the_full_unicode_white_space_set() {
+    let mut inputs: Vec<String> = WHITE_SPACE.iter().map(|&ch| format!("{ch}x{ch}")).collect();
+
+    let all: String = WHITE_SPACE.iter().collect();
+    let all_reversed: String = WHITE_SPACE.iter().rev().collect();
+    inputs.push(format!("{all}x{all_reversed}"));
+
+    // Internal whitespace is preserved, and similarly named non-White_Space
+    // scalars (U+200B ZERO WIDTH SPACE) are not stripped.
+    inputs.push(format!("a{}b", '\u{3000}'));
+    inputs.push("\u{200B}x\u{200B}".to_string());
+    inputs.push("plain".to_string());
+
+    let source = trim_program(&inputs);
+    assert_all_pass_on_both(&source, inputs.len());
+}


### PR DESCRIPTION
## Summary
- make wasm-gc/wasip2 `String.trim` decode UTF-8 and trim the full Unicode `White_Space` set like Rust `str::trim`
- add VM vs wasm-gc regression coverage for all whitespace scalars
- add wasip2 runtime trim coverage and update docs/README parity notes

Fixes #1189

## Tests
- `cargo fmt --check`
- `cargo test --features wasm --test wasm_gc_unicode_trim_regression -- --nocapture`
- `cargo test --features wasip2 --test wasip2_unicode_case wasip2_trim_matches_rust_unicode_whitespace -- --nocapture`
