### PR TITLE
fix(proof): measure SCC list drop edges

### DIFF
--- a/src/codegen/lean/toplevel/lex_list.rs
+++ b/src/codegen/lean/toplevel/lex_list.rs
@@ -41,6 +41,10 @@ enum LexListArg {
     /// of `g`'s actual arguments (`rest pivot`), used to instantiate the
     /// synthesised `<g>_len_le` lemma in `decreasing_by`.
     Filtered { helper: String, lemma_args: String },
+    /// The argument is `List.drop(s, n)` or `List.take(s, n)`, where `s` is
+    /// the caller's measure param or a cons-tail. Core Lean supplies the
+    /// non-growing length theorem, so no helper lemma is synthesised.
+    ListBuiltin { length_lemma: &'static str },
 }
 
 /// One recognised recursive edge inside the SCC, in body source order
@@ -76,6 +80,10 @@ struct LexListMemberPlan<'a> {
     offset: usize,
     /// Lex second component (rank).
     rank: usize,
+    /// This plan came from the shared cycle measure with zero offsets. A
+    /// strict cons-tail edge then decreases the length component directly,
+    /// rather than becoming equal through the helper-filter offset scheme.
+    direct_length_decrease: bool,
     /// Recognised recursive edges, in body source order.
     edges: Vec<LexListEdge>,
 }
@@ -105,6 +113,55 @@ fn lex_list_measure_param(fd: &FnDef, ctx: &CodegenContext) -> Option<(usize, St
         }
     }
     found
+}
+
+/// Select exactly one List measure per SCC member with the shared call-edge
+/// analysis. This is the multi-List counterpart of
+/// [`lex_list_measure_param`]: it can discard a growing List accumulator and
+/// retain the list passed verbatim, as a cons-tail, or through a known
+/// non-growing builtin. Int parameters are never candidates here.
+fn cycle_selected_list_measure_params(
+    fns: &[&FnDef],
+    ctx: &CodegenContext,
+) -> Option<Vec<(usize, String, usize)>> {
+    use crate::codegen::recursion::cycle_measure::{Candidate, MeasureKind};
+
+    let candidates: Vec<Vec<Candidate>> = fns
+        .iter()
+        .map(|fd| {
+            let rfd = crate::codegen::common::fn_id_for_decl(ctx, fd)
+                .and_then(|id| ctx.resolved_program.fn_by_id(id))?;
+            let mut member = Vec::new();
+            for (index, (_, ty)) in rfd.params.iter().enumerate() {
+                match ty {
+                    crate::types::Type::List(_) => member.push(Candidate {
+                        index,
+                        kind: MeasureKind::Structural,
+                    }),
+                    crate::types::Type::Vector(_) | crate::types::Type::Str => return None,
+                    _ => {}
+                }
+            }
+            Some(member)
+        })
+        .collect::<Option<_>>()?;
+    let measures =
+        crate::codegen::recursion::cycle_measure::measure_for_cycle(fns, &candidates, false)
+            .ok()?;
+
+    fns.iter()
+        .zip(measures)
+        .map(|(fd, measure)| {
+            let [candidate] = measure.params.as_slice() else {
+                return None;
+            };
+            if candidate.kind != MeasureKind::Structural {
+                return None;
+            }
+            let name = fd.params.get(candidate.index)?.0.as_str();
+            Some((candidate.index, aver_name_to_lean(name), measure.rank))
+        })
+        .collect()
 }
 
 /// True iff `g` is a non-growing structural list filter: a recursive fn
@@ -250,13 +307,27 @@ fn classify_lex_list_arg(
     // is a non-growing list filter defined in the program.
     if let Expr::FnCall(callee, args) = &arg.node {
         let dotted = expr_to_dotted_name(callee)?;
-        let bare = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
         let first = args.first()?;
         let s = local_name_of(first)?;
         let s_ok = s == caller_list_param || tail_binders.contains(s);
         if !s_ok {
             return None;
         }
+        // Aver uses list-first order (`List.drop(xs, n)`), while the Lean
+        // lowering reverses these to `List.drop n xs`. The classifier stays
+        // on the Aver AST and records only the core length theorem the emitter
+        // must cite for the lowered call.
+        if args.len() == 2 {
+            let length_lemma = match dotted.as_str() {
+                "List.drop" => Some("List.length_drop"),
+                "List.take" => Some("List.length_take"),
+                _ => None,
+            };
+            if let Some(length_lemma) = length_lemma {
+                return Some(LexListArg::ListBuiltin { length_lemma });
+            }
+        }
+        let bare = dotted.rsplit('.').next().unwrap_or(&dotted).to_string();
         let helper_fd = find_user_fn_by_name(ctx, &bare)?;
         // Kernel-provable non-growing filter shape required.
         lex_list_filter_helper(helper_fd, ctx)?;
@@ -285,6 +356,66 @@ fn find_user_fn_by_name<'a>(ctx: &'a CodegenContext, name: &str) -> Option<&'a F
         .find(|fd| fd.name == name)
 }
 
