### PR TITLE
fix(fuzz,rust,typecheck): replay with provenance, no namespace field access, no ICE on an unknown field type

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -373,26 +373,9 @@ jobs:
           fi
           echo "::endgroup::"
 
-      - name: Rust codegen oracle (bounded real rustc)
-        if: matrix.target == 'fuzz_codegen_rust'
-        # AFL's hot loop emits projects in-process. Spawning Cargo for every
-        # mutation would collapse throughput, so ask the public `--check`
-        # gate about a deterministic sample of accepted queue entries after
-        # the campaign. The committed corpus is a fallback that guarantees
-        # the oracle still has valid seeds if AFL exits before writing a
-        # usable queue. One shared target amortises aver-rt and dependencies.
-        run: |
-          cargo build --locked --bin aver
-          python3 tools/validate_rust_fuzz_corpus.py \
-            --aver target/debug/aver \
-            --corpus fuzz/corpus/parser \
-            --corpus fuzz/out/fuzz_codegen_rust/default/queue \
-            --limit 24 \
-            --max-candidates 256 \
-            --target-dir target/rust-fuzz-oracle
-
       - name: Summarise findings
         working-directory: fuzz
+        if: always()
         # Crash-only failure policy. AFL "hangs" are wall-clock
         # timeouts — anything taking longer than ~1s. In a wasmtime
         # + cranelift pipeline that occasionally cold-starts a JIT,
@@ -421,6 +404,27 @@ jobs:
           if [ "${#crashes[@]}" -gt 0 ]; then
             exit 1
           fi
+
+      - name: Rust codegen oracle (bounded real rustc)
+        # `always()`: the crash gate above exits 1 on any saved crash, and a
+        # skipped oracle would then hide whether real rustc also has
+        # something to say. Both signals are reported on every run.
+        if: always() && matrix.target == 'fuzz_codegen_rust'
+        # AFL's hot loop emits projects in-process. Spawning Cargo for every
+        # mutation would collapse throughput, so ask the public `--check`
+        # gate about a deterministic sample of accepted queue entries after
+        # the campaign. The committed corpus is a fallback that guarantees
+        # the oracle still has valid seeds if AFL exits before writing a
+        # usable queue. One shared target amortises aver-rt and dependencies.
+        run: |
+          cargo build --locked --bin aver
+          python3 tools/validate_rust_fuzz_corpus.py \
+            --aver target/debug/aver \
+            --corpus fuzz/corpus/parser \
+            --corpus fuzz/out/fuzz_codegen_rust/default/queue \
+            --limit 24 \
+            --max-candidates 256 \
+            --target-dir target/rust-fuzz-oracle
 
       - name: Pack AFL output
         # AFL filenames contain `:` characters that

--- a/fuzz/fuzz_targets/codegen_rust.rs
+++ b/fuzz/fuzz_targets/codegen_rust.rs
@@ -12,6 +12,17 @@
 // sample of this target's evolved queue and replays it through
 // `aver compile --target rust --check`. Splitting the two loops preserves AFL
 // throughput while retaining a real rustc oracle.
+//
+// What counts as a finding: a `compile_error!` substitution is the emitter
+// refusing to render a construct, and two different things wear that shape.
+// One says the PROGRAM is wrong — "fn `sumTree` writes the constructor
+// `Tyac.Node`, but no type `Tyac` … is in scope there" — which is the
+// CORRECT output for a byte the mutator flipped inside a type name, and
+// aborting on it buries the other class under dozens of copies of the same
+// non-bug. The other says this BACKEND is incomplete ("MIR walker could not
+// render fn `abs`"), and that is the finding. `generated_backend_gaps()` is
+// the emitter's own record of which is which — never a scan of the wording,
+// which would go quiet the day a message is reworded.
 
 #[path = "common.rs"]
 mod common;
@@ -110,8 +121,15 @@ fn main() {
         );
         let output = aver::codegen::rust::transpile(&mut ctx);
 
