### PR TITLE
Reserve wasip2 certificate envelope manifest surface

### DIFF
--- a/aver-cert/src/format.rs
+++ b/aver-cert/src/format.rs
@@ -11,11 +11,106 @@ pub const FORMAT_VERSION: u32 = 1;
 /// will add their own envelope instead of reinterpreting wasm-gc bytes.
 pub const TARGET_WASM_GC: &str = "wasm-gc";
 
+/// Reserved artifact target identifier for the WASI 0.2 Component Model
+/// certificate envelope. Schema 5 still rejects this target fail-closed; this
+/// constant names the manifest value future schemas will dispatch on.
+pub const TARGET_WASIP2: &str = "wasip2";
+
 /// Only emitted-fragment profile admitted by schema 5.
 pub const PROFILE_ID: &str = "AverUserProfile/v1";
 
 /// Runtime ABI admitted for the wasm-gc artifact target in schema 5.
 pub const RUNTIME_ABI_WASM_GC: &str = "aver-wasm-gc/0";
+
+/// Reserved runtime ABI for future wasip2 component certificates.
+pub const RUNTIME_ABI_WASIP2: &str = "aver-wasip2/0";
+
+/// Reserved top-level manifest field for a wasip2 component envelope
+/// declaration. It is intentionally target-specific: schema 5 ignores unknown
+/// top-level fields and rejects `target = "wasip2"` before validation.
+pub const WASIP2_COMPONENT_ENVELOPE_FIELD: &str = "wasip2ComponentEnvelope";
+
+/// Field names inside the reserved wasip2 component-envelope object.
+pub const WASIP2_COMPONENT_ENVELOPE_KIND_FIELD: &str = "kind";
+pub const WASIP2_COMPONENT_ENVELOPE_PREFIX_LEN_FIELD: &str = "prefix_len";
+pub const WASIP2_COMPONENT_ENVELOPE_CORE_LEN_FIELD: &str = "embedded_core_module_len";
+pub const WASIP2_COMPONENT_ENVELOPE_SUFFIX_LEN_FIELD: &str = "suffix_len";
+
+/// Version tag for the declared `prefix ++ embedded_core_module ++ suffix`
+/// component split.
+pub const WASIP2_COMPONENT_ENVELOPE_KIND: &str = "prefix-core-suffix/v1";
+
+/// Manifest-facing declaration of the wasip2 component envelope.
+///
+/// The declaration carries byte counts only. A verifier that consumes it must
+/// slice the delivered component by these declared lengths and confirm equality
+/// against the separately supplied declared bytes; it must not rediscover the
+/// embedded core by parsing or navigating the delivered component.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Wasip2ComponentEnvelopeDeclaration {
+    /// Bytes before the embedded Aver user-core module payload.
+    pub prefix_len: u64,
+    /// Bytes in the embedded Aver user-core module payload.
+    pub embedded_core_module_len: u64,
+    /// Bytes after the embedded Aver user-core module payload.
+    pub suffix_len: u64,
+}
+
+impl Wasip2ComponentEnvelopeDeclaration {
+    pub const fn from_lengths(
+        prefix_len: u64,
+        embedded_core_module_len: u64,
+        suffix_len: u64,
+    ) -> Self {
+        Self {
+            prefix_len,
+            embedded_core_module_len,
+            suffix_len,
+        }
+    }
+
+    pub const fn kind(&self) -> &'static str {
+        WASIP2_COMPONENT_ENVELOPE_KIND
+    }
+
+    pub fn component_len(&self) -> Option<u64> {
+        self.prefix_len
+            .checked_add(self.embedded_core_module_len)?
+            .checked_add(self.suffix_len)
+    }
+
+    pub fn embedded_core_module_range(&self) -> Option<std::ops::Range<u64>> {
+        let start = self.prefix_len;
+        let end = start.checked_add(self.embedded_core_module_len)?;
+        Some(start..end)
+    }
+
+    /// Split component bytes by declared lengths only. This helper does not
+    /// inspect the bytes and is therefore suitable for the future trusted path,
+    /// provided the caller also checks the returned slices against the declared
+    /// byte sequences.
+    pub fn split_component<'a>(
+        &self,
+        component: &'a [u8],
+    ) -> Option<(&'a [u8], &'a [u8], &'a [u8])> {
+        if self.embedded_core_module_len == 0 {
+            return None;
+        }
+        let prefix_len = usize::try_from(self.prefix_len).ok()?;
+        let core_len = usize::try_from(self.embedded_core_module_len).ok()?;
+        let suffix_len = usize::try_from(self.suffix_len).ok()?;
+        let core_end = prefix_len.checked_add(core_len)?;
+        let declared_len = core_end.checked_add(suffix_len)?;
+        if declared_len != component.len() {
+            return None;
+        }
+        Some((
+            &component[..prefix_len],
+            &component[prefix_len..core_end],
+            &component[core_end..],
+        ))
+    }
+}
 
 /// Manifest schema accepted by the standalone verifier. Version 2 made the
 /// subject's `hostRoleTable` optional: modules without the Int box helper
