### PR TITLE
Add wasip2 component envelope artifact API

### DIFF
--- a/docs/certification-architecture.md
+++ b/docs/certification-architecture.md
@@ -79,8 +79,9 @@ The steps are:
 
 1. Read the actual module, run the standard WebAssembly validator, compute its
    SHA-256, and parse `cert-manifest.json`.
-2. Require package format `1`, statement schema `2`, the expected artifact
-   root, the actual hash, and a `wall_id` embedded in this verifier.
+2. Require package format `1`, statement schema `5`, the expected artifact
+   root, target/profile/ABI identity, the actual hash, and a `wall_id` embedded
+   in this verifier.
 3. Assemble a fresh project from the checker-owned wall and the allowed
    artifact-specific data. Checker-owned module names, build files, toolchain
    files, witnesses, and caches supplied by the package cannot replace the
@@ -134,6 +135,13 @@ No other producer analysis is needed for a positive verdict. In particular,
 the verifier does not re-run the producer's obligation classifier,
 disassembler, candidate derivation, or reconstruction of
 `AverCert.Artifact.data`.
+
+For the planned `wasip2` target (#1146), the same rule applies to the component
+wrapper: the producer may declare a `prefix ++ embedded_core_module ++ suffix`
+split while constructing the component, but the trusted verifier path must not
+rediscover the user core by walking component bytes. It should consume the
+declaration, confirm byte equality against the caller-supplied component, and
+then run the core-module checks on the declared embedded module.
 
 ## Lean acceptance wall
 

--- a/src/codegen/wasip2/error.rs
+++ b/src/codegen/wasip2/error.rs
@@ -18,6 +18,12 @@ pub enum Wasip2Error {
     /// validates its own output. Carries the validator's message
     /// when it does.
     Validation(String),
+    /// The produced component could not be represented as a declared
+    /// `prefix ++ embedded_core_module ++ suffix` envelope. This is a
+    /// producer-side preparation check for artifact certificates; the
+    /// future verifier path must confirm the declaration by equality,
+    /// not rediscover it by walking the component.
+    Envelope(String),
     /// A surface feature is not yet wired by the current Phase 1
     /// increment. Distinct from a capability target-manifest rejection,
     /// which describes an operation the selected target cannot bind.
@@ -30,6 +36,9 @@ impl fmt::Display for Wasip2Error {
             Wasip2Error::Wrap(msg) => write!(f, "wasip2: component wrap failed — {msg}"),
             Wasip2Error::Validation(msg) => {
                 write!(f, "wasip2: component validation failed — {msg}")
+            }
+            Wasip2Error::Envelope(msg) => {
+                write!(f, "wasip2: component envelope declaration failed — {msg}")
             }
             Wasip2Error::NotImplemented(msg) => {
                 write!(f, "wasip2: not yet implemented — {msg}")

--- a/src/codegen/wasip2/mod.rs
+++ b/src/codegen/wasip2/mod.rs
@@ -57,4 +57,8 @@ pub use plan::{
 #[cfg(feature = "wasip2")]
 pub use wit::{emit_world_wit, emit_world_wit_with_capabilities};
 #[cfg(feature = "wasip2")]
-pub use wrap::{Wasip2World, compile_to_component, compile_to_component_with_capabilities};
+pub use wrap::{
+    Wasip2ComponentArtifact, Wasip2ComponentEnvelope, Wasip2World, compile_to_component,
+    compile_to_component_artifact, compile_to_component_artifact_with_capabilities,
+    compile_to_component_with_capabilities,
+};

--- a/src/codegen/wasip2/wrap.rs
+++ b/src/codegen/wasip2/wrap.rs
@@ -53,6 +53,119 @@ impl Wasip2World {
     }
 }
 
+/// Declared component envelope used by the wasip2 certificate work.
+///
+/// The producer is allowed to discover this split while constructing the
+/// component. The trusted verifier path must not rediscover it by walking the
+/// component bytes; it will receive the declaration and confirm only the byte
+/// equality `component == prefix ++ embedded_core_module ++ suffix` before
+/// applying the existing core-module certificate checks to `embedded_core_module`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Wasip2ComponentEnvelope {
+    /// Component bytes before the embedded core module section payload.
+    pub prefix: Vec<u8>,
+    /// Exact core wasm module payload embedded by `wit-component`.
+    /// This is the post-encoder module bytes found in the component's core
+    /// module section; it is not assumed to be byte-identical to the input
+    /// `core_wasm` passed to the wrapper.
+    pub embedded_core_module: Vec<u8>,
+    /// Component bytes after the embedded core module section payload.
+    pub suffix: Vec<u8>,
+}
+
+impl Wasip2ComponentEnvelope {
+    /// Declare the single embedded core module section of a produced component.
+    ///
+    /// This walks the component only on the producer side, immediately after
+    /// `wit-component` returns bytes. Certificate verification must consume the
+    /// resulting declaration and check byte equality instead of repeating this
+    /// discovery step on the trusted path.
+    fn from_component(component: &[u8]) -> Result<Self, Wasip2Error> {
+        use wasmparser::{Parser, Payload};
+
+        let mut ranges = Vec::new();
+        for payload in Parser::new(0).parse_all(component) {
+            match payload.map_err(|error| {
+                Wasip2Error::Envelope(format!("cannot parse produced component: {error}"))
+            })? {
+                Payload::ModuleSection {
+                    unchecked_range, ..
+                } => ranges.push(unchecked_range),
+                _ => {}
+            }
+        }
+        let range = match ranges.as_slice() {
+            [range] => range.clone(),
+            [] => {
+                return Err(Wasip2Error::Envelope(
+                    "component contains no embedded core module section".to_string(),
+                ));
+            }
+            _ => {
+                let marked = ranges
+                    .iter()
+                    .filter_map(|range| {
+                        module_range(component, range).ok().and_then(|module| {
+                            module_has_aver_user_core_marker(module).then(|| range.clone())
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                match marked.as_slice() {
+                    [range] => range.clone(),
+                    [] => {
+                        return Err(Wasip2Error::Envelope(format!(
+                            "component contains {} embedded core module sections, but none carries the Aver user-core marker exports",
+                            ranges.len()
+                        )));
+                    }
+                    _ => {
+                        return Err(Wasip2Error::Envelope(format!(
+                            "component contains {} embedded core module sections with Aver user-core marker exports; exactly one user core is supported",
+                            marked.len()
+                        )));
+                    }
+                }
+            }
+        };
+        if range.start >= range.end || range.end > component.len() {
+            return Err(Wasip2Error::Envelope(format!(
+                "component parser returned out-of-bounds core module range {}..{} for {} bytes",
+                range.start,
+                range.end,
+                component.len()
+            )));
+        }
+        Ok(Self {
+            prefix: component[..range.start].to_vec(),
+            embedded_core_module: component[range.clone()].to_vec(),
+            suffix: component[range.end..].to_vec(),
+        })
+    }
+
+    /// Reconstruct the full component from the declared envelope.
+    pub fn component_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(
+            self.prefix.len() + self.embedded_core_module.len() + self.suffix.len(),
+        );
+        bytes.extend_from_slice(&self.prefix);
+        bytes.extend_from_slice(&self.embedded_core_module);
+        bytes.extend_from_slice(&self.suffix);
+        bytes
+    }
+}
+
+/// Component output plus the explicit envelope declaration needed by the
+/// wasip2 certificate path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Wasip2ComponentArtifact {
+    /// Delivered `.component.wasm` bytes.
+    pub component_bytes: Vec<u8>,
+    /// Sibling `.wit` source emitted for human/tooling inspection.
+    pub wit_source: String,
+    /// Declared `prefix/core/suffix` split of `component_bytes`.
+    pub envelope: Wasip2ComponentEnvelope,
+}
+
 /// Wrap a core wasm-gc module as a Component.
 ///
 /// `core_wasm` is the output of the wasm-gc backend re-targeted at
@@ -75,11 +188,46 @@ pub fn compile_to_component(
     compile_to_component_with_capabilities(core_wasm, world, &CapabilityWitPlan::default())
 }
 
+/// Wrap a core wasm-gc module as a Component and retain the declared component
+/// envelope that future wasip2 certificate emission will serialize.
+pub fn compile_to_component_artifact(
+    core_wasm: &[u8],
+    world: Wasip2World,
+) -> Result<Wasip2ComponentArtifact, Wasip2Error> {
+    compile_to_component_artifact_with_capabilities(core_wasm, world, &CapabilityWitPlan::default())
+}
+
 /// Wrap a core module whose custom canonical imports were generated
 /// from `capabilities`. The same plan emits the sibling WIT and the
 /// embedded component metadata; neither surface is reconstructed by
 /// scanning the other.
 pub fn compile_to_component_with_capabilities(
+    core_wasm: &[u8],
+    world: Wasip2World,
+    capabilities: &CapabilityWitPlan,
+) -> Result<(Vec<u8>, String), Wasip2Error> {
+    compile_to_component_bytes_with_capabilities(core_wasm, world, capabilities)
+}
+
+/// Wrap a core module and return the component plus a producer-declared
+/// `prefix/core/suffix` envelope for the embedded core payload.
+pub fn compile_to_component_artifact_with_capabilities(
+    core_wasm: &[u8],
+    world: Wasip2World,
+    capabilities: &CapabilityWitPlan,
+) -> Result<Wasip2ComponentArtifact, Wasip2Error> {
+    let (component_bytes, wit_source) =
+        compile_to_component_bytes_with_capabilities(core_wasm, world, capabilities)?;
+    let envelope = Wasip2ComponentEnvelope::from_component(&component_bytes)?;
+
+    Ok(Wasip2ComponentArtifact {
+        component_bytes,
+        wit_source,
+        envelope,
+    })
+}
+
+fn compile_to_component_bytes_with_capabilities(
     core_wasm: &[u8],
     world: Wasip2World,
     capabilities: &CapabilityWitPlan,
@@ -132,14 +280,51 @@ pub fn compile_to_component_with_capabilities(
         .map_err(|e| Wasip2Error::Wrap(format!("embed component-type metadata: {e}")))?;
 
     // Wrap as a component WITHOUT the preview-1 adapter.
-    let component = ComponentEncoder::default()
+    let component_bytes = ComponentEncoder::default()
         .module(&core)
         .map_err(|e| Wasip2Error::Wrap(format!("ComponentEncoder::module rejected core: {e}")))?
         .validate(true)
         .encode()
         .map_err(|e| Wasip2Error::Wrap(format!("ComponentEncoder::encode failed: {e}")))?;
+    Ok((component_bytes, wit_source))
+}
 
-    Ok((component, wit_source))
+fn module_range<'a>(
+    component: &'a [u8],
+    range: &std::ops::Range<usize>,
+) -> Result<&'a [u8], Wasip2Error> {
+    if range.start >= range.end || range.end > component.len() {
+        return Err(Wasip2Error::Envelope(format!(
+            "component parser returned out-of-bounds core module range {}..{} for {} bytes",
+            range.start,
+            range.end,
+            component.len()
+        )));
+    }
+    Ok(&component[range.clone()])
+}
+
+fn module_has_aver_user_core_marker(module: &[u8]) -> bool {
+    use wasmparser::{ExternalKind, Parser, Payload};
+
+    let mut caller_fn_count = false;
+    let mut caller_fn_name = false;
+    for payload in Parser::new(0).parse_all(module) {
+        let Ok(Payload::ExportSection(reader)) = payload else {
+            continue;
+        };
+        for export in reader.into_iter().flatten() {
+            if export.kind != ExternalKind::Func {
+                continue;
+            }
+            match export.name {
+                "__caller_fn_count" => caller_fn_count = true,
+                "__caller_fn_name" => caller_fn_name = true,
+                _ => {}
+            }
+        }
+    }
+    caller_fn_count && caller_fn_name
 }
 
 /// Scan a core wasm module's imports for any module name starting
@@ -166,4 +351,17 @@ fn core_imports_use_wasi_http(core_wasm: &[u8]) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn component_envelope_rejects_bytes_with_no_embedded_core_payload() {
+        let err = Wasip2ComponentEnvelope::from_component(b"\0asm\x01\0\0\0")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no embedded core module section"), "{err}");
+    }
 }

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -170,6 +170,91 @@ fn compile_core_flattened(
 }
 
 #[test]
+fn component_artifact_declares_prefix_core_suffix_envelope() {
+    let source = r#"module Probe
+    intent = "Expose a small wasip2 component for envelope preparation."
+    exposes [main]
+    effects []
+
+fn main() -> Int
+    42
+"#;
+    let items = parse_pipeline(source).unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let core_bytes = compile_core_flattened(&items, &Default::default())
+        .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
+    let artifact = aver::codegen::wasip2::compile_to_component_artifact(
+        &core_bytes,
+        aver::codegen::wasip2::Wasip2World::CliCommand,
+    )
+    .unwrap_or_else(|e| panic!("wasip2 component artifact wrap: {e}\n--- source ---\n{source}"));
+
+    assert_eq!(
+        artifact.envelope.component_bytes(),
+        artifact.component_bytes
+    );
+    assert!(
+        artifact.envelope.embedded_core_module.starts_with(b"\0asm"),
+        "the declared core payload should be a complete core wasm module"
+    );
+    assert_ne!(
+        artifact.envelope.embedded_core_module, core_bytes,
+        "the envelope must describe the core module bytes delivered inside the component, not assume the pre-encoder core is preserved"
+    );
+    wasmparser::Validator::new()
+        .validate_all(&artifact.envelope.embedded_core_module)
+        .expect("declared embedded core module validates as a core module");
+    wasmparser::Validator::new_with_features(wasmparser::WasmFeatures::default())
+        .validate_all(&artifact.component_bytes)
+        .expect("declared component validates as a component");
+}
+
+#[test]
+fn component_artifact_selects_aver_user_core_among_adapter_modules() {
+    let source_path = examples_dir().join("core/hello.av");
+    let source = fs::read_to_string(&source_path).expect("read hello example");
+    let (items, type_aliases) =
+        parse_pipeline_with_module_root(&source, Some(env!("CARGO_MANIFEST_DIR")))
+            .unwrap_or_else(|e| panic!("{e}\n--- source ---\n{source}"));
+    let core_bytes = compile_core_flattened(&items, &type_aliases)
+        .unwrap_or_else(|e| panic!("wasip2 core compile: {e}\n--- source ---\n{source}"));
+    let artifact = aver::codegen::wasip2::compile_to_component_artifact(
+        &core_bytes,
+        aver::codegen::wasip2::Wasip2World::CliCommand,
+    )
+    .unwrap_or_else(|e| panic!("wasip2 component artifact wrap: {e}\n--- source ---\n{source}"));
+
+    assert_eq!(
+        artifact.envelope.component_bytes(),
+        artifact.component_bytes
+    );
+    assert!(
+        core_module_exports(&artifact.envelope.embedded_core_module, "__caller_fn_count"),
+        "declared embedded module should be the Aver user core, not a wit-component shim"
+    );
+    assert!(
+        core_module_exports(&artifact.envelope.embedded_core_module, "main"),
+        "declared embedded user core should retain Aver exports"
+    );
+    wasmparser::Validator::new()
+        .validate_all(&artifact.envelope.embedded_core_module)
+        .expect("declared embedded core module validates as a core module");
+}
+
+fn core_module_exports(module: &[u8], expected: &str) -> bool {
+    for payload in wasmparser::Parser::new(0).parse_all(module) {
+        let Ok(wasmparser::Payload::ExportSection(reader)) = payload else {
+            continue;
+        };
+        for export in reader.into_iter().flatten() {
+            if export.name == expected && export.kind == wasmparser::ExternalKind::Func {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[test]
 fn recursive_string_index_compiles_and_validates_as_component() {
     let source = r#"module Probe
     intent = "Carry a hidden Unicode index through a recursive wasip2 worker."
@@ -477,16 +562,17 @@ fn wasip2_codegen_emits_valid_component_for_every_single_file_example() {
                 continue;
             }
         };
-        let component_bytes = match aver::codegen::wasip2::compile_to_component(
+        let artifact = match aver::codegen::wasip2::compile_to_component_artifact(
             &core_bytes,
             aver::codegen::wasip2::Wasip2World::CliCommand,
         ) {
-            Ok((bytes, _wit)) => bytes,
+            Ok(artifact) => artifact,
             Err(e) => {
                 failures.push(format!("{}: compile_to_component: {}", path.display(), e));
                 continue;
             }
         };
+        let component_bytes = artifact.component_bytes;
         // Component validation needs the component-model feature
         // explicitly enabled — `WasmFeatures::default()` enables it,
         // but spell it out so a future wasmparser default flip


### PR DESCRIPTION
## Summary
- add a producer-side wasip2 component artifact API that returns component bytes, WIT source, and a declared prefix/core/suffix envelope
- select the embedded Aver user core by marker exports when wit-component emits additional adapter modules
- document the #1146 trust boundary: future verifier consumes the declared envelope and checks byte equality instead of rediscovering the user core

Refs #1146

## Tests
- cargo fmt --all -- --check
- cargo test --features wasip2 --test wasip2_codegen_regression component_ -- --nocapture
- cargo test --features wasip2 codegen::wasip2::wrap::tests::component_envelope_rejects_bytes_with_no_embedded_core_payload -- --nocapture