-        if !output.generated_compile_errors().is_empty() {
+        let gaps: Vec<&str> = output.generated_backend_gaps().collect();
+        if !gaps.is_empty() {
+            eprintln!("codegen_rust: backend could not render: {gaps:?}");
             std::process::abort();
+        }
+        // A program the emitter refused with a diagnostic produces no crate
+        // to check the shape of; that is the refusal working, not a finding.
+        if !output.generated_compile_errors().is_empty() {
+            return;
         }
         let has_manifest = output.files.iter().any(|(path, _)| path == "Cargo.toml");
         let has_entry = output

--- a/fuzz/fuzz_targets/replay_roundtrip.rs
+++ b/fuzz/fuzz_targets/replay_roundtrip.rs
@@ -10,11 +10,26 @@
 // Pipeline per AFL exec:
 //   1. lex / parse / typecheck / pipeline (zero-error gate)
 //   2. compile + VM run with `start_recording()`, capture stdout +
-//      decoded entry-fn return value + effect trace.
-//   3. fresh compile + VM run with `start_replay(effects)`,
-//      capture stdout + decoded return value.
+//      decoded entry-fn return value + effect trace + the recording
+//      machine's capability provenance.
+//   3. fresh compile + VM run with
+//      `start_replay_with_provenance(effects, provenance)`, capture
+//      stdout + decoded return value.
 //   4. assert stdout identical, output identical, replay consumed
 //      the entire trace (`ensure_replay_consumed` Ok).
+//
+// Step 2 and 3 are the pair `aver run --record` / `aver replay`
+// themselves use (`main/commands.rs` writes
+// `machine.provider_registry().provenance()` into the
+// `SessionRecording`; `main/replay_cmd/backends.rs` hands that table
+// back to `start_replay_with_provenance`). Replaying through the
+// provenance-less `start_replay` instead is NOT a cheaper spelling of
+// the same thing: `Console.print/error/warn` are `replay = reissued`,
+// so `validate_replay_provenance_for_operations` refuses an empty
+// provenance table for every program that so much as names Console —
+// which is most of the seed corpus. The harness must record what
+// production records and replay what production replays, or it fuzzes
+// a preflight rejection instead of the recorder/replayer pair.
 //
 // Bug class this surfaces:
 //   - recorder dropping events / under-counting (replay runs out of
@@ -51,6 +66,13 @@ struct RunOutcome {
     /// The replay run takes this as input and the comparison
     /// asserts `ensure_replay_consumed`.
     recorded_effects: Option<Vec<aver::replay::EffectRecord>>,
+    /// Capability provenance of the recording machine's provider
+    /// registry — populated only on the record run, exactly as
+    /// `SessionRecording.capabilities` is on `aver run --record`.
+    /// The replay run needs it: pure and `reissued` operations run a
+    /// LIVE provider during replay, so their implementation identity
+    /// has to be pinned by the recording.
+    provenance: Vec<aver::replay::CapabilityProvenance>,
 }
 
 fn main() {
@@ -115,12 +137,13 @@ fn main() {
             None => return,
         };
 
-        // Second run: replay against the recorded trace. Same
-        // program, fresh VM, recorder swapped for replayer.
+        // Second run: replay against the recorded trace and the
+        // recording's own provenance table. Same program, fresh VM,
+        // recorder swapped for replayer.
         let Some(replay) = run_vm(
             &pipeline_result.resolved_items,
             &pipeline_result.symbol_table,
-            RecordMode::Replay(trace),
+            RecordMode::Replay(trace, record.provenance.clone()),
             base_dir,
         ) else {
             // Replay refused / panicked under catch_unwind. Real
@@ -153,7 +176,10 @@ fn main() {
 
 enum RecordMode {
     Record,
-    Replay(Vec<aver::replay::EffectRecord>),
+    Replay(
+        Vec<aver::replay::EffectRecord>,
+        Vec<aver::replay::CapabilityProvenance>,
+    ),
 }
 
 fn run_vm(
@@ -181,17 +207,21 @@ fn run_vm(
                 machine.start_recording();
                 true
             }
-            RecordMode::Replay(trace) => {
+            RecordMode::Replay(trace, provenance) => {
                 // `validate_args = true` so a replay that supplies
                 // mismatched effect args fails loudly instead of
-                // silently consuming the wrong slot.
-                machine.start_replay(trace.clone(), true);
+                // silently consuming the wrong slot. The provenance
+                // table is the recording's — the `aver replay` call
+                // shape, see the module comment.
+                machine
+                    .start_replay_with_provenance(trace.clone(), provenance, true)
+                    .ok()?;
                 false
             }
         };
         let (run_res, stdout, _stderr) = aver::services::console::capture_output(|| machine.run());
         let nv = run_res.ok()?;
-        if let RecordMode::Replay(_) = &mode {
+        if let RecordMode::Replay(..) = &mode {
             // `ensure_replay_consumed` is the load-bearing assertion
             // here: a recording that under-runs (program reads N
             // events on record, M < N on replay) silently passes
@@ -207,15 +237,19 @@ fn run_vm(
             &machine.arena,
         );
         let json = aver::replay::value_to_json(&value).ok()?;
-        let recorded_effects = if want_record {
-            Some(machine.recorded_effects().to_vec())
+        let (recorded_effects, provenance) = if want_record {
+            (
+                Some(machine.recorded_effects().to_vec()),
+                machine.provider_registry().provenance(),
+            )
         } else {
-            None
+            (None, Vec::new())
         };
         Some(RunOutcome {
             stdout,
             value: json,
             recorded_effects,
+            provenance,
         })
     }));
     match result {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -407,20 +407,21 @@ pub struct CodegenContext {
     /// several times per claim, and a `Vec` would multiply-count.
     pub declined_claims: std::cell::RefCell<std::collections::BTreeMap<String, DeclinedClaim>>,
     /// Every construct the Rust emitter substituted a `compile_error!` for,
-    /// in emit order, as the message it wrote.
+    /// in emit order, as the message it wrote and whose problem it is.
     ///
     /// Same reason as `declined_claims` one field up: the emitter knows it
     /// refused, so it says so here. Re-discovering the refusal by scanning
     /// the generated files for the macro name cannot tell the backend's own
     /// output apart from a program's data — a `String` literal quoting
     /// `compile_error!` is ordinary Aver — and it goes quiet the day the
-    /// wording changes.
+    /// wording changes. The [`CompileErrorCause`] is recorded for the same
+    /// reason and not re-derived from the message text.
     ///
     /// Written by `rust::toplevel::emit_codegen_error_expr` and by the
     /// mutual-TCO block fallback; read out into
     /// [`ProjectOutput::substituted_compile_errors`] at the end of a Rust
     /// transpile.
-    pub substituted_compile_errors: std::cell::RefCell<Vec<String>>,
+    pub substituted_compile_errors: std::cell::RefCell<Vec<SubstitutedCompileError>>,
     /// Verify cases the Rust emitter left out of the generated
     /// `#[cfg(test)]` module because the MIR walker could not render them,
     /// as "`fn` name: reason".
@@ -568,14 +569,44 @@ pub struct UniversalLawClaim {
     pub statement: String,
 }
 
+/// Whose problem a `compile_error!` substitution is.
+///
+/// Both classes wear the same shape in the emitted file, and both make the
+/// crate unbuildable, so `compile` reports both and exits non-zero on
+/// either. They are not the same finding, though: one says the `.av`
+/// source is wrong, the other says this compiler is incomplete. A fuzz
+/// harness must gate on the second and let the first through — a mutated
+/// type name is SUPPOSED to be refused — and the only place that can tell
+/// them apart without guessing from wording is the emitter that made the
+/// substitution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompileErrorCause {
+    /// The program names something that is not in scope where it writes
+    /// it. The message is a user-facing diagnostic; the fix is in the
+    /// source, and refusing was the right answer.
+    Program,
+    /// The backend has no rendering for a construct the program is
+    /// entitled to write. A gap in this compiler.
+    BackendGap,
+}
+
+/// One `compile_error!` a backend substituted for a construct it did not
+/// emit, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubstitutedCompileError {
+    pub cause: CompileErrorCause,
+    /// The sentence written into the generated file.
+    pub message: String,
+}
+
 /// Output files from a codegen backend.
 pub struct ProjectOutput {
     /// Files to write: (relative_path, content).
     pub files: Vec<(String, String)>,
     /// What the backend substituted a `compile_error!` for while producing
-    /// `files`, one message per construct, in emit order. Empty for a
+    /// `files`, one entry per construct, in emit order. Empty for a
     /// backend that has no such construct (Lean, Dafny).
-    pub substituted_compile_errors: Vec<String>,
+    pub substituted_compile_errors: Vec<SubstitutedCompileError>,
     /// Verify cases the backend left out of the generated test module, one
     /// line each. Not a failure — the generated crate builds and its
     /// `cargo test` passes — but the user is told which of their cases the
@@ -613,8 +644,23 @@ impl ProjectOutput {
     /// because both are just text in the same file. Reading the fact from
     /// the emitter that produced it cannot be triggered by program data at
     /// all, and cannot go quiet when someone rewords a message.
-    pub fn generated_compile_errors(&self) -> &[String] {
+    pub fn generated_compile_errors(&self) -> &[SubstitutedCompileError] {
         &self.substituted_compile_errors
+    }
+
+    /// The subset of [`Self::generated_compile_errors`] the backend wrote
+    /// because IT could not render the construct — [`CompileErrorCause::BackendGap`].
+    ///
+    /// This is the half that is a finding rather than a verdict. `aver
+    /// compile` refuses on either class, but a fuzz harness driving mutated
+    /// source must gate on this one alone: a program that names a type
+    /// nobody declared is SUPPOSED to be refused, and treating that
+    /// refusal as a crash buries the coverage gaps under it.
+    pub fn generated_backend_gaps(&self) -> impl Iterator<Item = &str> {
+        self.substituted_compile_errors
+            .iter()
+            .filter(|error| error.cause == CompileErrorCause::BackendGap)
+            .map(|error| error.message.as_str())
     }
 }
 
@@ -1382,7 +1428,7 @@ pub(crate) fn test_module(prefix: &str, depends: &[&str], type_defs: Vec<TypeDef
 
 #[cfg(test)]
 mod project_output_tests {
-    use super::ProjectOutput;
+    use super::{CompileErrorCause, ProjectOutput, SubstitutedCompileError};
 
     fn output(files: &[(&str, &str)]) -> ProjectOutput {
         ProjectOutput::of(
@@ -1403,11 +1449,36 @@ mod project_output_tests {
                 "pub fn added() { compile_error!(\"MIR walker could not render fn `added`\"); }\n",
             ),
         ]);
-        out.substituted_compile_errors = vec!["MIR walker could not render fn `added`".to_string()];
+        out.substituted_compile_errors = vec![SubstitutedCompileError {
+            cause: CompileErrorCause::BackendGap,
+            message: "MIR walker could not render fn `added`".to_string(),
+        }];
         assert_eq!(
             out.generated_compile_errors(),
-            ["MIR walker could not render fn `added`".to_string()]
+            [SubstitutedCompileError {
+                cause: CompileErrorCause::BackendGap,
+                message: "MIR walker could not render fn `added`".to_string(),
+            }]
         );
+        // The gap view is the fuzz gate: this one IS a finding.
+        assert_eq!(
+            out.generated_backend_gaps().collect::<Vec<_>>(),
+            ["MIR walker could not render fn `added`"]
+        );
+    }
+
+    #[test]
+    fn a_program_diagnostic_is_reported_but_is_not_a_backend_gap() {
+        // Both refuse the crate; only one says the compiler is incomplete.
+        let mut out = output(&[("Cargo.toml", "[package]\nname = \"app\"\n")]);
+        out.substituted_compile_errors = vec![SubstitutedCompileError {
+            cause: CompileErrorCause::Program,
+            message: "the entry module, line 4: fn `f` writes the constructor `Nope.Some`, \
+                      but no type `Nope` with a variant `Some` is in scope there"
+                .to_string(),
+        }];
+        assert_eq!(out.generated_compile_errors().len(), 1);
+        assert_eq!(out.generated_backend_gaps().count(), 0);
     }
 
     #[test]

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -2167,6 +2167,23 @@ pub(super) fn emit_mir_guest_entry_body(
     emit_mir_fn_body(&mir_fn.body, &emit_ctx)
 }
 
+/// One rendered top-level statement value, and the one fact about it the
+/// caller cannot see from the emitted string.
+pub(super) struct TopStmtValue {
+    /// The rendered Rust expression.
+    pub value: String,
+    /// `true` when the MIR value has no observable effect and cannot trap
+    /// — the SAME classification
+    /// [`crate::ir::mir::optimize::dead_code::is_pure`] applies inside a
+    /// fn body. A fn body's statement chain lowers to a `Let` chain that
+    /// the DCE pass then walks, so a pure value bound to a name nothing
+    /// reads is gone before any emitter sees it. Module-level statements
+    /// are lowered one value at a time, outside `MirProgram.fns`, so DCE
+    /// never runs on them: without this flag the caller has no way to
+    /// apply the same rule and the two positions diverge.
+    pub pure: bool,
+}
+
 /// Render every **top-level statement value** through the MIR walker,
 /// all-or-nothing. Free-standing module-scope statements (`x = expr` / a
 /// bare `expr`) belong to no `ResolvedFnDef`, so this mirrors the VM
@@ -2179,8 +2196,8 @@ pub(super) fn emit_mir_guest_entry_body(
 /// half-written main body (exactly what the VM `compile_top_level` does
 /// with `mir_expr_compilable`).
 ///
-/// Returns the rendered value strings in statement order on full success
-/// (the caller wraps each in the explicit `let {name} @ _ = …;` /
+/// Returns the rendered values in statement order on full success (the
+/// caller wraps each in the explicit `let {name} @ _ = …;` /
 /// bare-expr-discard
 /// `…;` templating), or `None` if there's no MIR program or ANY
 /// statement falls outside the lowerable / renderable subset — the
@@ -2189,7 +2206,7 @@ pub(super) fn emit_mir_guest_entry_body(
 pub(super) fn emit_mir_top_stmt_values(
     resolved_values: &[&Spanned<crate::ir::hir::ResolvedExpr>],
     ctx: &CodegenContext,
-) -> Option<Vec<String>> {
+) -> Option<Vec<TopStmtValue>> {
     let base = ctx.mir_program.as_ref()?;
     // One clone shared across every statement: the lowerer grows its
     // builtin / instantiation tables in place, so all the `Call(Builtin)`
@@ -2207,7 +2224,12 @@ pub(super) fn emit_mir_top_stmt_values(
     // rather than leaving a half-MIR / half-HIR main body.
     lowered
         .iter()
-        .map(|low| emit_mir_expr(low, &emit_ctx))
+        .map(|low| {
+            Some(TopStmtValue {
+                value: emit_mir_expr(low, &emit_ctx)?,
+                pure: crate::ir::mir::optimize::dead_code::is_pure(low),
+            })
+        })
         .collect::<Option<Vec<_>>>()
 }
 

--- a/src/codegen/rust/from_mir.rs
+++ b/src/codegen/rust/from_mir.rs
@@ -764,7 +764,10 @@ fn unresolved_packed_carrier(type_name: &str, ctx: &MirEmitCtx<'_>) -> String {
          `depends [...]`"
     );
     match ctx.codegen {
-        Some(codegen) => super::toplevel::emit_codegen_error_expr(codegen, message),
+        // The program wrote a type name that resolves to nothing here, and
+        // the sentence says how to fix the source — a `Program` refusal,
+        // not a gap in this backend.
+        Some(codegen) => super::toplevel::emit_program_refusal_expr(codegen, message),
         None => message,
     }
 }

--- a/src/codegen/rust/mod.rs
+++ b/src/codegen/rust/mod.rs
@@ -685,14 +685,26 @@ fn emit_mutual_tco_block_routed(
         // takes the whole group with it. Report that name rather than the
         // roster: the roster is what the reporter of #1076 was handed, and
         // it points at every function except the one at fault.
-        let message = group_fns
+        let diagnostic = group_fns
             .iter()
             .filter_map(|fd| toplevel::unresolved_name_reason(fd, scope))
-            .next()
-            .unwrap_or_else(|| format!("MIR walker could not render mutual-TCO block [{names}]"));
+            .next();
+        // Same classification rule as `emit_codegen_error_expr`: an
+        // unresolved name is the program's problem, anything else is this
+        // backend's.
+        let (cause, message) = match diagnostic {
+            Some(message) => (crate::codegen::CompileErrorCause::Program, message),
+            None => (
+                crate::codegen::CompileErrorCause::BackendGap,
+                format!("MIR walker could not render mutual-TCO block [{names}]"),
+            ),
+        };
         ctx.substituted_compile_errors
             .borrow_mut()
-            .push(message.clone());
+            .push(crate::codegen::SubstitutedCompileError {
+                cause,
+                message: message.clone(),
+            });
         let helper = syntax::generated_ident(&format!("mutual_tco_block_{group_id}_render_error"));
         format!(
             "{}fn {}() {{ compile_error!({:?}); }}",
@@ -709,9 +721,14 @@ fn missing_resolved_fn_error(fd: &FnDef, scope: Option<&str>, ctx: &CodegenConte
         "Rust codegen requires resolved HIR for function `{qualified}`; \
          all synthesis and rewriting must finish before CodegenContext is built"
     );
+    // A pipeline invariant this backend depends on and did not get — the
+    // program is not at fault.
     ctx.substituted_compile_errors
         .borrow_mut()
-        .push(message.clone());
+        .push(crate::codegen::SubstitutedCompileError {
+            cause: crate::codegen::CompileErrorCause::BackendGap,
+            message: message.clone(),
+        });
     format!("compile_error!({message:?});")
 }
 
@@ -1524,7 +1541,7 @@ fn helper(n: Int) -> Int
         assert!(
             out.generated_compile_errors()
                 .iter()
-                .any(|error| error.contains("resolved HIR for function `helper`")),
+                .any(|error| error.message.contains("resolved HIR for function `helper`")),
             "{:?}",
             out.generated_compile_errors()
         );

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -8,7 +8,7 @@ use super::representation::{
 };
 use super::types::type_annotation_to_rust_scoped;
 use crate::ast::*;
-use crate::codegen::CodegenContext;
+use crate::codegen::{CodegenContext, CompileErrorCause, SubstitutedCompileError};
 use crate::ir::thin_kind_is_parent_thin_candidate;
 use crate::types::{Type, parse_type_str};
 /// Top-level Aver items → Rust items (structs, enums, functions, tests).
@@ -574,9 +574,8 @@ fn emit_fn_def_with_visibility(
                     "    {}",
                     emit_codegen_error_expr(
                         ctx,
-                        unresolved_name_reason(resolved_fd, scope).unwrap_or_else(|| {
-                            format!("MIR walker could not render guest-entry fn `{}`", fd.name)
-                        }),
+                        unresolved_name_reason(resolved_fd, scope),
+                        || format!("MIR walker could not render guest-entry fn `{}`", fd.name),
                     )
                 )
             });
@@ -693,9 +692,8 @@ fn emit_fn_def_with_visibility(
                     ret_type,
                     emit_codegen_error_expr(
                         ctx,
-                        unresolved_name_reason(resolved_fd, scope).unwrap_or_else(|| {
-                            format!("MIR walker could not render self-TCO fn `{}`", fd.name)
-                        }),
+                        unresolved_name_reason(resolved_fd, scope),
+                        || format!("MIR walker could not render self-TCO fn `{}`", fd.name),
                     )
                 )
             });
@@ -723,9 +721,8 @@ fn emit_fn_def_with_visibility(
                     "    {}",
                     emit_codegen_error_expr(
                         ctx,
-                        unresolved_name_reason(resolved_fd, scope).unwrap_or_else(|| {
-                            format!("MIR walker could not render fn `{}`", fd.name)
-                        }),
+                        unresolved_name_reason(resolved_fd, scope),
+                        || format!("MIR walker could not render fn `{}`", fd.name),
                     )
                 )
             });
@@ -1307,20 +1304,19 @@ fn emit_main_with_visibility(
             resolved
                 .iter()
                 .map(|value| {
-                    let reason = crate::ir::hir::collect_unresolved_in_value(value)
+                    let diagnostic = crate::ir::hir::collect_unresolved_in_value(value)
                         .first()
                         .map(|first| {
                             first.explain(
                                 "a top-level statement",
                                 &first.at_module(ectx.current_module_scope.as_deref()),
                             )
-                        })
-                        .unwrap_or_else(|| {
-                            "MIR walker could not render a top-level statement".to_string()
                         });
                     // A refusal is never dead: it has to reach the reader.
                     super::from_mir::TopStmtValue {
-                        value: emit_codegen_error_expr(ctx, reason),
+                        value: emit_codegen_error_expr(ctx, diagnostic, || {
+                            "MIR walker could not render a top-level statement".to_string()
+                        }),
                         pure: false,
                     }
                 })
@@ -1376,10 +1372,8 @@ fn emit_main_with_visibility(
                             .and_then(|fn_id| ctx.resolved_program.fn_by_id(fn_id))
                             .and_then(|fd| {
                                 unresolved_name_reason(fd, ectx.current_module_scope.as_deref())
-                            })
-                            .unwrap_or_else(|| {
-                                "MIR walker could not render the `main` fn body".to_string()
                             }),
+                        || "MIR walker could not render the `main` fn body".to_string(),
                     )
                 )
             });
@@ -1472,13 +1466,41 @@ pub(super) fn unresolved_name_reason(
     ))
 }
 
-pub(super) fn emit_codegen_error_expr(ctx: &CodegenContext, message: String) -> String {
+/// Write a `compile_error!` in place of a construct, and record on the
+/// context that the emitter refused — with whose problem it is.
+///
+/// `diagnostic` is the user-facing sentence when the PROGRAM is at fault
+/// (an unresolved name, from `unresolved_name_reason`); `gap` names the
+/// construct when it is not, i.e. when this backend simply has no
+/// rendering for it. Which of the two produced the message IS the
+/// classification, so it is taken here rather than passed separately and
+/// kept in sync by hand — and never re-derived from the wording, which is
+/// the recovery [`crate::codegen::CodegenContext::substituted_compile_errors`]
+/// exists to avoid.
+pub(super) fn emit_codegen_error_expr(
+    ctx: &CodegenContext,
+    diagnostic: Option<String>,
+    gap: impl FnOnce() -> String,
+) -> String {
+    let (cause, message) = match diagnostic {
+        Some(message) => (CompileErrorCause::Program, message),
+        None => (CompileErrorCause::BackendGap, gap()),
+    };
     let message_lit = format!("{:?}", message);
-    ctx.substituted_compile_errors.borrow_mut().push(message);
+    ctx.substituted_compile_errors
+        .borrow_mut()
+        .push(SubstitutedCompileError { cause, message });
     format!(
         "{{ compile_error!({}); unreachable!(\"unreachable after compile_error\") }}",
         message_lit
     )
+}
+
+/// [`emit_codegen_error_expr`] where the refusal is always the program's:
+/// the caller already holds the diagnostic and there is no gap branch to
+/// fall back to.
+pub(super) fn emit_program_refusal_expr(ctx: &CodegenContext, diagnostic: String) -> String {
+    emit_codegen_error_expr(ctx, Some(diagnostic), String::new)
 }
 
 /// True when a verify case is a verify-only Oracle/trace shape that the
@@ -1711,12 +1733,28 @@ mod tests {
         // --target rust` reads THIS, not the files it just wrote: a program
         // is free to carry the text `compile_error!` in a string, and a scan
         // of the output cannot tell that apart from a refusal.
+        // The cause is recorded the same way and for the same reason:
+        // which branch produced the sentence is not recoverable from the
+        // sentence.
         let ctx = empty_ctx();
-        let emitted = emit_codegen_error_expr(&ctx, "could not render fn `f`".to_string());
+        let emitted = emit_codegen_error_expr(&ctx, None, || "could not render fn `f`".to_string());
         assert!(emitted.contains("compile_error!"));
         assert_eq!(
             *ctx.substituted_compile_errors.borrow(),
-            vec!["could not render fn `f`".to_string()]
+            vec![SubstitutedCompileError {
+                cause: CompileErrorCause::BackendGap,
+                message: "could not render fn `f`".to_string(),
+            }]
+        );
+
+        let ctx = empty_ctx();
+        emit_program_refusal_expr(&ctx, "fn `f` calls `Nope.thing`".to_string());
+        assert_eq!(
+            *ctx.substituted_compile_errors.borrow(),
+            vec![SubstitutedCompileError {
+                cause: CompileErrorCause::Program,
+                message: "fn `f` calls `Nope.thing`".to_string(),
+            }]
         );
     }
 

--- a/src/codegen/rust/toplevel.rs
+++ b/src/codegen/rust/toplevel.rs
@@ -1318,20 +1318,41 @@ fn emit_main_with_visibility(
                         .unwrap_or_else(|| {
                             "MIR walker could not render a top-level statement".to_string()
                         });
-                    emit_codegen_error_expr(ctx, reason)
+                    // A refusal is never dead: it has to reach the reader.
+                    super::from_mir::TopStmtValue {
+                        value: emit_codegen_error_expr(ctx, reason),
+                        pure: false,
+                    }
                 })
                 .collect()
         });
