### PR TITLE
Fix law proof simplification and typed empty-list samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **Empty-list equality samples keep their declared element types in Lean.** Imported laws could emit `[] == []` without the `List<Int>` or nested list type supplied by `given`, failing before the proof ran. Equality and inequality now preserve that type when both literals lack an element witness, including comparisons in `when` guards.
+
 - **Cited accumulator equations no longer make executable law explanations loop in simplification.** Selected lemmas remain available to proof search while the simplifier handles the local facts and definitions. Conditional induction also joins its rewrite terms structurally, so an empty safe unfold set cannot emit malformed Lean or degrade neighboring proofs during the probe.
 
 - **Finite observations of countdown output can compose the writer's equations with its earlier laws.** The shared citation pool now includes earlier laws about the current subject. A bounded `grind` step serves both composition and the residual goals of fuel induction, proving digit removal and a nonzero leading digit for a base-seven writer. Failed claims retain their `sorry` and receive no universal credit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **Cited accumulator equations no longer make executable law explanations loop in simplification.** Selected lemmas remain available to proof search while the simplifier handles the local facts and definitions. Conditional induction also joins its rewrite terms structurally, so an empty safe unfold set cannot emit malformed Lean or degrade neighboring proofs during the probe.
+
 - **Finite observations of countdown output can compose the writer's equations with its earlier laws.** The shared citation pool now includes earlier laws about the current subject. A bounded `grind` step serves both composition and the residual goals of fuel induction, proving digit removal and a nonzero leading digit for a base-seven writer. Failed claims retain their `sorry` and receive no universal credit.
 
 - **Conditional list-layout proofs decide Boolean parameters before simplifying the reader.** The shared arithmetic step now keeps comparison normalization separate from default simplification, preventing opposing negation rewrites from looping. A layout law with an arbitrary positive marker threshold now certifies universally.

--- a/src/codegen/lean/expr.rs
+++ b/src/codegen/lean/expr.rs
@@ -65,6 +65,29 @@ fn canonical_literal_key_order(
     Some(keyed.into_iter().map(|(_, entry)| entry).collect())
 }
 
