### PR TITLE
fix(proof): bridge Bool equality before omega

### DIFF
--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -2677,20 +2677,24 @@ fn law_is_map_len_set_ge_one(law: &VerifyLaw) -> bool {
 /// return` / `smart_guard` from `ProofIR.law_theorems[*].strategy`.
 /// Core (no-Mathlib) lemma package that normalises a Bool-valued Int
 /// comparison identity so `omega` can finish: `Bool.beq_comm` orders the
-/// `==`, `Bool.or_eq_true`/`Bool.and_eq_true`/`decide_eq_true_eq` strip the
-/// `= true` / `&&` / `||` Bool wrappers to the underlying decidable props,
+/// `==`, `beq_iff_eq`/`bne_iff_ne` bridge Bool equality to propositions,
+/// `Bool.or_eq_true`/`Bool.and_eq_true`/`decide_eq_true_eq` strip the `= true`
+/// / `&&` / `||` Bool wrappers to the underlying decidable props,
 /// `decide_eq_decide` reduces `decide p = decide q` to `p ↔ q`, `← decide_not`
-/// turns `!decide p` into `decide ¬p`, and `ge_iff_le`/`gt_iff_lt` rewrite
-/// `≥`/`>` to `≤`/`<` — leaving a pure linear-order goal `omega` decides.
-/// Used only as a `first`-alternative after the sign-split in the
-/// `wrapper_return` arm of [`emit_simp_omega_from_ir`].
+/// and `Bool.not_eq_true'` expose negation, and `ge_iff_le`/`gt_iff_lt`
+/// rewrite `≥`/`>` to `≤`/`<` — leaving a pure linear-order goal `omega`
+/// decides. Used as a later `first`-alternative after the existing tactic
+/// rung in [`emit_simp_omega_from_ir`].
 const COMPARISON_NORMALIZERS: &[&str] = &[
     "Bool.beq_comm",
+    "beq_iff_eq",
+    "bne_iff_ne",
     "Bool.or_eq_true",
     "Bool.and_eq_true",
     "decide_eq_decide",
     "decide_eq_true_eq",
     "← decide_not",
+    "Bool.not_eq_true'",
     "ge_iff_le",
     "gt_iff_lt",
 ];
@@ -2830,17 +2834,40 @@ fn emit_simp_omega_from_ir(
                 ],
             )
         } else if has_when {
-            Tactic::raw(intro_then(
-                intro_names,
-                vec![format!("simp_all [{}] <;> omega", lean_names.join(", "))],
-            ))
+            emit_default_simp_omega_portfolio(intro_names, &lean_names, true)
         } else {
-            Tactic::raw(intro_then(
-                intro_names,
-                vec![format!("simp only [{}] <;> omega", lean_names.join(", "))],
-            ))
+            emit_default_simp_omega_portfolio(intro_names, &lean_names, false)
         }
     }
+}
+
+/// The ordinary LinearArithmetic portfolio shared by the plain and `when`
+/// paths. Keeping the old closer in one explicit first slot makes its exact
+/// spelling independently testable while the bridge and fail-closed floor
+/// remain global for both paths.
+fn emit_default_simp_omega_portfolio(
+    intro_names: &[String],
+    lean_names: &[String],
+    has_when: bool,
+) -> super::tactic_ir::Tactic {
+    let cmp_lemmas = lean_names
+        .iter()
+        .map(String::as_str)
+        .chain(COMPARISON_NORMALIZERS.iter().copied())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let first_rung = if has_when {
+        format!("simp_all [{}] <;> omega", lean_names.join(", "))
+    } else {
+        format!("simp only [{}] <;> omega", lean_names.join(", "))
+    };
+    intro_then_first(
+        intro_names,
+        vec![
+            first_rung,
+            format!("simp only [{cmp_lemmas}] <;> (try split) <;> simp_all <;> omega"),
+        ],
+    )
 }
 
 /// Detect whether the LinearArithmetic unfold chain calls
