### PR TITLE
Fix wasm-gc Env.get canonical Option ABI

### DIFF
--- a/src/codegen/wasm_gc/body.rs
+++ b/src/codegen/wasm_gc/body.rs
@@ -401,13 +401,11 @@ pub(super) struct Wasip2Lowering {
     /// `Some(...)` when `Env.get` is registered.
     pub(super) get_environment_fn_idx: Option<u32>,
     /// `__rt_canonical_env_lookup(retptr, key_ptr, key_len) ->
-    /// String` helper wasm fn idx. Walks the canonical-ABI
+    /// Option<String>` helper wasm fn idx. Walks the canonical-ABI
     /// lowered `list<tuple<string, string>>` at retptr,
     /// linear-searches for an entry whose key matches the
-    /// caller-supplied LM byte range, and materialises the
-    /// matching value as a fresh GC `(array i8)`. Returns an
-    /// empty `(array i8)` when no match — preserves Aver
-    /// `Env.get(name) -> String` semantics (no Option/Result).
+    /// caller-supplied LM byte range, and materialises the canonical
+    /// Option wrapper, preserving missing versus present-empty values.
     pub(super) env_get_lookup_fn_idx: Option<u32>,
     /// Phase 1.4b — `__rt_format_iso8601(secs i64, nanos i32) ->
     /// ref null $string` helper wasm fn idx. Pure-compute helper

--- a/src/codegen/wasm_gc/effects.rs
+++ b/src/codegen/wasm_gc/effects.rs
@@ -75,8 +75,8 @@ pub(super) enum EffectName {
     HttpAddRequestHeader,
     /// `() -> Unit`.
     HttpClearRequestHeaders,
-    /// `(name: String) -> String` — Workers env binding lookup;
-    /// returns empty string when the binding is absent.
+    /// `(name: String) -> Option<String>` — environment lookup;
+    /// preserves absence separately from a present empty string.
     EnvGet,
     /// `(name: String, value: String) -> Result<Unit, String>` — no-op Ok on
     /// Workers (env is read-only); hosted runtimes report write failures.
@@ -709,11 +709,10 @@ impl EffectName {
             | Self::ProviderContractViolation => Ok(vec![]),
             Self::TimeUnixMs => Ok(vec![ValType::I64]),
             Self::ProcessStopRequested => Ok(vec![ValType::I32]),
-            Self::RequestMethod
-            | Self::RequestUrl
-            | Self::RequestQuery
-            | Self::RequestBody
-            | Self::EnvGet => Ok(vec![string_ref_ty(registry)?]),
+            Self::RequestMethod | Self::RequestUrl | Self::RequestQuery | Self::RequestBody => {
+                Ok(vec![string_ref_ty(registry)?])
+            }
+            Self::EnvGet => Ok(vec![option_ref_ty(registry, "Option<String>")?]),
             Self::RequestHeadersLoad => Ok(vec![map_string_list_string_ref_ty(registry)?]),
             Self::ResponseText
             | Self::ResponseSetHeader
@@ -918,6 +917,19 @@ mod certificate_format_tests {
             );
         }
     }
+}
+
+fn option_ref_ty(registry: &TypeRegistry, canonical: &str) -> Result<ValType, WasmGcError> {
+    let idx = registry
+        .option_type_idx(canonical)
+        .ok_or(WasmGcError::Validation(format!(
+            "effect requires `{canonical}` slot but none was registered (available: {:?})",
+            registry.option_order
+        )))?;
+    Ok(ValType::Ref(wasm_encoder::RefType {
+        nullable: true,
+        heap_type: wasm_encoder::HeapType::Concrete(idx),
+    }))
 }
 
 fn result_ref_ty(registry: &TypeRegistry, canonical: &str) -> Result<ValType, WasmGcError> {

--- a/src/codegen/wasm_gc/module.rs
+++ b/src/codegen/wasm_gc/module.rs
@@ -1297,10 +1297,8 @@ pub(super) fn emit_module_with(
     //     `list<tuple<string, string>>` retptr that
     //     `wasi:cli/environment.get-environment` writes to.
     //     Signature: `(retptr i32, key_ptr i32, key_len i32) ->
-    //     ref null $string`. Returns the matching value as a
-    //     fresh GC `(array i8)`, or an empty array when no key
-    //     matches — preserves Aver's `Env.get(name) -> String`
-    //     no-Option semantics.
+    //     ref null $option_string`. Returns the matching value in
+    //     Option.Some, or Option.None when no key matches.
     // Phase 1.4b — `__rt_format_iso8601(secs i64, nanos i32) ->
     // Phase 1.3.4 — `__rt_console_read_line() ->
     // Result<String, String>` body. Caches `wasi:cli/stdin.get-stdin`
@@ -7564,7 +7562,7 @@ fn emit_list_string_cons(registry: &TypeRegistry) -> Result<wasm_encoder::Functi
 #[derive(Default)]
 struct FactoryExports {
     /// `__rt_option_string_some(s)` / `__rt_option_string_none()` —
-    /// emitted when `Terminal.readKey` is registered.
+    /// emitted when `Env.get` or `Terminal.readKey` is registered.
     opt_string_some: Option<FactorySlot>,
     opt_string_none: Option<FactorySlot>,
     /// `Terminal.readKey` host/replay builders for
@@ -7792,20 +7790,25 @@ fn allocate_factory_exports(
         ..FactoryExports::default()
     };
 
-    // Option<String> factories — driven by `Terminal.readKey`.
-    if effect_registry
+    let needs_option_string = effect_registry
         .iter()
-        .any(|e| e == EffectName::TerminalReadKey)
-    {
+        .any(|e| matches!(e, EffectName::EnvGet | EffectName::TerminalReadKey));
+    let needs_result_option_string = effect_registry
+        .iter()
+        .any(|e| e == EffectName::TerminalReadKey);
+
+    // Direct Option<String> factories — both Env.get and Terminal.readKey's
+    // nested result need the host to materialise the canonical guest wrapper.
+    if needs_option_string {
         let opt_idx = registry
             .option_type_idx("Option<String>")
             .ok_or(WasmGcError::Validation(
-                "Terminal.readKey factory requires Option<String> slot".into(),
+                "Option<String>-returning effect requires its registry slot".into(),
             ))?;
         let s_idx = registry
             .string_array_type_idx
             .ok_or(WasmGcError::Validation(
-                "Terminal.readKey factory requires String slot".into(),
+                "Option<String>-returning effect requires the String slot".into(),
             ))?;
         let s_ref = ref_null(s_idx);
         let opt_ref = ref_null(opt_idx);
@@ -7825,20 +7828,28 @@ fn allocate_factory_exports(
         });
         *next_type_idx += 1;
         *next_fn_idx += 1;
+    }
 
+    // Only Terminal.readKey wraps Option<String> in Result<_, String>.
+    if needs_result_option_string {
+        let opt_idx = registry
+            .option_type_idx("Option<String>")
+            .expect("checked while allocating direct Option<String> factories");
+        let s_idx = registry
+            .string_array_type_idx
+            .expect("checked while allocating direct Option<String> factories");
         let result_idx = registry
             .result_type_idx("Result<Option<String>,String>")
             .ok_or(WasmGcError::Validation(
                 "Terminal.readKey factory requires Result<Option<String>,String> slot".into(),
             ))?;
-        let result_ref = ref_null(result_idx);
         allocate_result_pair(
             types,
             next_type_idx,
             next_fn_idx,
-            &[opt_ref],
-            &[s_ref],
-            result_ref,
+            &[ref_null(opt_idx)],
+            &[ref_null(s_idx)],
+            ref_null(result_idx),
             &mut fx.result_option_string_string_ok,
             &mut fx.result_option_string_string_err,
         );

--- a/src/codegen/wasm_gc/wasip2_imports.rs
+++ b/src/codegen/wasm_gc/wasip2_imports.rs
@@ -94,7 +94,7 @@ define_wasip2_import_slots! {
     /// list-returning via retptr (8 bytes: list_ptr + list_len);
     /// each entry is a flattened tuple — 16 bytes packed
     /// `(key_ptr i32, key_len i32, val_ptr i32, val_len i32)`.
-    /// Phase 1.3.3 drives `Env.get(name) -> String` via a
+    /// Phase 1.3.3 drives `Env.get(name) -> Option<String>` via a
     /// linear-search lookup helper.
     CliEnvironmentGetEnvironment,
     /// `wasi:cli/stdin.get-stdin: func() -> input-stream`.

--- a/src/runtime/wasm_gc/imports/env.rs
+++ b/src/runtime/wasm_gc/imports/env.rs
@@ -2,10 +2,15 @@
 //! process environment.
 
 use super::super::RunWasmGcHost;
-use super::super::decode::{decode_result_unit, decode_string};
-use super::factories::{host_result_err_unit_string, host_result_ok_unit};
-use super::lm::{lm_string_from_host, lm_string_to_host};
-use super::replay_glue::{json_err, json_ok, record_effect_if_recording, try_replay};
+use super::super::decode::{decode_option_string, decode_result_unit};
+use super::factories::{
+    host_option_string_none, host_option_string_some, host_result_err_unit_string,
+    host_result_ok_unit,
+};
+use super::lm::lm_string_to_host;
+use super::replay_glue::{
+    json_err, json_none, json_ok, json_some, record_effect_if_recording, try_replay,
+};
 
 pub(super) fn dispatch(
     name: &str,
@@ -20,20 +25,18 @@ pub(super) fn dispatch(
             let name = lm_string_to_host(caller, params.first())?.unwrap_or_default();
             let args = vec![aver::replay::JsonValue::String(name.clone())];
             if let Some(cached) = try_replay(caller, "Env.get", args.clone())? {
-                let r = decode_string(caller, &cached)?;
-                results[0] = Val::AnyRef(r);
+                results[0] = Val::AnyRef(decode_option_string(caller, &cached)?);
                 return Ok(true);
             }
-            let value = aver_rt::env_get(&name).unwrap_or_default();
-            let r = lm_string_from_host(caller, &value)?;
-            results[0] = Val::AnyRef(r);
-            record_effect_if_recording(
-                caller,
-                "Env.get",
-                args,
-                aver::replay::JsonValue::String(value),
-                caller_fn,
-            );
+            let (result, outcome) = match aver_rt::env_get(&name) {
+                Some(value) => (
+                    host_option_string_some(caller, &value)?,
+                    json_some(aver::replay::JsonValue::String(value)),
+                ),
+                None => (host_option_string_none(caller)?, json_none()),
+            };
+            results[0] = Val::AnyRef(result);
+            record_effect_if_recording(caller, "Env.get", args, outcome, caller_fn);
             Ok(true)
         }
         "env_set" => {

--- a/tests/wasm_gc_capture_output.rs
+++ b/tests/wasm_gc_capture_output.rs
@@ -78,6 +78,104 @@ fn wasm_gc_console_print_writes_to_capture_buffer() {
 }
 
 #[test]
+fn wasm_gc_env_get_preserves_option_across_a_named_function() {
+    const SOURCE: &str = r#"module EnvOption
+    intent = "Exercise present and missing environment values through one helper."
+    effects [Console.print, Env.get]
+
+fn stateOf(value: Option<String>) -> String
+    match value
+        Option.Some(_) -> "some"
+        Option.None -> "none"
+
+fn main() -> Unit
+    ! [Console.print, Env.get]
+    present = stateOf(Env.get("PATH"))
+    missing = stateOf(Env.get("AVER_ISSUE_1255_DEFINITELY_MISSING_6C64A1"))
+    Console.print("{present},{missing}")
+"#;
+    let mut lexer = aver::lexer::Lexer::new(SOURCE);
+    let tokens = lexer.tokenize().expect("lex");
+    let mut parser = aver::parser::Parser::new(tokens);
+    let mut items = parser.parse().expect("parse");
+    let result = aver::ir::pipeline::run(
+        &mut items,
+        PipelineConfig {
+            typecheck: Some(TypecheckMode::Full { base_dir: None }),
+            ..Default::default()
+        },
+    );
+
+    let (run_res, stdout, stderr) = aver::services::console::capture_output(|| {
+        aver::runtime::wasm_gc::run_in_process(
+            &items,
+            result.analysis.as_ref(),
+            aver::runtime::wasm_gc::RunConfig {
+                mode: aver::runtime::wasm_gc::EffectMode::Record,
+                ..Default::default()
+            },
+        )
+    });
+
+    let outcome = run_res.expect("Env.get Option<String> must execute without a wasm type trap");
+    assert_eq!(stdout, b"some,none\n");
+    assert!(stderr.is_empty());
+
+    let effects = outcome
+        .recorded_effects
+        .expect("record mode must return the captured effects");
+    let env_outcomes = effects
+        .iter()
+        .filter(|effect| effect.effect_type == "Env.get")
+        .map(|effect| &effect.outcome)
+        .collect::<Vec<_>>();
+    assert_eq!(env_outcomes.len(), 2);
+    match env_outcomes[0] {
+        aver::replay::RecordedOutcome::Value(value) => {
+            assert!(value.get("$some").is_some_and(|inner| inner.is_string()));
+        }
+        other => panic!("present Env.get recorded the wrong outcome: {other:?}"),
+    }
+    match env_outcomes[1] {
+        aver::replay::RecordedOutcome::Value(value) => {
+            assert_eq!(value.get("$none"), Some(&serde_json::Value::Bool(true)));
+        }
+        other => panic!("missing Env.get recorded the wrong outcome: {other:?}"),
+    }
+
+    let recording = aver::replay::SessionRecording {
+        schema_version: 1,
+        request_id: "env-option-test".to_string(),
+        timestamp: String::new(),
+        program_file: String::new(),
+        module_root: String::new(),
+        entry_fn: "main".to_string(),
+        input: aver::replay::JsonValue::Null,
+        capabilities: Vec::new(),
+        effects,
+        output: aver::replay::RecordedOutcome::Value(outcome.output),
+    };
+    let (replay_res, replay_stdout, replay_stderr) =
+        aver::services::console::capture_output(|| {
+            aver::runtime::wasm_gc::run_in_process(
+                &items,
+                result.analysis.as_ref(),
+                aver::runtime::wasm_gc::RunConfig {
+                    mode: aver::runtime::wasm_gc::EffectMode::Replay(Box::new(recording), true),
+                    ..Default::default()
+                },
+            )
+        });
+    let replayed = replay_res.expect("recorded Env.get Options must decode during replay");
+    assert_eq!(replayed.effects_consumed, replayed.effects_total);
+    assert!(
+        replay_stdout.is_empty(),
+        "replay must suppress Console.print"
+    );
+    assert!(replay_stderr.is_empty());
+}
+
+#[test]
 fn wasm_gc_runtime_pipeline_lowers_string_join_builder() {
     const SOURCE: &str = r#"module Builder
     intent =

--- a/tests/wasm_gc_codegen_regression.rs
+++ b/tests/wasm_gc_codegen_regression.rs
@@ -1003,6 +1003,33 @@ fn main()
     );
 }
 
+/// Regression for #1255: the host import for `Env.get` must return the same
+/// canonical `Option<String>` ref that user-function signatures use. Returning
+/// a bare String happened to work only while the value was consumed inline;
+/// crossing this named call boundary exposed the mismatched concrete GC refs.
+#[test]
+fn env_get_option_crosses_a_named_function_boundary() {
+    assert_compiles_and_validates(
+        r#"module Main
+    intent = "Env.get and a helper that takes Option<String>."
+    exposes [main]
+    effects [Console.print, Env.get]
+
+fn nameOf(held: Option<String>) -> String
+    ? "Whatever it held."
+    Option.withDefault(held, "unset")
+
+verify nameOf
+    nameOf(Option.None) => "unset"
+
+fn main() -> Unit
+    ? "One call."
+    ! [Console.print, Env.get]
+    Console.print(nameOf(Env.get("X")))
+"#,
+    );
+}
+
 /// Regression for #1084: flattening rewrites an entry signature from the
 /// dependency-qualified spelling to the linked type name. The wasm function
 /// type and the MIR body must read the same post-link identity.

--- a/tools/website/playground/wasm_host.js
+++ b/tools/website/playground/wasm_host.js
@@ -541,13 +541,30 @@ export class AverBrowserHost {
                     );
                 },
                 env_get: (nameRef, callerIdx) => {
+                    const exports = this.instance.exports;
                     const name = this.averToJs(nameRef);
+                    let outcome = { $none: true };
                     return this.recordOrDispatch(
                         "Env.get",
                         [name],
-                        () => this.jsToAver(this.environment.get(name) ?? ""),
-                        (json) => this.jsToAver(json ?? ""),
-                        () => this.environment.get(name) ?? "",
+                        () => {
+                            const value = this.environment.get(name);
+                            if (value === undefined) {
+                                outcome = { $none: true };
+                                return exports.__rt_option_string_none();
+                            }
+                            outcome = { $some: value };
+                            return exports.__rt_option_string_some(this.jsToAver(value));
+                        },
+                        (json) => {
+                            if (json && typeof json === "object" && "$some" in json) {
+                                return exports.__rt_option_string_some(
+                                    this.jsToAver(json.$some ?? ""),
+                                );
+                            }
+                            return exports.__rt_option_string_none();
+                        },
+                        () => outcome,
                         this.callerFnFromIdx(callerIdx),
                     );
                 },

--- a/tools/website/playground/wasm_host.js
+++ b/tools/website/playground/wasm_host.js
@@ -83,11 +83,9 @@ function decodeKeyCode(code) {
 /// cross via the LM transport (`__rt_string_from_lm` / `_to_lm` —
 /// host writes UTF-8 bytes into linear memory, calls a getter that
 /// materialises the bytes as a wasm-gc `(array i8)` ref, and vice
-/// versa). Structured returns (`Option<String>`, `Result<String,String>`,
-/// `Terminal.Size`) are constructed via wasm-owned factory exports
-/// (`__rt_option_string_some/none`, `__rt_result_string_string_ok/err`,
-/// `__rt_record_terminal_size_make`) — JS can't build wasm-gc structs
-/// directly so the binary exports per-type constructors.
+/// versa). Structured returns (`Option<String>`, `Result<_,String>`,
+/// `Terminal.Size`) are constructed via wasm-owned factory exports — JS can't
+/// build wasm-gc structs directly, so the binary exports per-type constructors.
 export class AverBrowserHost {
     constructor(postMessageFn) {
         this.post = postMessageFn;
@@ -556,14 +554,7 @@ export class AverBrowserHost {
                             outcome = { $some: value };
                             return exports.__rt_option_string_some(this.jsToAver(value));
                         },
-                        (json) => {
-                            if (json && typeof json === "object" && "$some" in json) {
-                                return exports.__rt_option_string_some(
-                                    this.jsToAver(json.$some ?? ""),
-                                );
-                            }
-                            return exports.__rt_option_string_none();
-                        },
+                        (json) => this.decodeOptionStringMarker(json),
                         () => outcome,
                         this.callerFnFromIdx(callerIdx),
                     );
@@ -609,37 +600,31 @@ export class AverBrowserHost {
                 float_atan2: (y, x, _callerIdx) => Math.atan2(y, x),
                 float_pow: (b, e, _callerIdx) => Math.pow(b, e),
                 terminal_enable_raw_mode: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.enableRawMode",
                         [],
+                        callerIdx,
                         () => {
                             this.rawMode = true;
                             this.post({ type: "raw-mode", enabled: true });
                         },
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 terminal_disable_raw_mode: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.disableRawMode",
                         [],
+                        callerIdx,
                         () => {
                             this.rawMode = false;
                             this.post({ type: "raw-mode", enabled: false });
                         },
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 terminal_clear: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.clear",
                         [],
+                        callerIdx,
                         () => this.terminal.clear(),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 terminal_move_to: (xRef, yRef, callerIdx) => {
                     const exports = this.instance.exports;
@@ -657,76 +642,73 @@ export class AverBrowserHost {
                     }
                     const xi = Number(x);
                     const yi = Number(y);
-                    return this.recordOrDispatch(
+                    return this.dispatchResultUnitEffect(
                         "Terminal.moveTo",
                         [xi, yi],
-                        () => {
-                            this.terminal.moveTo(xi, yi);
-                            return exports.__rt_result_unit_string_ok();
-                        },
-                        (json) => this.decodeResultUnitMarker(json),
-                        () => ({ $ok: null }),
-                        this.callerFnFromIdx(callerIdx),
+                        callerIdx,
+                        () => this.terminal.moveTo(xi, yi),
                     );
                 },
                 terminal_print: (sref, callerIdx) => {
                     const text = this.averToJs(sref);
-                    this.recordOrDispatch(
+                    return this.dispatchResultUnitEffect(
                         "Terminal.print",
                         [text],
+                        callerIdx,
                         () => this.terminal.print(text),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     );
                 },
                 terminal_set_color: (sref, callerIdx) => {
                     const color = this.averToJs(sref);
-                    this.recordOrDispatch(
+                    return this.dispatchResultUnitEffect(
                         "Terminal.setColor",
                         [color],
+                        callerIdx,
                         () =>
                             this.terminal.setColor(
                                 COLOR_NAMES.has(color) ? color : "default",
                             ),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     );
                 },
                 terminal_reset_color: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.resetColor",
                         [],
+                        callerIdx,
                         () => this.terminal.resetColor(),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 terminal_read_key: (callerIdx) => {
                     const exports = this.instance.exports;
+                    let outcome = null;
                     return this.recordOrDispatch(
                         "Terminal.readKey",
                         [],
                         () => {
-                            const key = this.dequeueKey();
-                            if (!key) return exports.__rt_option_string_none();
-                            return exports.__rt_option_string_some(this.jsToAver(key));
-                        },
-                        (json) => {
-                            if (json && typeof json === "object" && "$some" in json) {
-                                return exports.__rt_option_string_some(
-                                    this.jsToAver(json.$some ?? ""),
+                            try {
+                                const key = this.dequeueKey();
+                                let option = exports.__rt_option_string_none();
+                                if (key) {
+                                    option = exports.__rt_option_string_some(
+                                        this.jsToAver(key),
+                                    );
+                                }
+                                outcome = {
+                                    $ok: key ? { $some: key } : { $none: true },
+                                };
+                                return exports.__rt_result_option_string_string_ok(
+                                    option,
+                                );
+                            } catch (err) {
+                                const message =
+                                    err instanceof Error ? err.message : String(err);
+                                outcome = { $err: message };
+                                return exports.__rt_result_option_string_string_err(
+                                    this.jsToAver(message),
                                 );
                             }
-                            return exports.__rt_option_string_none();
                         },
-                        (_ref) => {
-                            const head = this.keyQueue[0];
-                            return head
-                                ? { $some: head }
-                                : { $none: true };
-                        },
+                        (json) => this.decodeResultOptionStringMarker(json),
+                        () => outcome,
                         this.callerFnFromIdx(callerIdx),
                     );
                 },
@@ -769,31 +751,25 @@ export class AverBrowserHost {
                     );
                 },
                 terminal_hide_cursor: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.hideCursor",
                         [],
+                        callerIdx,
                         () => this.terminal.hideCursor(),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 terminal_show_cursor: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.showCursor",
                         [],
+                        callerIdx,
                         () => this.terminal.showCursor(),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 terminal_flush: (callerIdx) =>
-                    this.recordOrDispatch(
+                    this.dispatchResultUnitEffect(
                         "Terminal.flush",
                         [],
+                        callerIdx,
                         () => this.postTerminalSnapshot(),
-                        () => undefined,
-                        () => null,
-                        this.callerFnFromIdx(callerIdx),
                     ),
                 // Independent-product structural-scope markers — same
                 // contract the wasm-gc CLI host enforces. Trailing
@@ -831,6 +807,31 @@ export class AverBrowserHost {
         return exports.__rt_result_string_string_ok(this.jsToAver(""));
     }
 
+    dispatchResultUnitEffect(effectType, args, callerIdx, realCall) {
+        const exports = this.instance.exports;
+        let outcome = null;
+        return this.recordOrDispatch(
+            effectType,
+            args,
+            () => {
+                try {
+                    realCall();
+                    outcome = { $ok: null };
+                    return exports.__rt_result_unit_string_ok();
+                } catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    outcome = { $err: message };
+                    return exports.__rt_result_unit_string_err(
+                        this.jsToAver(message),
+                    );
+                }
+            },
+            (json) => this.decodeResultUnitMarker(json),
+            () => outcome,
+            this.callerFnFromIdx(callerIdx),
+        );
+    }
+
     decodeResultUnitMarker(json) {
         const exports = this.instance.exports;
         if (json && typeof json === "object" && "$err" in json) {
@@ -839,6 +840,27 @@ export class AverBrowserHost {
             );
         }
         return exports.__rt_result_unit_string_ok();
+    }
+
+    decodeOptionStringMarker(json) {
+        const exports = this.instance.exports;
+        if (json && typeof json === "object" && "$some" in json) {
+            return exports.__rt_option_string_some(
+                this.jsToAver(json.$some ?? ""),
+            );
+        }
+        return exports.__rt_option_string_none();
+    }
+
+    decodeResultOptionStringMarker(json) {
+        const exports = this.instance.exports;
+        if (json && typeof json === "object" && "$err" in json) {
+            return exports.__rt_result_option_string_string_err(
+                this.jsToAver(json.$err ?? ""),
+            );
+        }
+        const option = this.decodeOptionStringMarker(json?.$ok);
+        return exports.__rt_result_option_string_string_ok(option);
     }
 
     decodeResultIntMarker(json) {


### PR DESCRIPTION
## Summary

- make the wasm-gc `Env.get` import return the canonical `Option<String>` GC ref instead of a bare `String` ref
- emit and use the `Option<String>` factories for `Env.get` in native and browser hosts
- preserve `Some("")` vs `None` and record/replay them as `$some` / `$none`
- add compile, runtime, recording, and replay regressions for the named-function boundary from #1255
- fix the same class of pre-existing browser-host ABI mismatch for `Terminal.readKey` and the nine `Terminal.* -> Result<Unit, String>` operations

## Related ABI audit

I compared standard capability contracts with `EffectName::params/results`, factory allocation, native host codecs, the browser host, and wasip2 lowering.

The native wasm-gc and wasip2 paths had no additional confirmed mismatches. The browser audit found:

- `Terminal.readKey` returned `Option<String>` instead of `Result<Option<String>, String>`
- nine terminal operations returned JS `undefined` instead of `Result<Unit, String>`
- `Terminal.readKey` recorded a flat Option marker and inspected the queue after dequeue, so it could record the next key or `None`

Those browser-host findings are fixed here with canonical wasm-owned result factories and matching record/replay markers.

Fixes #1255

## Validation

- `cargo fmt --check`
- `git diff --check`
- `node --check tools/website/playground/wasm_host.js`
- `cargo test --features wasm,wasip2 --test wasm_gc_codegen_regression --test wasm_gc_capture_output --test wasip2_codegen_regression`
- issue reproducer compiled through the CLI and passed `wasm-tools validate --features all`
- native wasm-gc issue reproducer executed successfully
- Node/V8 browser-host smoke: `Env.get` distinguished present, present-empty, and missing values
- Node/V8 browser-host smoke: every implemented `Terminal` Result wrapper executed through a named function; record/replay consumed all 13 effects and preserved `{"$ok":{"$some":"z"}}` for `Terminal.readKey`