+/// Recognise the core-builtin non-growing shape with the shared cycle
+/// measure. Unlike the older helper-filter path, this accepts multiple List
+/// parameters and lets the call graph discard an accumulator that grows.
+/// It is gated on an actual `List.drop`/`List.take` edge so existing
+/// structural and user-filter SCCs retain their byte-identical plans.
+fn recognize_core_list_builtin_wf_scc<'a>(
+    fns: &'a [&'a FnDef],
+    ctx: &CodegenContext,
+) -> Option<Vec<LexListMemberPlan<'a>>> {
+    if fns.len() < 2 || fns.iter().any(|fd| !is_pure_fn(fd)) {
+        return None;
+    }
+    let selected = cycle_selected_list_measure_params(fns, ctx)?;
+    let names: HashSet<String> = fns.iter().map(|fd| fd.name.clone()).collect();
+    let mut saw_builtin = false;
+    let mut plans = Vec::new();
+
+    for (member, fd) in fns.iter().enumerate() {
+        let (_, list_param, rank) = &selected[member];
+        let tail_binders =
+            crate::codegen::recursion::detect::collect_list_tail_binders(fd, list_param);
+        let mut edges = Vec::new();
+        for (callee_raw, args) in
+            crate::codegen::recursion::detect::collect_calls_from_body(fd.body.as_ref())
+        {
+            let Some(callee) =
+                crate::codegen::recursion::detect::canonical_callee_name(&callee_raw, &names)
+            else {
+                continue;
+            };
+            let callee_member = fns.iter().position(|peer| peer.name == callee)?;
+            let callee_list_idx = selected[callee_member].0;
+            let arg = args.get(callee_list_idx)?;
+            let classified = classify_lex_list_arg(arg, list_param, &tail_binders, ctx)?;
+            match &classified {
+                LexListArg::ListBuiltin { .. } => saw_builtin = true,
+                LexListArg::Subterm { .. } => {}
+                LexListArg::Filtered { .. } => return None,
+            }
+            edges.push(LexListEdge {
+                callee,
+                arg: classified,
+            });
+        }
+        if edges.is_empty() {
+            return None;
+        }
+        plans.push(LexListMemberPlan {
+            fd,
+            list_param_lean: list_param.clone(),
+            offset: 0,
+            rank: *rank,
+            direct_length_decrease: true,
+            edges,
+        });
+    }
+
+    saw_builtin.then_some(plans)
+}
+
 /// Recognise a mutual SCC whose every recursive call decreases either by a
 /// structural subterm (cons-tail) or through a non-growing list filter,
 /// and assign each member a lex measure `(list_param.length + offset, rank)`