@@ -180,6 +275,57 @@ mod tests {
     use super::*;
 
     #[test]
+    fn wasip2_envelope_surface_is_reserved_but_schema_five_stays_wasm_gc_only() {
+        assert_eq!(TARGET_WASM_GC, "wasm-gc");
+        assert_eq!(TARGET_WASIP2, "wasip2");
+        assert_eq!(RUNTIME_ABI_WASM_GC, "aver-wasm-gc/0");
+        assert_eq!(RUNTIME_ABI_WASIP2, "aver-wasip2/0");
+        assert_eq!(WASIP2_COMPONENT_ENVELOPE_FIELD, "wasip2ComponentEnvelope");
+        assert_eq!(WASIP2_COMPONENT_ENVELOPE_KIND_FIELD, "kind");
+        assert_eq!(WASIP2_COMPONENT_ENVELOPE_PREFIX_LEN_FIELD, "prefix_len");
+        assert_eq!(
+            WASIP2_COMPONENT_ENVELOPE_CORE_LEN_FIELD,
+            "embedded_core_module_len"
+        );
+        assert_eq!(WASIP2_COMPONENT_ENVELOPE_SUFFIX_LEN_FIELD, "suffix_len");
+        assert_eq!(WASIP2_COMPONENT_ENVELOPE_KIND, "prefix-core-suffix/v1");
+        assert_eq!(CERT_SCHEMA_VERSION, 5);
+    }
+
+    #[test]
+    fn wasip2_component_envelope_declaration_splits_by_declared_lengths_only() {
+        let declaration = Wasip2ComponentEnvelopeDeclaration::from_lengths(2, 3, 1);
+        assert_eq!(declaration.kind(), WASIP2_COMPONENT_ENVELOPE_KIND);
+        assert_eq!(declaration.component_len(), Some(6));
+        assert_eq!(declaration.embedded_core_module_range(), Some(2..5));
+
+        let (prefix, core, suffix) = declaration
+            .split_component(b"abcdef")
+            .expect("declared lengths match the component");
+        assert_eq!(prefix, b"ab");
+        assert_eq!(core, b"cde");
+        assert_eq!(suffix, b"f");
+
+        assert!(
+            Wasip2ComponentEnvelopeDeclaration::from_lengths(2, 0, 1)
+                .split_component(b"abc")
+                .is_none(),
+            "an empty embedded core declaration is not meaningful"
+        );
+        assert!(
+            Wasip2ComponentEnvelopeDeclaration::from_lengths(2, 2, 0)
+                .split_component(b"abc")
+                .is_none(),
+            "the declaration must account for the whole delivered component"
+        );
+        assert_eq!(
+            Wasip2ComponentEnvelopeDeclaration::from_lengths(u64::MAX, 1, 0).component_len(),
+            None,
+            "length overflow must fail closed"
+        );
+    }
+
+    #[test]
     fn capability_pairs_are_unique() {
         let unique = WASM_GC_CAPABILITIES
             .iter()
@@ -247,6 +393,26 @@ mod tests {
                 spec.contains(&phrase),
                 "certificate-format.md does not state \"{phrase}\"; \
                  update the schema version printed in the spec"
+            );
+        }
+    }
+
+    #[test]
+    fn format_spec_documents_reserved_wasip2_envelope_surface() {
+        let spec = include_str!("../../docs/certificate-format.md");
+        for phrase in [
+            TARGET_WASIP2,
+            RUNTIME_ABI_WASIP2,
+            WASIP2_COMPONENT_ENVELOPE_FIELD,
+            WASIP2_COMPONENT_ENVELOPE_KIND_FIELD,
+            WASIP2_COMPONENT_ENVELOPE_PREFIX_LEN_FIELD,
+            WASIP2_COMPONENT_ENVELOPE_CORE_LEN_FIELD,
+            WASIP2_COMPONENT_ENVELOPE_SUFFIX_LEN_FIELD,
+            WASIP2_COMPONENT_ENVELOPE_KIND,
+        ] {
+            assert!(
+                spec.contains(phrase),
+                "certificate-format.md does not document reserved wasip2 envelope surface `{phrase}`"
             );
         }
     }

