### PR TITLE
Keep String.eq certificate fixture canonical

### DIFF
--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -2404,11 +2404,6 @@ fn certify_verbatim_variant_dispatch_lake_builds_kernel_clean() {
 
 #[test]
 fn certify_string_eq_host_contract_lake_builds_kernel_clean() {
-    if Command::new("lake").arg("--version").output().is_err() {
-        eprintln!("skipping certify String.eq host-contract test: `lake` not available");
-        return;
-    }
-
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out_dir = temp_dir("certify-stringeq");
 
@@ -2548,6 +2543,13 @@ fn certify_string_eq_host_contract_lake_builds_kernel_clean() {
             && !certificate.contains("quoteOrSelf_simulates"),
         "String.eq must not emit bespoke proofs:\n{certificate}"
     );
+
+    // Classification and plan-shape regressions must remain visible on CI
+    // workers without Lean. Only the final kernel build needs `lake`.
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping String.eq certificate kernel build: `lake` not available");
+        return;
+    }
 
     materialize_wall(&cert_dir);
     let combined = lake_build_package(&cert_dir, "emitted String.eq host-contract cert");

--- a/tools/certkit/fixtures/stringeq.av
+++ b/tools/certkit/fixtures/stringeq.av
@@ -1,7 +1,6 @@
 module StringEq
     intent =
-        "A string match with a multi-character control arm. That arm deliberately"
-        "keeps the match on String.eq when single-ASCII arms fuse to codepoints;"
+        "A one-literal String match pins the certified source traversal to String.eq;"
         "the int helper makes the box carrier exist for the host-contract fixture."
     exposes [quoteOrSelf, bump]
 
@@ -9,7 +8,6 @@ fn quoteOrSelf(c: String) -> String
   ? "Escape a quote byte, otherwise return the input string verbatim."
   match c
     "\"" -> "\\\""
-    "verbatim" -> "verbatim"
     _ -> c
 
 fn bump(n: Int) -> Int
@@ -18,5 +16,4 @@ fn bump(n: Int) -> Int
 
 verify quoteOrSelf
     quoteOrSelf("\"") => "\\\""
-    quoteOrSelf("verbatim") => "verbatim"
     quoteOrSelf("x") => "x"


### PR DESCRIPTION
## Summary

- restore the String.eq certificate fixture to the canonical one-comparison shape covered by the byte-level wall
- keep all classification, runtime-contract, and generated-plan assertions active when Lean is unavailable; only skip the final kernel build without `lake`

## Why

#1210 correctly disabled cursor fabrication for `--certify`, but the same follow-up commit also added a redundant multi-character control arm to `tools/certkit/fixtures/stringeq.av`. The MIR emitter faithfully preserved that extra `String.eq` cascade, while the certificate wall deliberately supports the previously covered one-comparison template. The wall therefore failed closed and classified only `bump`.

The control arm is no longer needed: with `run_chars_fusion: false` on certified artifacts, the original one-literal fixture emits `String.eq` and directly tests the certification seam. It restores the previously covered 6,680-byte artifact (`952613228bd9857089cfb5b387940442e1f9edf1547d2623fa66932ffaf9dfb0`).

Moving the `lake` availability check after the manifest/plan assertions makes this regression visible in ordinary CI environments that do not install Lean.

## Validation

- `cargo test --features wasm,wasip2 --test cert_certify_spec certify_string_eq_host_contract_lake_builds_kernel_clean -- --exact --test-threads=1`
- the same test binary with `lake` absent from `PATH` (classification and plan checks pass; kernel build alone is skipped)
- `cargo fmt --all -- --check`
- `git diff --check`
