### PR TITLE
feat(proof): prove laws over well-founded Int countdowns by fuel induction; keep such defs out of blind simp sets

### DIFF
--- a/docs/lean.md
+++ b/docs/lean.md
@@ -267,9 +267,12 @@ summary line. Fields of the Lean summary:
   `sorry` never count), at least one theorem is explicitly classed
   universal, and the file has no sorries
 - `universal_laws` — how many law theorems classed universal passed that
-  same per-theorem axiom whitelist. On a file with sorries the axiom
-  audit does not run at all, so this reports `0` — pin it together with
-  `sorries == 0`, not instead of it
+  same per-theorem axiom whitelist. The audit is per theorem, so on a
+  file with sorries it still runs: a sorry-floored theorem's own axiom
+  line carries `sorryAx` and records tier `failed`, while every
+  kernel-clean sibling keeps its `universal` record and counts. Only the
+  file-level `universal` bool keeps the "no sorries" conjunct — pin the
+  count together with `sorries`, not instead of it
 - `bounded_laws` — how many law theorems the emitter classed
   bounded-domain (stated only over the finite sample grid, e.g. guarded
   `when`-law enumerations); these never earn universal credit

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -23,6 +23,7 @@ mod spec;
 mod suffix_roundtrip;
 mod transparent_chain;
 mod triangle_sum;
+mod wf_fuel;
 
 use super::VerifyEmitMode;
 use super::expr::aver_name_to_lean;
@@ -51,7 +52,15 @@ pub(in crate::codegen::lean) use induction::recognize_conditional_comparison_bri
 /// lemmas pool). Also feeds the `omit_domain` statement driver, kept in
 /// lockstep with the emit.
 pub(in crate::codegen::lean) use induction::recognize_conditional_inductive_generic;
+
 pub(in crate::codegen::lean) use induction::recognize_pool_composition_generic;
+/// Fuel induction over a well-founded Int-countdown fn
+/// (`RecursionContract::WellFoundedToNat`): the law's single countdown fn is
+/// unfolded once under a `Nat` fuel bounding the countdown given, with ground
+/// IH instances computed from the fn's own self-calls. A recognized `when`-law
+/// is stated universally (`omit_domain`), so the statement driver keys on the
+/// same recognizer as the emit.
+pub(in crate::codegen::lean) use wf_fuel::recognize_wf_fuel_induction;
 
 /// Validated-wrapper shape (the Theorem-2 wrapper-correctness law: a thin
 /// error-checking wrapper returning `Result.Ok(core(…))` on valid input). Feeds
