### PR TITLE
Reject wasip2 --certify until component envelope lands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -338,7 +338,9 @@ aver cert explain out/app.wasm out/cert
 ```
 
 `--certify` emits a version-1 artifact certificate for admitted exports of the
-exact wasm-gc module. Install `aver-cert` separately; it is an independently
+exact wasm-gc module. It is currently rejected on `--target wasip2` until the
+wasip2 component envelope from #1146 lands; the flag must not silently emit an
+uncertified component. Install `aver-cert` separately; it is an independently
 versioned verifier using Lean 4.32. A crates.io compiler install needs the
 backend enabled: `cargo install aver-lang --features wasm`. Verification also
 requires a standard Elan installation for the pinned toolchain.

--- a/src/cli_entry.rs
+++ b/src/cli_entry.rs
@@ -382,17 +382,26 @@ fn main_impl(
                 eprintln!("{}", error.red());
                 std::process::exit(1);
             }
-            // `--certify` is a wasm-gc-only artifact certificate. Clap
-            // already blocks `--certify --optimize`; reject any non-wasm-gc
-            // target here so the flag never silently no-ops.
+            // `--certify` is available only for the current wasm-gc certificate
+            // target. In particular, fail closed for `--target wasip2 --certify`
+            // until #1146 lands the declared component-envelope byte binding;
+            // otherwise users could mistake an uncertified component for a
+            // certified artifact.
             if *certify && !matches!(effective_target, cli::CompileTarget::WasmGc) {
                 use colored::Colorize;
-                eprintln!(
-                    "{}",
-                    "--certify requires --target wasm-gc (the artifact certificate is emitted \
-                     for the wasm-gc module)"
-                        .red()
-                );
+                let error = match effective_target {
+                    cli::CompileTarget::Wasip2 => {
+                        "--target wasip2 --certify is not available yet: issue #1146 needs a \
+                         declared component envelope whose prefix/core/suffix bytes are checked \
+                         by equality against the delivered component. Use --target wasm-gc \
+                         --certify for certificate output today."
+                    }
+                    _ => {
+                        "--certify requires --target wasm-gc (the artifact certificate is emitted \
+                         for the wasm-gc module)"
+                    }
+                };
+                eprintln!("{}", error.red());
                 std::process::exit(1);
             }
             if matches!(preset, Some(cli::DeployPreset::Cloudflare)) && handler.is_none() {

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -6359,6 +6359,25 @@ fn certify_flag_rejection(certify: bool) -> Option<&'static str> {
     }
 }
 
+/// Target-level gate for the still-open wasip2 certificate-envelope work.
+///
+/// Once the certificate engine exists, `--target wasip2 --certify` must not fall
+/// through and silently emit only `<name>.component.wasm`. Until #1146 lands the
+/// declared component envelope, fail closed with a named reason at target
+/// dispatch. The feature-level gate above still owns certify-less binaries.
+fn wasip2_certify_rejection(certify: bool) -> Option<&'static str> {
+    if certify {
+        Some(
+            "--target wasip2 --certify is not available yet: issue #1146 needs a \
+             declared component envelope whose prefix/core/suffix bytes are checked \
+             by equality against the delivered component. Use --target wasm-gc \
+             --certify for certificate output today.",
+        )
+    } else {
+        None
+    }
+}
+
 pub(super) fn capability_target_rejection(
     items: &[TopLevel],
     modules: &[ModuleInfo],
@@ -6481,6 +6500,10 @@ pub(super) fn cmd_compile(opts: CompileOptions<'_>) {
     // stays untouched. Phase 1 of 0.18 "Span" — see `docs/wasip2.md`
     // for the contract.
     if matches!(target, super::cli::CompileTarget::Wasip2) {
+        if let Some(error) = wasip2_certify_rejection(certify) {
+            eprintln!("{}", error.red());
+            process::exit(1);
+        }
         cmd_compile_wasip2(
             file,
             output_dir,
@@ -11977,6 +12000,16 @@ mod tests {
             assert!(error.contains("certify"));
         }
         assert!(super::certify_flag_rejection(false).is_none());
+    }
+
+    #[test]
+    fn wasip2_certify_is_rejected_until_component_envelope_lands() {
+        let error = super::wasip2_certify_rejection(true)
+            .expect("wasip2 --certify must not be silently ignored");
+        assert!(error.contains("--target wasip2 --certify"));
+        assert!(error.contains("#1146"));
+        assert!(error.contains("declared component envelope"));
+        assert!(super::wasip2_certify_rejection(false).is_none());
     }
 
     #[test]

--- a/tests/compile_spec.rs
+++ b/tests/compile_spec.rs
@@ -227,6 +227,39 @@ fn compile_check_rejects_non_rust_target_before_codegen() {
     );
 }
 
+#[cfg(all(feature = "certify", feature = "wasip2"))]
+#[test]
+fn compile_wasip2_certify_is_rejected_instead_of_ignored() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = temp_output_dir("aver-wasip2-certify-reject");
+    let output_dir = workspace.join("out");
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(&repo_root)
+        .arg("compile")
+        .arg("examples/core/hello.av")
+        .arg("--target")
+        .arg("wasip2")
+        .arg("--certify")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("run aver compile --target wasip2 --certify");
+
+    assert_eq!(output.status.code(), Some(1), "{}", format_output(&output));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--target wasip2 --certify is not available yet"),
+        "wrong wasip2 certify rejection:\n{}",
+        format_output(&output)
+    );
+    assert!(
+        !output_dir.join("hello.component.wasm").exists(),
+        "rejected --certify must not still emit an uncertified component"
+    );
+
+    let _ = fs::remove_dir_all(&workspace);
+}
+
 #[test]
 fn repeated_compile_preserves_byte_identical_generated_file_mtimes() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
Refs #1146.

This is a small fail-closed prep slice before enabling wasip2 certificates.

Changes:
- reject `aver compile --target wasip2 --certify` with an explicit #1146 component-envelope message
- keep `--certify` wasm-gc-only instead of letting wasip2 produce an uncertified component
- add direct unit coverage and a feature-gated CLI regression test for `certify + wasip2` builds
- document the current wasm-gc-only certificate flag behavior

Validated locally:
- `cargo fmt --all -- --check`
- `cargo test certify_flag_is_rejected_exactly_on_certify_less_builds`
- `cargo test wasip2_certify_is_rejected_until_component_envelope_lands`
- `cargo test --features certify,wasip2 --test compile_spec compile_wasip2_certify_is_rejected_instead_of_ignored -- --nocapture`