-        for (stmt, value) in top_stmts.iter().zip(values.iter()) {
+        for (stmt, rendered) in top_stmts.iter().zip(values.iter()) {
             // Same templating as the MIR fn-body let-chain: `Binding` → a
             // named `let`, `Expr` → a discarded statement.
-            let rendered = match stmt {
+            let line = match stmt {
                 Stmt::Binding(name, _, _) => {
-                    format!("let {} = {};", explicit_binding_pattern(name), value)
+                    format!(
+                        "let {} = {};",
+                        explicit_binding_pattern(name),
+                        rendered.value
+                    )
                 }
-                Stmt::Expr(_) => format!("{};", value),
+                // A bare expression statement binds nothing, so a value with
+                // no observable effect is DEAD — and dropping it is what the
+                // same statement inside a fn body already gets: the body
+                // lowers to a `Let` chain and MIR's DCE elides
+                // `let <unread> = <pure>; body`. Module-level statements are
+                // lowered one value at a time, outside `MirProgram.fns`, so
+                // that pass never sees them. Emitting them anyway is not a
+                // harmless difference: `Result.Err` alone under a `module M`
+                // is a `Project` over a `FnValue`, which renders as the Rust
+                // field access `Result.Err;` — E0423, a namespace is not a
+                // value — while the identical statement in a fn body was
+                // dropped before any emitter saw it.
+                Stmt::Expr(_) if rendered.pure => continue,
+                Stmt::Expr(_) => format!("{};", rendered.value),
             };
-            writeln!(out, "{}{}", indent, rendered).unwrap();
+            writeln!(out, "{}{}", indent, line).unwrap();
         }
     }
 

--- a/src/ir/mir/optimize/dead_code.rs
+++ b/src/ir/mir/optimize/dead_code.rs
@@ -95,10 +95,12 @@ fn divisor_proven_nonzero(rhs: &Spanned<MirExpr>) -> bool {
 
 /// Conservative purity classification — `true` means the
 /// expression has no observable side effect AND cannot diverge
-/// or raise. Exported `pub(super)` so the algebraic pass can
-/// reuse it for `x * 0` (only collapse when the surviving
-/// operand is pure).
-pub(super) fn is_pure(expr: &Spanned<MirExpr>) -> bool {
+/// or raise. Public so the algebraic pass can reuse it for
+/// `x * 0` (only collapse when the surviving operand is pure),
+/// and so the Rust emitter can apply the SAME rule to the
+/// module-level statement chain, which is lowered value-by-value
+/// outside `MirProgram.fns` and so never reaches [`dead_code`].
+pub fn is_pure(expr: &Spanned<MirExpr>) -> bool {
     match &expr.node {
         MirExpr::Literal(_) | MirExpr::Local(_) | MirExpr::FnValue(_) => true,
         MirExpr::Neg(inner) => is_pure(inner),

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4150,8 +4150,8 @@ fn prepare_codegen_output(
             )
             .red()
         );
-        for message in unrenderable {
-            eprintln!("  {}", message.dimmed());
+        for error in unrenderable {
+            eprintln!("  {}", error.message.dimmed());
         }
         eprintln!(
             "{}",

--- a/src/types/checker/modules.rs
+++ b/src/types/checker/modules.rs
@@ -304,6 +304,48 @@ impl TypeChecker {
         }
     }
 
+    /// Resolve the type annotation a DECLARED FIELD carries — a sum-type
+    /// variant field or a record field — and report the annotation itself
+    /// when the language has no such spelling.
+    ///
+    /// `parse_type_str_strict` refuses what a user may not write: a
+    /// lowercase `tree`, an unclosed `Result<`, the compiler-internal
+    /// `__Buffer`. Both `TypeDef` arms used to swallow that refusal with
+    /// `.unwrap_or(Type::Invalid)` — but `Type::Invalid` is the checker's
+    /// INTERNAL post-error recovery value, and reaching it without an
+    /// error means nothing downstream knows the program was rejected.
+    /// `type Tree / Leaf / Node(tree, Int)` therefore typechecked ✓, ran
+    /// on the VM, and only died in Rust codegen, where `type_to_rust`
+    /// panics on `Type::Invalid` by design ("unresolved typing leaked
+    /// into codegen") — 45 of the 121 `fuzz_codegen_rust` crashes.
+    ///
+    /// A fn parameter or return type spelled the same way has always been
+    /// a check-time error (`Function 'f': unknown type 'tree' for
+    /// parameter 'x'`); a declared field now says the same thing, in the
+    /// wording [`Self::report_ambiguous_named`] uses for the neighbouring
+    /// "this name resolves to nothing" case.
+    fn declared_field_type(&mut self, annotation: &str, line: usize, source_ctx: &str) -> Type {
+        match parse_type_str_strict(annotation) {
+            Ok(ty) => self.canonicalize_named(ty),
+            Err(unknown) => {
+                // The overwhelming shape here is a lowercase name — Aver
+                // has no type variables in a declaration, so `tree` reads
+                // as a forgotten capital. Say so only when it IS one; a
+                // malformed `Result<` gets the bare sentence.
+                let hint = if unknown.chars().next().is_some_and(char::is_lowercase) {
+                    " — type names are capitalized"
+                } else {
+                    ""
+                };
+                self.error_at_line(
+                    line,
+                    format!("{source_ctx}: Unknown type '{unknown}'{hint}"),
+                );
+                Type::Invalid
+            }
+        }
+    }
+
     /// Resolve a single type name in `owner_module`'s context. See
     /// `canonicalize_named_in_module` for the three-case ordering.
     fn resolve_in_owner_context(&self, name: &str, owner_module: &str) -> Option<TypeId> {
@@ -449,10 +491,8 @@ impl TypeChecker {
                         .fields
                         .iter()
                         .map(|f| {
-                            let canon = self.canonicalize_named(
-                                parse_type_str_strict(f).unwrap_or(Type::Invalid),
-                            );
                             let ctx = format!("Type '{}', variant '{}'", type_name, variant.name);
+                            let canon = self.declared_field_type(f, *line, &ctx);
                             self.report_ambiguous_named(&canon, *line, &ctx);
                             self.reject_fn_in_type(&canon, false, *line, &ctx);
                             canon
@@ -536,9 +576,8 @@ impl TypeChecker {
                 // `canonical_type_name` resolving through the symbol
                 // table on lookup.
                 for (field_name, ty_str) in fields {
-                    let field_ty = self
-                        .canonicalize_named(parse_type_str_strict(ty_str).unwrap_or(Type::Invalid));
                     let ctx = format!("Type '{}', field '{}'", type_name, field_name);
+                    let field_ty = self.declared_field_type(ty_str, *line, &ctx);
                     self.report_ambiguous_named(&field_ty, *line, &ctx);
                     self.reject_fn_in_type(&field_ty, false, *line, &ctx);
                     let canonical_type = if module_name != type_name {

--- a/tests/provider_spec.rs
+++ b/tests/provider_spec.rs
@@ -429,6 +429,86 @@ fn main() -> Int
     );
 }
 
+/// The 58-byte `fuzz_replay_roundtrip` repro, verbatim. `Console.warn`
+/// is `replay = reissued`, so it names a LIVE capability during replay
+/// and the operation is reachable from the compiled program whether or
+/// not the run reaches it.
+const CONSOLE_REISSUED: &str = "\
+module M
+
+fn f()->Unit
+ ![Console.warn]
+ Console.warn(\"\")
+";
+
+/// Record and replay a Console program through exactly the two calls
+/// production makes, so an embedder — the `fuzz_replay_roundtrip`
+/// harness above all — cannot drift from the CLI without this failing.
+///
+/// `aver run --record` writes `machine.provider_registry().provenance()`
+/// into the recording (`main/commands.rs`); `aver replay` hands that
+/// table back through `start_replay_with_provenance`
+/// (`main/replay_cmd/backends.rs`). `Console.print/error/warn` became
+/// `replay = reissued` in d05c0581, which means a replay executes a live
+/// Console provider, which in turn means
+/// `validate_replay_provenance_for_operations` demands the recording pin
+/// that provider's identity. The provenance-less `start_replay` is
+/// therefore NOT a shorter spelling of the same replay: it refuses every
+/// program that so much as names Console, at preflight, before a single
+/// effect is consumed. The fuzz harness called it and reported 47 of 47
+/// "crashes" that were all this refusal — including on its own committed
+/// `corpus/parser/{hello,effects}.av` seeds. Both halves are pinned here.
+#[test]
+fn console_reissued_replay_needs_the_recording_provenance() {
+    let root = temp_root("console-reissued-replay");
+    fs::write(root.join("main.av"), CONSOLE_REISSUED).expect("write entry");
+
+    // Record. No `set_provider_registry`: the VM's own standard registry
+    // is what an embedder gets, and it is the registry whose provenance
+    // the recording carries.
+    let (mut recording_vm, _) = compile_vm(&root, "main.av");
+    recording_vm.start_recording();
+    recording_vm.run().expect("record top level");
+    let (recorded, record_stdout, _) =
+        aver::services::console::capture_output(|| recording_vm.run_named_function("f", &[]));
+    recorded.expect("record Console.warn");
+    let effects = recording_vm.recorded_effects().to_vec();
+    let provenance = recording_vm.provider_registry().provenance();
+    assert_eq!(effects.len(), 1, "one reissued Console.warn event");
+    assert!(
+        provenance.iter().any(|entry| entry.capability == "Console"),
+        "the recording pins the live Console provider: {provenance:?}"
+    );
+
+    // Replay through the recording's provenance — the `aver replay` call.
+    let (mut replay_vm, _) = compile_vm(&root, "main.av");
+    replay_vm
+        .start_replay_with_provenance(effects.clone(), &provenance, true)
+        .expect("recorded provenance admits the reissued Console replay");
+    replay_vm.run().expect("replay top level");
+    let (replayed, replay_stdout, _) =
+        aver::services::console::capture_output(|| replay_vm.run_named_function("f", &[]));
+    replayed.expect("replay Console.warn");
+    replay_vm
+        .ensure_replay_consumed()
+        .expect("transcript consumed");
+    assert_eq!(record_stdout, replay_stdout, "replay reproduces the run");
+
+    // The provenance-less API refuses the same trace — the drift the
+    // harness had, stated as a fact instead of a comment.
+    let (mut empty_provenance_vm, _) = compile_vm(&root, "main.av");
+    empty_provenance_vm.start_replay(effects, true);
+    let error = empty_provenance_vm
+        .run()
+        .expect_err("empty provenance must not admit a reissued capability");
+    assert!(
+        error
+            .to_string()
+            .contains("live replay capability 'Console' has no provider provenance in the replay"),
+        "unexpected refusal: {error}"
+    );
+}
+
 #[test]
 fn removing_standard_time_binding_proves_there_is_no_legacy_vm_bypass() {
     let root = temp_root("time-fault-injection");

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -6120,6 +6120,72 @@ fn value() -> Int
     result.unwrap_or_else(|error| panic!("{error}"));
 }
 
+/// A lowercase name in a sum-type variant field is refused with a
+/// diagnostic, not an emitter panic.
+///
+/// `type Tree / Leaf / Node(tree, Int)` used to pass `aver check` ✓ — the
+/// strict annotation parser refused `tree`, and both `TypeDef` arms
+/// swallowed the refusal into the checker's internal `Type::Invalid`
+/// recovery value without reporting it. Codegen then hit
+/// `type_to_rust`'s deliberate panic on `Type::Invalid` ("unresolved
+/// typing leaked into codegen"), which is the right assertion in the
+/// wrong place: 45 of the 121 `fuzz_codegen_rust` crashes on the
+/// 2026-08-31 nightly were this one shape. The compiler must refuse the
+/// program where the annotation is, and must not abort.
+#[test]
+fn a_lowercase_variant_field_type_is_a_diagnostic_not_a_codegen_panic() {
+    let ws = temp_dir("lowercase_variant_field");
+    let entry = ws.join("main.av");
+    fs::write(
+        &entry,
+        r#"module M
+    intent = "A variant field annotated with a name that is not a type."
+    effects []
+
+type Tree
+    Leaf
+    Node(tree, Int)
+
+fn size(t: Tree) -> Int
+    ? "Never reached — the declaration above does not typecheck."
+    1
+"#,
+    )
+    .expect("write lowercase-variant entry");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+
+    let out = Command::new(aver_bin())
+        .current_dir(repo_root())
+        .arg("compile")
+        .arg(&entry)
+        .arg("--target")
+        .arg("rust")
+        .arg("--module-root")
+        .arg(&ws)
+        .arg("-o")
+        .arg(&project)
+        .output()
+        .expect("expected `aver compile --target rust` to spawn");
+    let rendered = format_output(&out);
+    let _ = fs::remove_dir_all(&ws);
+
+    assert!(
+        !out.status.success(),
+        "compile must refuse the program:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("Type 'Tree', variant 'Node'")
+            && rendered.contains("Unknown type 'tree'"),
+        "expected the annotation to be named:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("panicked"),
+        "the emitter must not abort:\n{rendered}"
+    );
+}
+
 // ─── Mode (h): Int.fromString / Float.fromString Err-message bytes ────────
 //
 // `Int.fromString` / `Float.fromString` return a `Result<_, String>`.

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -6048,6 +6048,78 @@ fn main() -> Int
     result.unwrap_or_else(|error| panic!("{error}"));
 }
 
+/// A bare namespace reference written as a MODULE-LEVEL statement is dead
+/// code, exactly as it is inside a fn body.
+///
+/// `Vector.set` alone on a line is legal Aver — see
+/// `tests/regressions/parser/bare_namespace_method_ref.av`, where it sits
+/// in a fn body and the program runs. In a body the statement chain lowers
+/// to a MIR `Let` chain and the DCE pass elides `let <unread> = <pure>;`
+/// before any emitter sees it. Module-level statements are lowered one
+/// value at a time, outside `MirProgram.fns`, so DCE never ran on them and
+/// the Rust emitter rendered the `Project` over a `FnValue` verbatim:
+/// `Result.Err;`, a field access on a namespace, E0423. `aver check` said
+/// ✓ and the failure surfaced only at `cargo build` of the emitted crate.
+/// `fuzz_codegen_rust` found the 20-byte `module M\n\nResult.Err`.
+#[test]
+fn a_module_level_bare_namespace_reference_is_dead_code_not_a_field_access() {
+    let ws = temp_dir("module_level_bare_namespace");
+    let entry = ws.join("main.av");
+    fs::write(
+        &entry,
+        r#"module M
+    intent = "Bare namespace references at module level are no-ops."
+    effects []
+
+Result.Err
+String.len
+Option.None
+
+fn value() -> Int
+    ? "Give the crate something to emit besides the dead statements."
+    7
+"#,
+    )
+    .expect("write bare-namespace entry");
+
+    let project = ws.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    let shared_target = shared_target_dir();
+    let shared_target = shared_target
+        .to_str()
+        .expect("shared Cargo target path should be UTF-8");
+
+    let result = (|| -> Result<(), String> {
+        // The VM already treats the three statements as no-ops; Rust must
+        // agree, and `--check` is rustc's own verdict on the emitted crate.
+        run_vm(&entry, Some(&ws))?;
+        compile_rust_env(
+            &entry,
+            &project,
+            "module_level_bare_namespace",
+            Some(&ws),
+            &["--check"],
+            &[
+                ("CARGO_TARGET_DIR", shared_target),
+                ("CARGO_NET_OFFLINE", "true"),
+            ],
+        )?;
+        let entry_rs = fs::read_to_string(project.join("src/aver_generated/entry/mod.rs"))
+            .map_err(|e| format!("read generated entry module: {e}"))?;
+        for namespace in ["Result.Err", "String.len", "Option.None"] {
+            if entry_rs.contains(namespace) {
+                return Err(format!(
+                    "emitted `{namespace}` as a Rust field access on a namespace:\n{entry_rs}"
+                ));
+            }
+        }
+        Ok(())
+    })();
+
+    let _ = fs::remove_dir_all(&ws);
+    result.unwrap_or_else(|error| panic!("{error}"));
+}
+
 // ─── Mode (h): Int.fromString / Float.fromString Err-message bytes ────────
 //
 // `Int.fromString` / `Float.fromString` return a `Result<_, String>`.

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -4952,6 +4952,39 @@ fn undeclared_type_name_is_reported_in_every_annotation_position() {
     }
 }
 
+/// A LOWERCASE name in a declared field is the same phantom, one step
+/// earlier: the strict annotation parser refuses it outright, so it never
+/// even becomes a `Type::Named` for the undeclared-name rule above to catch.
+/// Both `TypeDef` arms used to swallow that refusal into the checker's
+/// internal `Type::Invalid` recovery value without reporting anything, so
+/// `type Tree / Leaf / Node(tree, Int)` passed `aver check`, ran on the VM,
+/// and reached the Rust emitter, where `type_to_rust` panics on
+/// `Type::Invalid` by design — 45 of the 121 `fuzz_codegen_rust` crashes on
+/// the 2026-08-31 nightly. The same annotation on a fn parameter has always
+/// been an error.
+#[test]
+fn a_lowercase_type_name_in_a_declared_field_is_reported() {
+    let errs = errors(
+        "type Tree\n\
+         \x20   Leaf\n\
+         \x20   Node(tree, Int)\n\
+         \n\
+         record Holder\n\
+         \x20   slot: ghost\n",
+    );
+    for (position, name) in [
+        ("Type 'Tree', variant 'Node'", "tree"),
+        ("Type 'Holder', field 'slot'", "ghost"),
+    ] {
+        assert!(
+            errs.iter().any(|e| e.contains(position)
+                && e.contains(&format!("Unknown type '{name}'"))
+                && e.contains("type names are capitalized")),
+            "expected {position} to report Unknown type '{name}', got: {errs:?}"
+        );
+    }
+}
+
 /// The names the compiler itself declares have no `type` declaration to
 /// resolve against, yet a user may legitimately write every one of them in an
 /// annotation: the host records effect signatures hand back, the opaque `Tcp`


### PR DESCRIPTION
## Summary

The Fuzz nightly has been red since 2026-08-28 in two of its nine targets. Triage of the saved crashes found one harness defect and two compiler defects; all are fixed here, and the workflow now reports both of its signals on every run.

## `fuzz_replay_roundtrip` (47 crashes, one class)

Since `Console.print/error/warn` became `replay = reissued` (d05c0581), replaying a recording requires the recording's provider provenance; the harness replayed with none, so every program that so much as names `Console` was refused at preflight — including two of the committed seeds. The harness now replays the way `aver replay` does, with the provenance carried off the recording machine. A regression test records and replays the 58-byte reproducer through both APIs and pins that the provenance-less path still refuses it.

## `fuzz_codegen_rust`

- **Module-level bare namespace reference emitted as a Rust field access** (`Result.Err` at module level became `Result.Err;` → E0423; `check` was green). Module-level statements were lowered outside the dead-code pass that already drops the same statement inside a function body; a pure, unread module-level statement is now dropped before emission. Covered in the rustc-backed differential suite for `Result.Err`, `String.len` and `Option.None`.
- **Compiler ICE on a typo in a declared field type** (`Node(tree, Int)` passed `check` and panicked the Rust backend on `Type::Invalid`). Variant and record field annotations were resolved with `unwrap_or(Type::Invalid)`, the checker's own post-error recovery value, so nothing ever reported the error. Both now report `Type 'Tree', variant 'Node': Unknown type 'tree' — type names are capitalized` (the capitalization hint only when the name is lowercase); `check`, `run` and every `compile` target refuse. The remaining `Type::Invalid`/`Type::Var` panics in the Rust and Lean type printers are noted in the code for the day another path admits an unresolved annotation.
- **Workflow and harness gating.** The rustc oracle step ran before the crash summary and short-circuited it, so 121 saved crashes were never gated; both steps now run with `if: always()`. The emitter records *why* it substituted a `compile_error!` (`Program` diagnostic vs `BackendGap`), and the harness aborts only on backend gaps — a proper diagnostic for a mutated type name is the right answer, not a crash. Over the 121 saved inputs: 45 now fail typecheck, 45 are program diagnostics, and 31 are real backend gaps (`MIR walker could not render fn 'abs'` and friends) that now reach the nightly gate instead of being buried; they are not fixed here.

## Verification

Reproducers before/after (E0423 crate now `pub fn main() {}` and `cargo check` clean; the ICE program exits 1 with the diagnostic on `check`, `run`, `compile`; the replay reproducer round-trips), 40/40 saved replay inputs round-trip, the seed corpus round-trips, `cargo check` of the fuzz crate, typechecker/eval/parser/provider specs (585), Rust codegen differential + regression (73), lib (1586), self-host freshness, fmt, all three CI clippy lines.

Not addressed, noted for a separate change: `Tyac.Node(...)` in a match pattern passes `check` but leaves an unresolved constructor that `compile` (correctly) refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
