### PR TITLE
test(cert): update the main-only lane expectations after the compute-face fold

### DIFF
--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -1709,9 +1709,19 @@ fn cert_hostile_model_baseline_is_preflight_clean_and_lake_builds() {
     assert_certificate_target_builds(&build_green.join("cert"), "mutual hostile-model baseline");
 }
 
-/// Hostile model: the generated expression-fragment leaf definition `addTwo`
-/// in `cert/CertGoals.lean` computes `x + 3` instead of `x + 2`, with the wasm
-/// bytes and the manifest's model reference left untouched.
+/// Hostile model: the generated expression-fragment leaf definition
+/// `inAsciiDigit` in `cert/CertGoals.lean` accepts one code point too many
+/// (`c <= 58` instead of `c <= 57`), with the wasm bytes and the manifest's
+/// model reference left untouched.
+///
+/// The vector used to target `addTwo`. Folding the straight-line integer face
+/// into the declared compute face moved that obligation's model off the leaf
+/// definition and onto the emitted plan
+/// (`AverCert.StandardFace.recordComputeModel Plans.addTwoPlan.body`), so
+/// `CertGoals.addTwo` is no longer cited by anything in the package and
+/// rewriting it proves nothing. `inAsciiDigit` is the closest remaining
+/// export: same `expr-fragment-v1` class, and its obligation still names the
+/// generated leaf (`model := CertGoals.inAsciiDigit`).
 #[test]
 fn cert_hostile_model_expr_fragment_leaf_definition_is_declined() {
     let Some(out_dir) = hostile_models_baseline("certify-hostile-expr-fragment-baseline") else {
@@ -1723,8 +1733,8 @@ fn cert_hostile_model_expr_fragment_leaf_definition_is_declined() {
     copy_dir_all(&out_dir, &tampered);
     let model = tampered.join("cert/CertGoals.lean");
     let source = std::fs::read_to_string(&model).unwrap();
-    let honest = "def addTwo (x : Int) : Int :=\n  (x + 2)";
-    let hostile = "def addTwo (x : Int) : Int :=\n  (x + 3)";
+    let honest = "def inAsciiDigit (c : Int) : Bool :=\n  (if (c >= 48) then (c <= 57)";
+    let hostile = "def inAsciiDigit (c : Int) : Bool :=\n  (if (c >= 48) then (c <= 58)";
     let edited = source.replacen(honest, hostile, 1);
     assert_ne!(
         source, edited,
@@ -1738,7 +1748,7 @@ fn cert_hostile_model_expr_fragment_leaf_definition_is_declined() {
     );
     let manifest = std::fs::read_to_string(tampered.join("cert/Manifest.lean")).unwrap();
     assert!(
-        manifest.contains("model := fun ns => CertGoals.addTwo (ns.headD 0)"),
+        manifest.contains("model := CertGoals.inAsciiDigit"),
         "expr-fragment hostile regression must leave the manifest model reference untouched"
     );
 

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -1949,9 +1949,12 @@ fn certify_straight_line_fixture_lake_builds_kernel_clean() {
     let combined = lake_build_package(&cert_dir, "emitted cert");
     // Kernel-clean: the certificate theorem's `#print axioms` must show the
     // core whitelist and never `sorryAx`.
+    // `addTwo` certifies through the declared compute face since the
+    // straight-line integer face was folded into it; the package root is the
+    // theorem whose axiom closure matters.
     assert!(
         combined.contains(
-            "addTwo_exprFragmentSemanticBridge' depends on axioms: [propext, Classical.choice, Quot.sound]"
+            "'AverCert.Final.cert' depends on axioms: [propext, Classical.choice, Quot.sound]"
         ),
         "certificate theorem not kernel-clean:\n{combined}"
     );

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -3727,12 +3727,13 @@ fn certify_then_verify_carrierless_module_acceptance_pin_closes() {
 /// to live in this file. `empty_cert_is_admission_only_and_exits_nonzero`
 /// (`tests/cert_verify_spec.rs`) runs the same `compile --certify` then
 /// `cert verify` pipeline on `tools/certkit/fixtures/certempty.av`, whose only
-/// export is a two-argument `Int` add that no certified template admits, and
-/// pins the same banner, the same nonzero exit and the absence of the green
-/// path. Restating it here would duplicate a full Lean verification in a second
-/// CI lane for no additional guarantee, so this comment stands in for the test:
-/// if that one is ever deleted or repointed at a module that certifies
-/// something, the admission-only verdict loses its only coverage.
+/// export measures a `String` through `String.len` — a parameter shape only the
+/// projection, variant-dispatch and String templates admit, over a body none of
+/// them match — and pins the same banner, the same nonzero exit, and the absence
+/// of the green path. Restating it here would duplicate a full Lean verification
+/// in a second CI lane for no additional guarantee, so this comment stands in
+/// for the test: if that one is ever deleted or repointed at a module that
+/// certifies something, the admission-only verdict loses its only coverage.
 #[cfg(test)]
 const _ADMISSION_ONLY_COVERAGE_NOTE: () = ();
 

--- a/tests/cert_certify_spec.rs
+++ b/tests/cert_certify_spec.rs
@@ -4064,11 +4064,13 @@ fn certify_nested_module_models_close_end_to_end() {
         "nestedmods --certify failed:\n{report}"
     );
     assert!(
-        report.contains("3 certified"),
-        "nestedmods must certify the entry export and both nested-module exports:\n{report}"
+        report.contains("4 certified"),
+        "nestedmods must certify the entry export and all three nested-module exports:\n{report}"
     );
     assert!(
-        report.contains("Nested_Deep_Util_bump") && report.contains("Nested_Deep_Util_tally"),
+        report.contains("Nested_Deep_Util_combine")
+            && report.contains("Nested_Deep_Util_bump")
+            && report.contains("Nested_Deep_Util_tally"),
         "nestedmods must certify the exports whose models live in the nested module:\n{report}"
     );
 
@@ -4093,22 +4095,29 @@ fn certify_nested_module_models_close_end_to_end() {
             "{file} must not emit a path-shaped import line:\n{contents}"
         );
     }
-    // The nested-module export's obligation must cite its model by the
-    // QUALIFIED name the model file declares (inside `namespace
+    // A nested-module export whose obligation names a model LEAF must name it
+    // by the QUALIFIED name the model file declares (inside `namespace
     // Nested.Deep.Util`), never by the flattened wasm export name — the
     // flattened form is not a Lean identifier in the model and fails the
-    // package build.
+    // package build. `tally` is the export that still carries this: `combine`
+    // and `bump` certify through the declared compute face, whose model is the
+    // emitted plan and names no model leaf at all, so their side of the rule is
+    // that the plan is keyed by the flattened name the plan file declares.
     let manifest_lean =
         std::fs::read_to_string(cert_dir.join("Manifest.lean")).expect("Manifest.lean exists");
     assert!(
-        manifest_lean.contains("model := fun ns => Nested.Deep.Util.bump (ns.headD 0)")
-            && manifest_lean.contains("model := fun ns => Nested.Deep.Util.tally (ns.headD 0)"),
-        "each nested export's obligation must cite the qualified model name:\n{manifest_lean}"
+        manifest_lean.contains("model := fun ns => Nested.Deep.Util.tally (ns.headD 0)"),
+        "the nested export that names a model leaf must cite the qualified name:\n{manifest_lean}"
     );
     assert!(
-        !manifest_lean.contains("model := fun ns => Nested_Deep_Util_bump")
-            && !manifest_lean.contains("model := fun ns => Nested_Deep_Util_tally"),
+        !manifest_lean.contains("model := fun ns => Nested_Deep_Util_tally"),
         "the obligation must never cite the flattened export name as the model:\n{manifest_lean}"
+    );
+    assert!(
+        manifest_lean.contains(
+            "model := AverCert.StandardFace.recordComputeModel Plans.Nested_Deep_Util_bumpPlan.body"
+        ),
+        "the nested compute-face export must cite its emitted plan:\n{manifest_lean}"
     );
     // The nested recursion bridge must also cite the model's qualified fuel
     // form (`Nested.Deep.Util.tally__fuel`), never a flattened one.

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -622,11 +622,13 @@ fn cert_verify_accepts_nested_module_certificate() {
     );
     assert!(report.contains("CERTIFIED"), "missing CERTIFIED:\n{report}");
     assert!(
-        report.contains("3 certified exports"),
-        "expected the entry export and both nested-module exports:\n{report}"
+        report.contains("4 certified exports"),
+        "expected the entry export and all three nested-module exports:\n{report}"
     );
     assert!(
-        report.contains("Nested_Deep_Util_bump") && report.contains("Nested_Deep_Util_tally"),
+        report.contains("Nested_Deep_Util_combine")
+            && report.contains("Nested_Deep_Util_bump")
+            && report.contains("Nested_Deep_Util_tally"),
         "the exports whose models live in the nested module must certify:\n{report}"
     );
 }

--- a/tests/cert_verify_spec.rs
+++ b/tests/cert_verify_spec.rs
@@ -2327,7 +2327,7 @@ fn cert_verify_declines_tampered_array_new_data_operands() {
     let (ok, report) = aver_check(&wasm, &cert);
     assert!(ok, "expected clean json certificate to verify:\n{report}");
     assert!(
-        report.contains("12 checked exports"),
+        report.contains("13 checked exports"),
         "json should certify the widened data-segment functions:\n{report}"
     );
     assert!(

--- a/tools/certkit/fixtures/certempty.av
+++ b/tools/certkit/fixtures/certempty.av
@@ -1,12 +1,14 @@
 module CertEmpty
     intent =
-        "Probe with no certifiable exports: the only function is outside the"
-        "single-argument certified fragment, so nothing is certified."
-    exposes [addPair]
+        "Probe with no certifiable exports: the only function takes a String"
+        "and measures it, and a String parameter is admitted only by the"
+        "projection, variant-dispatch and String templates — none of which"
+        "match a String.len body, so nothing is certified."
+    exposes [nameLen]
 
-fn addPair(a: Int, b: Int) -> Int
-    ? "Two-argument add; declined by the Stage-B single-argument templates."
-    a + b
+fn nameLen(s: String) -> Int
+    ? "String length; declined because no certified face covers String.len."
+    String.len(s)
 
-verify addPair
-    addPair(1, 2) => 3
+verify nameLen
+    nameLen("ab") => 2

--- a/tools/certkit/fixtures/nestedmods/nested/deep/util.av
+++ b/tools/certkit/fixtures/nestedmods/nested/deep/util.av
@@ -1,14 +1,16 @@
 module Util
     exposes [combine, bump, tally]
     intent =
-        "Nested dependency for the certificate staging fixture. `combine`"
-        "takes two arguments on purpose: it stays outside the certified"
-        "templates, so the package always carries a declined dependency"
-        "function. `bump` is deliberately CERTIFIABLE (straight-line n + 2):"
-        "its wasm export is the flattened `Nested_Deep_Util_bump`, while its"
-        "Lean model lives inside `namespace Nested.Deep.Util` in the nested"
-        "model file (Nested/Deep/Util.lean) — so the generated certificate"
-        "must cite the model by its qualified name for the package to build."
+        "Nested dependency for the certificate staging fixture. `combine` and"
+        "`bump` are straight-line integer arithmetic, so both certify through"
+        "the declared compute face, whose obligation model is the emitted plan"
+        "keyed by the flattened export name. `tally` is single-argument self"
+        "recursion, so its obligation names a model LEAF: its wasm export is"
+        "the flattened `Nested_Deep_Util_tally`, while its Lean model lives"
+        "inside `namespace Nested.Deep.Util` in the nested model file"
+        "(Nested/Deep/Util.lean) — so the generated certificate must cite that"
+        "model, and its fuel form, by the qualified name for the package to"
+        "build."
     effects []
 
 fn combine(a: Int, b: Int) -> Int


### PR DESCRIPTION
## Summary

Five test expectations in the main-only Certification lanes (`cert_certify_spec rest`, `hostile-models-3/5`, `cert_verify_spec rest-2/8`, `rest-4/8`) broke after #1248 widened the declared compute face to scalar parameters, which certified more exports. Tests and fixtures only; no producer, verifier or wall change.

- nestedmods now certifies four exports: `Nested_Deep_Util_combine` (`a + b + 2`, two scalar parameters) joined; the qualified-model-name pin moves to `tally` and a live pin covers the compute face's plan reference.
- The `certempty` fixture certified `addPair` and no longer exercised the admission-only verdict; its body is now `nameLen(s: String) = String.len(s)`, refused by every face (`parameter 1 is a String …`), so the package is claim-free again.
- json's verifier read-back expects 13 checked exports (the producer-side KPI had already moved in #1248).
- The hostile leaf-definition rewrite is unreachable for `addTwo` (its model is the plan now); the test targets `inAsciiDigit`, whose obligation still cites the model leaf, and the DECLINE assertion is unchanged.

## Verification

The five tests by name (2 + 3 passed, ~15 min of package builds), `cert_decode_spec` (7), fmt, all three CI clippy lines. The full Certification matrix was dispatched on this branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
