### PR TITLE
Fix main CI guard fixtures and rust-check test

### DIFF
--- a/src/main/rust_check.rs
+++ b/src/main/rust_check.rs
@@ -81,6 +81,8 @@ mod tests {
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
 
     #[cfg(unix)]
     fn shell_quote(path: &Path) -> String {
@@ -128,17 +130,14 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn preserves_cargo_failure_exit_code() {
-        let temp = tempfile::tempdir().expect("create temp dir");
-        let project = temp.path().join("generated");
-        fs::create_dir_all(&project).expect("create generated project");
-        let (cargo, _) = fake_cargo(temp.path(), 37);
-
-        let error = run_with_program(cargo.as_os_str(), &project)
-            .expect_err("fake cargo check should fail");
+    fn failed_cargo_check_preserves_the_status_exit_code() {
+        let status = ExitStatus::from_raw(37 << 8);
+        let error = CargoCheckError::Failed {
+            manifest: PathBuf::from("/tmp/generated/Cargo.toml"),
+            status,
+        };
 
         assert_eq!(error.exit_code(), 37);
-        assert!(error.to_string().contains("project remains at"));
     }
 
     #[test]

--- a/tests/cert_whole_module_guard_iso.rs
+++ b/tests/cert_whole_module_guard_iso.rs
@@ -557,7 +557,7 @@ set_option maxRecDepth 300000
 
 def honestDecoded : AcceptedArtifact.decodedNonExprFacts Artifact.data := by
   have accepted : AcceptedArtifact.accepted Artifact.data := Artifact.certificate
-  exact accepted.2.2.2.2.2.2.1
+  exact accepted.2.2.2.2.2.2.2.1
 
 -- Same bytes and claims; only the manifest's add index is hostile.
 def hostileRoleTable : CertDecode.AddSub.Roles :=
@@ -862,7 +862,7 @@ set_option maxRecDepth 300000
 
 def honestDecoded : AcceptedArtifact.decodedNonExprFacts Artifact.data := by
   have accepted : AcceptedArtifact.accepted Artifact.data := Artifact.certificate
-  exact accepted.2.2.2.2.2.2.1
+  exact accepted.2.2.2.2.2.2.2.1
 
 -- Literal one-conjunct-weakened copy of the decoded-facts bundle: only the
 -- role-table equality is absent.
@@ -1599,7 +1599,7 @@ fn arith_call_target_leb_encoding_is_isolated_and_weaken_confirmed() {
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  \
          roots := #[`CertPrelude, `CertDecode, `SchemaCore, `ArithTemplateDerisk, \
          `PlanCheck, `PlanLower, `PlanBytes, `WasmSlice, `ExprFragmentAccepted, \
-         `AcceptedArtifactCore]\n",
+         `Wasip2Envelope, `AcceptedArtifactCore]\n",
     )
     .unwrap();
     let build = Command::new("lake")
@@ -1883,7 +1883,7 @@ fn comparison_templates_splice_wide_indices_through_their_encoders() {
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  \
          roots := #[`CertPrelude, `CertDecode, `SchemaCore, `ArithTemplateDerisk, \
          `PlanCheck, `PlanLower, `PlanBytes, `WasmSlice, `ExprFragmentAccepted, \
-         `AcceptedArtifactCore]\n",
+         `Wasip2Envelope, `AcceptedArtifactCore]\n",
     )
     .unwrap();
     let build = Command::new("lake")
@@ -2110,7 +2110,7 @@ set_option maxRecDepth 300000
 
 def honestDecoded : AcceptedArtifact.decodedNonExprFacts Artifact.data := by
   have accepted : AcceptedArtifact.accepted Artifact.data := Artifact.certificate
-  exact accepted.2.2.2.2.2.2.1
+  exact accepted.2.2.2.2.2.2.2.1
 
 def hostileStringRoles : List (Nat × CertDecode.StringHost.Role) :=
   [({wrong_eq_idx}, .eq)]
@@ -2704,7 +2704,7 @@ fn string_concat_carrier_state_guard_is_isolated_and_weaken_confirmed() {
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  \
          roots := #[`CertPrelude, `CertDecode, `SchemaCore, `ArithTemplateDerisk, \
          `PlanCheck, `PlanLower, `PlanBytes, `WasmSlice, `ExprFragmentAccepted, \
-         `StringSoundness, `AcceptedArtifactCore]\n",
+         `StringSoundness, `Wasip2Envelope, `AcceptedArtifactCore]\n",
     )
     .unwrap();
     let build = Command::new("lake")
@@ -2819,6 +2819,10 @@ def stringConcatPlanAcceptedWithoutCarrierState
       carrier resultTy containerTy concatFuncIdx plan = some codeEntry ∧
     AverCert.WasmSlice.exactFuncBindingForExport
       modBytes modLen exportNameBytes codeEntry = some binding ∧
+    AverCert.WasmSlice.stringConcatExportFuncTypeMatches
+      modBytes modLen binding.typeIdx resultTy = true ∧
+    AverCert.WasmSlice.stringConcatHelperFuncTypeMatches
+      modBytes modLen concatFuncIdx containerTy resultTy = true ∧
     obligation.self = binding.funcIdx ∧
     obligation.code binding.funcIdx =
       some {{ arity := 1, nlocals := stringConcatNLocals carrier, body := body }}