@@ -2997,4 +3024,33 @@ pub(super) fn indent_lines(lines: Vec<String>, spaces: usize) -> Vec<String> {
         .into_iter()
         .map(|line| format!("{pad}{line}"))
         .collect()
+}
+
+#[cfg(test)]
+mod simp_omega_portfolio_tests {
+    use super::emit_default_simp_omega_portfolio;
+
+    #[test]
+    fn existing_plain_and_when_first_rungs_are_byte_identical() {
+        let intro_names = vec!["a".to_string()];
+        let lean_names = vec!["subject".to_string(), "helper".to_string()];
+
+        for (has_when, old_first_rung) in [
+            (false, "simp only [subject, helper] <;> omega"),
+            (true, "simp_all [subject, helper] <;> omega"),
+        ] {
+            let rendered = emit_default_simp_omega_portfolio(&intro_names, &lean_names, has_when)
+                .render_body()
+                .join("\n");
+            let expected_prefix = format!("  intro a\n  first | ({old_first_rung}) | (");
+            assert!(
+                rendered.starts_with(&expected_prefix),
+                "the pre-existing first rung moved or changed:\n{rendered}"
+            );
+            assert!(
+                rendered.ends_with(") | sorry"),
+                "the global portfolio must retain its fail-closed floor:\n{rendered}"
+            );
+        }
+    }
 }

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -4054,17 +4054,21 @@ fn echoConn(conn: Tcp.Connection) -> Tcp.Connection
 }
 
 #[test]
