### PR TITLE
Fix Tcp.dialled deadline ordering

### DIFF
--- a/aver-rt/src/tcp.rs
+++ b/aver-rt/src/tcp.rs
@@ -577,6 +577,40 @@ mod tests {
     }
 
     #[test]
+    fn dialled_promotes_connected_socket_even_after_the_deadline() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind connected dial target");
+        let address = listener
+            .local_addr()
+            .expect("connected dial target address");
+        let (release_tx, release_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (_stream, _) = listener.accept().expect("accept connected dial");
+            release_rx.recv().expect("hold connected dial peer open");
+        });
+        let stream = TcpStream::connect(address).expect("connect test dial");
+        stream
+            .set_nonblocking(true)
+            .expect("make test dial nonblocking");
+        let expired_deadline = Instant::now()
+            .checked_sub(Duration::from_secs(1))
+            .unwrap_or_else(Instant::now);
+        let dial = reactor::insert_test_dial_with_deadline(
+            stream,
+            expired_deadline,
+            Duration::from_secs(5),
+        );
+
+        let connection = dialled(&dial)
+            .expect("inspect expired connected dial")
+            .expect("expired connected dial is still connected");
+        assert!(reactor::connection_exists(&connection));
+
+        close(&connection).expect("close promoted dial");
+        release_tx.send(()).expect("release connected dial peer");
+        server.join().expect("connected dial server");
+    }
+
+    #[test]
     fn read_some_returns_available_bytes_without_filling_the_maximum() {
         let (written_tx, written_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
@@ -767,8 +801,10 @@ mod tests {
             elapsed < Duration::from_millis(300),
             "ignored dial deadline: {elapsed:?}"
         );
-        let error = dialled(&blocked_dial).expect_err("expired dial must fail");
-        assert!(error.contains("timed out"), "{error}");
+        let promoted_after_deadline = dialled(&blocked_dial)
+            .expect("inspect deadline-ready connected dial")
+            .expect("connected dial survives an expired deadline");
+        close(&promoted_after_deadline).expect("close deadline-ready dial");
         release_blocked_tx.send(()).expect("release blocked peer");
         blocked_server.join().expect("blocked server");
     }

--- a/aver-rt/src/tcp/reactor.rs
+++ b/aver-rt/src/tcp/reactor.rs
@@ -225,13 +225,17 @@ pub(super) fn dialled(dial: &TcpDial) -> Result<Option<TcpConnection>, String> {
         let Some(pending) = dials.get(id) else {
             return Err(format!("Tcp.dialled: unknown dial '{}'", dial.id));
         };
-        if Instant::now() >= pending.deadline {
-            let timeout = pending.timeout;
-            dials.remove(id);
-            return Err(format!(
-                "Tcp.beginConnect: socket establishment timed out (deadline: {} ms)",
-                timeout.as_millis()
-            ));
+        if pending.stream.peer_addr().is_ok() {
+            let pending = dials.remove(id).expect("checked connected dial");
+            pending
+                .stream
+                .set_nonblocking(false)
+                .map_err(|error| format_io_error("Tcp.dialled", &error))?;
+            return Ok(Some(register_connection(
+                pending.stream,
+                pending.host,
+                pending.port,
+            )));
         }
         if let Some(error) = pending
             .stream
@@ -242,20 +246,15 @@ pub(super) fn dialled(dial: &TcpDial) -> Result<Option<TcpConnection>, String> {
             dials.remove(id);
             return Err(format_connect_error("Tcp.beginConnect", &error, timeout));
         }
-        if pending.stream.peer_addr().is_err() {
-            return Ok(None);
+        if Instant::now() >= pending.deadline {
+            let timeout = pending.timeout;
+            dials.remove(id);
+            return Err(format!(
+                "Tcp.beginConnect: socket establishment timed out (deadline: {} ms)",
+                timeout.as_millis()
+            ));
         }
-
-        let pending = dials.remove(id).expect("checked live dial");
-        pending
-            .stream
-            .set_nonblocking(false)
-            .map_err(|error| format_io_error("Tcp.dialled", &error))?;
-        Ok(Some(register_connection(
-            pending.stream,
-            pending.host,
-            pending.port,
-        )))
+        Ok(None)
     })
 }
 
@@ -523,6 +522,15 @@ pub(super) fn listener_local_address(listener: &TcpListener) -> SocketAddr {
 
 #[cfg(test)]
 pub(super) fn insert_test_dial(stream: TcpStream, deadline_after: Duration) -> TcpDial {
+    insert_test_dial_with_deadline(stream, Instant::now() + deadline_after, deadline_after)
+}
+
+#[cfg(test)]
+pub(super) fn insert_test_dial_with_deadline(
+    stream: TcpStream,
+    deadline: Instant,
+    timeout: Duration,
+) -> TcpDial {
     let id = next_id("tcp-test-dial");
     DIALS.with(|dials| {
         dials.borrow_mut().insert(
@@ -531,8 +539,8 @@ pub(super) fn insert_test_dial(stream: TcpStream, deadline_after: Duration) -> T
                 stream,
                 host: "test.invalid".to_string(),
                 port: 9,
-                deadline: Instant::now() + deadline_after,
-                timeout: deadline_after,
+                deadline,
+                timeout,
                 poll_source_disabled: true,
             },
         );


### PR DESCRIPTION
## Summary
- promote already-connected nonblocking dials before evaluating their deadline
- keep connection errors ahead of timeout for still-pending dials
- add regression coverage for connected dials inspected after the deadline

## Tests
- cargo fmt --all -- --check
- cargo test -p aver-rt

Fixes #1213