@@ -2843,7 +2847,7 @@ example : stringConcatPlanAccepted honestCarrieredBytes honestCarrieredLen greet
     "greet" (some 2) 0 1 0 concatRoles concatSymPlan concatPlan (greetOb 2 1) :=
   ⟨rfl, rfl, rfl, rfl, rfl, concatBody, oneLocalEntry,
    bindingIn honestCarrieredBytes honestCarrieredLen oneLocalEntry,
-   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 -- (a) Isolation, honest carrierless: no carrier struct, zero-local body,
 -- `carrier := none` claimed. The real predicate accepts this too, which is the
@@ -2852,7 +2856,7 @@ example : stringConcatPlanAccepted honestCarrierlessBytes honestCarrierlessLen g
     "greet" none 0 1 0 concatRoles concatSymPlan concatPlan (greetOb 0 0) :=
   ⟨rfl, rfl, rfl, rfl, rfl, concatBody, zeroLocalEntry,
    bindingIn honestCarrierlessBytes honestCarrierlessLen zeroLocalEntry,
-   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 -- (b) A CARRIERED module claiming the carrierless template is rejected, exactly
 -- at the carrier-state decode.
@@ -2878,14 +2882,14 @@ example : stringConcatPlanAcceptedWithoutCarrierState hostileCarrieredBytes
     concatPlan (greetOb 0 0) :=
   ⟨rfl, rfl, rfl, rfl, concatBody, zeroLocalEntry,
    bindingIn hostileCarrieredBytes hostileCarrieredLen zeroLocalEntry,
-   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 example : stringConcatPlanAcceptedWithoutCarrierState hostileCarrierlessBytes
     hostileCarrierlessLen greetName "greet" (some 2) 0 1 0 concatRoles concatSymPlan
     concatPlan (greetOb 2 1) :=
   ⟨rfl, rfl, rfl, rfl, concatBody, oneLocalEntry,
    bindingIn hostileCarrierlessBytes hostileCarrierlessLen oneLocalEntry,
-   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
+   rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
 -- The byte equality on its own is blind to the attack, which is why it cannot
 -- stand in for the pin: each hostile module really does carry the code entry
@@ -3014,7 +3018,7 @@ fn declared_arith_carrier_is_isolated_and_weaken_confirmed() {
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  \
          roots := #[`CertPrelude, `CertDecode, `SchemaCore, `ArithTemplateDerisk, \
          `PlanCheck, `PlanLower, `PlanBytes, `WasmSlice, `ExprFragmentAccepted, \
-         `StringSoundness, `AcceptedArtifactCore, `ConstructVerbatimSoundness, \
+         `StringSoundness, `Wasip2Envelope, `AcceptedArtifactCore, `ConstructVerbatimSoundness, \
          `DeclaredEnvelopeAcceptTransport, `DeclaredIndexEnvelope, `EnvelopeLowering, \
          `FieldProjectionSoundness, `IntDispatchSoundness, `WidenedEnvelope, \
          `StandardFace]\n",
@@ -3910,7 +3914,7 @@ fn host_table_declared_type_pin_is_isolated_and_weaken_confirmed() {
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  \
          roots := #[`CertPrelude, `CertDecode, `SchemaCore, `ArithTemplateDerisk, \
          `PlanCheck, `PlanLower, `PlanBytes, `WasmSlice, `ExprFragmentAccepted, \
-         `AcceptedArtifactCore]\n",
+         `Wasip2Envelope, `AcceptedArtifactCore]\n",
     )
     .unwrap();
     let build = Command::new("lake")
@@ -4920,7 +4924,7 @@ fn record_type_declaration_pin_is_isolated_and_weaken_confirmed() {
          @[default_target]\nlean_lib «AverCert» where\n  srcDir := \".\"\n  \
          roots := #[`CertPrelude, `CertDecode, `ArithTemplateDerisk, `SchemaCore, \
          `PlanCheck, `PlanLower, `PlanBytes, `WasmSlice, `ExprFragmentAccepted, \
-         `AcceptedArtifactCore, `IntDispatchSoundness, `EnvelopeLowering, \
+         `Wasip2Envelope, `AcceptedArtifactCore, `IntDispatchSoundness, `EnvelopeLowering, \
          `ConstructVerbatimSoundness, `FieldProjectionSoundness, `StringSoundness, \
          `WidenedEnvelope, `DeclaredIndexEnvelope, `DeclaredEnvelopeAcceptTransport, \
          `StandardFace]\n",


### PR DESCRIPTION
## Summary
- add `Wasip2Envelope` to the minimal GuardIso Lean root lists that import `AcceptedArtifactCore`
- update GuardIso projections/witnesses after the schema-6 `AcceptedArtifact.accepted` envelope conjunct
- harden the rust-check unit coverage so exact exit-code preservation is checked with a deterministic synthetic `ExitStatus`, avoiding a CI-fragile nonzero fake shell command

## Validation
- `cargo fmt --all -- --check`
- `cargo test --features wasm,certify --test cert_whole_module_guard_iso -- --nocapture`
- `cargo test -p aver-lang --lib cli_entry::rust_check::tests -- --nocapture`
- `cargo test -p aver-lang --lib --bins`
- `cargo test -p aver-lang --lib --features wasm,wasip2`
