### PR TITLE
fix(proof): resolve dotted call names by module, and let dependency laws be cited across files

### DIFF
--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -922,7 +922,7 @@ pub(super) fn earlier_law_lemmas(
     law: &VerifyLaw,
     ctx: &CodegenContext,
 ) -> Vec<crate::codegen::lemma_discovery::CommittedLemma> {
-    use crate::ast::{TopLevel, VerifyKind};
+    use crate::ast::VerifyKind;
     let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
     let cone = crate::codegen::proof_lower::LawProofCone::compute(law, &vb.fn_name, &inputs);
     let mut scope: BTreeSet<String> = cone
@@ -937,12 +937,33 @@ pub(super) fn earlier_law_lemmas(
         .into_iter()
         .map(|l| (l.clone(), l))
         .collect();
+    // Under a DEPENDENCY module's scope the statement renderer spells that
+    // module's own fns namespace-qualified (`M.f`), so the in-file gate must
+    // compare in the same qualified identity the cross-file half uses —
+    // otherwise a module's own siblings never match its bare-name cone and
+    // the pool comes back empty for every dependency law.
+    let active_module = ctx
+        .active_module_scope()
+        .and_then(|s| ctx.modules.iter().find(|m| m.prefix == s));
+    let (program_index, scope, subject) = match active_module {
+        Some(m) => {
+            let (mut qscope, _) = consumer_law_qualified_scope(vb, law, ctx);
+            let qsubject = format!("{}.{}", m.prefix, subject);
+            qscope.insert(qsubject.clone());
+            (dep_membership_index(m, ctx), qscope, qsubject)
+        }
+        None => (program_index, scope, subject),
+    };
+    let sibling_subject = |prev: &VerifyBlock| match active_module {
+        Some(m) => format!("{}.{}", m.prefix, aver_name_to_lean(&prev.fn_name)),
+        None => aver_name_to_lean(&prev.fn_name),
+    };
 
     let mut out = Vec::new();
-    for item in &ctx.items {
-        let TopLevel::Verify(prev) = item else {
-            continue;
-        };
+    // "Same file" is the file this theorem lands in: the dependency module's
+    // own blocks under its scope, the entry items otherwise (see
+    // `same_file_verify_blocks`).
+    for prev in super::shared::same_file_verify_blocks(ctx) {
         // Stop at the consumer law itself; only earlier blocks are eligible.
         if prev.line == vb.line && prev.fn_name == vb.fn_name {
             break;
@@ -978,7 +999,7 @@ pub(super) fn earlier_law_lemmas(
         // proof — is inert in the goal (nothing to rewrite) and only adds noise.
         // The genuine decomposition case is preserved: a count-homomorphism
         // helper IS a law about `count`, the very subject it shares.
-        let prev_subject = aver_name_to_lean(&prev.fn_name);
+        let prev_subject = sibling_subject(prev);
         // THIRD rule — LHS-rooted relevance. A Forward sibling fires against the
         // consumer goal only through its LHS shape, so a helper whose LHS sits
         // ENTIRELY inside this proof's cone is relevant even when its RHS
@@ -1012,7 +1033,7 @@ pub(super) fn earlier_law_lemmas(
             let pmentions: BTreeSet<String> = raw
                 .iter()
                 .map(|n| aver_name_to_lean(n))
-                .filter(|n| program_index.contains_key(n))
+                .filter_map(|n| program_index.get(&n).cloned())
                 .collect();
             !pmentions.is_empty() && pmentions.is_subset(&scope) && scope.contains(&prev_subject)
         });
@@ -1162,12 +1183,12 @@ fn bridge_law_lean_names(
 /// the tight rung does not yet render. Unconditional (`when.is_none`) universal-
 /// form laws only; the per-declaration `#print axioms` gate keeps soundness, so
 /// the dafny-only opaque/native-mutual/oracle filters are not mirrored here.
-fn earlier_law_cites<'a>(
+fn earlier_law_cites(
     vb: &VerifyBlock,
     law: &VerifyLaw,
-    ctx: &'a CodegenContext,
-) -> Vec<(String, &'a VerifyLaw)> {
-    use crate::ast::{TopLevel, VerifyKind};
+    ctx: &CodegenContext,
+) -> Vec<(String, VerifyLaw)> {
+    use crate::ast::VerifyKind;
     let inputs = crate::codegen::proof_lower::ProofLowerInputs::from_ctx(ctx);
     let cone = crate::codegen::proof_lower::LawProofCone::compute(law, &vb.fn_name, &inputs);
     let mut scope: BTreeSet<String> = cone
@@ -1182,12 +1203,27 @@ fn earlier_law_cites<'a>(
         .into_iter()
         .map(|l| (l.clone(), l))
         .collect();
+    // Same qualified-identity rule as `earlier_law_lemmas` under a dependency
+    // module's scope.
+    let active_module = ctx
+        .active_module_scope()
+        .and_then(|s| ctx.modules.iter().find(|m| m.prefix == s));
+    let (program_index, scope, subject) = match active_module {
+        Some(m) => {
+            let (mut qscope, _) = consumer_law_qualified_scope(vb, law, ctx);
+            let qsubject = format!("{}.{}", m.prefix, subject);
+            qscope.insert(qsubject.clone());
+            (dep_membership_index(m, ctx), qscope, qsubject)
+        }
+        None => (program_index, scope, subject),
+    };
+    let sibling_subject = |prev: &VerifyBlock| match active_module {
+        Some(m) => format!("{}.{}", m.prefix, aver_name_to_lean(&prev.fn_name)),
+        None => aver_name_to_lean(&prev.fn_name),
+    };
 
     let mut out = Vec::new();
-    for item in &ctx.items {
-        let TopLevel::Verify(prev) = item else {
-            continue;
-        };
+    for prev in super::shared::same_file_verify_blocks(ctx) {
         // Only blocks earlier in source are eligible; stop at the consumer.
         if prev.line == vb.line && prev.fn_name == vb.fn_name {
             break;
@@ -1220,7 +1256,7 @@ fn earlier_law_cites<'a>(
         // SAME three admission rules as `earlier_law_lemmas`: the sibling stays in
         // the cone, OR it mentions the consumer's subject (decomposition that
         // introduces a combinator), OR its LHS is cone-rooted.
-        let prev_subject = aver_name_to_lean(&prev.fn_name);
+        let prev_subject = sibling_subject(prev);
         let lhs_mentions = crate::codegen::lemma_discovery::lemma_lhs_fns(&text, &program_index);
         let lhs_rooted = !lhs_mentions.is_empty()
             && lhs_mentions.is_subset(&scope)
@@ -1229,10 +1265,79 @@ fn earlier_law_cites<'a>(
             || (mentions.contains(&subject) && scope.contains(&prev_subject))
             || lhs_rooted
         {
-            out.push((name, prev_law.as_ref()));
+            out.push((name, prev_law.as_ref().clone()));
+        }
+    }
+    // Cross-file half: a dependency module's exposed, unconditional laws,
+    // admitted by the SAME gate as `earlier_law_lemmas` and cited by their
+    // namespace-qualified theorem name. The instantiation engine matches call
+    // heads by their dotted spelling, so the dependency law's calls to its
+    // own fns are re-spelled the way the consumer writes them (`M.f`) before
+    // it is handed over. Only modules strictly earlier in the DAG than the
+    // consumer's are eligible (a dependency precedes its consumers).
+    let (qualified_scope, qualified_subject) = consumer_law_qualified_scope(vb, law, ctx);
+    let consumer_module_idx = ctx
+        .active_module_scope()
+        .and_then(|s| ctx.modules.iter().position(|m| m.prefix == s));
+    for (module_idx, module) in ctx.modules.iter().enumerate() {
+        if let Some(consumer_idx) = consumer_module_idx
+            && module_idx >= consumer_idx
+        {
+            continue;
+        }
+        let dep_index = dep_membership_index(module, ctx);
+        for prev in &module.verify_laws {
+            let VerifyKind::Law(prev_law) = &prev.kind else {
+                continue;
+            };
+            if prev_law.when.is_some()
+                || crate::codegen::cite_instantiate::law_rewrites_to_self(prev_law)
+            {
+                continue;
+            }
+            if let Some((name, _text)) = dep_law_admissible(
+                module,
+                prev,
+                prev_law,
+                &qualified_scope,
+                &qualified_subject,
+                &dep_index,
+                ctx,
+            ) {
+                out.push((name, qualify_module_calls(prev_law, module)));
+            }
         }
     }
     out
+}
+
+/// A dependency law's expressions with every call to one of that module's own
+/// fns spelled the way a consumer writes it (`M.f`), so the instantiation
+/// engine's dotted-name matching lines up with the consumer's goal. Binders
+/// are respected by the scoped rewriter; a fn name never shadows a given.
+fn qualify_module_calls(law: &VerifyLaw, module: &crate::codegen::ModuleInfo) -> VerifyLaw {
+    use crate::ast::{Expr, Spanned};
+    fn dotted(path: &str) -> Spanned<Expr> {
+        let mut parts = path.split('.');
+        let mut expr = Spanned::bare(Expr::Ident(parts.next().unwrap_or_default().to_string()));
+        for part in parts {
+            expr = Spanned::bare(Expr::Attr(Box::new(expr), part.to_string()));
+        }
+        expr
+    }
+    let own: BTreeSet<&str> = module.fn_defs.iter().map(|d| d.name.as_str()).collect();
+    let qualify = |e: &Spanned<Expr>| {
+        crate::ast_rewrite::rewrite_idents_scoped(e, |name| {
+            own.contains(name)
+                .then(|| dotted(&format!("{}.{}", module.prefix, name)))
+        })
+    };
+    VerifyLaw {
+        when: law.when.as_ref().map(&qualify),
+        lhs: qualify(&law.lhs),
+        rhs: qualify(&law.rhs),
+        ..law.clone()
+    }
 }
 
 /// Render a computed instantiation argument (from `cite_instantiate`) to a Lean
@@ -1368,7 +1473,7 @@ fn b_tight_decomposition_arms(
     if cites.is_empty() {
         return None;
     }
-    let cited: Vec<&VerifyLaw> = cites.iter().map(|(_, l)| *l).collect();
+    let cited: Vec<&VerifyLaw> = cites.iter().map(|(_, l)| l).collect();
     let insts =
         crate::codegen::cite_instantiate::compute_instantiations(law, ind_aver_name, &cited, ctx);
     if insts.is_empty() {

--- a/src/codegen/lean/law_auto/shared.rs
+++ b/src/codegen/lean/law_auto/shared.rs
@@ -906,6 +906,32 @@ fn collect_user_fn_simp_names(
     }
 }
 
+/// The verify blocks of the FILE a law theorem is emitted into, in source
+/// order: a dependency module's blocks when the emitter runs under that
+/// module's scope (`with_module_scope(Some(prefix))`), the entry module's
+/// top-level verify items otherwise. Pools of "earlier laws in the same file"
+/// must read this sequence — `ctx.items` holds the entry module only, so
+/// scanning it from inside a dependency cites theorems of another file (an
+/// unknown identifier there) and misses the dependency's own siblings.
+pub(super) fn same_file_verify_blocks(ctx: &CodegenContext) -> Vec<&VerifyBlock> {
+    match ctx.active_module_scope().as_deref() {
+        Some(prefix) => ctx
+            .modules
+            .iter()
+            .find(|m| m.prefix == prefix)
+            .map(|m| m.verify_blocks.iter().collect())
+            .unwrap_or_default(),
+        None => ctx
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                crate::ast::TopLevel::Verify(vb) => Some(vb),
+                _ => None,
+            })
+            .collect(),
+    }
+}
+
 pub(super) fn find_fn_def<'a>(ctx: &'a CodegenContext, fn_name: &str) -> Option<&'a FnDef> {
     ctx.modules
         .iter()
@@ -914,14 +940,36 @@ pub(super) fn find_fn_def<'a>(ctx: &'a CodegenContext, fn_name: &str) -> Option<
         .find(|fd| fd.name == fn_name)
 }
 
+/// Resolve a call's dotted source name to the fn def it denotes, the way the
+/// checker does: a qualifier that names a loaded module picks THAT module's
+/// fn (`Bytes.concat`, `Domain.StackItem.asNumber`); a qualifier that is a
+/// builtin namespace (`List.concat`, `Int.div`, `Crypto.sha256`) denotes a
+/// builtin and never a user fn; only an unqualified name, or a qualifier this
+/// program does not know, falls back to a bare-name lookup. The bare fallback
+/// used to run for every dotted name, so `List.concat` in a law resolved to
+/// `Bytes.concat` whenever `Bytes` was in the program closure — and the stray
+/// `concat` in the law's simp set made every tactic arm fail, so laws that
+/// closed as an entry module fell to `sorry` as a dependency module.
 pub(super) fn find_fn_def_by_call_name<'a>(
     ctx: &'a CodegenContext,
     call_name: &str,
 ) -> Option<&'a FnDef> {
-    find_fn_def(ctx, call_name).or_else(|| {
-        let short = call_name.rsplit('.').next()?;
-        find_fn_def(ctx, short)
-    })
+    if let Some(found) = find_fn_def(ctx, call_name) {
+        return Some(found);
+    }
+    let (prefix, short) = call_name.rsplit_once('.')?;
+    if let Some(module) = ctx.modules.iter().find(|m| m.prefix == prefix) {
+        return module.fn_defs.iter().find(|fd| fd.name == short);
+    }
+    if crate::ir::is_builtin_namespace(prefix)
+        || prefix
+            .split('.')
+            .next()
+            .is_some_and(crate::ir::is_builtin_namespace)
+    {
+        return None;
+    }
+    find_fn_def(ctx, short)
 }
 
 pub(super) fn expr_dotted_name(expr: &Spanned<Expr>) -> Option<String> {

--- a/src/codegen/lean/law_auto/wf_fuel.rs
+++ b/src/codegen/lean/law_auto/wf_fuel.rs
@@ -26,12 +26,10 @@ use super::super::expr::aver_name_to_lean;
 use super::AutoProof;
 use super::shared::{
     call_name_args, child_exprs, direct_user_calls, find_fn_def, find_fn_def_by_call_name,
-    ident_name, law_simp_defs_blind, render, simp_def_name, substitute_expr, wf_countdown_fn_names,
-    wf_countdown_param,
+    ident_name, law_simp_defs_blind, render, same_file_verify_blocks, simp_def_name,
+    substitute_expr, wf_countdown_fn_names, wf_countdown_param,
 };
-use crate::ast::{
-    BinOp, Expr, FnDef, Literal, Spanned, Stmt, TopLevel, VerifyBlock, VerifyKind, VerifyLaw,
-};
+use crate::ast::{BinOp, Expr, FnDef, Literal, Spanned, Stmt, VerifyBlock, VerifyKind, VerifyLaw};
 use crate::codegen::CodegenContext;
 
 /// A recognized fuel-induction law: the single well-founded countdown fn the
@@ -265,10 +263,14 @@ fn reaches(from: &str, target: &str, ctx: &CodegenContext) -> bool {
     false
 }
 
-/// An earlier, same-file, unconditional law whose LHS is a direct call to `f`
-/// on bare, distinct givens covering all of its givens: `f(g_1..g_n)`. Cited
-/// as a ground instance at every IH tuple (the accumulator law is exactly this
-/// shape and is a looping simp rule, so it never joins a simp set).
+/// An earlier law whose LHS is a direct call to `f` on bare, distinct givens
+/// covering all of its givens: `f(g_1..g_n)`. Cited as a ground instance at
+/// every IH tuple (the accumulator law is exactly this shape and is a looping
+/// simp rule, so it never joins a simp set). Two sources: laws earlier in the
+/// FILE this theorem lands in, and the exposed laws of the dependency module
+/// that OWNS `f` (cited by their namespace-qualified theorem name; the
+/// consumer file imports and opens every dependency, and a dependency always
+/// precedes its consumers in the module DAG, so a cycle is impossible).
 struct GroundLaw {
     theorem: String,
     /// For each of the law's givens, the `f` argument position it occupies.
@@ -276,40 +278,33 @@ struct GroundLaw {
 }
 
 fn ground_laws_about(vb: &VerifyBlock, plan: &WfFuelPlan, ctx: &CodegenContext) -> Vec<GroundLaw> {
-    let mut out = Vec::new();
-    // Only laws from the FILE this theorem is emitted into can be cited by
-    // name: a dependency module's laws are emitted under
-    // `with_module_scope(Some(prefix))` from that module's own verify blocks,
-    // while `ctx.items` holds the ENTRY module's items. Scanning the wrong
-    // sequence would cite an entry-module theorem from a dependency file (an
-    // unknown identifier) or stop at a same-line block of another file.
-    let scope = ctx.active_module_scope();
-    let blocks: Vec<&VerifyBlock> = match scope.as_deref() {
-        Some(prefix) => ctx
-            .modules
-            .iter()
-            .find(|m| m.prefix == prefix)
-            .map(|m| m.verify_blocks.iter().collect())
-            .unwrap_or_default(),
-        None => ctx
-            .items
-            .iter()
-            .filter_map(|item| match item {
-                TopLevel::Verify(prev) => Some(prev),
-                _ => None,
-            })
-            .collect(),
-    };
-    for prev in blocks {
+    // Candidate blocks, each with the dependency module it comes from (`None`
+    // = this file). `ctx.items` holds the ENTRY module only, so the in-file
+    // sequence is read through `same_file_verify_blocks`.
+    let mut candidates: Vec<(Option<&crate::codegen::ModuleInfo>, &VerifyBlock)> = Vec::new();
+    for prev in same_file_verify_blocks(ctx) {
         if prev.line == vb.line && prev.fn_name == vb.fn_name {
             break;
         }
+        candidates.push((None, prev));
+    }
+    let active = ctx.active_module_scope();
+    if let Some(owner) = ctx
+        .modules
+        .iter()
+        .find(|m| m.fn_defs.iter().any(|d| d.name == plan.f))
+        && active.as_deref() != Some(owner.prefix.as_str())
+    {
+        // `verify_laws` holds only the laws whose subject the module exposes.
+        for prev in &owner.verify_laws {
+            candidates.push((Some(owner), prev));
+        }
+    }
+    let mut out = Vec::new();
+    for (owner, prev) in candidates {
         let VerifyKind::Law(prev_law) = &prev.kind else {
             continue;
         };
-        if prev_law.when.is_some() {
-            continue;
-        }
         let Some((name, args)) = call_name_args(&prev_law.lhs) else {
             continue;
         };
@@ -336,10 +331,31 @@ fn ground_laws_about(vb: &VerifyBlock, plan: &WfFuelPlan, ctx: &CodegenContext) 
         if !covered || args.iter().any(|a| ident_name(a).is_none()) {
             continue;
         }
-        let Some((theorem, _)) =
-            crate::codegen::lean::toplevel::law_as_lemma_statement(prev, prev_law, ctx)
-        else {
+        // The theorem must exist in its universal form. An unconditional law
+        // is stated so exactly when `law_as_lemma_statement` accepts it; a
+        // `when`-law is stated so only when this strategy recognises it
+        // (verify.rs classes exactly those `conditional_universal`), and is
+        // then cited as the implication `<when> = true -> claim`, which
+        // `simp_all` uses as a conditional rewrite — never discharged here.
+        let base = ctx.with_module_scope(owner.map(|m| m.prefix.as_str()), || {
+            if prev_law.when.is_some() {
+                recognize_wf_fuel_induction(prev, prev_law, ctx)
+                    .map(|_| crate::codegen::lean::toplevel::law_theorem_base(prev, prev_law, ctx))
+            } else {
+                crate::codegen::lean::toplevel::law_as_lemma_statement(prev, prev_law, ctx)
+                    .map(|(name, _)| name)
+            }
+        });
+        let Some(base) = base else {
             continue;
+        };
+        let theorem = match owner {
+            Some(m) => format!(
+                "{}.{}",
+                crate::codegen::lean::syntax::aver_path_to_lean(&m.prefix),
+                base
+            ),
+            None => base,
         };
         out.push(GroundLaw {
             theorem,

--- a/tests/fixtures/dep_law_builtin_names/digits.av
+++ b/tests/fixtures/dep_law_builtin_names/digits.av
@@ -1,0 +1,40 @@
+module Digits
+    intent =
+        "A big-endian reader, a little-endian digit writer with a well-founded"
+        "countdown, and the laws about them that a consumer module cites."
+    exposes [bigEndian, digits]
+    depends []
+    effects []
+
+fn bigEndian(bytes: List<Int>, acc: Int) -> Int
+    ? "Most significant byte first."
+    match bytes
+        [] -> acc
+        [head, ..tail] -> bigEndian(tail, acc * 256 + head)
+
+verify bigEndian
+    bigEndian([], 0) => 0
+    bigEndian([1], 0) => 1
+    bigEndian([1, 2], 0) => 258
+
+verify bigEndian law readsTheLastByteLast
+    given bytes: List<Int> = [[], [1], [1, 2], [255, 0, 7]]
+    given b: Int = [0, 1, 128, 255]
+    given acc: Int = [0, 1, 300]
+    bigEndian(List.concat(bytes, [b]), acc) => bigEndian(bytes, acc) * 256 + b
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    ? "Least significant byte first; a non-positive value writes nothing."
+    match value > 0
+        true -> digits(Int.div(value, 256), List.prepend(Int.mod(value, 256), acc))
+        false -> List.reverse(acc)
+
+verify digits
+    digits(0, []) => []
+    digits(1, []) => [1]
+    digits(258, []) => [2, 1]
+
+verify digits law accumulatorComesFirst
+    given value: Int = [-1, 0, 1, 255, 256, 65536]
+    given acc: List<Int> = [[], [9], [1, 2]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))

--- a/tests/fixtures/dep_law_builtin_names/main.av
+++ b/tests/fixtures/dep_law_builtin_names/main.av
@@ -1,0 +1,31 @@
+module DepLawEntry
+    intent =
+        "An entry that reaches Bytes and a dependency module whose laws it"
+        "cites: List.concat in a law must never resolve to Bytes.concat, and a"
+        "law proved here by fuel induction cites the dependency's own laws."
+    depends [Bytes, Digits]
+    effects []
+
+fn checksum(bytes: Bytes) -> Int
+    ? "The big-endian reading of a byte string, through the dependency."
+    Digits.bigEndian(Bytes.octets(bytes), 0)
+
+verify checksum
+    checksum(Bytes.fromList([1, 2])) => 258
+    checksum(Bytes.empty()) => 0
+
+fn readBack(value: Int) -> Int
+    ? "Write a magnitude as digits, then read it back."
+    Digits.bigEndian(List.reverse(Digits.digits(value, [])), 0)
+
+verify readBack
+    readBack(0) => 0
+    readBack(258) => 258
+
+verify readBack law readsBackDigits
+    given m: Int = [0, 1, 127, 128, 255, 256, 65535, 65536]
+    when m >= 0
+    Digits.bigEndian(List.reverse(Digits.digits(m, [])), 0) => m
+
+fn main() -> Unit
+    Unit

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -21,6 +21,8 @@ mod container_induction;
 mod cross_file;
 #[path = "proof_spec/dafny_inline.rs"]
 mod dafny_inline;
+#[path = "proof_spec/dep_law_names.rs"]
+mod dep_law_names;
 #[path = "proof_spec/dependency_effects.rs"]
 mod dependency_effects;
 #[path = "proof_spec/entry_opens.rs"]

--- a/tests/proof_spec/dep_law_names.rs
+++ b/tests/proof_spec/dep_law_names.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+/// A dependency module's law that spells a builtin call (`List.concat`) in a
+/// program whose closure also holds a module fn of the same bare name
+/// (`Bytes.concat`): the law's simp set must name the law's own fn only. The
+/// bare-name fallback of `find_fn_def_by_call_name` used to add a stray
+/// `concat`, which resolves to nothing inside the dependency's namespace and
+/// sent a law that closes as an entry module to `sorry` as a dependency
+/// (jasisz/aver#1270). Structural pin, Lean side (no toolchain needed).
+#[test]
+fn proof_export_dep_law_builtin_call_never_resolves_to_module_fn() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let root = repo_root.join("tests/fixtures/dep_law_builtin_names");
+    let output_dir = temp_output_dir("aver-proof-dep-law-names-export");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(root.join("main.av"))
+        .arg("--module-root")
+        .arg(&root)
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+    let lean = std::fs::read_to_string(output_dir.join("Digits.lean"))
+        .expect("Digits.lean must be emitted for the dependency module");
+    let theorem = lean
+        .split("theorem bigEndian_law_readsTheLastByteLast :")
+        .nth(1)
+        .expect("the dependency law theorem must be emitted");
+    let body: String = theorem.lines().take(12).collect::<Vec<_>>().join("\n");
+    assert!(
+        !body.contains("concat"),
+        "the law's simp set must not carry a bare `concat` (List.concat is a builtin, Bytes.concat is another module's fn):\n{body}"
+    );
+    assert!(
+        lean.contains("-- aver:law-class bigEndian_law_readsTheLastByteLast universal"),
+        "the dependency law must be classed universal"
+    );
+    // The entry law over the dependency's countdown fn is proved by fuel
+    // induction and cites the dependency's accumulator law as a ground
+    // instance by its namespace-qualified theorem name.
+    let entry = std::fs::read_to_string(output_dir.join("DepLawEntry.lean"))
+        .expect("DepLawEntry.lean must be emitted for the entry module");
+    let rung = entry
+        .split("theorem readBack_law_readsBackDigits :")
+        .nth(1)
+        .expect("the entry law theorem must be emitted");
+    let rung_body: String = rung.lines().take(30).collect::<Vec<_>>().join("\n");
+    assert!(
+        rung_body.contains("have key : ∀ (k : Nat)"),
+        "the entry law must be proved by fuel induction:\n{rung_body}"
+    );
+    assert!(
+        rung_body.contains("Digits.digits_law_accumulatorComesFirst"),
+        "the entry law must cite the dependency's accumulator law by its qualified name:\n{rung_body}"
+    );
+    assert!(
+        entry.contains("-- aver:law-class readBack_law_readsBackDigits universal"),
+        "the entry when-law must be stated universally"
+    );
+}
+
+/// The same fixture through `lake`: the dependency law closes kernel-genuine.
+#[test]
+fn proof_dep_law_builtin_names_lean_closes_kernel_genuine() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping dep-law names lake test: `lake` not available");
+        return;
+    }
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let root = repo_root.join("tests/fixtures/dep_law_builtin_names");
+    let output_dir = temp_output_dir("aver-proof-dep-law-names-check");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg(root.join("main.av"))
+        .arg("--module-root")
+        .arg(&root)
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&output_dir)
+        .arg("--check")
+        .arg("--check-json")
+        .output()
+        .expect("aver proof --check --check-json should run");
+    let json_line = run
+        .stdout
+        .split(|&b| b == b'\n')
+        .rev()
+        .find_map(|l| std::str::from_utf8(l).ok().filter(|s| s.starts_with('{')))
+        .unwrap_or_else(|| panic!("no JSON line:\n{}", format_output(&run)))
+        .to_string();
+    let summary: serde_json::Value = serde_json::from_str(&json_line).expect("check-json summary");
+    assert_eq!(summary["build_errors"], 0, "{json_line}");
+    assert_eq!(summary["sorries"], 0, "{json_line}");
+    assert_eq!(summary["universal"], true, "{json_line}");
+    assert_eq!(summary["universal_laws"], 3, "{json_line}");
+}


### PR DESCRIPTION
Closes #1270.

A law in a dependency module lost proofs it had as an entry module. On the reproducer (n1bor/btc-listener `Domain.StackItem` reached through `domain/scriptstate.av`) the snoc law and both fuel-induction rungs went from `sorry` to `universal`; as an entry module they were `universal` already. Three causes, one root: names compared bare where the file spells them qualified.

## What changes

- **Call-name resolution is module-aware.** `find_fn_def_by_call_name` used to fall back to the bare tail of any dotted name, so `List.concat` resolved to `Bytes.concat` whenever `Bytes` was in the program closure, and the stray `concat` in the law's simp set made every tactic arm fail. Now a qualifier that names a loaded module picks that module's fn, a builtin namespace never denotes a user fn, and only an unqualified name falls back to a bare lookup. This resolver has 87 call sites across proof lowering and the Lean emitter; all of them get the correction.
- **"Same file" means the file the theorem lands in.** The earlier-laws pools (`earlier_law_lemmas`, `earlier_law_cites`, and the fuel strategy's ground instances) scanned `ctx.items`, the entry module's items, even under a dependency's scope. `same_file_verify_blocks` reads the right sequence, and under a dependency scope the pool gates compare in the qualified identity the renderer uses there (the same `dep_membership_index` / `consumer_law_qualified_scope` the cross-file half already used).
- **Citations across files.** The fuel-induction strategy's ground instances now also cite the exposed laws of the module that owns the countdown function, by their namespace-qualified theorem name; a `when`-law the strategy can state universally is cited as the implication `<when> = true -> claim`. The tight-decomposition rung gains the same cross-file half under the existing `dep_law_admissible` gate, with the dependency law's own calls re-spelled the way the consumer writes them (`M.f`) so the instantiation engine's dotted-name matching lines up. Credit stays with `#print axioms`; a cited law that did not close taints the consumer through `sorryAx`.

## Evidence

Fixture `tests/fixtures/dep_law_builtin_names/` (entry `DepLawEntry` depends on `Bytes` and `Digits`; `Digits` has a structural `bigEndian`, a well-founded `digits`, a snoc law and an accumulator law): structural pins in `tests/proof_spec/dep_law_names.rs` (no bare `concat` in the dependency law's simp set; the entry's guarded round trip is proved by fuel induction and cites `Digits.digits_law_accumulatorComesFirst`), plus a lake-gated run: `build_errors 0, sorries 0, universal true, universal_laws 3`.

`cargo test --test proof_spec` (313, Lean-gated included), `cargo test --lib` (1495), fmt and the CI-shaped clippy gates are green locally.
