### PR TITLE
fix(proof): exclude induction target from generalization

### DIFF
--- a/src/codegen/lean/law_auto/induction/mod.rs
+++ b/src/codegen/lean/law_auto/induction/mod.rs
@@ -3940,6 +3940,7 @@ fn emit_list_induction(
                 law.givens
                     .iter()
                     .position(|g| g.name == fn_param)
+                    .filter(|gi| *gi != target_idx)
                     .map(|gi| intro_names[gi].clone())
             };
             // Peano sync-decremented param → generalize + cases.

--- a/tests/fixtures/list_induction_target.av
+++ b/tests/fixtures/list_induction_target.av
@@ -1,0 +1,20 @@
+module InductionTarget
+    intent = "Deletion is idempotent; the accumulator precedes the recursive driver."
+    effects []
+
+fn remove(values: List<Int>, target: Int) -> List<Int>
+    match values
+        [] -> []
+        [head, ..tail] -> match head == target
+            true -> remove(tail, target)
+            false -> List.prepend(head, remove(tail, target))
+
+fn removeEach(values: List<Int>, targets: List<Int>) -> List<Int>
+    match targets
+        [] -> values
+        [head, ..tail] -> removeEach(remove(values, head), tail)
+
+verify removeEach law idempotent
+    given values: List<Int> = [[], [1, 2, 1]]
+    given targets: List<Int> = [[], [1]]
+    removeEach(removeEach(values, targets), targets) => removeEach(values, targets)

--- a/tests/proof_spec/lemmas.rs
+++ b/tests/proof_spec/lemmas.rs
@@ -1961,3 +1961,20 @@ fn lean_proves_negated_premise_comparison_bridge_when_lake_is_available() {
         "the negated-premise comparison bridge must close le-totality as a universal\n{summary}"
     );
 }
+
+/// The first list given can itself be the threaded accumulator. Generalizing
+/// the induction target is invalid Lean; an open law must still build honestly.
+#[test]
+fn lean_list_induction_does_not_generalize_its_own_target_when_lake_is_available() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let summary = proof_check_summary(
+        include_str!("../fixtures/list_induction_target.av"),
+        "lean",
+        "aver-list-induction-target",
+    );
+    assert_eq!(summary["build_errors"], 0, "{summary}");
+    assert_eq!(summary["universal"], false, "{summary}");
+    assert!(summary["sorries"].as_u64().unwrap() > 0, "{summary}");
+}


### PR DESCRIPTION
A list law whose first given is also the subject function’s threaded accumulator could emit `induction values generalizing values`, causing Lean to reject the generated project. Exclude the induction target from generalization candidates, so an unproved law remains an honest open proof instead of a build error.

Fixes #1300.

Validation: the BTC-independent deletion-idempotence regression now builds and reports an open proof; six existing generalization tests pass, including list accumulators, Peano accumulators, reordered givens, and sibling lemmas. `cargo fmt --all -- --check` passes. This changes only automatic Lean proof selection.