@@ -222,7 +231,7 @@ pub struct AutoProof {
 /// Look up the strategy `proof_lower::populate_law_theorems` pinned
 /// on `(fn_name, law_name)`. Returns `None` when no contract was
 /// lowered (LawLower disabled or the verify block wasn't a Law).
-fn law_strategy_for(
+pub(super) fn law_strategy_for(
     ctx: &CodegenContext,
     fn_name: &str,
     law_name: &str,
@@ -675,6 +684,9 @@ fn emit_verify_law_forall_auto_proof_inner(
     // path — a figure's algebraic content (e.g. zip-reverse's snoc-distribution)
     // lives as Aver helper laws, not a hardcoded Lean template. Tried last among
     // the conditional arms; the bespoke recognizers above decline into it.
+    // (The generic conditional close declines a law the fuel-induction
+    // strategy below recognizes — see `recognize_conditional_inductive_generic`
+    // — so a `when`-law over a well-founded countdown fn reaches that arm.)
     if law.when.is_some()
         && let Some(proof) =
             induction::emit_conditional_inductive_generic_law(vb, law, ctx, &intro_names)
@@ -1037,6 +1049,22 @@ fn emit_verify_law_forall_auto_proof_inner(
     // names threaded through: the emit embeds the lemma texts, adds
     // the names to the simp sets, and tries a lemma-first fast path
     // before inducting.
+    // Fuel induction over a well-founded Int-countdown fn
+    // (`RecursionContract::WellFoundedToNat`): the accumulator law `f(v, acc)
+    // => concat(reverse(acc), f(v, []))` and the `when m >= 0 ->
+    // bigEndian(reverse(littleEndian(m, [])), 0) => m` round trip. The
+    // countdown fn is unfolded exactly once per fuel step, so the blind
+    // `simp_all [f]` portfolios and `fun_induction f …` rungs of the ladder
+    // below — which heartbeat-abort on the fn's unconditional unfold equation
+    // — are never reached for this class. Placed AFTER every bespoke
+    // recognizer (conditional and unconditional) and BEFORE the generic
+    // structural ladder; declines (fail-closed) for every other shape and for
+    // any law an IR pin hands to a bespoke template further down.
+    if let Some(proof) =
+        wf_fuel::emit_wf_fuel_induction_law(vb, law, ctx, &intro_names, quant_params, theorem_prop)
+    {
+        return Some(proof);
+    }
     let pinned = law_strategy_for(ctx, &vb.fn_name, &law.name);
     let discovered: Vec<String> = match &pinned {
         Some(crate::ir::ProofStrategy::SimpOverLemmas(names)) => names.clone(),
@@ -1855,8 +1883,17 @@ fn emit_verify_law_forall_auto_proof_inner(
             // blind-simp fallback for this case, so a non-closing split
             // degrades to the honest `sorry` floor rather than aborting the
             // build. A non-scanner cone keeps the byte-identical simp floor.
+            // The same hard timeout hits every well-founded Int-countdown fn
+            // (`RecursionContract::WellFoundedToNat`, `termination_by p.toNat`):
+            // its unfold equation is unconditional, so a blind `simp [f]`
+            // rewrites the recursive call forever. Such a cone drops the blind
+            // arm too (the countdown fn is closed by the fuel-induction
+            // strategy when the law has that shape; otherwise the honest
+            // `sorry`), and the countdown fn is never a `fun_induction` target
+            // (see `find_fun_induction_targets`).
             let scope = ctx.active_module_scope();
-            let cone_has_scanner = shared::law_simp_source_names(ctx, vb, law)
+            let cone = shared::law_simp_source_names(ctx, vb, law);
+            let cone_has_scanner = cone
                 .iter()
                 .filter_map(|n| {
                     ctx.fn_def_by_name(n, scope.as_deref())
@@ -1866,7 +1903,9 @@ fn emit_verify_law_forall_auto_proof_inner(
                     crate::codegen::lean::toplevel::fuel::detect_simple_string_pos_skip_literal(fd)
                         .is_some()
                 });
-            let tactic_line = if cone_has_scanner {
+            let wf_countdown = shared::wf_countdown_fn_names(ctx);
+            let cone_has_wf_countdown = cone.iter().any(|n| wf_countdown.contains(n));
+            let tactic_line = if cone_has_scanner || cone_has_wf_countdown {
                 let targets =
                     induction::find_fun_induction_targets(vb, law, ctx, &proof_intro_names);
                 let mut arms: Vec<String> = targets

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -14,7 +14,7 @@ use super::super::expr::aver_name_to_lean;
 use super::super::syntax::lean_ctor_name;
 use super::super::tactic_ir::{InductionArm, Tactic};
 use super::AutoProof;
-use super::shared::law_simp_defs;
+use super::shared::law_simp_defs_blind;
 use crate::ast::{TypeDef, TypeVariant, VerifyBlock, VerifyLaw};
 use crate::codegen::CodegenContext;
 
@@ -917,7 +917,7 @@ fn consumer_law_qualified_scope(
 /// analysis. Soundness rides on the same guard as everything else — if the
 /// referenced law itself only `sorry`s, this law's proof inherits `sorryAx`
 /// and the universal metric reports false.
-fn earlier_law_lemmas(
+pub(super) fn earlier_law_lemmas(
     vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
@@ -1016,6 +1016,16 @@ fn earlier_law_lemmas(
                 .collect();
             !pmentions.is_empty() && pmentions.is_subset(&scope) && scope.contains(&prev_subject)
         });
+        // LOOPING-REWRITE guard: a sibling whose RHS contains an instance of
+        // its own LHS pattern (the accumulator law `f v acc = acc.reverse ++
+        // f v []` — its RHS `f v []` is matched by the LHS `f ?v ?acc`) is a
+        // simp rule that never terminates (Lean's "Possibly looping simp
+        // theorem" warning is the symptom), so it must not join any
+        // `simp_all` pool. Consumers that need such a law cite it as a GROUND
+        // instance instead (see `wf_fuel`).
+        if super::shared::law_is_looping_rewrite(prev_law, ctx) {
+            continue;
+        }
         if mentions.is_subset(&scope)
             || (mentions.contains(&subject) && scope.contains(&prev_subject))
             || lhs_rooted
@@ -1077,6 +1087,10 @@ fn earlier_law_lemmas(
             let VerifyKind::Law(prev_law) = &prev.kind else {
                 continue;
             };
+            // Same looping-rewrite guard as the in-file pool above.
+            if super::shared::law_is_looping_rewrite(prev_law, ctx) {
+                continue;
+            }
             if let Some((name, text)) = dep_law_admissible(
                 module,
                 prev,
@@ -1383,7 +1397,7 @@ fn b_tight_decomposition_arms(
     }
     let (bridge_support, bridges, bridged_fns) =
         lean_nat_lift_support(law, ctx, law_uid, &cited_fns);
-    let defs: Vec<String> = law_simp_defs(ctx, vb, law)
+    let defs: Vec<String> = law_simp_defs_blind(ctx, vb, law)
         .into_iter()
         .filter(|n| !bridged_fns.contains(super::shared::bare_lean_name(n)))
         .collect();
@@ -2021,6 +2035,12 @@ pub(in crate::codegen::lean) fn recognize_conditional_inductive_generic(
     if recognize_conditional_comparison_bridge(vb, law, ctx) {
         return false;
     }
+    // Exclusive with the fuel-induction arm as well: a `when`-law over a
+    // well-founded Int-countdown fn is closed by `wf_fuel` (one unfold per
+    // fuel step), which this driver's blind `simp_all` portfolio cannot do.
+    if super::wf_fuel::recognize_wf_fuel_induction(vb, law, ctx).is_some() {
+        return false;
+    }
     // Class-1 recursion-incompatibility (single-list only): a cone fn that
     // DECREMENTS a co-given synchronously with the list — `drop`/`take` over a
     // free `Nat` (`prop_39`'s `elem(x, drop(y, z))`) — is not closed by plain
@@ -2062,7 +2082,7 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
     }
     let target_idx = find_list_induction_target(law)?;
     let target = intro_names.get(target_idx)?.clone();
-    let defs = law_simp_defs(ctx, vb, law)
+    let defs = law_simp_defs_blind(ctx, vb, law)
         .into_iter()
         .collect::<Vec<_>>()
         .join(", ");
@@ -2731,7 +2751,7 @@ fn emit_map_fold_homomorphism(
     target_idx: usize,
     plan: &MapFoldHomomorphism,
 ) -> AutoProof {
-    let simp_list = law_simp_defs(ctx, vb, law)
+    let simp_list = law_simp_defs_blind(ctx, vb, law)
         .into_iter()
         .collect::<Vec<_>>()
         .join(", ");
@@ -2878,7 +2898,14 @@ pub(super) fn find_fun_induction_targets(
     // noise, so restrict to the recursive pure fns — exactly the `.induct` set.
     // (`fn_body_has_match` is a redundant sanity guard: a recursive fn always
     // case-splits, but a fn lifted to a non-matching builtin would not.)
+    // A well-founded Int-countdown fn (`termination_by p.toNat`) is NOT a
+    // target: its `.induct` exists, but the rung's `simp_all [f]` closer
+    // unfolds the countdown forever (the unfold equation is unconditional)
+    // and dies in a `whnf` heartbeat timeout — a hard build error `first`
+    // cannot catch. That class is closed by the fuel-induction strategy
+    // (`law_auto::wf_fuel`) instead.
     let recursive_names = crate::codegen::lean::recursive_pure_fn_names(ctx);
+    let wf_countdown = super::shared::wf_countdown_fn_names(ctx);
     let induct_fns: std::collections::HashSet<String> = ctx
         .modules
         .iter()
@@ -2887,6 +2914,7 @@ pub(super) fn find_fun_induction_targets(
         .filter(|fd| {
             crate::codegen::common::is_pure_fn(fd)
                 && recursive_names.contains(&fd.name)
+                && !wf_countdown.contains(&fd.name)
                 && fn_body_has_match(fd)
         })
         .map(|fd| fd.name.clone())
@@ -3402,14 +3430,14 @@ fn emit_count_composition_rung(
     // chains the IH after rewriting `op a (k+1)` to `(a + k) + 1` (so `f` peels)
     // — `simp only [bridge, Nat.add_succ, f-defs] at *` exposes the one-step
     // unfolds, then `simp_all [base, ih]` lands the IH at the tail.
-    let mut base_set: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    let mut base_set: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law);
     base_set.insert(add_bridge.clone());
     base_set.extend(nil_simp.iter().cloned());
     let base = base_set.iter().cloned().collect::<Vec<_>>().join(", ");
     // The `simp only` unfold set for the succ arm: the law's defs (so `f`'s
     // equations fire) + the bridge + `Nat.add_succ` (reassociates `a + (k+1)` to
     // `(a + k) + 1` so `f` recognizes the `_ + 1` driver).
-    let mut unfold_set: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    let mut unfold_set: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law);
     unfold_set.insert(add_bridge.clone());
     unfold_set.insert("Nat.add_succ".to_string());
     let unfold = unfold_set.iter().cloned().collect::<Vec<_>>().join(", ");
@@ -3525,7 +3553,7 @@ fn emit_synchronous_multivar_induction(
     // + the proved nil-helpers + the append-peeling lemmas. `List.cons_append` /
     // `List.nil_append` let the appended list (`[y] ++ zs` in lemma_04) peel a
     // cons in lockstep with the recursing fn.
-    let mut simp_set: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    let mut simp_set: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law);
     simp_set.extend(helper_names.iter().cloned());
     simp_set.insert("List.cons_append".to_string());
     simp_set.insert("List.nil_append".to_string());
@@ -3587,7 +3615,7 @@ fn emit_list_induction(
             &plan,
         ));
     }
-    let mut simp_defs: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    let mut simp_defs: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law);
     let law_uid = format!(
         "{}_{}",
         aver_name_to_lean(&vb.fn_name),
@@ -3950,7 +3978,7 @@ fn emit_list_induction(
         if !fast_simp.is_empty() {
             fast_lemmas.extend(COMMUTE_NORMALIZERS.iter().map(|s| s.to_string()));
         }
-        let fast_unfolds: BTreeSet<String> = law_simp_defs(ctx, vb, law)
+        let fast_unfolds: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law)
             .into_iter()
             .chain(fast_simp.iter().cloned())
             .chain(arith_bridges.iter().cloned())
@@ -4474,7 +4502,7 @@ fn emit_both_args_peeling_law(
         return None;
     }
 
-    let simp_list = law_simp_defs(ctx, vb, law)
+    let simp_list = law_simp_defs_blind(ctx, vb, law)
         .into_iter()
         .collect::<Vec<_>>()
         .join(", ");
@@ -4538,7 +4566,7 @@ fn emit_simple_induction(
     variants: &[TypeVariant],
     discovered: &[String],
 ) -> Option<AutoProof> {
-    let mut simp_defs: BTreeSet<String> = law_simp_defs(ctx, vb, law);
+    let mut simp_defs: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law);
     // Discovery feedback: COMMITTED pins join the arm simp sets (see
     // `emit_list_induction`); EARLIER sibling laws (część A) feed only the
     // fast path. Empty `fast_simp` (no committed, no eligible sibling) keeps
@@ -4622,7 +4650,7 @@ fn emit_simple_induction(
             .filter_map(|s| s.strip_prefix(&format!("{law_uid}_")))
             .map(str::to_string)
             .collect();
-        let mut comm_set: Vec<String> = law_simp_defs(ctx, vb, law)
+        let mut comm_set: Vec<String> = law_simp_defs_blind(ctx, vb, law)
             .into_iter()
             .filter(|d| !commd_fns.contains(d))
             .collect();
@@ -4649,7 +4677,7 @@ fn emit_simple_induction(
         let bridge_thms = arith_bridges.iter().filter(|b| b.starts_with(&law_uid));
         // `law_simp_defs` may qualify an entry-module fn; `bridged_fns` holds
         // the bare Lean name, so compare basenames.
-        let mut acset: Vec<String> = law_simp_defs(ctx, vb, law)
+        let mut acset: Vec<String> = law_simp_defs_blind(ctx, vb, law)
             .into_iter()
             .filter(|d| !bridged_fns.contains(super::shared::bare_lean_name(d)))
             .collect();
@@ -4874,7 +4902,7 @@ fn emit_simple_induction(
             fast_lemmas.join(", ")
         ));
         if !fast_simp.is_empty() {
-            let fast_unfolds: BTreeSet<String> = law_simp_defs(ctx, vb, law)
+            let fast_unfolds: BTreeSet<String> = law_simp_defs_blind(ctx, vb, law)
                 .into_iter()
                 .chain(fast_simp.iter().cloned())
                 .chain(arith_bridges.iter().cloned())

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -284,6 +284,83 @@ pub(super) fn calls_fn_on_ident(expr: &Spanned<Expr>, fn_src: &str, ident: &str)
         .any(|c| calls_fn_on_ident(c, fn_src, ident))
 }
 
+/// Whether `law` read as a left-to-right rewrite rule LOOPS: its RHS contains
+/// an instance of its own LHS pattern (the LHS with the law's givens as
+/// pattern variables). The accumulator law `f(v, acc) => concat(reverse(acc),
+/// f(v, []))` is the canonical case — `f(v, [])` is matched by `f(?v, ?acc)`,
+/// so `simp [law]` rewrites forever (Lean warns "Possibly looping simp
+/// theorem"). A structurally decreasing rule (`g(concat(xs, [b]), acc) =>
+/// g(xs, acc) * 256 + b`) is NOT looping: `xs` is not matched by
+/// `concat(?xs, [?b])`. Matching is syntactic: a bare given matches anything
+/// (repeated givens are not checked for consistency — conservative towards
+/// "looping"), calls/operators match structurally, everything else by
+/// rendered Lean text.
+pub(super) fn law_is_looping_rewrite(law: &VerifyLaw, ctx: &CodegenContext) -> bool {
+    let Some((head, lhs_args)) = call_name_args(&law.lhs) else {
+        return false;
+    };
+    let givens: BTreeSet<&str> = law.givens.iter().map(|g| g.name.as_str()).collect();
+    fn instance_of(
+        pat: &Spanned<Expr>,
+        e: &Spanned<Expr>,
+        givens: &BTreeSet<&str>,
+        ctx: &CodegenContext,
+    ) -> bool {
+        if let Some(n) = ident_name(pat)
+            && givens.contains(n)
+        {
+            return true;
+        }
+        match (&pat.node, &e.node) {
+            (Expr::Literal(a), Expr::Literal(b)) => a == b,
+            (Expr::BinOp(o1, a1, b1), Expr::BinOp(o2, a2, b2)) => {
+                o1 == o2 && instance_of(a1, a2, givens, ctx) && instance_of(b1, b2, givens, ctx)
+            }
+            (Expr::Neg(a), Expr::Neg(b)) => instance_of(a, b, givens, ctx),
+            (Expr::List(xs), Expr::List(ys)) => {
+                xs.len() == ys.len()
+                    && xs
+                        .iter()
+                        .zip(ys)
+                        .all(|(x, y)| instance_of(x, y, givens, ctx))
+            }
+            _ => match (call_name_args(pat), call_name_args(e)) {
+                (Some((n1, a1)), Some((n2, a2))) => {
+                    n1 == n2
+                        && a1.len() == a2.len()
+                        && a1
+                            .iter()
+                            .zip(a2)
+                            .all(|(x, y)| instance_of(x, y, givens, ctx))
+                }
+                _ => render(pat, ctx) == render(e, ctx),
+            },
+        }
+    }
+    fn walk(
+        e: &Spanned<Expr>,
+        head: &str,
+        lhs_args: &[Spanned<Expr>],
+        givens: &BTreeSet<&str>,
+        ctx: &CodegenContext,
+    ) -> bool {
+        if let Some((name, args)) = call_name_args(e)
+            && name == head
+            && args.len() == lhs_args.len()
+            && lhs_args
+                .iter()
+                .zip(args)
+                .all(|(p, a)| instance_of(p, a, givens, ctx))
+        {
+            return true;
+        }
+        child_exprs(e)
+            .into_iter()
+            .any(|c| walk(c, head, lhs_args, givens, ctx))
+    }
+    walk(&law.rhs, &head, lhs_args, &givens, ctx)
+}
+
 /// Direct callees of `src` that are user fn defs (by source name), treating
 /// `TailCall` as a call site so mutual SCC recognition sees post-TCO bodies.
 pub(super) fn direct_user_calls(src: &str, ctx: &CodegenContext) -> BTreeSet<String> {
@@ -617,19 +694,68 @@ pub(super) fn law_simp_defs(
 ) -> BTreeSet<String> {
     law_simp_source_names(ctx, vb, law)
         .into_iter()
-        .map(|name| {
-            let rendered = aver_name_to_lean(&name);
-            // Entry-module fns use their module-qualified name so a user fn
-            // shadowing a stdlib symbol (for example `insert`) remains an
-            // unambiguous simp target. Dependency fns already live under an
-            // opened module namespace and keep their existing bare spelling.
-            if is_dep_module_fn(ctx, &name) {
-                rendered
-            } else {
-                entry_qualified_lean_name(ctx, &name)
-            }
-        })
+        .map(|name| simp_def_name(ctx, &name))
         .collect()
+}
+
+/// [`law_simp_defs`] for a BLIND simp portfolio (`simp [defs]` /
+/// `simp_all [defs]` with no driving induction): the same cone MINUS every
+/// well-founded Int-countdown fn ([`wf_countdown_fn_names`]). Such a fn's
+/// unfold equation is unconditional (`f n = if … then … else … f (n / k) …`),
+/// so a blind `simp [f]` rewrites the recursive call forever and dies in a
+/// heartbeat timeout — a HARD build error `first | … | sorry` cannot catch.
+/// The generic induction ladder and its closers source their def sets here;
+/// the countdown fn is closed by the dedicated fuel-induction strategy
+/// (`wf_fuel`) or the bespoke templates that drive its `.induct` on purpose.
+pub(super) fn law_simp_defs_blind(
+    ctx: &CodegenContext,
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+) -> BTreeSet<String> {
+    let wf = wf_countdown_fn_names(ctx);
+    law_simp_source_names(ctx, vb, law)
+        .into_iter()
+        .filter(|name| !wf.contains(name))
+        .map(|name| simp_def_name(ctx, &name))
+        .collect()
+}
+
+/// The Lean spelling a cone fn takes in a simp set / `unfold`.
+pub(super) fn simp_def_name(ctx: &CodegenContext, source_name: &str) -> String {
+    let rendered = aver_name_to_lean(source_name);
+    // Entry-module fns use their module-qualified name so a user fn
+    // shadowing a stdlib symbol (for example `insert`) remains an
+    // unambiguous simp target. Dependency fns already live under an
+    // opened module namespace and keep their existing bare spelling.
+    if is_dep_module_fn(ctx, source_name) {
+        rendered
+    } else {
+        entry_qualified_lean_name(ctx, source_name)
+    }
+}
+
+/// Every pure user fn emitted as a native well-founded def on
+/// `param.toNat` — the `RecursionContract::WellFoundedToNat` class (the
+/// guard-validated floor-division countdown and the graduated subtractive
+/// countdown), by source name. Keyed on the contract, never on names.
+pub(super) fn wf_countdown_fn_names(ctx: &CodegenContext) -> BTreeSet<String> {
+    super::super::pure_fns(ctx)
+        .into_iter()
+        .filter(|fd| wf_countdown_param(ctx, fd).is_some())
+        .map(|fd| fd.name.clone())
+        .collect()
+}
+
+/// The decreasing Int parameter (source name) of a
+/// `RecursionContract::WellFoundedToNat` fn; `None` for every other fn.
+pub(super) fn wf_countdown_param<'a>(ctx: &'a CodegenContext, fd: &FnDef) -> Option<&'a str> {
+    match crate::codegen::common::find_fn_contract_for_fn(ctx, fd)?
+        .recursion
+        .as_ref()?
+    {
+        crate::ir::RecursionContract::WellFoundedToNat { param, .. } => Some(param.as_str()),
+        _ => None,
+    }
 }
 
 pub(super) fn entry_qualified_lean_name(ctx: &CodegenContext, source_name: &str) -> String {

--- a/src/codegen/lean/law_auto/wf_fuel.rs
+++ b/src/codegen/lean/law_auto/wf_fuel.rs
@@ -1,0 +1,567 @@
+//! Fuel induction over a well-founded Int-countdown fn.
+//!
+//! A pure fn emitted as a native well-founded def on `param.toNat`
+//! (`RecursionContract::WellFoundedToNat` — the guard-validated floor-
+//! division countdown `f(Int.div(v, k), …)` and the graduated subtractive
+//! countdown `f(v - k, …)`) has an UNCONDITIONAL unfold equation, so every
+//! blind `simp [f]` / `fun_induction f … <;> simp_all [f]` rung in the generic
+//! ladder unfolds the recursive call forever and dies in a heartbeat timeout —
+//! a hard build error `first | … | sorry` cannot catch. This strategy closes
+//! laws over such a fn the way a human would: a `Nat` fuel `k` bounding
+//! `x.toNat`, induction on `k` with every law given re-quantified, one GROUND
+//! instance of the IH per unfolded recursive call (computed from the fn's own
+//! self-call arguments), the countdown fn unfolded exactly ONCE, and a
+//! `split`-then-`simp_all`/`omega` closer over a simp set that never contains
+//! the countdown fn. Earlier laws about the same fn that would loop as simp
+//! rules (the accumulator law) are cited as ground instances too.
+//!
+//! Shape-keyed and name-blind: the fn is discovered from its contract and the
+//! law's calls, never from a name. Fail-closed: the portfolio ends in `sorry`,
+//! so a non-closing instance degrades to the honest floor and `#print axioms`
+//! decides credit.
+
+use std::collections::{BTreeSet, HashMap};
+
+use super::super::expr::aver_name_to_lean;
+use super::AutoProof;
+use super::shared::{
+    call_name_args, child_exprs, direct_user_calls, find_fn_def, find_fn_def_by_call_name,
+    ident_name, law_simp_defs_blind, render, simp_def_name, substitute_expr, wf_countdown_fn_names,
+    wf_countdown_param,
+};
+use crate::ast::{
+    BinOp, Expr, FnDef, Literal, Spanned, Stmt, TopLevel, VerifyBlock, VerifyKind, VerifyLaw,
+};
+use crate::codegen::CodegenContext;
+
+/// A recognized fuel-induction law: the single well-founded countdown fn the
+/// law mentions, the law given driving its countdown, and the call shapes the
+/// emitter instantiates the induction hypothesis at.
+pub(in crate::codegen::lean) struct WfFuelPlan {
+    /// The countdown fn (source name).
+    pub f: String,
+    /// Its `unfold` spelling (module-qualified for entry-module fns).
+    pub f_lean: String,
+    /// The law given at the countdown position of every occurrence (Lean name).
+    pub x_lean: String,
+    /// `f`'s parameter names, in order.
+    pub params: Vec<String>,
+    /// Argument vectors of every call to `f` in the law (lhs, rhs, when).
+    pub occurrences: Vec<Vec<Spanned<Expr>>>,
+    /// Argument vectors of every self-call in `f`'s body (verbatim).
+    pub self_calls: Vec<Vec<Spanned<Expr>>>,
+}
+
+/// Recognize the fuel-induction shape (see the module doc). Declines unless
+/// exactly one well-founded countdown fn `f` is called in the law's claim
+/// (lhs/rhs — a `when`-only mention gives `unfold` nothing to unfold), every
+/// call passes the SAME bare `Int` given at `f`'s countdown position, `f` is
+/// self-recursive only (no other countdown fn in its body, no mutual SCC),
+/// and every self-call shrinks the countdown INLINE (`Int.div(p, k)` /
+/// `p - k`, the forms `omega` reads — never through a wrapper fn).
+pub(in crate::codegen::lean) fn recognize_wf_fuel_induction(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> Option<WfFuelPlan> {
+    if law.givens.is_empty() {
+        return None;
+    }
+    // An IR pin that hands the law to a bespoke template (the floor-division
+    // window family, the tail-recursive fold, ring identities, …) keeps it:
+    // those templates drive the countdown fn's own `.induct` and support
+    // stacks on purpose. Only the generic pins (structural induction, the
+    // discovery re-pin, backend dispatch, sorry) and unpinned laws are eligible.
+    match super::law_strategy_for(ctx, &vb.fn_name, &law.name) {
+        None
+        | Some(crate::ir::ProofStrategy::Induction { .. })
+        | Some(crate::ir::ProofStrategy::SimpOverLemmas(_))
+        | Some(crate::ir::ProofStrategy::BackendDispatch)
+        | Some(crate::ir::ProofStrategy::Sorry) => {}
+        Some(_) => return None,
+    }
+    let wf = wf_countdown_fn_names(ctx);
+    if wf.is_empty() {
+        return None;
+    }
+    // 1. Every call to a countdown fn in the law, deep. The CLAIM (lhs/rhs)
+    //    must mention the fn: each arm `unfold`s it in the goal, and `unfold`
+    //    throws on no progress — inside an `induction` alternative that is a
+    //    logged build error, not a fall-through to the `sorry` floor. Calls
+    //    in the `when` premise still feed the IH tuples.
+    let mut calls: Vec<(String, Vec<Spanned<Expr>>)> = Vec::new();
+    collect_wf_calls(&law.lhs, ctx, &wf, &mut calls);
+    collect_wf_calls(&law.rhs, ctx, &wf, &mut calls);
+    if calls.is_empty() {
+        return None;
+    }
+    if let Some(when) = &law.when {
+        collect_wf_calls(when, ctx, &wf, &mut calls);
+    }
+    let distinct: BTreeSet<&str> = calls.iter().map(|(n, _)| n.as_str()).collect();
+    if distinct.len() != 1 {
+        return None;
+    }
+    let f = calls[0].0.clone();
+    let fd = find_fn_def(ctx, &f)?;
+    // 2. The countdown position carries the same bare `Int` given everywhere.
+    let param = wf_countdown_param(ctx, fd)?;
+    let pos = fd.params.iter().position(|(n, _)| n == param)?;
+    let mut x: Option<&str> = None;
+    for (_, args) in &calls {
+        if args.len() != fd.params.len() {
+            return None;
+        }
+        let arg = ident_name(&args[pos])?;
+        match x {
+            None => x = Some(arg),
+            Some(seen) if seen == arg => {}
+            Some(_) => return None,
+        }
+    }
+    let x = x?;
+    let given = law.givens.iter().find(|g| g.name == x)?;
+    if given.type_name.trim() != "Int" {
+        return None;
+    }
+    // 3. Self-recursive only.
+    if !crate::codegen::lean::recursive_pure_fn_names(ctx).contains(&f) {
+        return None;
+    }
+    let direct = direct_user_calls(&f, ctx);
+    for callee in direct.iter().filter(|c| **c != f) {
+        if wf.contains(callee) || reaches(callee, &f, ctx) {
+            return None;
+        }
+    }
+    // 4. The self-call argument vectors, verbatim (params only — a local
+    //    binding or pattern variable in a self-call arg has no meaning at the
+    //    law's level, so decline rather than emit a dangling name).
+    let params: Vec<String> = fd.params.iter().map(|(n, _)| n.clone()).collect();
+    let mut self_calls: Vec<Vec<Spanned<Expr>>> = Vec::new();
+    for stmt in fd.body.stmts() {
+        match stmt {
+            Stmt::Expr(e) | Stmt::Binding(_, _, e) => collect_self_calls(e, &f, &mut self_calls),
+        }
+    }
+    if self_calls.is_empty() {
+        return None;
+    }
+    let param_set: BTreeSet<&str> = params.iter().map(String::as_str).collect();
+    for args in &self_calls {
+        if args.len() != params.len() || args.iter().any(|a| !idents_within(a, &param_set)) {
+            return None;
+        }
+    }
+    // 5. The fuel-decrease premise of every IH instance (`x.toNat ≤ k + 1 →
+    //    a.toNat ≤ k` for the shrunk `a`) is discharged by `omega`, which
+    //    reads `p / <lit>` and `p - <lit>` but treats a wrapper call
+    //    (`halve(a)`) as an atom. So the countdown position of every
+    //    self-call must be that inline arithmetic on the countdown param: a
+    //    wrapper shrink (`FloorDivShrink { helper_fn: Some(..) }`) and the
+    //    legacy `Result.withDefault(Int.div(p, k), d)` form both decline.
+    if !wf_shrink_is_inline(ctx, fd)
+        || self_calls
+            .iter()
+            .any(|args| !omega_readable_shrink(&args[pos], param))
+    {
+        return None;
+    }
+    Some(WfFuelPlan {
+        f_lean: simp_def_name(ctx, &f),
+        f,
+        x_lean: aver_name_to_lean(x),
+        params,
+        occurrences: calls.into_iter().map(|(_, args)| args).collect(),
+        self_calls,
+    })
+}
+
+/// Deep-collect every call to a fn in `wf` (by resolved source name).
+fn collect_wf_calls(
+    e: &Spanned<Expr>,
+    ctx: &CodegenContext,
+    wf: &BTreeSet<String>,
+    out: &mut Vec<(String, Vec<Spanned<Expr>>)>,
+) {
+    if let Some((name, args)) = call_name_args(e)
+        && let Some(fd) = find_fn_def_by_call_name(ctx, &name)
+        && wf.contains(&fd.name)
+    {
+        out.push((fd.name.clone(), args.to_vec()));
+    }
+    for c in child_exprs(e) {
+        collect_wf_calls(c, ctx, wf, out);
+    }
+}
+
+/// Deep-collect the argument vectors of every call to `f` (a `FnCall` or the
+/// post-TCO `TailCall`) in `e`, match arms included.
+fn collect_self_calls(e: &Spanned<Expr>, f: &str, out: &mut Vec<Vec<Spanned<Expr>>>) {
+    if let Some((name, args)) = call_name_args(e)
+        && name == f
+    {
+        out.push(args.to_vec());
+    }
+    for c in child_exprs(e) {
+        collect_self_calls(c, f, out);
+    }
+}
+
+/// Every value identifier in `e` (callee positions excluded) is in `allowed`.
+fn idents_within(e: &Spanned<Expr>, allowed: &BTreeSet<&str>) -> bool {
+    if let Some(n) = ident_name(e) {
+        return allowed.contains(n);
+    }
+    let children: Vec<&Spanned<Expr>> = match &e.node {
+        Expr::FnCall(_, args) => args.iter().collect(),
+        Expr::Match { .. } => return false,
+        _ => child_exprs(e),
+    };
+    children.iter().all(|c| idents_within(c, allowed))
+}
+
+/// `Int.div(p, <int literal>)` or `p - <int literal>`: the countdown shrink
+/// forms `omega` reads once rendered (`p / k`, `p - k`).
+fn omega_readable_shrink(arg: &Spanned<Expr>, p: &str) -> bool {
+    let is_p = |e: &Spanned<Expr>| ident_name(e) == Some(p);
+    let is_lit = |e: &Spanned<Expr>| matches!(&e.node, Expr::Literal(Literal::Int(_)));
+    match &arg.node {
+        Expr::BinOp(BinOp::Sub, a, b) => is_p(a) && is_lit(b),
+        _ => matches!(
+            call_name_args(arg),
+            Some((name, [a, b])) if name == "Int.div" && is_p(a) && is_lit(b)
+        ),
+    }
+}
+
+/// Whether `fd`'s `WellFoundedToNat` contract shrinks its countdown inline
+/// (no wrapper fn the kernel unfolds by name in `decreasing_by`).
+fn wf_shrink_is_inline(ctx: &CodegenContext, fd: &FnDef) -> bool {
+    let Some(contract) = crate::codegen::common::find_fn_contract_for_fn(ctx, fd) else {
+        return false;
+    };
+    match contract.recursion.as_ref() {
+        Some(crate::ir::RecursionContract::WellFoundedToNat { floor_div, .. }) => floor_div
+            .as_ref()
+            .is_none_or(|shrink| shrink.helper_fn.is_none()),
+        _ => false,
+    }
+}
+
+/// Whether `from`'s transitive user-fn call closure reaches `target`.
+fn reaches(from: &str, target: &str, ctx: &CodegenContext) -> bool {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut stack = vec![from.to_string()];
+    while let Some(name) = stack.pop() {
+        if name == target {
+            return true;
+        }
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        stack.extend(direct_user_calls(&name, ctx));
+    }
+    false
+}
+
+/// An earlier, same-file, unconditional law whose LHS is a direct call to `f`
+/// on bare, distinct givens covering all of its givens: `f(g_1..g_n)`. Cited
+/// as a ground instance at every IH tuple (the accumulator law is exactly this
+/// shape and is a looping simp rule, so it never joins a simp set).
+struct GroundLaw {
+    theorem: String,
+    /// For each of the law's givens, the `f` argument position it occupies.
+    given_positions: Vec<usize>,
+}
+
+fn ground_laws_about(vb: &VerifyBlock, plan: &WfFuelPlan, ctx: &CodegenContext) -> Vec<GroundLaw> {
+    let mut out = Vec::new();
+    // Only laws from the FILE this theorem is emitted into can be cited by
+    // name: a dependency module's laws are emitted under
+    // `with_module_scope(Some(prefix))` from that module's own verify blocks,
+    // while `ctx.items` holds the ENTRY module's items. Scanning the wrong
+    // sequence would cite an entry-module theorem from a dependency file (an
+    // unknown identifier) or stop at a same-line block of another file.
+    let scope = ctx.active_module_scope();
+    let blocks: Vec<&VerifyBlock> = match scope.as_deref() {
+        Some(prefix) => ctx
+            .modules
+            .iter()
+            .find(|m| m.prefix == prefix)
+            .map(|m| m.verify_blocks.iter().collect())
+            .unwrap_or_default(),
+        None => ctx
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                TopLevel::Verify(prev) => Some(prev),
+                _ => None,
+            })
+            .collect(),
+    };
+    for prev in blocks {
+        if prev.line == vb.line && prev.fn_name == vb.fn_name {
+            break;
+        }
+        let VerifyKind::Law(prev_law) = &prev.kind else {
+            continue;
+        };
+        if prev_law.when.is_some() {
+            continue;
+        }
+        let Some((name, args)) = call_name_args(&prev_law.lhs) else {
+            continue;
+        };
+        let Some(fd) = find_fn_def_by_call_name(ctx, &name) else {
+            continue;
+        };
+        if fd.name != plan.f || args.len() != plan.params.len() {
+            continue;
+        }
+        let mut given_positions = Vec::with_capacity(prev_law.givens.len());
+        let mut covered = true;
+        for g in &prev_law.givens {
+            match args
+                .iter()
+                .position(|a| ident_name(a) == Some(g.name.as_str()))
+            {
+                Some(j) => given_positions.push(j),
+                None => {
+                    covered = false;
+                    break;
+                }
+            }
+        }
+        if !covered || args.iter().any(|a| ident_name(a).is_none()) {
+            continue;
+        }
+        let Some((theorem, _)) =
+            crate::codegen::lean::toplevel::law_as_lemma_statement(prev, prev_law, ctx)
+        else {
+            continue;
+        };
+        out.push(GroundLaw {
+            theorem,
+            given_positions,
+        });
+    }
+    out
+}
+
+/// Render a Lean application argument: parenthesize anything that is not a
+/// single token or one already-parenthesized group.
+fn arg(text: &str) -> String {
+    if !text.chars().any(char::is_whitespace) || is_one_group(text) {
+        text.to_string()
+    } else {
+        format!("({text})")
+    }
+}
+
+/// `(…)` whose opening paren matches its closing one (`(a) + (b)` is not).
+fn is_one_group(text: &str) -> bool {
+    if !(text.starts_with('(') && text.ends_with(')')) {
+        return false;
+    }
+    let mut depth = 0usize;
+    for (i, c) in text.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 && i + 1 < text.len() {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+    }
+    true
+}
+
+/// Emit the fuel-induction proof for a recognized law. `quant_params` and
+/// `theorem_prop` are the caller's theorem statement pieces, used verbatim
+/// inside the `key` lemma; `intro_names` are the givens' Lean names in
+/// `quant_params` order.
+pub(in crate::codegen::lean) fn emit_wf_fuel_induction_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    intro_names: &[String],
+    quant_params: &str,
+    theorem_prop: &str,
+) -> Option<AutoProof> {
+    let plan = recognize_wf_fuel_induction(vb, law, ctx)?;
+    let conditional = law.when.is_some();
+    let givens: Vec<String> = intro_names.to_vec();
+    let given_source: Vec<&str> = law.givens.iter().map(|g| g.name.as_str()).collect();
+    // The proof's own binders must not shadow a law given (a given named `k`
+    // is common): pick each name fresh against the intro names.
+    let fresh = |base: &str| -> String {
+        let mut name = base.to_string();
+        let mut n = 1;
+        while givens.iter().any(|g| g == &name) {
+            name = format!("{base}_{n}");
+            n += 1;
+        }
+        name
+    };
+    let fuel = fresh("k");
+    let ih = fresh("ih");
+    let hk = fresh("hk");
+    let key = fresh("key");
+
+    // The IH tuples: every self-call instantiated at every occurrence
+    // (`f`'s params := the occurrence's args), rendered per position.
+    let mut tuples: Vec<Vec<String>> = Vec::new();
+    for occ in &plan.occurrences {
+        let bindings: HashMap<&str, &Spanned<Expr>> = plan
+            .params
+            .iter()
+            .map(String::as_str)
+            .zip(occ.iter())
+            .collect();
+        for call in &plan.self_calls {
+            let tuple: Vec<String> = call
+                .iter()
+                .map(|a| render(&substitute_expr(a, &bindings), ctx))
+                .collect();
+            if !tuples.contains(&tuple) {
+                tuples.push(tuple);
+            }
+        }
+    }
+
+    // IH instances: for each tuple and each occurrence PATTERN, the given
+    // vector that makes the pattern's bare-given positions equal the tuple
+    // (the countdown position always; other givens not pinned by the pattern
+    // stay themselves — an earlier ground law bridges the rest).
+    let mut ih_instances: Vec<Vec<String>> = Vec::new();
+    for tuple in &tuples {
+        for occ in &plan.occurrences {
+            let mut inst: Vec<String> = givens.clone();
+            let mut consistent = true;
+            for (j, a) in occ.iter().enumerate() {
+                let Some(n) = ident_name(a) else {
+                    continue;
+                };
+                let Some(gi) = given_source.iter().position(|g| *g == n) else {
+                    continue;
+                };
+                let value = arg(&tuple[j]);
+                if inst[gi] != givens[gi] && inst[gi] != value {
+                    consistent = false;
+                    break;
+                }
+                inst[gi] = value;
+            }
+            if consistent && !ih_instances.contains(&inst) {
+                ih_instances.push(inst);
+            }
+        }
+    }
+
+    // Ground instances of earlier direct laws about `f`, at every tuple.
+    let mut ground: Vec<String> = Vec::new();
+    for gl in ground_laws_about(vb, &plan, ctx) {
+        for tuple in &tuples {
+            let args: Vec<String> = gl.given_positions.iter().map(|j| arg(&tuple[*j])).collect();
+            let cite = format!("{} {}", gl.theorem, args.join(" "));
+            if !ground.contains(&cite) {
+                ground.push(cite);
+            }
+        }
+    }
+
+    // The safe simp set: the blind cone (no countdown fn) plus the earlier
+    // laws that are not looping rewrites (the pool is already filtered).
+    let mut safe: Vec<String> = law_simp_defs_blind(ctx, vb, law).into_iter().collect();
+    for lemma in super::induction::earlier_law_lemmas(vb, law, ctx) {
+        if !safe.contains(&lemma.name) {
+            safe.push(lemma.name);
+        }
+    }
+    let simp_all = if safe.is_empty() {
+        "simp_all".to_string()
+    } else {
+        format!("simp_all [{}]", safe.join(", "))
+    };
+    // Every inner portfolio ends in its own `sorry` floor. Lean runs the LAST
+    // alternative of a `first` with error recovery on: an alternative there
+    // that makes progress and then fails (`simp_all` leaving a goal, `omega`
+    // after a rewrite) is LOGGED as a build error and the goal admitted — the
+    // enclosing `first | (have key …) | sorry` never sees a failure to fall
+    // through on. With `sorry` last, a non-closing arm degrades to `sorryAx`
+    // (no credit, no build error); the middle alternatives fail cleanly.
+    let closer = format!(
+        "first | (split <;> {simp_all} <;> omega) | ({simp_all} <;> omega) | (split <;> {simp_all} <;> done) | sorry"
+    );
+    // The `when` premise at the shrunk value. A bare comparison premise is
+    // stated `(P) = true`, which elaborates as the Prop equation `P = (true =
+    // true)`; a Bool-valued premise (`f(..) && g(..)`) as `decide`-coerced
+    // Bool. Normalize both to Prop, then `omega`. Same recovery rule as the
+    // closers: the floor is `sorry`, never a progress-then-fail alternative.
+    let guard = "first | omega | (simp only [eq_iff_iff, iff_true, decide_eq_true_eq, Bool.and_eq_true, Bool.or_eq_true, Bool.not_eq_true', ge_iff_le, gt_iff_lt] at h_when ⊢; omega) | sorry";
+
+    let mut arm_intro = givens.clone();
+    arm_intro.push(hk.clone());
+    let mut outer_intro = givens.clone();
+    if conditional {
+        arm_intro.push("h_when".to_string());
+        outer_intro.push("h_when".to_string());
+    }
+    let arm_intro = arm_intro.join(" ");
+
+    let mut lines = vec![
+        format!("  intro {}", outer_intro.join(" ")),
+        "  first".to_string(),
+        format!(
+            "  | (have {key} : ∀ ({fuel} : Nat) {quant_params}, {}.toNat ≤ {fuel} → {theorem_prop} := by",
+            plan.x_lean
+        ),
+        format!("       intro {fuel}"),
+        format!("       induction {fuel} with"),
+        "       | zero =>".to_string(),
+        format!("         intro {arm_intro}"),
+        format!("         unfold {}", plan.f_lean),
+        format!("         {closer}"),
+        format!("       | succ {fuel} {ih} =>"),
+        format!("         intro {arm_intro}"),
+    ];
+    // The fuel-decrease discharge is floored like the closers: the arm runs
+    // under `induction`'s error recovery, so a bound `omega` cannot close
+    // (never expected — the recognizer admits only inline `p / k` / `p - k`
+    // shrinks — but the floor is what keeps the class fail-closed) degrades
+    // to `sorryAx`, never to a logged build error.
+    for (i, inst) in ih_instances.iter().enumerate() {
+        let premise = if conditional {
+            format!(" (by {guard})")
+        } else {
+            String::new()
+        };
+        lines.push(format!(
+            "         have {ih}{} := {ih} {} (by first | omega | sorry){premise}",
+            i + 1,
+            inst.join(" ")
+        ));
+    }
+    for (i, cite) in ground.iter().enumerate() {
+        lines.push(format!("         have {}{} := {cite}", fresh("l"), i + 1));
+    }
+    lines.push(format!("         clear {ih}"));
+    lines.push(format!("         unfold {}", plan.f_lean));
+    lines.push(format!("         {closer}"));
+    let when_arg = if conditional { " h_when" } else { "" };
+    lines.push(format!(
+        "     exact {key} _ {} (Nat.le_refl _){when_arg})",
+        givens.join(" ")
+    ));
+    lines.push("  | sorry".to_string());
+
+    Some(AutoProof {
+        support_lines: Vec::new(),
+        body: crate::codegen::lean::tactic_ir::Tactic::raw(lines),
+        replaces_theorem: false,
+    })
+}

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -4903,3 +4903,275 @@ verify nonNeg law nonNegOfPositive
         "the law must stay bounded-domain and be dropped from the certificate surface:\n{lean}"
     );
 }
+
+/// Fuel induction over a well-founded Int countdown (the `wf_fuel` strategy)
+/// and its two guards — G1 (the countdown fn never enters a blind simp set or
+/// a `fun_induction` rung) and G3 (a looping rewrite law is cited as a
+/// ground instance, never as a simp rule). Mirrors
+/// `tests/fixtures/wf_fuel_induction.av` at the unit level.
+#[test]
+fn wf_fuel_induction_emits_fuel_skeleton_and_keeps_countdown_fn_out_of_blind_simp() {
+    let mut ctx = ctx_from_source(
+        r#"
+module WfFuelUnit
+    intent = "fuel induction over a floor-division countdown"
+    effects []
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    ? "Least significant base-256 digit first."
+    match value < 1
+        true -> List.reverse(acc)
+        false -> digits(Int.div(value, 256), List.prepend(Int.mod(value, 256), acc))
+
+verify digits law accumulatorComesFirst
+    given value: Int = [0, 1, 256]
+    given acc: List<Int> = [[], [9]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))
+
+fn bigEndian(bytes: List<Int>, acc: Int) -> Int
+    ? "Most significant digit first."
+    match bytes
+        [] -> acc
+        [head, ..tail] -> bigEndian(tail, acc * 256 + head)
+
+verify bigEndian law readsTheLastByteLast
+    given bytes: List<Int> = [[], [1, 2]]
+    given b: Int = [0, 255]
+    given acc: Int = [0, 1]
+    bigEndian(List.concat(bytes, [b]), acc) => bigEndian(bytes, acc) * 256 + b
+
+verify digits law readsBackBigEndian
+    given m: Int = [0, 1, 256, 65536]
+    when m >= 0
+    bigEndian(List.reverse(digits(m, [])), 0) => m
+"#,
+        "wf_fuel_unit",
+    );
+    let lean = generated_lean_file(&transpile_for_proof_mode(
+        &mut ctx,
+        VerifyEmitMode::NativeDecide,
+    ));
+
+    // The countdown class and the fuel skeleton on both `digits` laws.
+    assert!(lean.contains("termination_by value.toNat"), "{lean}");
+    assert!(
+        lean.contains(
+            "have key : ∀ (k : Nat) (value : Int) (acc : List Int), value.toNat ≤ k → digits value acc = (acc.reverse ++ (digits value [])) := by"
+        ),
+        "the accumulator law must be proved by fuel induction:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "have ih1 := ih (value / 256) ((value % 256) :: acc) (by first | omega | sorry)"
+        ),
+        "the IH must be instantiated at the self-call arguments:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "theorem digits_law_readsBackBigEndian : ∀ (m : Int), (m >= 0) = true -> bigEndian ((digits m []).reverse) 0 = m := by"
+        ),
+        "the when-law must be stated universally:\n{lean}"
+    );
+    assert!(
+        lean.contains("have l1 := digits_law_accumulatorComesFirst (m / 256) ((m % 256) :: [])"),
+        "the looping accumulator law is cited as a ground instance:\n{lean}"
+    );
+    for base in [
+        "digits_law_accumulatorComesFirst",
+        "digits_law_readsBackBigEndian",
+        "bigEndian_law_readsTheLastByteLast",
+    ] {
+        assert!(
+            lean.contains(&format!("-- aver:law-class {base} universal")),
+            "{base} must be classed universal:\n{lean}"
+        );
+    }
+    // G1: the countdown fn is unfolded once per fuel step, never simp'd blindly
+    // and never a `fun_induction` target.
+    assert!(lean.contains("unfold WfFuelUnit.digits"), "{lean}");
+    assert!(
+        !lean.contains("simp_all [WfFuelUnit.digits")
+            && !lean.contains("simp [WfFuelUnit.digits")
+            && !lean.contains("fun_induction digits"),
+        "the countdown fn must stay out of every blind simp set:\n{lean}"
+    );
+    // G3: the accumulator law (RHS holds an instance of its LHS) never joins
+    // a simp set; the snoc law (structurally decreasing) does.
+    assert!(
+        !lean.contains("digits_law_accumulatorComesFirst]")
+            && !lean.contains("digits_law_accumulatorComesFirst,"),
+        "a looping rewrite must not join a simp set:\n{lean}"
+    );
+    assert!(
+        lean.contains("simp_all [WfFuelUnit.bigEndian, bigEndian_law_readsTheLastByteLast]"),
+        "a non-looping earlier law joins the safe simp set:\n{lean}"
+    );
+}
+
+/// The fuel strategy DECLINES a countdown position carrying an expression
+/// (`digits(magnitudeOf(value), [])`): no `generalize` in v1. The law keeps an
+/// honest `sorry` floor and no rung unfolds the countdown fn blindly (the
+/// former hard heartbeat timeout).
+#[test]
+fn wf_fuel_induction_declines_composite_countdown_arg_without_blind_simp() {
+    let mut ctx = ctx_from_source(
+        r#"
+module WfFuelDecline
+    intent = "composite countdown argument is out of scope"
+    effects []
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    ? "Least significant base-256 digit first."
+    match value < 1
+        true -> List.reverse(acc)
+        false -> digits(Int.div(value, 256), List.prepend(Int.mod(value, 256), acc))
+
+fn magnitudeOf(value: Int) -> Int
+    ? "Size without sign."
+    match value < 0
+        true -> 0 - value
+        false -> value
+
+fn bigEndian(bytes: List<Int>, acc: Int) -> Int
+    ? "Most significant digit first."
+    match bytes
+        [] -> acc
+        [head, ..tail] -> bigEndian(tail, acc * 256 + head)
+
+verify digits law readsBackBigEndian
+    given value: Int = [-5, 0, 1, 256]
+    bigEndian(List.reverse(digits(magnitudeOf(value), [])), 0) => magnitudeOf(value)
+"#,
+        "wf_fuel_decline",
+    );
+    let lean = generated_lean_file(&transpile_for_proof_mode(
+        &mut ctx,
+        VerifyEmitMode::NativeDecide,
+    ));
+    let start = lean
+        .find("theorem digits_law_readsBackBigEndian :")
+        .unwrap_or_else(|| panic!("theorem must be emitted:\n{lean}"));
+    let body = &lean[start..];
+    let body = &body[..body.find("_checked_domain").unwrap_or(body.len())];
+    assert!(!body.contains("have key : ∀ (k : Nat)"), "{body}");
+    assert!(
+        !body.contains("simp [WfFuelDecline.digits")
+            && !body.contains("simp_all [WfFuelDecline.digits")
+            && !body.contains("fun_induction digits"),
+        "the declined law must never unfold the countdown fn blindly:\n{body}"
+    );
+    assert!(
+        body.contains("sorry"),
+        "the declined law keeps its honest floor:\n{body}"
+    );
+}
+
+/// The fuel strategy DECLINES a countdown that shrinks through a WRAPPER fn
+/// (`ticks(halve(a), …)`, contract `FloorDivShrink { helper_fn: Some(..) }`):
+/// the fuel-decrease premise `(halve a).toNat ≤ k` is an atom to `omega`, and
+/// a failing discharge inside an `induction` arm is a logged build error, not
+/// a fall-through. The law keeps its honest floor with no bare `(by omega)`.
+#[test]
+fn wf_fuel_induction_declines_wrapper_shrink_countdown() {
+    let mut ctx = ctx_from_source(
+        r#"
+module WfFuelWrapper
+    intent = "wrapper shrink is out of scope for fuel induction"
+    effects []
+
+fn halve(a: Int) -> Int
+    ? "Floor half of a."
+    Int.div(a, 2)
+
+fn ticks(a: Int, acc: Int) -> Int
+    ? "Counts the halvings down to zero."
+    match a < 1
+        true -> acc
+        false -> ticks(halve(a), acc + 1)
+
+verify ticks law accumulatorAdds
+    given a: Int = [0, 1, 7, 64]
+    given acc: Int = [0, 3]
+    ticks(a, acc) => ticks(a, 0) + acc
+"#,
+        "wf_fuel_wrapper",
+    );
+    let lean = generated_lean_file(&transpile_for_proof_mode(
+        &mut ctx,
+        VerifyEmitMode::NativeDecide,
+    ));
+    assert!(
+        lean.contains("termination_by a.toNat")
+            && lean.contains("simp [halve, Except.withDefault] <;> omega"),
+        "the wrapper shrink must still be a well-founded countdown:\n{lean}"
+    );
+    let start = lean
+        .find("theorem ticks_law_accumulatorAdds :")
+        .unwrap_or_else(|| panic!("theorem must be emitted:\n{lean}"));
+    let body = &lean[start..];
+    let body = &body[..body.find("_checked_domain").unwrap_or(body.len())];
+    assert!(
+        !body.contains("have key : ∀ (k : Nat)"),
+        "a wrapper shrink is out of scope for fuel induction:\n{body}"
+    );
+    assert!(
+        !body.contains("(by omega)"),
+        "no unfloored fuel-decrease discharge may be emitted:\n{body}"
+    );
+    assert!(
+        !body.contains("simp [WfFuelWrapper.ticks")
+            && !body.contains("simp_all [WfFuelWrapper.ticks")
+            && !body.contains("fun_induction ticks"),
+        "the declined law must never unfold the countdown fn blindly:\n{body}"
+    );
+    assert!(
+        body.contains("sorry"),
+        "the declined law keeps its honest floor:\n{body}"
+    );
+}
+
+/// The fuel strategy DECLINES a law whose only mention of the countdown fn
+/// sits in the `when` premise: the arms `unfold` the fn in the GOAL, and
+/// `unfold` throws on no progress — a logged build error inside an
+/// `induction` arm. Such a law is stated over its sampled domain as before.
+#[test]
+fn wf_fuel_induction_declines_when_only_countdown_mention() {
+    let mut ctx = ctx_from_source(
+        r#"
+module WfFuelWhenOnly
+    intent = "a when-only mention gives unfold nothing to unfold"
+    effects []
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    ? "Least significant base-256 digit first."
+    match value < 1
+        true -> List.reverse(acc)
+        false -> digits(Int.div(value, 256), List.prepend(Int.mod(value, 256), acc))
+
+verify digits law emptyMeansSmall
+    given m: Int = [0, 1, 256]
+    when digits(m, []) == []
+    m < 1 => true
+"#,
+        "wf_fuel_when_only",
+    );
+    let lean = generated_lean_file(&transpile_for_proof_mode(
+        &mut ctx,
+        VerifyEmitMode::NativeDecide,
+    ));
+    let start = lean
+        .find("theorem digits_law_emptyMeansSmall")
+        .unwrap_or_else(|| panic!("theorem must be emitted:\n{lean}"));
+    let body = &lean[start..];
+    let body = &body[..body.find("_checked_domain").unwrap_or(body.len())];
+    assert!(
+        !body.contains("have key : ∀ (k : Nat)") && !body.contains("unfold WfFuelWhenOnly.digits"),
+        "a when-only mention must not be closed by fuel induction:\n{body}"
+    );
+    assert!(
+        !body.contains("simp [WfFuelWhenOnly.digits")
+            && !body.contains("simp_all [WfFuelWhenOnly.digits")
+            && !body.contains("fun_induction digits"),
+        "the declined law must never unfold the countdown fn blindly:\n{body}"
+    );
+}

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -1105,6 +1105,13 @@ fn emit_verify_law_block(
                 &law_for_auto_proof,
                 ctx,
             )
+            // Fuel induction over a well-founded Int-countdown fn: proven
+            // universally by `induction k` on a `Nat` fuel bounding the
+            // countdown given, so the statement drops the sampled domain to
+            // `∀ givens, <when> = true -> claim`. The proof emit keys on the
+            // same recognizer; credit stays fail-closed behind `#print axioms`.
+            || super::law_auto::recognize_wf_fuel_induction(vb, &law_for_auto_proof, ctx)
+                .is_some()
             // A `when`-premised `NonlinearNonneg` law (the Newton-Raphson
             // factor-sign guards) is proved UNIVERSALLY by the generic
             // `aver_int_order` step, so its statement drops the sampled
@@ -1855,6 +1862,9 @@ pub(crate) fn law_as_lemma_statement(
     if law.when.is_some()
         && !(super::law_auto::recognize_conditional_comparison_bridge(vb, law, ctx)
             || super::law_auto::recognize_conditional_inductive_generic(vb, law, ctx)
+            // The fuel-induction `when`-law is stated universally (see
+            // `conditional_universal`), so it is a sound conditional rewrite.
+            || super::law_auto::recognize_wf_fuel_induction(vb, law, ctx).is_some()
             // The exact-rational at-least-one (`F(k) >= 1` for `k >= 0`) and
             // monotonicity (`F(LO) <= F(HI)` for `LO <= HI`) conditional laws are
             // proven universally by their dedicated composition rungs, so they are

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -8634,12 +8634,12 @@ fn run_proof_check(
         // The OPEN laws to probe = every emitted MAIN law theorem (with its
         // `fn.law` identity from the class marker) MINUS the ones the manifest
         // already records as tier Universal (a genuinely-closed law has no
-        // residual). Reading the open set from the emitted markers — not just
-        // `m.laws` — is essential: a sorry-floored, universal-CLASSED law earns
-        // NO manifest record at all (the audit returns early on `sorries > 0`),
-        // so it would otherwise be invisible to a `m.laws`-only scan. A Bounded
-        // record IS probed (its native_decide twin closes, but the law's own
-        // universal `∀`-statement is the residual-bearing shape).
+        // residual). The open set is read from the emitted markers — not just
+        // `m.laws` — so a law the audit could not record at all (no lakefile
+        // root, an unreadable class channel) is still probed rather than
+        // silently skipped. A Bounded record IS probed (its native_decide twin
+        // closes, but the law's own universal `∀`-statement is the
+        // residual-bearing shape).
         let closed_universal: std::collections::HashSet<&str> = m
             .laws
             .iter()
@@ -8651,16 +8651,15 @@ fn run_proof_check(
             .filter(|(label, _)| !closed_universal.contains(label.as_str()))
             .collect();
         open_goals = lean_residual_goals(output_dir, &open);
-        // Attribute residuals to the law that ACTUALLY failed. When the gate
-        // build has residual sorries the audit bailed on `sorries > 0`, so
-        // `closed_universal` above is empty and the coarse normalization-only
-        // probe runs over EVERY emitted law — including healthy, kernel-proven
-        // ones (a proven law still yields an "unsolved goals" residual once its
-        // closing tactics are stripped). Keying that borrowed residual as the
-        // failure is what sent the P4 cold-start report to "fix" a law that was
-        // already proven. So split by `sorry_laws` (the laws whose theorem truly
-        // carries the gate-build sorry): sorry-bearers are the genuine
-        // `open_goals`; a residual from a non-sorry law is probe context
+        // Attribute residuals to the law that ACTUALLY failed. A proven law
+        // still yields an "unsolved goals" residual once its closing tactics
+        // are stripped, and the coarse normalization-only probe can run over
+        // such a law (a kernel-clean theorem the per-law audit did not record
+        // as Universal — the audit used to bail on `sorries > 0` and drop every
+        // record, which is what sent the P4 cold-start report to "fix" a law
+        // that was already proven). So split by `sorry_laws` (the laws whose
+        // theorem truly carries the gate-build sorry): sorry-bearers are the
+        // genuine `open_goals`; a residual from a non-sorry law is probe context
         // (`probe_of`), never presented as the failure. With no sorries the probe
         // only ran over bounded laws, so keep every residual as `open_goals`
         // (unchanged behavior — no `probe_of`).
@@ -9801,6 +9800,13 @@ impl LeanLawAudit {
 ///   - `bounded_laws`: law theorems classed `bounded-domain` (a pure
 ///     classification count — no certificate involved).
 ///
+/// A file with residual sorries still gets its per-theorem probe: the
+/// sorry-floored theorem's own axiom line carries `sorryAx` (tier `failed`,
+/// not counted), while every kernel-clean sibling keeps its `universal`
+/// record and counts — one open law in a module no longer erases the
+/// certificate of the laws that did close. The file-level bool alone keeps
+/// the "no sorries" conjunct.
+///
 /// The bool's semantics are untouched: `universal` remains the
 /// all-or-nothing verdict over the whole crediting set (universal-classed
 /// AND unmarked theorems), computed from the exact same expression as
@@ -9937,14 +9943,14 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
         }
         by_label.into_values().collect()
     };
-    if sorries > 0 {
-        return LeanLawAudit {
-            universal: false,
-            universal_laws: 0,
-            bounded_laws,
-            laws: bounded_records,
-        };
-    }
+    // A build with residual sorries still runs the per-theorem probe below:
+    // `#print axioms` on a sorry-floored theorem lists `sorryAx`, so that law
+    // records tier `failed` while every kernel-clean sibling keeps its own
+    // `universal` record and counts in `universal_laws`. Only the FILE-level
+    // `universal` bool keeps its all-or-nothing "no sorries" conjunct (see
+    // the final assembly). Per-law credit is decided by each theorem's own
+    // axiom line, never by the dir's sorry count.
+    let file_has_sorries = sorries > 0;
     // Consume the statement-class channel (see the doc comment above):
     // bounded-domain theorems leave the crediting set; at least one
     // explicitly universal-classed theorem must remain or the dir earns no
@@ -10014,7 +10020,8 @@ fn lean_universal_audit(dir: &str, sorries: usize) -> LeanLawAudit {
             // output format is `'name' depends on axioms: [a, b]` (or `does
             // not depend on any axioms`); the two blacklist probes stay as a
             // belt-and-suspenders floor against output-format drift.
-            let universal = o.status.success()
+            let universal = !file_has_sorries
+                && o.status.success()
                 && lean_axiom_lines_whitelisted(&combined)
                 && !combined.contains("Lean.ofReduceBool")
                 && !combined.contains("sorryAx");
@@ -10193,8 +10200,8 @@ fn lean_sorry_laws(dir: &str, build_output: &str) -> Vec<String> {
 /// marker's third field (falling back to the theorem name on an older emission
 /// without the label, matching `manifest_label_for`). Used by `--explain` to
 /// build the open-law set DIRECTLY from the markers — robust to the audit
-/// returning early (no manifest record) for a sorry-floored universal-classed
-/// law. Returns `(fn.law, theorem)` pairs, deduped by theorem name. Only the
+/// recording nothing for a law (no lakefile root, an unreadable class
+/// channel). Returns `(fn.law, theorem)` pairs, deduped by theorem name. Only the
 /// entry module's namespace is scanned; dependency law pools remain transitive
 /// inputs to those theorems.
 fn emitted_main_law_theorems(dir: &str) -> Vec<(String, String)> {

--- a/tests/fixtures/wf_fuel_induction.av
+++ b/tests/fixtures/wf_fuel_induction.av
@@ -1,0 +1,44 @@
+module WfFuel
+    intent =
+        "Fuel induction over a well-founded Int countdown: a base-256 digit"
+        "writer that shrinks its value by floor division, an accumulator"
+        "law about it, and a round trip through a structural reader."
+    effects []
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    ? "Least significant base-256 digit first, with no leading zero."
+    match value < 1
+        true -> List.reverse(acc)
+        false -> digits(Int.div(value, 256), List.prepend(Int.mod(value, 256), acc))
+
+verify digits
+    digits(0, []) => []
+    digits(1, []) => [1]
+    digits(258, []) => [2, 1]
+
+verify digits law accumulatorComesFirst
+    given value: Int = [-1, 0, 1, 255, 256, 65536, 2147483648]
+    given acc: List<Int> = [[], [9], [1, 2]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))
+
+fn bigEndian(bytes: List<Int>, acc: Int) -> Int
+    ? "Most significant digit first, which is what reversing the digits gives."
+    match bytes
+        [] -> acc
+        [head, ..tail] -> bigEndian(tail, acc * 256 + head)
+
+verify bigEndian
+    bigEndian([], 0) => 0
+    bigEndian([1], 0) => 1
+    bigEndian([1, 2], 0) => 258
+
+verify bigEndian law readsTheLastByteLast
+    given bytes: List<Int> = [[], [1], [1, 2], [255, 0, 7]]
+    given b: Int = [0, 1, 128, 255]
+    given acc: Int = [0, 1, 300]
+    bigEndian(List.concat(bytes, [b]), acc) => bigEndian(bytes, acc) * 256 + b
+
+verify digits law readsBackBigEndian
+    given m: Int = [0, 1, 127, 128, 255, 256, 65535, 65536, 2147483647, 2147483648]
+    when m >= 0
+    bigEndian(List.reverse(digits(m, [])), 0) => m

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -41,6 +41,8 @@ mod opaque_closure;
 mod oracle_verify;
 #[path = "proof_spec/panics.rs"]
 mod panics;
+#[path = "proof_spec/wf_fuel.rs"]
+mod wf_fuel;
 #[path = "proof_spec/when_lane.rs"]
 mod when_lane;
 

--- a/tests/proof_spec/wf_fuel.rs
+++ b/tests/proof_spec/wf_fuel.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+/// Fuel induction over a well-founded Int countdown
+/// (`tests/fixtures/wf_fuel_induction.av`): a base-256 digit writer
+/// `digits(value, acc)` that recurses on `Int.div(value, 256)` under a
+/// `value < 1` guard (emitted as a native `termination_by value.toNat`
+/// def), an accumulator law about it, a structural reader with a snoc
+/// law, and a `when m >= 0` round trip through both.
+///
+/// Export-structure pin (no toolchain needed). Before the fix a law
+/// mentioning such a fn hit the generic ladder's blind `simp [digits]`
+/// / `fun_induction digits … <;> simp_all [digits]` rungs, whose
+/// unconditional unfold equation heartbeat-aborts — a HARD build error
+/// `first | … | sorry` cannot catch, which cost the whole module its
+/// tier. Post-fix the two `digits` laws carry the fuel-induction
+/// skeleton (`have key : ∀ (k : Nat) …`, one `unfold` per fuel step),
+/// the countdown fn sits in NO blind simp set and is NO `fun_induction`
+/// target, and every law theorem is classed `universal`.
+#[test]
+fn proof_export_wf_fuel_induction_lean_structure() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-wf-fuel-export");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/wf_fuel_induction.av")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(output_dir.join("WfFuel.lean"))
+        .expect("WfFuel.lean must be emitted");
+
+    // The recursion class: a native well-founded def, never partial.
+    assert!(
+        !lean.contains("partial def"),
+        "the floor-division countdown must emit as a well-founded def"
+    );
+    assert!(lean.contains("def digits"));
+    assert!(lean.contains("termination_by value.toNat"));
+
+    // Both `digits` laws carry the fuel-induction skeleton.
+    for base in [
+        "digits_law_accumulatorComesFirst",
+        "digits_law_readsBackBigEndian",
+    ] {
+        let start = lean
+            .find(&format!("theorem {base} :"))
+            .unwrap_or_else(|| panic!("{base} theorem must be emitted:\n{lean}"));
+        let body = &lean[start..];
+        let end = body.find("_checked_domain").unwrap_or(body.len());
+        let body = &body[..end];
+        assert!(
+            body.contains("have key : ∀ (k : Nat)"),
+            "{base} must be proved by fuel induction:\n{body}"
+        );
+        assert!(
+            body.contains("induction k with") && body.contains("| succ k ih =>"),
+            "{base} must induct on the fuel:\n{body}"
+        );
+        assert!(
+            body.contains("unfold WfFuel.digits"),
+            "{base} must unfold the countdown fn once per fuel step:\n{body}"
+        );
+        assert!(
+            body.contains("exact key _"),
+            "{base} must project the fuel lemma at the countdown's own measure:\n{body}"
+        );
+        assert!(
+            !body.contains("fun_induction digits") && !body.contains("fun_induction WfFuel.digits"),
+            "{base} must not drive the countdown fn's .induct blindly:\n{body}"
+        );
+        assert!(
+            !body.contains("simp_all [WfFuel.digits") && !body.contains("simp [WfFuel.digits"),
+            "{base} must keep the countdown fn out of every blind simp set:\n{body}"
+        );
+        assert!(
+            lean.contains(&format!("-- aver:law-class {base} universal")),
+            "{base} must be classed universal"
+        );
+    }
+    // The when-law is stated in TRUE universal form (no sampled-domain
+    // disjunction on the theorem statement).
+    assert!(
+        lean.contains(
+            "theorem digits_law_readsBackBigEndian : ∀ (m : Int), (m >= 0) = true -> bigEndian ((digits m []).reverse) 0 = m := by"
+        ),
+        "the when-law must drop its sampled domain:\n{lean}"
+    );
+    // The round trip cites the accumulator law as a GROUND instance (it is a
+    // looping rewrite, so it never joins a simp set) and the ground IH at the
+    // shrunk value.
+    assert!(
+        lean.contains("have l1 := digits_law_accumulatorComesFirst (m / 256) ((m % 256) :: [])"),
+        "the round trip must cite the accumulator law at the recursive call:\n{lean}"
+    );
+    assert!(
+        lean.contains("have ih1 := ih (m / 256) (by first | omega | sorry)"),
+        "the round trip must instantiate the IH at the shrunk value:\n{lean}"
+    );
+    assert!(
+        !lean.contains("simp_all [WfFuel.bigEndian, digits_law_accumulatorComesFirst"),
+        "the looping accumulator law must not join a simp set:\n{lean}"
+    );
+    // The structural reader's snoc law is universal too.
+    assert!(lean.contains("-- aver:law-class bigEndian_law_readsTheLastByteLast universal"));
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// Documented DECLINE: the countdown position carrying an expression
+/// (`digits(magnitudeOf(value), [])`) is out of the fuel strategy's scope
+/// (no `generalize`), so the law keeps an honest `sorry` floor — and no
+/// blind rung ever unfolds the countdown fn into a hard build error. The
+/// export pin only checks the emitted shape; the lake gate below proves the
+/// module still builds.
+#[test]
+fn proof_export_wf_fuel_declines_composite_countdown_arg_honestly() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-wf-fuel-decline");
+    let source = std::fs::read_to_string(repo_root.join("tests/fixtures/wf_fuel_induction.av"))
+        .expect("fixture source");
+    let source = source.replace(
+        "verify digits law readsBackBigEndian\n    given m: Int = [0, 1, 127, 128, 255, 256, 65535, 65536, 2147483647, 2147483648]\n    when m >= 0\n    bigEndian(List.reverse(digits(m, [])), 0) => m\n",
+        "fn magnitudeOf(value: Int) -> Int\n    ? \"Size without sign.\"\n    match value < 0\n        true -> 0 - value\n        false -> value\n\nverify magnitudeOf\n    magnitudeOf(5) => 5\n    magnitudeOf(0 - 5) => 5\n\nverify digits law readsBackBigEndian\n    given value: Int = [-5, 0, 1, 255, 256, 2147483648]\n    bigEndian(List.reverse(digits(magnitudeOf(value), [])), 0) => magnitudeOf(value)\n",
+    );
+    assert!(
+        source.contains("magnitudeOf(value), [])"),
+        "fixture edit must apply"
+    );
+    let src_dir = temp_output_dir("aver-proof-wf-fuel-decline-src");
+    std::fs::create_dir_all(&src_dir).expect("src dir");
+    let src_path = src_dir.join("wf_fuel_decline.av");
+    std::fs::write(&src_path, source).expect("write source");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(&src_path)
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(output_dir.join("WfFuel.lean"))
+        .expect("WfFuel.lean must be emitted");
+    let start = lean
+        .find("theorem digits_law_readsBackBigEndian :")
+        .expect("round-trip theorem must be emitted");
+    let body = &lean[start..];
+    let end = body.find("_checked_domain").unwrap_or(body.len());
+    let body = &body[..end];
+    assert!(
+        !body.contains("have key : ∀ (k : Nat)"),
+        "a composite countdown arg is out of scope for fuel induction:\n{body}"
+    );
+    assert!(
+        !body.contains("simp [WfFuel.digits")
+            && !body.contains("simp_all [WfFuel.digits")
+            && !body.contains("fun_induction digits")
+            && !body.contains("fun_induction WfFuel.digits"),
+        "the declined law must never unfold the countdown fn blindly:\n{body}"
+    );
+    assert!(
+        body.contains("sorry"),
+        "the declined law keeps its honest sorry floor:\n{body}"
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+    let _ = std::fs::remove_dir_all(&src_dir);
+}
+
+/// Live Lean gate: the fixture builds green with ZERO sorries and every law
+/// theorem earns kernel-genuine `universal` credit — the fuel-induction
+/// proofs close inside the axiom whitelist (`propext`, `Classical.choice`,
+/// `Quot.sound`), no `native_decide`, no Mathlib. Before the fix the module
+/// reported build errors (heartbeat timeouts) and no tier at all.
+#[test]
+fn proof_wf_fuel_induction_lean_closes_kernel_genuine() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping wf-fuel proof test: `lake` not available");
+        return;
+    }
+    let output_dir = temp_output_dir("aver-proof-wf-fuel");
+    let (summary, run) =
+        run_lean_check_json("tests/fixtures/wf_fuel_induction.av", &output_dir, 0, &[]);
+    assert_eq!(
+        summary["build_errors"].as_u64(),
+        Some(0),
+        "no blind rung may heartbeat-abort on the countdown fn.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "wf-fuel laws must close sorry-free.\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "all three law theorems are stated universally and must be \
+         kernel-genuine (axioms within the whitelist).\n{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        (
+            summary["universal_laws"].as_u64(),
+            summary["bounded_laws"].as_u64(),
+        ),
+        (Some(3), Some(0)),
+        "explicit law counts: exactly the three universal-classed law \
+         theorems certified, none degraded to bounded-domain.\n{}",
+        format_output(&run)
+    );
+    let _ = std::fs::remove_dir_all(&output_dir);
+}


### PR DESCRIPTION
Closes #1266.

A law whose cone reaches a function exported with `termination_by param.toNat` (`RecursionContract::WellFoundedToNat`) hard-failed the Lean build instead of landing on `sorry`: the blind `simp [<cone defs>]` fallback unfolded the recursive call forever (`timeout at isDefEq`), and the induction ladder's `fun_induction f … <;> simp_all [f]` timed out at `whnf`. Heartbeat timeouts escape `first | … | sorry`, so the whole module lost its tier.

## What changes

- **No blind simp over WellFoundedToNat defs.** Such functions never enter a blind simp set and are not `fun_induction` targets. The generic fallback drops its blind-simp arm when the cone holds one; this generalises the string-scanner special case (`cone_has_scanner`). Bespoke templates (floor window, floor arith, recursive mono, keystone) are untouched.
- **New strategy `law_auto/wf_fuel.rs`.** A law over such a function is proved by fuel induction on `param.toNat`: `∀ k givens, param.toNat ≤ k → claim`, the IH instantiated at the body's own self-call arguments as ground facts (`have ih1 := ih (value / 256) ((value % 256) :: acc) (by omega)`), then `clear ih; unfold f; split <;> simp_all <;> omega`, under a `sorry` floor. Earlier laws about the same function are cited as ground instances at the same argument tuples, never as simp rules (an accumulator law loops as a rewrite). Applies when exactly one such function occurs in the law, always with the same bare `Int` given at its countdown position; anything else declines honestly. `when`-laws of this shape are stated universally, keyed on the same recognizer in `verify.rs` and the emitter.
- **Self-referential rewrites stay out of simp pools** (`law_is_looping_rewrite`).
- **Per-theorem audit on files with sorries.** `lean_universal_audit` no longer returns early on `sorries > 0`: a sorry-floored theorem records tier `failed` (its own axiom line carries `sorryAx`), kernel-clean siblings keep their `universal` records and count in `universal_laws`. Only the file-level `universal` bool keeps the no-sorries conjunct. This is what lets `--gate` track per-law tiers while a module still has open laws. `docs/lean.md` updated.

## Evidence

Fixture `tests/fixtures/wf_fuel_induction.av` (a little-endian digit writer with `termination_by value.toNat`, a structural `bigEndian`), with `tests/proof_spec/wf_fuel.rs`: structural pins plus a lake-gated `--check-json` run. Three laws close kernel-genuine, axioms `[propext, Classical.choice, Quot.sound]`: the accumulator law `digits(v, acc) == reverse(acc) ++ digits(v, [])`, the snoc lemma `bigEndian(bytes ++ [b], acc) == bigEndian(bytes, acc) * 256 + b`, and the guarded round trip `bigEndian(reverse(digits(m, [])), 0) == m` under `when m >= 0`.

On the reproducer from n1bor/btc-listener (`Domain.StackItem`), the same three rungs go from `build_errors: 2` to `universal`, and the remaining round trip `asNumber(fromNumber(v)) == v` stays an honest `sorry`.

`cargo test --test proof_spec` (311, Lean-gated included), `cargo test --lib` (1495), `cargo test -p aver-lang --features wasm --test cert_certify_spec` (38), fmt and the CI-shaped clippy gates are green locally.