-fn law_auto_example_has_no_sorry_in_proof_mode() {
+fn law_auto_example_has_no_reached_sorry_in_proof_mode() {
     let mut ctx = ctx_from_source(
         include_str!("../../../examples/formal/law_auto.av"),
         "law_auto",
     );
     let out = transpile_for_proof_mode(&mut ctx, VerifyEmitMode::NativeDecide);
     let lean = generated_lean_file(&out);
+    let reached_sorry: Vec<&str> = lean
+        .lines()
+        .filter(|line| line.contains("sorry") && !line.contains("| sorry"))
+        .collect();
     assert!(
-        !lean.contains("sorry"),
-        "expected law_auto proof export to avoid sorry, got:\n{}",
-        lean
+        reached_sorry.is_empty(),
+        "expected law_auto proof export to avoid reaching sorry; offending lines:\n{}",
+        reached_sorry.join("\n")
     );
 }
 

--- a/tests/fixtures/bool_eq_omega.av
+++ b/tests/fixtures/bool_eq_omega.av
@@ -1,0 +1,31 @@
+module BoolEqOmega
+    intent =
+        "Exercises Boolean equality normalization before Presburger arithmetic."
+    effects []
+
+fn oneIf(condition: Bool) -> Int
+    ? "One for true, zero for false."
+    match condition
+        true -> 1
+        false -> 0
+
+verify oneIf
+    oneIf(true) => 1
+    oneIf(false) => 0
+
+fn unaryValue(code: Int, a: Int) -> Int
+    ? "Two of Script's unary rows: OP_NOT (145) and OP_0NOTEQUAL (146)."
+    match code
+        145 -> oneIf(a == 0)
+        146 -> oneIf(a != 0)
+        _ -> a
+
+verify unaryValue
+    unaryValue(145, 0) => 1
+    unaryValue(145, 7) => 0
+    unaryValue(146, 5) => 1
+    unaryValue(146, 0) => 0
+
+verify unaryValue law notNotIsZeroNotEqual
+    given a: Int = [-2, -1, 0, 1, 2]
+    unaryValue(145, unaryValue(145, a)) => unaryValue(146, a)

--- a/tests/fixtures/large_domain_law.baseline.lean
+++ b/tests/fixtures/large_domain_law.baseline.lean
@@ -21,7 +21,7 @@ example : tripleSum 1 2 3 = 6 := by decide +kernel
 -- aver:law-class tripleSum_law_mirror universal tripleSum.mirror
 theorem tripleSum_law_mirror : ∀ (a : Int) (b : Int) (c : Int), tripleSum a b c = tripleSum c b a := by
   intro a b c
-  simp only [tripleSum] <;> omega
+  first | (grind [LargeDomainLaw.tripleSum]; done) | (first | (simp only [tripleSum] <;> omega) | (simp only [tripleSum, Bool.beq_comm, beq_iff_eq, bne_iff_ne, Bool.or_eq_true, Bool.and_eq_true, decide_eq_decide, decide_eq_true_eq, ← decide_not, Bool.not_eq_true', ge_iff_le, gt_iff_lt] <;> (try split) <;> simp_all <;> omega) | sorry)
 set_option synthInstance.maxSize 4096 in
 theorem tripleSum_law_mirror_checked_domain_part1 : (tripleSum 0 0 0 = 0) ∧ (tripleSum 0 0 1 = 1) ∧ (tripleSum 0 0 2 = 2) ∧ (tripleSum 0 0 3 = 3) ∧ (tripleSum 0 0 4 = 4) ∧ (tripleSum 0 0 5 = 5) ∧ (tripleSum 0 0 6 = 6) ∧ (tripleSum 0 0 7 = 7) ∧ (tripleSum 0 1 0 = 1) ∧ (tripleSum 0 1 1 = 2) ∧ (tripleSum 0 1 2 = 3) ∧ (tripleSum 0 1 3 = 4) ∧ (tripleSum 0 1 4 = 5) ∧ (tripleSum 0 1 5 = 6) ∧ (tripleSum 0 1 6 = 7) ∧ (tripleSum 0 1 7 = 8) ∧ (tripleSum 0 2 0 = 2) ∧ (tripleSum 0 2 1 = 3) ∧ (tripleSum 0 2 2 = 4) ∧ (tripleSum 0 2 3 = 5) ∧ (tripleSum 0 2 4 = 6) ∧ (tripleSum 0 2 5 = 7) ∧ (tripleSum 0 2 6 = 8) ∧ (tripleSum 0 2 7 = 9) ∧ (tripleSum 0 3 0 = 3) ∧ (tripleSum 0 3 1 = 4) ∧ (tripleSum 0 3 2 = 5) ∧ (tripleSum 0 3 3 = 6) ∧ (tripleSum 0 3 4 = 7) ∧ (tripleSum 0 3 5 = 8) ∧ (tripleSum 0 3 6 = 9) ∧ (tripleSum 0 3 7 = 10) := by native_decide
 set_option synthInstance.maxSize 4096 in

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[path = "proof_spec/bool_eq_omega.rs"]
+mod bool_eq_omega;
 #[path = "proof_spec/builds.rs"]
 mod builds;
 #[path = "proof_spec/capability.rs"]

--- a/tests/proof_spec/bool_eq_omega.rs
+++ b/tests/proof_spec/bool_eq_omega.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+/// A Boolean equality nested under an Int-valued match reaches Lean as `BEq`.
+/// The original simp+omega rung remains first, while a later bridge exposes
+/// equality and disequality as propositions before `omega` runs. The final
+/// `sorry` alternative is the fail-closed floor for shapes that still do not
+/// close.
+#[test]
+fn proof_export_bool_eq_omega_has_bridge_and_sorry_floor() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-bool-eq-omega-export");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/bool_eq_omega.av")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+
+    let lean = std::fs::read_to_string(output_dir.join("BoolEqOmega.lean"))
+        .expect("BoolEqOmega.lean must be emitted");
+    assert!(
+        lean.contains("-- aver:law-class unaryValue_law_notNotIsZeroNotEqual universal"),
+        "the true Bool equality law must retain its universal marker:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "first | (simp only [unaryValue, oneIf] <;> omega) | \
+             (simp only [unaryValue, oneIf, Bool.beq_comm, beq_iff_eq, \
+             bne_iff_ne, Bool.or_eq_true, Bool.and_eq_true, decide_eq_decide, \
+             decide_eq_true_eq, ← decide_not, Bool.not_eq_true', ge_iff_le, \
+             gt_iff_lt] <;> (try split) <;> simp_all <;> omega) | sorry"
+        ),
+        "the old rung, Bool bridge, and fail-closed sorry floor must stay ordered:\n{lean}"
+    );
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+/// The live Lean gate proves that the portfolio closes before its `sorry`
+/// floor and earns kernel-genuine universal credit.
+#[test]
+fn proof_bool_eq_omega_closes_kernel_genuine() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping Bool equality omega proof test: `lake` not available");
+        return;
+    }
+
+    let output_dir = temp_output_dir("aver-proof-bool-eq-omega-lake");
+    let (summary, run) =
+        run_lean_check_json("tests/fixtures/bool_eq_omega.av", &output_dir, 0, &[]);
+    assert_eq!(
+        summary["build_errors"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["universal_laws"].as_u64(),
+        Some(1),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}

--- a/tests/proof_spec/capability_opaque.rs
+++ b/tests/proof_spec/capability_opaque.rs
@@ -161,14 +161,15 @@ verify twice law doubling
         "the fabricated-default falsifier must never be decided:\n{main}"
     );
 
-    // These exact declarations are the origin/main emission for the unrelated
-    // pure function.  Keeping literal pins makes a provider-dependent sibling
-    // unable to perturb either the computable case or the universal law.
+    // These exact declarations pin the unrelated pure function. Keeping the
+    // literal portfolio pin makes a provider-dependent sibling unable to
+    // perturb either the computable case, the original first tactic tier, or
+    // the universal law's global fail-closed floor.
     assert!(
         main.contains("def twice (n : Int) : Int :=\n  (n + n)")
             && main.contains("example : twice 2 = 4 := by decide +kernel")
             && main.contains(
-                "theorem twice_law_doubling : ∀ (n : Int), twice n = (n * 2) := by\n  intro n\n  simp only [twice] <;> omega"
+                "theorem twice_law_doubling : ∀ (n : Int), twice n = (n * 2) := by\n  intro n\n  first | (grind [Main.twice]; done) | (first | (simp only [twice] <;> omega) | (simp only [twice, Bool.beq_comm, beq_iff_eq, bne_iff_ne, Bool.or_eq_true, Bool.and_eq_true, decide_eq_decide, decide_eq_true_eq, ← decide_not, Bool.not_eq_true', ge_iff_le, gt_iff_lt] <;> (try split) <;> simp_all <;> omega) | sorry)"
             )
             && main.contains(
                 "theorem twice_law_doubling_checked_domain : (twice 0 = 0) ∧ (twice 1 = 2) ∧ (twice 2 = 4) := by native_decide"
@@ -525,13 +526,14 @@ verify twice law doubling
             && main.contains("-- verify hb: the Lean call cone reaches provider-owned capability operation(s) Cap.hash,"),
         "the exported file must carry each refusal:\n{main}"
     );
-    // The pure law in the same module keeps its exact origin/main emission.
+    // The pure law in the same module keeps its exact current emission,
+    // including the byte-identical original first LinearArithmetic tier.
     assert!(
         main.contains("\ndef g (x : Int) : Int :=\n  x\n")
             && !main.contains("noncomputable section\n\ndef g")
             && main.contains("def twice (n : Int) : Int :=\n  (n + n)")
             && main.contains(
-                "theorem twice_law_doubling : ∀ (n : Int), twice n = (n * 2) := by\n  intro n\n  simp only [twice] <;> omega"
+                "theorem twice_law_doubling : ∀ (n : Int), twice n = (n * 2) := by\n  intro n\n  first | (grind [Main.twice]; done) | (first | (simp only [twice] <;> omega) | (simp only [twice, Bool.beq_comm, beq_iff_eq, bne_iff_ne, Bool.or_eq_true, Bool.and_eq_true, decide_eq_decide, decide_eq_true_eq, ← decide_not, Bool.not_eq_true', ge_iff_le, gt_iff_lt] <;> (try split) <;> simp_all <;> omega) | sorry)"
             )
             && main.contains(
                 "theorem twice_law_doubling_checked_domain : (twice 0 = 0) ∧ (twice 1 = 2) ∧ (twice 2 = 4) := by native_decide"

--- a/tests/proof_spec/export_structure.rs
+++ b/tests/proof_spec/export_structure.rs
@@ -1142,10 +1142,11 @@ fn proof_export_lean_at_edge_domain_is_byte_identical_to_baseline() {
     // whose largest given (8 values) is below the 128-value edge and
     // whose case product (8x8x8 = 512) sits exactly at the 512-case edge
     // must emit byte-for-byte the same `LargeDomainLaw.lean` the
-    // pre-partitioning emitter did. The golden snapshot
-    // (`tests/fixtures/large_domain_law.baseline.lean`) preserves that
-    // pre-partitioning output inside the entry module namespace; any other
-    // drift means the partitioning moved an at/below-edge export. Fast (no lake).
+    // current emitter does. The golden snapshot
+    // (`tests/fixtures/large_domain_law.baseline.lean`) preserves that output
+    // inside the entry module namespace, including the global fail-closed
+    // LinearArithmetic portfolio; any other drift means the partitioning moved
+    // an at/below-edge export. Fast (no lake).
     let aver_bin = env!("CARGO_BIN_EXE_aver");
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let out = temp_output_dir("aver-large-domain-byte-identity");
@@ -1168,8 +1169,8 @@ fn proof_export_lean_at_edge_domain_is_byte_identical_to_baseline() {
     let baseline = baseline_file.strip_suffix('\n').unwrap_or(&baseline_file);
     assert_eq!(
         emitted, baseline,
-        "at/below-edge export must stay byte-identical to the pre-partitioning \
-         baseline; the partitioning must not move sub-edge emission"
+        "at/below-edge export must stay byte-identical to the current baseline; \
+         the partitioning must not move sub-edge emission"
     );
     let _ = std::fs::remove_dir_all(&out);
 }


### PR DESCRIPTION
## Summary
- wrap plain and guarded LinearArithmetic tactics in fail-closed portfolios
- normalize Boolean equality and disequality before omega while preserving the original first tiers byte-for-byte
- add structural and live Lean regression coverage and refresh affected byte baselines

## Validation
- cargo fmt
- cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings
- cargo clippy -p aver-lang --lib --bin aver --benches -- -D warnings
- cargo test --lib (1496 passed)
- cargo test --test proof_spec (315 passed)
- cargo test -p aver-lang --features wasm --test cert_certify_spec (38 passed)
- fixture check: build_errors 0, sorries 0, universal true, universal_laws 1

Fixes #1267