--- a/aver-cert/src/verifier.rs
+++ b/aver-cert/src/verifier.rs
@@ -1759,6 +1759,21 @@ mod tests {
     }
 
     #[test]
+    fn wasip2_identity_is_reserved_but_not_accepted_by_schema_five() {
+        let error = require_supported_identity(&ManifestIdentity {
+            target: format::TARGET_WASIP2.to_string(),
+            profile: format::PROFILE_ID.to_string(),
+            abi: format::RUNTIME_ABI_WASIP2.to_string(),
+        })
+        .unwrap_err();
+        assert!(
+            error.contains("unsupported certificate target `wasip2`"),
+            "{error}"
+        );
+        assert!(error.contains(format::TARGET_WASM_GC), "{error}");
+    }
+
+    #[test]
     fn candidate_strings_cannot_escape_lean_literals() {
         assert!(gate_candidate("test", "plain ASCII").is_ok());
         assert!(gate_candidate("test", "quote: \"").is_err());

--- a/docs/certificate-format.md
+++ b/docs/certificate-format.md
@@ -150,6 +150,23 @@ For claim matching, an absent table binds no roles at all (`Subject.hostRoles` m
 
 The subject fields split along one criterion: what their kernel pin is stated against. Fields pinned against fixed constants or against other manifest data — `wasm_sha256`/`artifactHash` (the pin shape; the hash function itself is a target choice), `target`, `profile`, `abi`, `artifact_certificate_root`, the certified export names, `declaredUncertified`, and `runtime_contracts` — are **target-generic core**: they describe the claim structure and the selected envelope, not WebAssembly sections. Fields pinned against byte decoders over the artifact — `capabilities`, `start`, `hostRoleTable`, and `stringHostRoles` — are the **wasm envelope**: facts about wasm sections (the import section, the start section, the Int-carrier helper exports, the string-helper function bodies) that only exist because the target is WebAssembly. Section 4.3 and the decode-bound rows above are envelope material, as are the byte-level mechanisms of sections 6–7 (the fragment IR, the byte lowering, the section framing and closure scan). A future non-wasm target would keep the core — obligations, policies, plan-claim agreement, faces, axes, the whole-module accounting principles — and replace the envelope with its own decoder-pinned facts, specified as an added envelope section of this document rather than a rewrite. Schema version 5 still transports core and envelope fields as siblings in one flat manifest object, but the `target` field is now the explicit dispatch point: this version admits only `wasm-gc`, and a later component schema must add a target-specific envelope instead of treating component bytes as a core wasm module.
 
+### 4.5 Reserved wasip2 component-envelope surface
+
+The implementation reserves the target/ABI pair `target = "wasip2"`, `abi = "aver-wasip2/0"` and the top-level field name `wasip2ComponentEnvelope` for the future WASI 0.2 Component Model envelope. Schema version 5 **does not accept** that target: a conforming version-5 verifier must still reject `target = "wasip2"` before byte validation and must not treat this reserved surface as trust-bearing evidence.
+
+The reserved envelope declaration is a length-only object:
+
+```json
+"wasip2ComponentEnvelope": {
+  "kind": "prefix-core-suffix/v1",
+  "prefix_len": 123,
+  "embedded_core_module_len": 456,
+  "suffix_len": 789
+}
+```
+
+A later schema may use those declared lengths to split the caller-supplied component as `prefix ++ embedded_core_module ++ suffix`, then check equality against the declared parts and run the existing core-module certificate checks on the declared embedded core. The split must be driven only by the declared lengths; the trusted verifier path must not parse, scan, or navigate the delivered component to rediscover which core module is the Aver user core. The producer-side `wit-component` wrapper may discover the split while constructing the package, but that discovery is not an acceptance rule.
+
 ## 5. Obligations, claims, and policies
 
 The Lean manifest (`Schema.Manifest`) carries the subject, eleven per-family plan association lists keyed by export name (`symFragmentPlans`, `stringEqPlans`, `stringConcatPlans`, `constructPlans`, `exprFragmentPlans`, `recursionPlans`, `mutualPlans`, `compositionPlans`, `verbatimPlans`, `intDispatchPlans`, `fieldProjectionPlans`), and `obligations : List Obligation`.

--- a/docs/certification-architecture.md
+++ b/docs/certification-architecture.md
@@ -138,10 +138,12 @@ disassembler, candidate derivation, or reconstruction of
 
 For the planned `wasip2` target (#1146), the same rule applies to the component
 wrapper: the producer may declare a `prefix ++ embedded_core_module ++ suffix`
-split while constructing the component, but the trusted verifier path must not
+split while constructing the component, surfaced under the reserved
+`wasip2ComponentEnvelope` manifest field, but the trusted verifier path must not
 rediscover the user core by walking component bytes. It should consume the
-declaration, confirm byte equality against the caller-supplied component, and
-then run the core-module checks on the declared embedded module.
+declaration, split only by declared lengths, confirm byte equality against the
+caller-supplied component, and then run the core-module checks on the declared
+embedded module.
 
 ## Lean acceptance wall
 

--- a/src/codegen/wasip2/wrap.rs
+++ b/src/codegen/wasip2/wrap.rs
@@ -74,6 +74,16 @@ pub struct Wasip2ComponentEnvelope {
 }
 
 impl Wasip2ComponentEnvelope {
+    /// Manifest-facing length declaration for this envelope.
+    pub fn declaration(&self) -> aver_cert::format::Wasip2ComponentEnvelopeDeclaration {
+        aver_cert::format::Wasip2ComponentEnvelopeDeclaration::from_lengths(
+            u64::try_from(self.prefix.len()).expect("prefix length fits in u64"),
+            u64::try_from(self.embedded_core_module.len())
+                .expect("embedded core module length fits in u64"),
+            u64::try_from(self.suffix.len()).expect("suffix length fits in u64"),
+        )
+    }
+
     /// Declare the single embedded core module section of a produced component.
     ///
     /// This walks the component only on the producer side, immediately after

--- a/tests/wasip2_codegen_regression.rs
+++ b/tests/wasip2_codegen_regression.rs
@@ -192,6 +192,24 @@ fn main() -> Int
         artifact.envelope.component_bytes(),
         artifact.component_bytes
     );
+    let declaration = artifact.envelope.declaration();
+    assert_eq!(
+        declaration.kind(),
+        aver::codegen::cert::format::WASIP2_COMPONENT_ENVELOPE_KIND
+    );
+    assert_eq!(
+        declaration.component_len(),
+        Some(artifact.component_bytes.len() as u64)
+    );
+    let (prefix, embedded_core, suffix) = declaration
+        .split_component(&artifact.component_bytes)
+        .expect("declaration accounts for the whole produced component");
+    assert_eq!(prefix, artifact.envelope.prefix.as_slice());
+    assert_eq!(
+        embedded_core,
+        artifact.envelope.embedded_core_module.as_slice()
+    );
+    assert_eq!(suffix, artifact.envelope.suffix.as_slice());
     assert!(
         artifact.envelope.embedded_core_module.starts_with(b"\0asm"),
         "the declared core payload should be a complete core wasm module"
@@ -226,6 +244,17 @@ fn component_artifact_selects_aver_user_core_among_adapter_modules() {
     assert_eq!(
         artifact.envelope.component_bytes(),
         artifact.component_bytes
+    );
+    let declaration = artifact.envelope.declaration();
+    assert_eq!(
+        declaration.component_len(),
+        Some(artifact.component_bytes.len() as u64)
+    );
+    let core_start = artifact.envelope.prefix.len() as u64;
+    let core_end = core_start + artifact.envelope.embedded_core_module.len() as u64;
+    assert_eq!(
+        declaration.embedded_core_module_range(),
+        Some(core_start..core_end)
     );
     assert!(
         core_module_exports(&artifact.envelope.embedded_core_module, "__caller_fn_count"),


### PR DESCRIPTION
## Summary
- reserve the wasip2 certificate target/ABI constants and manifest envelope field names
- add a length-only `Wasip2ComponentEnvelopeDeclaration` helper that splits by declared lengths without inspecting component bytes
- expose declaration lengths from the wasip2 producer artifact API while keeping schema 5 fail-closed for `target = wasip2`
- document the reserved `wasip2ComponentEnvelope` surface and trusted-path boundary

Refs #1146

## Tests
- cargo fmt --all -- --check
- cargo test -p aver-cert wasip2 -- --nocapture
- cargo test --features wasip2 --test wasip2_codegen_regression component_ -- --nocapture