@@ -294,6 +425,9 @@ fn recognize_lex_list_wf_scc<'a>(
     fns: &'a [&'a FnDef],
     ctx: &CodegenContext,
 ) -> Option<(Vec<LexListMemberPlan<'a>>, Vec<LengthLemma>)> {
+    if let Some(plans) = recognize_core_list_builtin_wf_scc(fns, ctx) {
+        return Some((plans, Vec::new()));
+    }
     let names: HashSet<String> = fns.iter().map(|fd| fd.name.clone()).collect();
     if fns.len() < 2 {
         // Single-fn "mutual" SCCs are emitted by the self-recursive path,
@@ -392,7 +526,10 @@ fn recognize_lex_list_wf_scc<'a>(
     for raw in &raws {
         let off_f = offset[&raw.fd.name];
         for edge in &raw.edges {
-            if matches!(edge.arg, LexListArg::Filtered { .. }) {
+            if matches!(
+                &edge.arg,
+                LexListArg::Filtered { .. } | LexListArg::ListBuiltin { .. }
+            ) {
                 let off_c = offset[&edge.callee];
                 if off_c >= off_f {
                     return None;
@@ -415,6 +552,7 @@ fn recognize_lex_list_wf_scc<'a>(
             list_param_lean,
             offset: off,
             rank,
+            direct_length_decrease: false,
             edges: raw.edges,
         });
     }
@@ -563,6 +701,12 @@ pub(super) fn emit_native_mutual_lex_list_wf_group(
         lines.push("  decreasing_by".to_string());
         for edge in &plan.edges {
             match &edge.arg {
+                LexListArg::Subterm { strict } if plan.direct_length_decrease && *strict => {
+                    // The zero-offset core-builtin plan keeps a cons-tail
+                    // strict in the first component; `simp_wf` exposes the
+                    // length arithmetic for omega.
+                    lines.push("    · simp_wf; omega".to_string());
+                }
                 LexListArg::Subterm { .. } => {
                     // Equal first component, decrease lives in the rank — a
                     // `Prod.Lex` goal omega can't discharge directly.
@@ -576,6 +720,12 @@ pub(super) fn emit_native_mutual_lex_list_wf_group(
                         "    · simp_wf; have := {} {}; omega",
                         lemma_name, lemma_args
                     ));
+                }
+                LexListArg::ListBuiltin { length_lemma } => {
+                    // The core theorem rewrites the computed length to a
+                    // non-growing arithmetic expression; omega combines it
+                    // with the cycle rank when equality is possible.
+                    lines.push(format!("    · simp only [{length_lemma}]; omega"));
                 }
             }
         }

--- a/src/codegen/recursion/cycle_measure.rs
+++ b/src/codegen/recursion/cycle_measure.rs
@@ -396,6 +396,40 @@ fn relation(arg: &Spanned<Expr>, caller: &FnDef, scope: &Scope) -> Relation {
             None => Relation::Unknown,
         };
     }
+    // `List.drop(s, n)` and `List.take(s, n)` never grow `s`. When `s` is
+    // the caller's measured list or a cons-tail tracked from it, classify the
+    // result as the same non-strict source. The operation is computed rather
+    // than a structural subterm, so its path is deliberately empty: equality
+    // is possible (`drop 0`, or `take n` with `length s <= n`) and the SCC's
+    // rank must order that edge exactly like a verbatim list pass.
+    if let Expr::FnCall(callee, args) = &arg.node
+        && args.len() == 2
+        && matches!(
+            expr_to_dotted_name(callee).as_deref(),
+            Some("List.drop" | "List.take")
+        )
+        && let Some(source) = local_name_of(&args[0])
+        && let Some(origin) = scope.tracked.get(source)
+    {
+        let is_list_param_or_tail =
+            caller
+                .params
+                .get(origin.param)
+                .is_some_and(|(param_name, type_name)| {
+                    let is_list = type_name == "List" || type_name.starts_with("List<");
+                    let is_tail = crate::codegen::recursion::detect::collect_list_tail_binders(
+                        caller, param_name,
+                    )
+                    .contains(source);
+                    is_list && (origin.path.is_empty() || is_tail)
+                });
+        if is_list_param_or_tail {
+            return Relation::Part {
+                param: origin.param,
+                path: Vec::new(),
+            };
+        }
+    }
     // `Map.entries(m)` lowers to `m` itself in the proof model (the map is
     // list-backed), so it carries exactly the size of its argument.
     if let Expr::FnCall(callee, args) = &arg.node

--- a/tests/fixtures/scc_list_drop.av
+++ b/tests/fixtures/scc_list_drop.av
@@ -1,0 +1,44 @@
+module SccListDrop
+    intent =
+        "Mutual list recursion may pass a measured tail through List.drop or List.take without growing it."
+    exposes [scan, scanTake]
+    depends []
+    effects []
+
+fn scan(bytes: List<Int>, acc: Int) -> Int
+    ? "Read a head and hand the strict cons tail to the next member."
+    match bytes
+        [] -> acc
+        [code, ..rest] -> head(code, rest, acc)
+
+fn head(code: Int, rest: List<Int>, acc: Int) -> Int
+    ? "Pass the measured list verbatim while choosing a skip count."
+    skip(code, 1, rest, acc)
+
+fn skip(code: Int, n: Int, rest: List<Int>, acc: Int) -> Int
+    ? "Return through List.drop while changing only unmeasured Int arguments."
+    scan(List.drop(rest, n), acc + code)
+
+fn scanTake(bytes: List<Int>, acc: Int) -> Int
+    ? "Read a head for the List.take variant and hand on the strict cons tail."
+    match bytes
+        [] -> acc
+        [code, ..rest] -> headTake(code, rest, acc)
+
+fn headTake(code: Int, rest: List<Int>, acc: Int) -> Int
+    ? "Pass the measured list verbatim to the List.take edge."
+    skipTake(code, 1, rest, acc)
+
+fn skipTake(code: Int, n: Int, rest: List<Int>, acc: Int) -> Int
+    ? "Return through List.take while changing only unmeasured Int arguments."
+    scanTake(List.take(rest, n), acc + code)
+
+verify scan
+    scan([], 7) => 7
+    scan([1], 0) => 1
+    scan([1, 2, 3], 0) => 4
+
+verify scanTake
+    scanTake([], 7) => 7
+    scanTake([1], 0) => 1
+    scanTake([1, 2, 3], 0) => 3

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -43,6 +43,8 @@ mod opaque_closure;
 mod oracle_verify;
 #[path = "proof_spec/panics.rs"]
 mod panics;
+#[path = "proof_spec/scc_list_drop.rs"]
+mod scc_list_drop;
 #[path = "proof_spec/wf_fuel.rs"]
 mod wf_fuel;
 #[path = "proof_spec/when_lane.rs"]

--- a/tests/proof_spec/scc_list_drop.rs
+++ b/tests/proof_spec/scc_list_drop.rs
@@ -1,0 +1,85 @@
+use super::*;
+
+#[test]
+fn proof_export_scc_list_drop_and_take_are_native_mutual_groups() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let output_dir = temp_output_dir("aver-proof-scc-list-drop-export");
+    let run = Command::new(aver_bin)
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/scc_list_drop.av")
+        .arg("-o")
+        .arg(&output_dir)
+        .output()
+        .expect("aver proof should run");
+    assert!(run.status.success(), "{}", format_output(&run));
+
+    let lean = std::fs::read_to_string(output_dir.join("SccListDrop.lean"))
+        .expect("SccListDrop.lean must be emitted");
+    assert_eq!(
+        lean.matches("\nmutual\n").count(),
+        2,
+        "drop and take must each emit one genuine mutual block:\n{lean}"
+    );
+    assert!(
+        !lean.contains("__fuel") && !lean.contains("partial def") && !lean.contains("declined"),
+        "the recognised groups must not retain a fuel, partial, or declined fallback:\n{lean}"
+    );
+    for measure in [
+        "termination_by (bytes.length, 1)",
+        "termination_by (rest.length, 2)",
+        "termination_by (rest.length, 3)",
+    ] {
+        assert_eq!(
+            lean.matches(measure).count(),
+            2,
+            "both builtin variants must use the call-graph-selected length/rank measure {measure}:\n{lean}"
+        );
+    }
+    assert!(
+        lean.contains("simp only [List.length_drop]; omega")
+            && lean.contains("simp only [List.length_take]; omega"),
+        "computed list edges must cite their core non-growing length theorems:\n{lean}"
+    );
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}
+
+#[test]
+fn proof_scc_list_drop_and_take_build_without_declines() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        eprintln!("skipping SCC List.drop/List.take proof test: `lake` not available");
+        return;
+    }
+
+    let output_dir = temp_output_dir("aver-proof-scc-list-drop-lake");
+    let (summary, run) =
+        run_lean_check_json("tests/fixtures/scc_list_drop.av", &output_dir, 0, &[]);
+    assert_eq!(
+        summary["build_errors"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["declined"].as_u64().unwrap_or(0),
+        0,
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["sorries"].as_u64(),
+        Some(0),
+        "{}",
+        format_output(&run)
+    );
+    assert_eq!(
+        summary["passed"].as_bool(),
+        Some(true),
+        "{}",
+        format_output(&run)
+    );
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+}


### PR DESCRIPTION
## Summary
- classify List.drop and List.take of a measured list or cons tail as non-growing SCC edges
- let the Lean lex-list recognizer select the single useful list measure while ignoring unrelated list accumulators and Int parameters
- discharge builtin decreasing obligations with the core List.length_drop and List.length_take theorems
- add structural and live Lean coverage for both builtin variants

## Validation
- cargo fmt
- cargo clippy --workspace --all-targets --exclude aver-lang -- -D warnings
- cargo clippy -p aver-lang --lib --bin aver --benches -- -D warnings
- cargo test --lib (1495 passed)
- cargo test --test proof_spec (315 passed)
- cargo test -p aver-lang --features wasm --test cert_certify_spec (38 passed)
- fixture: build_errors 0, sorries 0, declined 0
- btc-listener ScriptParse: declined 12 to 3; all 9 recursion-cone declines removed, leaving only unrelated hash capability declines

Fixes #1268