### PR TITLE
fix(vm): register HttpRequest query field

### DIFF
--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -31,14 +31,15 @@ pub use types::{CallFrame, CodeStore, FnChunk, VmError};
 /// Register compiler-owned host record types in the arena before compilation.
 /// Capability-owned records are compiled from their embedded Aver modules.
 pub fn register_service_types(arena: &mut crate::nan_value::Arena) {
+    let http_request = crate::codegen::builtin_records::find("HttpRequest")
+        .expect("HttpRequest must be declared as a compiler-owned host record");
     arena.register_record_type(
-        "HttpRequest",
-        vec![
-            "method".into(),
-            "path".into(),
-            "body".into(),
-            "headers".into(),
-        ],
+        http_request.aver_name,
+        http_request
+            .fields
+            .iter()
+            .map(|field| field.name.to_string())
+            .collect(),
     );
     arena.register_record_type(
         "Tcp.Connection",

--- a/tests/hir_mir_differential.rs
+++ b/tests/hir_mir_differential.rs
@@ -263,6 +263,19 @@ fn builtin_record_construction_and_projection() {
 }
 
 #[test]
+fn http_request_query_construction_and_projection() {
+    // Keep the VM arena shape for this compiler-owned record aligned with
+    // the typechecker and the other backends. A missing `query` slot used to
+    // let `aver check` pass while MIR compilation rejected the constructor.
+    let src = prog(
+        "fn request() -> HttpRequest\n    \
+         HttpRequest(method = \"GET\", path = \"/search\", query = \"q=aver\", body = \"\", headers = {})\n\n\
+         fn run() -> String\n    request().query\n",
+    );
+    assert_golden("http_request_query", &src, "run", "Str(\"q=aver\")");
+}
+
+#[test]
 fn discard_binding_evaluates_for_effect() {
     // `_ = step(5)?` — the idiomatic "run it, drop the Ok, continue"
     // form. The resolver assigns `_` no slot; the lowerer evaluates the


### PR DESCRIPTION
## Summary

- derive the VM arena layout for HttpRequest from the shared compiler-owned record descriptor
- restore construction and projection of the query field
- add a MIR/VM regression covering the complete request shape

## Problem

The typechecker and backend record descriptor include HttpRequest.query, but the VM arena registered only method, path, body, and headers. This let aver check succeed while MIR compilation failed with: MIR-VM: unknown field query in record HttpRequest.

The mismatch was exposed by the downstream [avgo](https://github.com/konradhalas/avgo) application.

## Validation

- cargo test --test hir_mir_differential http_request_query_construction_and_projection -- --exact
- full hir_mir_differential suite: 17/17 passed
- avgo check: 6/6 modules passed
- avgo verify: 180/180 cases passed