+/// Empty list literals, including nested empty lists, carry no element-type
+/// witness in Lean. Preserve the checked Aver type on comparisons where
+/// neither operand can supply that witness (notably substituted law samples).
+pub(super) fn typed_comparison_operands(
+    op: &BinOp,
+    left: &Spanned<ResolvedExpr>,
+    right: &Spanned<ResolvedExpr>,
+    mut l: String,
+    r: String,
+) -> (String, String) {
+    fn only_empty_lists(expr: &Spanned<ResolvedExpr>) -> bool {
+        matches!(&expr.node, ResolvedExpr::List(items) if items.iter().all(only_empty_lists))
+    }
+    if matches!(op, BinOp::Eq | BinOp::Neq)
+        && only_empty_lists(left)
+        && only_empty_lists(right)
+        && let Some(ty @ crate::types::Type::List(_)) = left.ty().or_else(|| right.ty())
+    {
+        l = format!("({l} : {})", super::types::type_to_lean(ty));
+    }
+    (l, r)
+}
+
 /// Emit a Lean 4 expression from an Aver Expr.
 pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
     match &expr.node {
@@ -160,8 +183,13 @@ pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
         ResolvedExpr::Call(callee, args) => emit_fn_call(callee, args, ctx),
         ResolvedExpr::Neg(inner) => format!("(-{})", emit_expr(inner, ctx)),
         ResolvedExpr::BinOp(op, left, right) => {
-            let l = emit_expr(left, ctx);
-            let r = emit_expr(right, ctx);
+            let (l, r) = typed_comparison_operands(
+                op,
+                left,
+                right,
+                emit_expr(left, ctx),
+                emit_expr(right, ctx),
+            );
             let op_str = match op {
                 BinOp::Add => "+",
                 BinOp::Sub => "-",

--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -2221,10 +2221,9 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
     }
     let target_idx = find_list_induction_target(law)?;
     let target = intro_names.get(target_idx)?.clone();
-    let defs = law_simp_defs_blind(ctx, vb, law)
+    let mut simp_terms = law_simp_defs_blind(ctx, vb, law)
         .into_iter()
-        .collect::<Vec<_>>()
-        .join(", ");
+        .collect::<Vec<_>>();
     // The laws-as-lemmas pool: earlier sibling laws eligible for this proof's
     // cone ∪ subject. Their NAMES join the induction-arm `simp_all` set (the
     // membership emit only feeds them to its flat fast path; a conditional
@@ -2233,13 +2232,24 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         .iter()
         .map(|l| l.name.clone())
         .collect();
-    let defs_pool = if pool_names.is_empty() {
-        defs.clone()
-    } else {
-        format!("{defs}, {}", pool_names.join(", "))
+    simp_terms.extend(pool_names.iter().cloned());
+    // Countdown definitions can leave the safe unfold set empty. Join actual
+    // terms, rather than inserting a comma after an empty rendered set.
+    let simp_set = |extra: &[&str]| {
+        simp_terms
+            .iter()
+            .map(String::as_str)
+            .chain(extra.iter().copied())
+            .collect::<Vec<_>>()
+            .join(", ")
     };
-    let with_append =
-        format!("{defs_pool}, List.cons_append, List.nil_append, List.singleton_append");
+    let defs_pool = simp_set(&[]);
+    let with_when = simp_set(&["h_when"]);
+    let with_append = simp_set(&[
+        "List.cons_append",
+        "List.nil_append",
+        "List.singleton_append",
+    ]);
     // Peano comparison bridges (`(f a b = true) = (a R b)`) for the relations the
     // law mentions — premise included (seeded into `extra`). They let `omega`
     // discharge a dispatcher branch a COMPARISON premise rules out (`prop_86`'s
@@ -2272,7 +2282,7 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
     let bridge_rung: Option<String> = if cmp_bridges.is_empty() {
         None
     } else {
-        let defs_pool_br = format!("{defs_pool}, {}", cmp_bridges.join(", "));
+        let defs_pool_br = simp_set(&cmp_bridges.iter().map(String::as_str).collect::<Vec<_>>());
         let bridges_csv = cmp_bridges.join(", ");
         Some(format!(
             "    | (simp only [{with_append}, {bridges_csv}] at h_when ⊢ <;> (split <;> simp_all [{defs_pool_br}]) <;> (try omega) <;> done)"
@@ -2336,9 +2346,8 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
     // `simp` + `split` + `simp_all` rung is CHEAP (no search) and closes the
     // wrapper helper laws (`sortTail`, `sortedConsLeHead`, `leHeadInsort`).
     let subject = aver_name_to_lean(&vb.fn_name);
-    let subject_split_rung = format!(
-        "    | (simp only [{subject}] <;> (split <;> simp_all [{defs_pool}, h_when]) <;> done)"
-    );
+    let subject_split_rung =
+        format!("    | (simp only [{subject}] <;> (split <;> simp_all [{with_when}]) <;> done)");
     // GOAL-DIRECTED closer — the EXPENSIVE rung (`apply` each pool law + bounded
     // `solve_by_elim` + Bool adapters). Restricted to the shape that needs it: a
     // conclusion that WRAPS the verified fn's call in a DIFFERENT predicate
@@ -2427,7 +2436,7 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         .map(|given| format!("cases {} <;> ", aver_name_to_lean(&given.name)))
         .collect::<String>();
     let arithmetic_rung = format!(
-        "    | ({bool_cases}simp only [{subject}, Bool.false_eq_true, Bool.true_eq_false, ite_true, ite_false] <;> (try split) <;> simp_all [{defs_pool}, h_when] <;> (try simp_all only [{normalizers}]) <;> omega)"
+        "    | ({bool_cases}simp only [{subject}, Bool.false_eq_true, Bool.true_eq_false, ite_true, ite_false] <;> (try split) <;> simp_all [{with_when}] <;> (try simp_all only [{normalizers}]) <;> omega)"
     );
     let mut body = vec![format!("  intro {}", before.join(" "))];
     body.extend([
@@ -2441,7 +2450,7 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         // A wrapper-conclusion base case (`leHead z (insort x [])`) needs the
         // verified fn unfolded then `simp_all`; the bare `simp_all` above leaves
         // it under a stuck dependent match.
-        format!("    | (simp only [{subject}] <;> simp_all [{defs_pool}, h_when] <;> done)"),
+        format!("    | (simp only [{subject}] <;> simp_all [{with_when}] <;> done)"),
         // Non-inductive closer: a conditional law whose content is a case split
         // plus linear arithmetic (a sign byte placed by `if top >= 128`, a
         // clamp, a guard) needs no induction hypothesis at all — `split`
@@ -2468,14 +2477,14 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         format!(
             "    | ({case_other}simp only [{with_append}] at h_when ⊢ <;> (split <;> simp_all [{defs_pool}]) <;> done)"
         ),
-        format!("    | (simp only [{with_append}] <;> simp_all [{defs_pool}, h_when] <;> done)"),
-        format!("    | (split <;> simp_all [{defs_pool}, h_when] <;> done)"),
-        format!("    | (simp_all [{defs_pool}, h_when] <;> done)"),
+        format!("    | (simp only [{with_append}] <;> simp_all [{with_when}] <;> done)"),
+        format!("    | (split <;> simp_all [{with_when}] <;> done)"),
+        format!("    | (simp_all [{with_when}] <;> done)"),
         // Single-list per-element-fold shape (`when allZ(xs) -> sumN(xs) => Z`):
         // the cons-head premise (`allZ (hd :: tl)` unfolds to a match on `hd`)
         // needs the head split before the conditional IH applies. Fail-closed for
         // a non-inductive head (`cases hd` on an `Int` fails, `first` advances).
-        format!("    | (cases hd <;> simp_all [{defs_pool}, h_when] <;> done)"),
+        format!("    | (cases hd <;> simp_all [{with_when}] <;> done)"),
         // The non-inductive closer, as in the nil arm.
         arithmetic_rung,
         // Cheap subject-unfold + split (closes the wrapper helper laws).
@@ -2496,7 +2505,7 @@ pub(in crate::codegen::lean) fn emit_conditional_inductive_generic_law(
         body.insert(
             at + 1,
             format!(
-                "    | (rcases tl with {pattern} <;> simp_all [{defs_pool}, h_when, {normalizers}] <;> omega)"
+                "    | (rcases tl with {pattern} <;> simp_all [{with_when}, {normalizers}] <;> omega)"
             ),
         );
     }

--- a/src/codegen/lean/law_auto/reasons.rs
+++ b/src/codegen/lean/law_auto/reasons.rs
@@ -94,7 +94,20 @@ fn premise_chain(premises: &[String], prop: &str) -> String {
         + prop
 }
 
-fn solver(defs: &str, grind_defs: &str, label: &str, indent: &str) -> Vec<String> {
+fn solver(
+    defs: &str,
+    grind_defs: &str,
+    label: &str,
+    indent: &str,
+    fact_count: usize,
+) -> Vec<String> {
+    // Cited theorems remain available to grind, but are not unconditional
+    // rewrite rules: an accumulator equation can rewrite its own result.
+    let simp_defs = std::iter::once(defs.to_string())
+        .filter(|s| !s.is_empty())
+        .chain((0..fact_count).map(|i| format!("-_fact{i}")))
+        .collect::<Vec<_>>()
+        .join(", ");
     let grind_defs = [grind_defs, "List.take, List.reverse_eq_nil_iff"]
         .into_iter()
         .filter(|s| !s.is_empty())
@@ -102,7 +115,7 @@ fn solver(defs: &str, grind_defs: &str, label: &str, indent: &str) -> Vec<String
         .join(", ");
     vec![
         format!("{indent}first"),
-        format!("{indent}| (simp_all +zetaDelta [{defs}]; done)"),
+        format!("{indent}| (simp_all +zetaDelta [{simp_defs}]; done)"),
         format!("{indent}| ((try simp only [List.contains_eq_mem]); grind [{grind_defs}])"),
         format!("{indent}| (trace \"AVER_REASON_OPEN:{label}\"; trace_state; sorry)"),
     ]
@@ -180,6 +193,11 @@ pub(in crate::codegen::lean) fn emit_reason_law(
         ));
         let hypotheses = previous.iter().map(|h| format!(" {h}")).collect::<String>();
         lines.push(format!("  intro {args}{hypotheses}{guard_intro}"));
+        let fact_count = if !final_step || reasons.is_empty() {
+            facts.as_ref().map_or(0, Vec::len)
+        } else {
+            0
+        };
         if !final_step || reasons.is_empty() {
             if let Some(facts) = &facts {
                 for (i, fact) in facts.iter().enumerate() {
@@ -204,7 +222,7 @@ pub(in crate::codegen::lean) fn emit_reason_law(
                 }
             }
             lines.push("  all_goals".to_string());
-            lines.extend(solver(&defs, &grind_defs, &label, "    "));
+            lines.extend(solver(&defs, &grind_defs, &label, "    ", fact_count));
         } else {
             if let Some(call) = &targets[index] {
                 // Guards and previous explanations belong in the motive:
@@ -222,7 +240,7 @@ pub(in crate::codegen::lean) fn emit_reason_law(
                 "  all_goals repeat' first | apply {and_rule} | intro"
             ));
             lines.push("  all_goals".to_string());
-            lines.extend(solver(&defs, &grind_defs, &label, "    "));
+            lines.extend(solver(&defs, &grind_defs, &label, "    ", fact_count));
             previous.push(format!("h_reason{index}"));
         }
     }

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -84,8 +84,13 @@ fn emit_sample_guard_resolved(
             format!("(!{})", emit_sample_guard_resolved(&args[0], ctx))
         }
         ResolvedExpr::BinOp(op, left, right) => {
-            let l = emit_sample_guard_resolved(left, ctx);
-            let r = emit_sample_guard_resolved(right, ctx);
+            let (l, r) = super::expr::typed_comparison_operands(
+                op,
+                left,
+                right,
+                emit_sample_guard_resolved(left, ctx),
+                emit_sample_guard_resolved(right, ctx),
+            );
             // Operator spellings mirror `expr::emit_expr` exactly.
             let op_str = match op {
                 BinOp::Add => "+",

--- a/tests/fixtures/cited_accumulator_reason.av
+++ b/tests/fixtures/cited_accumulator_reason.av
@@ -1,0 +1,47 @@
+module CitedAccumulatorReason
+    intent = "Isolate the digit encoding step with the existing prover."
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    match value > 0
+        true -> digits(Int.div(value, 256), List.prepend(Int.mod(value, 256), acc))
+        false -> List.reverse(acc)
+
+verify digits law accumulatorComesFirst
+    given value: Int = [-1, 0, 1, 255, 256, 65536, 2147483648]
+    given acc: List<Int> = [[], [9], [1, 2]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))
+
+fn afterFirstDigit(value: Int) -> List<Int>
+    ? "Write the remaining magnitude with its first digit already collected."
+    digits(Int.div(value, 256), [Int.mod(value, 256)])
+
+verify afterFirstDigit
+    afterFirstDigit(1) => [1]
+    afterFirstDigit(256) => [0, 1]
+
+verify digits law positiveStep
+    given value: Int = [1, 127, 128, 256, 2147483648]
+    when value > 0
+    afterFirstDigit(value) => digits(value, [])
+
+fn digitStepReason(prefix: Int, digit: Int) -> Bool
+    ? "The quotient recovers the prefix and the remainder recovers the digit."
+    value = prefix * 256 + digit
+    Bool.and(value > 0, Bool.and(
+        digits(value, []) == afterFirstDigit(value),
+        Bool.and(Int.div(value, 256) == prefix, Bool.and(Int.mod(value, 256) == digit,
+            digits(prefix, [digit]) == List.prepend(digit, digits(prefix, []))))
+    ))
+
+verify digitStepReason
+    digitStepReason(1, 0) => true
+    digitStepReason(128, 255) => true
+
+verify digits law positivePrefixAndDigit
+    given prefix: Int = [1, 127, 128, 256, 2147483648]
+    given digit: Int = [0, 1, 127, 128, 255]
+    when Bool.and(prefix > 0, Bool.and(digit >= 0, digit < 256))
+    because digitStepReason(prefix, digit)
+    using [digits.positiveStep, digits.accumulatorComesFirst]
+    digits(prefix * 256 + digit, []) => List.prepend(digit, digits(prefix, []))
+

--- a/tests/fixtures/conditional_empty_simp.av
+++ b/tests/fixtures/conditional_empty_simp.av
@@ -1,0 +1,20 @@
+module ConditionalEmptySimp
+    intent = "Reproduce the empty leading simp entry for a list-parameter step law."
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    match value > 0
+        true -> digits(Int.div(value, 7), List.prepend(Int.mod(value, 7), acc))
+        false -> List.reverse(acc)
+
+verify digits law doesNotAddOutsideDigits
+    given m: Int = [-1, 0, 1, 7, 49]
+    given acc: List<Int> = [[], [-1], [7]]
+    given b: Int = [-1, 0, 7]
+    when Bool.or(b < 0, b >= 7)
+    List.contains(digits(m, acc), b) => List.contains(acc, b)
+
+verify digits law positiveStep
+    given value: Int = [1, 7]
+    given acc: List<Int> = [[], [-1], [7]]
+    when value > 0
+    digits(value, acc) => digits(Int.div(value, 7), List.prepend(Int.mod(value, 7), acc))

--- a/tests/fixtures/typed_empty_comparisons/comparisons.av
+++ b/tests/fixtures/typed_empty_comparisons/comparisons.av
@@ -1,0 +1,35 @@
+module Comparisons
+    intent = "Empty list comparisons keep their checked element types."
+    exposes [same]
+
+fn same(xs: List<Int>, ys: List<Int>) -> Bool
+    xs == ys
+
+verify same law agrees
+    given xs: List<Int> = [[], [1]]
+    given ys: List<Int> = [[], [2]]
+    using []
+    same(xs, ys) => xs == ys
+
+verify same law guarded
+    given xs: List<Int> = [[], [1]]
+    given ys: List<Int> = [[], [2]]
+    when xs == ys
+    using []
+    same(xs, ys) holds
+
+fn sameNested(xs: List<List<String>>, ys: List<List<String>>) -> Bool
+    xs == ys
+
+verify sameNested law agrees
+    given xs: List<List<String>> = [[], [[]], [["x"]]]
+    given ys: List<List<String>> = [[], [[]], [["y"]]]
+    using []
+    sameNested(xs, ys) => xs == ys
+
+verify sameNested law different
+    given xs: List<List<String>> = [[], [[]], [["x"]]]
+    given ys: List<List<String>> = [[], [[]], [["y"]]]
+    when xs != ys
+    using []
+    sameNested(xs, ys) => false

--- a/tests/fixtures/typed_empty_comparisons/main.av
+++ b/tests/fixtures/typed_empty_comparisons/main.av
@@ -1,0 +1,6 @@
+module EmptyComparisonEntry
+    intent = "Imported law samples retain their given types."
+    depends [Comparisons]
+
+fn main() -> Unit
+    Unit

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -61,6 +61,8 @@ mod oracle_verify;
 mod panics;
 #[path = "proof_spec/pool_composition_recursive.rs"]
 mod pool_composition_recursive;
+#[path = "proof_spec/reason_rough_edges.rs"]
+mod reason_rough_edges;
 #[path = "proof_spec/recursive_law_reasons.rs"]
 mod recursive_law_reasons;
 #[path = "proof_spec/scc_list_drop.rs"]

--- a/tests/proof_spec/reason_rough_edges.rs
+++ b/tests/proof_spec/reason_rough_edges.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+#[test]
+fn conditional_probe_handles_an_empty_unfold_set_with_sibling_lemmas() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-empty-simp");
+    let probe_log = dir.with_extension("probe.log");
+    let run = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .args([
+            "proof",
+            "tests/fixtures/conditional_empty_simp.av",
+            "--check-json",
+            "-o",
+        ])
+        .arg(&dir)
+        .env("AVER_SPECULATIVE_LOG", &probe_log)
+        .output()
+        .unwrap();
+    let probe = std::fs::read_to_string(&probe_log).unwrap();
+    assert!(!probe.contains("unexpected token"), "{probe}");
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("proof_manifest.json")).unwrap())
+            .unwrap();
+    let sibling = manifest["laws"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|law| law["law"] == "digits.doesNotAddOutsideDigits")
+        .unwrap();
+    assert_eq!(sibling["tier"], "universal", "{}", format_output(&run));
+    let _ = std::fs::remove_dir_all(dir);
+    let _ = std::fs::remove_file(probe_log);
+}
+
+#[test]
+fn cited_accumulator_equations_do_not_loop_as_simp_rules_in_reasons() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-cited-accumulator");
+    let (summary, run) =
+        run_lean_check_json("tests/fixtures/cited_accumulator_reason.av", &dir, 0, &[]);
+    assert!(run.status.success(), "{}", format_output(&run));
+    assert_eq!(summary["build_errors"], 0, "{summary}");
+    assert_eq!(summary["universal_laws"], 3, "{summary}");
+    assert_eq!(summary["sorries"], 0, "{summary}");
+    assert_eq!(
+        summary["obligations"]["digits.positivePrefixAndDigit.because1"],
+        "universal"
+    );
+    assert_eq!(
+        summary["obligations"]["digits.positivePrefixAndDigit.implication"],
+        "universal"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/tests/proof_spec/reason_rough_edges.rs
+++ b/tests/proof_spec/reason_rough_edges.rs
@@ -56,3 +56,22 @@ fn cited_accumulator_equations_do_not_loop_as_simp_rules_in_reasons() {
     );
     let _ = std::fs::remove_dir_all(dir);
 }
+
+#[test]
+fn imported_empty_list_comparisons_keep_types_in_samples_and_guards() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-empty-list-comparisons");
+    let (summary, run) = run_lean_check_json(
+        "tests/fixtures/typed_empty_comparisons/main.av",
+        &dir,
+        0,
+        &["--module-root", "tests/fixtures/typed_empty_comparisons"],
+    );
+    assert!(run.status.success(), "{}", format_output(&run));
+    assert_eq!(summary["build_errors"], 0, "{summary}");
+    assert_eq!(summary["universal_laws"], 4, "{summary}");
+    assert_eq!(summary["sorries"], 0, "{summary}");
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/tests/proof_spec/reason_rough_edges.rs
+++ b/tests/proof_spec/reason_rough_edges.rs
@@ -63,10 +63,11 @@ fn imported_empty_list_comparisons_keep_types_in_samples_and_guards() {
         return;
     }
     let dir = temp_output_dir("aver-empty-list-comparisons");
-    let (summary, run) = run_lean_check_json(
+    let (summary, run) = run_lean_check_json_with_args(
         "tests/fixtures/typed_empty_comparisons/main.av",
         &dir,
         0,
+        &[],
         &["--module-root", "tests/fixtures/typed_empty_comparisons"],
     );
     assert!(run.status.success(), "{}", format_output(&run));


### PR DESCRIPTION
Citing an accumulator law could turn a checked `because` explanation into a Lean heartbeat error: `simp_all` treated the quantified equation as a rewrite rule and rewrote its own result. Keep cited theorems available to `grind`, while excluding them from the simplifier’s rewrite set. The reproducer goes from a build error to three universally proved laws, including both reason obligations.

Conditional induction also emitted `simp_all [, lemma, ...]` when its safe unfold set was empty. Compose the term lists before rendering them, including the guard and append variants, so the probe cannot fail on malformed syntax.

An imported law could also lose its declared list element type in a ground sample such as `[] == []`. Preserve the checked type for comparisons of empty list literals, including nested lists and guards. The dependency fixture goes from seven Lean errors to four universally proved laws.

Validation: three live Lean regression tests; 12 existing law-reason/induction tests; 32 nearby conditional, well-founded, citation-order and proof-gate tests; 169 Lean exporter unit tests; `cargo fmt --all -- --check`; CI-scoped clippy for the Aver library, binary and benches. The fixtures exercise ordinary digit encoders and existing generic proof machinery.

The formatted btc-listener interpreter export also retains every previous law tier and proves all 17 new canonicality/supporting laws: 41 universal, 3 bounded, one pre-existing open law, zero build errors.

Refs #1288.
