### PR TITLE
Infer empty equality literals from their typed operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **Empty lists take their element type from the other side of equality.** `items == []` and `[] != items` now preserve the checked element type, including nested lists and tuple literals. This reuses the expected-type inference already used for `Option.None`, preventing generated Rust from comparing `AverIntList` with an unresolved generic list.
+
 - **Empty-list equality samples keep their declared element types in Lean.** Imported laws could emit `[] == []` without the `List<Int>` or nested list type supplied by `given`, failing before the proof ran. Equality and inequality now preserve that type when both literals lack an element witness, including comparisons in `when` guards.
 
 - **Cited accumulator equations no longer make executable law explanations loop in simplification.** Selected lemmas remain available to proof search while the simplifier handles the local facts and definitions. Conditional induction also joins its rewrite terms structurally, so an empty safe unfold set cannot emit malformed Lean or degrade neighboring proofs during the probe.

--- a/src/types/checker/infer/expr.rs
+++ b/src/types/checker/infer/expr.rs
@@ -172,6 +172,18 @@ pub(in crate::types::checker) fn is_bare_none_expr(expr: &Expr) -> bool {
     }
 }
 
+/// These literals need the opposite equality operand to supply an element
+/// type before their set-once type stamps reach the backends.
+fn equality_needs_context(expr: &Expr) -> bool {
+    match expr {
+        Expr::List(items) => {
+            items.is_empty() || items.iter().any(|item| equality_needs_context(&item.node))
+        }
+        Expr::Tuple(items) => items.iter().any(|item| equality_needs_context(&item.node)),
+        _ => is_bare_none_expr(expr),
+    }
+}
+
 impl TypeChecker {
     /// Infer the type of `expr` and record it on the `Spanned` node so later
     /// passes can read the result without re-running inference. The actual
@@ -1139,20 +1151,13 @@ impl TypeChecker {
             }
 
             Expr::BinOp(op, left, right) => {
-                // Bidirectional equality: a bare `Option.None` on one side
-                // of `==` / `!=` has no payload to fix its `T`, so plain
-                // inference stamps it `Option<T>` — and the stamp is
-                // set-once, so the imprecision is permanent. The wasm-gc
-                // backend then fails to resolve the `Option<T>`
-                // instantiation slot (the verify runner synthesizes exactly
-                // this shape: `__verify_X_check() -> Bool` with body
-                // `f(args) == Option.None`). Infer the concrete side first
-                // and propagate its type into the bare-None side; when both
-                // sides are bare (or the concrete side isn't fully
-                // concrete) fall back to the plain left-then-right order.
-                let bare_none_eq = matches!(op, BinOp::Eq | BinOp::Neq);
-                let l_bare = bare_none_eq && is_bare_none_expr(&left.node);
-                let r_bare = bare_none_eq && is_bare_none_expr(&right.node);
+                // Infer the concrete side first: `[]` and `Option.None`
+                // (also inside collection literals) otherwise keep an
+                // unresolved set-once stamp. Forward the checked type using
+                // the same expected-type path as arguments and returns.
+                let equality = matches!(op, BinOp::Eq | BinOp::Neq);
+                let l_bare = equality && equality_needs_context(&left.node);
+                let r_bare = equality && equality_needs_context(&right.node);
                 let (lt, rt) = if l_bare && !r_bare {
                     let rt = self.infer_type(right);
                     let lt = if type_is_fully_concrete(&rt) {

--- a/tests/fixtures/empty_list_equality.av
+++ b/tests/fixtures/empty_list_equality.av
@@ -1,0 +1,61 @@
+module EmptyListEquality
+    intent = "Empty list comparisons keep the element type supplied by the other operand."
+    effects [Console.print]
+
+fn emptyRight(items: List<Int>) -> Bool
+    items == []
+
+verify emptyRight
+    emptyRight([]) => true
+    emptyRight([1]) => false
+
+fn emptyLeft(items: List<Int>) -> Bool
+    [] == items
+
+verify emptyLeft
+    emptyLeft([]) => true
+    emptyLeft([1]) => false
+
+fn nonemptyRight(items: List<Int>) -> Bool
+    items != []
+
+verify nonemptyRight
+    nonemptyRight([]) => false
+    nonemptyRight([1]) => true
+
+fn nonemptyLeft(items: List<Int>) -> Bool
+    [] != items
+
+verify nonemptyLeft
+    nonemptyLeft([]) => false
+    nonemptyLeft([1]) => true
+
+fn nestedEmpty(items: List<List<Int>>) -> Bool
+    [[]] == items
+
+verify nestedEmpty
+    nestedEmpty([[]]) => true
+    nestedEmpty([[1]]) => false
+
+fn emptyStrings(items: List<String>) -> Bool
+    items == []
+
+verify emptyStrings
+    emptyStrings([]) => true
+    emptyStrings(["a"]) => false
+
+fn reversedEmpty(items: List<Int>) -> Bool
+    match List.reverse(items)
+        [] -> items == []
+        [head, ..tail] -> false
+
+verify reversedEmpty
+    reversedEmpty([]) => true
+    reversedEmpty([1]) => false
+
+fn main() -> Unit
+    ! [Console.print]
+    Console.print("{emptyRight([])}/{emptyRight([1])}/{emptyLeft([])}/{emptyLeft([1])}")
+    Console.print("{nonemptyRight([])}/{nonemptyRight([1])}/{nonemptyLeft([])}/{nonemptyLeft([1])}")
+    Console.print("{nestedEmpty([[]])}/{nestedEmpty([[1]])}/{emptyStrings([])}/{emptyStrings(["a"])}")
+    Console.print("{reversedEmpty([])}/{reversedEmpty([1])}")

--- a/tests/rust_codegen_differential.rs
+++ b/tests/rust_codegen_differential.rs
@@ -2444,6 +2444,15 @@ fn main() -> Unit
     assert_eq!(rust, vm, "Rust Int endian codecs diverged from VM");
 }
 
+/// An untyped `[]` used to become `AverList` even when compared with an
+/// `AverIntList`. Real compilation catches the representation mismatch;
+/// VM parity also checks both operand orders, inequality and nested lists.
+#[test]
+fn rust_empty_list_equality_matches_vm() {
+    assert_plain_parity("tests/fixtures/empty_list_equality.av", None)
+        .expect("empty list equality must compile and match the VM");
+}
+
 /// `List.drop` on the compiled backend: stepping through a list must see
 /// exactly what stepping by destructuring sees, and the two answers are
 /// printed side by side so a skipped or duplicated element shows up in the

--- a/tests/typechecker_spec.rs
+++ b/tests/typechecker_spec.rs
@@ -93,6 +93,54 @@ fn assert_parse_error_containing(src: &str, snippet: &str) {
     );
 }
 
+#[test]
+fn equality_stamps_contextual_literals_from_the_other_operand() {
+    use aver::ast::{Expr, FnBody, Stmt};
+
+    for (ty, literal) in [
+        ("List<Int>", "[]"),
+        ("List<List<Int>>", "[[]]"),
+        ("List<String>", "[]"),
+        ("Option<Int>", "Option.None"),
+        ("List<Option<Int>>", "[Option.None]"),
+        ("Tuple<List<Int>, Int>", "([], 1)"),
+    ] {
+        for op in ["==", "!="] {
+            for comparison in [format!("xs {op} {literal}"), format!("{literal} {op} xs")] {
+                let source = format!("fn compare(xs: {ty}) -> Bool\n    {comparison}\n");
+                let items = parse(&source);
+                let errs = run_type_check(&items);
+                assert!(errs.is_empty(), "{source}: {errs:?}");
+                let TopLevel::FnDef(function) = &items[0] else {
+                    panic!("expected function");
+                };
+                let body = match &*function.body {
+                    FnBody::Block(stmts) => match &stmts[0] {
+                        Stmt::Expr(body) => body,
+                        _ => panic!("expected expression statement"),
+                    },
+                };
+                let Expr::BinOp(_, left, right) = &body.node else {
+                    panic!("expected comparison");
+                };
+                let expected = aver::types::parse_type_str(ty);
+                assert_eq!(left.ty(), Some(&expected), "{source}: left operand");
+                assert_eq!(right.ty(), Some(&expected), "{source}: right operand");
+            }
+        }
+    }
+}
+
+#[test]
+fn equality_context_keeps_rejecting_incompatible_elements() {
+    for expression in ["xs == [[], [true]]", "[[], [true]] != xs"] {
+        assert_error_containing(
+            &format!("fn compare(xs: List<List<Int>>) -> Bool\n    {expression}\n"),
+            "expected Int, got Bool",
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Valid programs — must pass with zero errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Comparing a typed integer list with `[]` passed the checker and VM but generated Rust comparing `AverIntList` with `AverList<_>`. This broke the native build of n1bor/btc-listener#338; reversed operands, inequality and nested empty lists had the same problem.

Reuse the existing bidirectional equality inference for `Option.None`: infer the concrete operand first and pass its checked type into contextual list and tuple literals. No Rust-specific coercion or runtime change is needed. Type mismatches inside the literal are still rejected.

Validation:
- A standalone fixture passes all 14 VM verify cases; before this change its generated Rust fails with six E0277 errors. With the fix, the Rust binary builds and matches VM output.
- 323 typechecker specifications, 121 checker unit tests and 7 typed-HIR stamp tests pass, including concrete stamps in both operand orders and negative type cases.
- Cargo fmt and the CI-scoped clippy command pass.

The full btc-listener generated project now passes `cargo build --release`. Re-exporting `domain/interp.av` gives an identical proof manifest: 41 universal, 3 bounded, 1 existing open law, zero build errors.
