### PR TITLE
Keep runtime String.eq mutation fixture explicit

### DIFF
--- a/tests/cert_decode_spec.rs
+++ b/tests/cert_decode_spec.rs
@@ -819,12 +819,30 @@ fn f5_mutated_string_eq_loop_opcode_changes_kernel_classification() {
     let prelude = build_prelude();
     let out = temp_dir("cdec-f5-mutation");
     std::fs::create_dir_all(&out).unwrap();
-    let bytes = compile_wasm_at(
-        &repo,
-        &repo.join("tools/certkit/fixtures/stringeq.av"),
-        "stringeq",
-        &out,
-    );
+    // The certificate fixture deliberately stays on the one-comparison shape
+    // covered by the String.eq wall. Ordinary runtime compilation can scalarise
+    // a match whose literal arms are all one-byte ASCII, so this mutation test
+    // owns a multi-byte control arm that keeps the host helper reachable.
+    let runtime_fixture = out.join("runtime_stringeq.av");
+    std::fs::write(
+        &runtime_fixture,
+        r#"module RuntimeStringEq
+    intent =
+        "keep the ordinary wasm String.eq loop reachable for byte mutation"
+    exposes [quoteOrSelf, bump]
+
+fn quoteOrSelf(c: String) -> String
+    match c
+        "\"" -> "\\\""
+        "verbatim" -> "verbatim"
+        _ -> c
+
+fn bump(n: Int) -> Int
+    n + 1
+"#,
+    )
+    .unwrap();
+    let bytes = compile_wasm_at(&repo, &runtime_fixture, "runtime_stringeq", &out);
     let roles = aver::codegen::cert::byte_derived_string_host_roles(&bytes).unwrap();
     assert_eq!(roles, vec![(3, aver::codegen::cert::StringHostRole::Eq)]);
     let eq_idx = roles[0].0;


### PR DESCRIPTION
## Summary

- give the F5 ordinary-runtime String.eq opcode-mutation test its own multi-byte control fixture
- keep `tools/certkit/fixtures/stringeq.av` on the one-comparison shape covered by the certificate wall

## Why

#1214 restored the canonical certificate fixture, but `cert_decode_spec` also compiled that file through the ordinary wasm-gc pipeline. A one-byte-only String match is scalarised there, so the runtime `String.eq` helper is intentionally absent and the F5 mutation test had no loop to mutate.

The two tests need different source shapes: certification pins the covered one-comparison template, while the runtime decoder mutation needs a multi-byte arm to keep the host helper reachable. The runtime-only source now lives directly beside the mutation assertion instead of overloading the certificate fixture.

## Validation

- `cargo test --features wasm,wasip2 --test cert_decode_spec f5_mutated_string_eq_loop_opcode_changes_kernel_classification -- --exact --test-threads=1`
- `cargo fmt --all -- --check`
- `git diff --check`
