### PR TITLE
fix(proof): reflect structural equality and retain checked mutual equations

### DIFF
--- a/src/codegen/lean/law_auto/reasons/induction.rs
+++ b/src/codegen/lean/law_auto/reasons/induction.rs
@@ -21,10 +21,7 @@ fn callee<'a>(
     ctx: &'a CodegenContext,
     scope: Option<&str>,
 ) -> Option<&'a FnDef> {
-    let Expr::FnCall(callee, _) = &expr.node else {
-        return None;
-    };
-    let name = super::super::shared::expr_dotted_name(callee)?;
+    let (name, _) = super::super::shared::call_name_args(expr)?;
     let id = ctx.symbol_table.resolve_fn_id_in(&name, scope)?;
     let key = &ctx.symbol_table.fn_entry(id).key;
     ctx.fn_def_by_name(&key.name, key.scope_str())
@@ -136,6 +133,28 @@ pub(super) fn definitions(
             include_structural,
         );
     }
+    // A mutual helper's original equation is available only when the same
+    // checked measure that emits its native definition succeeds. Fuel remains opaque.
+    common::route_pure_components_per_scope(
+        ctx,
+        |fd| fd.effects.is_empty(),
+        |fns, _| {
+            if fns.len() > 1
+                && fns
+                    .iter()
+                    .any(|fd| common::fn_id_for_decl(ctx, fd).is_some_and(|id| seen.contains(&id)))
+                && crate::codegen::lean::toplevel::fuel::native_mutual_sizeof_measures(fns, ctx)
+                    .is_some()
+            {
+                for fd in fns {
+                    if common::fn_id_for_decl(ctx, fd).is_some_and(|id| seen.contains(&id)) {
+                        out.insert(format!("= {}.eq_def", lean_name(fd, ctx)), true);
+                    }
+                }
+            }
+            Vec::new()
+        },
+    );
     // An induction hypothesis says reason(rest) = true. Its match equation
     // reveals the checked facts even when `rest` is not a known constructor.
     for reason in &law.because {

--- a/src/codegen/lean/toplevel/fuel.rs
+++ b/src/codegen/lean/toplevel/fuel.rs
@@ -1500,21 +1500,11 @@ pub(in crate::codegen::lean) fn native_measure_refusal(
     Some(reasons.join("; "))
 }
 
-/// Native termination emission for mutual-recursion SCCs planned as
-/// `MutualSizeOfRanked` — a Lean 4 `mutual ... end` block with one
-/// `termination_by` per def, the lex tuple `(measure, rank)` chosen by the
-/// call edge analysis so it decreases on every call between the members.
-/// Mirrors the Dafny native path from #83.
-///
-/// Returns `None` when:
-/// - SCC isn't fully `MutualSizeOfRanked` (caller picks fuel)
-/// - The analysis finds no measure that decreases on every call
-/// - This backend backs off from the measure it finds: see
-///   [`native_measure_back_off`]
-pub(super) fn emit_native_mutual_sizeof_group(
+/// The same checked measure gates native emission and equation use in reasons.
+pub(in crate::codegen::lean) fn native_mutual_sizeof_measures(
     fns: &[&FnDef],
     ctx: &CodegenContext,
-) -> Option<String> {
+) -> Option<Vec<NativeMeasure>> {
     for fd in fns {
         if !is_pure_fn(fd) {
             return None;
@@ -1537,6 +1527,26 @@ pub(super) fn emit_native_mutual_sizeof_group(
     if native_measure_back_off(fns, &measures).is_some() {
         return None;
     }
+
+    Some(measures)
+}
+
+/// Native termination emission for mutual-recursion SCCs planned as
+/// `MutualSizeOfRanked` — a Lean 4 `mutual ... end` block with one
+/// `termination_by` per def, the lex tuple `(measure, rank)` chosen by the
+/// call edge analysis so it decreases on every call between the members.
+/// Mirrors the Dafny native path from #83.
+///
+/// Returns `None` when:
+/// - SCC isn't fully `MutualSizeOfRanked` (caller picks fuel)
+/// - The analysis finds no measure that decreases on every call
+/// - This backend backs off from the measure it finds: see
+///   [`native_measure_back_off`]
+pub(super) fn emit_native_mutual_sizeof_group(
+    fns: &[&FnDef],
+    ctx: &CodegenContext,
+) -> Option<String> {
+    let measures = native_mutual_sizeof_measures(fns, ctx)?;
 
     let mut lines: Vec<String> = vec!["mutual".to_string()];
     for (fd, measure) in fns.iter().zip(&measures) {

--- a/src/codegen/lean/toplevel/type_def.rs
+++ b/src/codegen/lean/toplevel/type_def.rs
@@ -1,3 +1,5 @@
+mod equality;
+
 use std::collections::{HashMap, HashSet};
 
 use super::expr::aver_name_to_lean;
@@ -429,6 +431,12 @@ fn emit_sum_type(
     });
     // #14: Recursive types cannot derive DecidableEq automatically
     lines.push(derives_line(inhabited, !is_recursive));
+    if equality::reflects_equality(&crate::types::Type::named(name), ctx, scope) {
+        lines.push(format!(
+            "deriving instance ReflBEq, LawfulBEq for {}",
+            aver_name_to_lean(name)
+        ));
+    }
     lines.join("\n")
 }
 
@@ -485,6 +493,12 @@ fn emit_product_type(
         .iter()
         .all(|(_, field)| field_is_inhabitable(field, ctx, scope, &mut Vec::new()));
     lines.push(derives_line(inhabited, !is_recursive));
+    if equality::reflects_equality(&crate::types::Type::named(name), ctx, scope) {
+        lines.push(format!(
+            "deriving instance ReflBEq, LawfulBEq for {}",
+            aver_name_to_lean(name)
+        ));
+    }
     lines.join("\n")
 }
 

--- a/src/codegen/lean/toplevel/type_def/equality.rs
+++ b/src/codegen/lean/toplevel/type_def/equality.rs
@@ -1,0 +1,54 @@
+//! Eligibility for kernel-derived reflection of executable structural equality.
+//! Float and composites containing it retain their IEEE Boolean semantics.
+
+use crate::codegen::CodegenContext;
+use crate::types::Type;
+
+pub(super) fn reflects_equality(ty: &Type, ctx: &CodegenContext, scope: Option<&str>) -> bool {
+    fn visit(ty: &Type, ctx: &CodegenContext, scope: Option<&str>, seen: &mut Vec<String>) -> bool {
+        match ty {
+            Type::Int | Type::Str | Type::Bool | Type::Unit => true,
+            Type::List(t) | Type::Vector(t) | Type::Option(t) => visit(t, ctx, scope, seen),
+            Type::Result(a, b) | Type::Map(a, b) => {
+                visit(a, ctx, scope, seen) && visit(b, ctx, scope, seen)
+            }
+            Type::Tuple(ts) => ts.iter().all(|t| visit(t, ctx, scope, seen)),
+            Type::Named { name, .. } => {
+                let Some((td, owner)) = super::find_type_def_scoped(ctx, name, scope) else {
+                    return false;
+                };
+                if crate::codegen::proof_recognize::detect_canonical_peano(td).is_some() {
+                    return true;
+                }
+                let name = crate::codegen::common::type_def_name(td);
+                let key = super::canonical_type_name(name, owner);
+                // Recursive derived BEq needs a separate inductive reflection proof.
+                if seen.contains(&key) {
+                    return false;
+                }
+                seen.push(key);
+                let mut field = |annotation: &str| {
+                    visit(&crate::types::parse_type_str(annotation), ctx, owner, seen)
+                };
+                let result = if let Some(refined) =
+                    crate::codegen::common::find_refined_type_scoped(ctx, name, owner)
+                {
+                    field(&refined.carrier_type)
+                } else {
+                    match td {
+                        crate::ast::TypeDef::Product { fields, .. } => {
+                            fields.iter().all(|(_, ty)| field(ty))
+                        }
+                        crate::ast::TypeDef::Sum { variants, .. } => {
+                            variants.iter().all(|v| v.fields.iter().all(|ty| field(ty)))
+                        }
+                    }
+                };
+                seen.pop();
+                result
+            }
+            Type::Float | Type::Fn(..) | Type::Var(_) | Type::Invalid => false,
+        }
+    }
+    visit(ty, ctx, scope, &mut Vec::new())
+}

--- a/src/codegen/lean/toplevel/type_def/equality.rs
+++ b/src/codegen/lean/toplevel/type_def/equality.rs
@@ -13,8 +13,11 @@ pub(super) fn reflects_equality(ty: &Type, ctx: &CodegenContext, scope: Option<&
                 visit(a, ctx, scope, seen) && visit(b, ctx, scope, seen)
             }
             Type::Tuple(ts) => ts.iter().all(|t| visit(t, ctx, scope, seen)),
-            Type::Named { name, .. } => {
-                let Some((td, owner)) = super::find_type_def_scoped(ctx, name, scope) else {
+            Type::Named { .. } => {
+                let Some(name) = crate::codegen::common::backend_named_type_key(ctx, ty) else {
+                    return false;
+                };
+                let Some((td, owner)) = super::find_type_def_scoped(ctx, &name, scope) else {
                     return false;
                 };
                 if crate::codegen::proof_recognize::detect_canonical_peano(td).is_some() {

--- a/tests/fixtures/law_reason_equality.av
+++ b/tests/fixtures/law_reason_equality.av
@@ -1,0 +1,60 @@
+module ReasonEquality
+    intent = "Executable equality reflects structural data but not IEEE NaN."
+    effects []
+
+record Count
+    value: Int
+
+record Containers
+    optional: Option<List<Count>>
+    result: Result<Tuple<Int, Count>, String>
+    vector: Vector<Count>
+    table: Map<Int, Count>
+
+record FloatBox
+    value: Float
+
+record NestedFloat
+    values: List<FloatBox>
+
+fn identity(value: Int) -> Int
+    value
+
+verify identity law recordExplanation
+    given value: Int = [-1, 0, 1]
+    because recordReason(value)
+    using []
+    identity(value) => value
+
+fn recordReason(value: Int) -> Bool
+    Count(value = identity(value)) == Count(value = value)
+
+fn equalContainers(value: Containers) -> Bool
+    value == value
+
+verify equalContainers law reflexive
+    given value: Containers = [Containers(optional = Option.Some([Count(value = 1)]), result = Result.Ok((2, Count(value = 3))), vector = Vector.fromList([Count(value = 4)]), table = Map.fromList([(1, Count(value = 5))]))]
+    because equalContainers(value)
+    using []
+    equalContainers(value) holds
+
+fn floatIdentity(value: Float) -> Float
+    value
+
+verify floatIdentity law noNaNReflexivity
+    given value: Float = [0.0, 1.0]
+    because floatReason(value)
+    using []
+    floatIdentity(value) => value
+
+verify floatIdentity law noNestedNaNReflexivity
+    given value: Float = [0.0, 1.0]
+    because nestedFloatReason(value)
+    using []
+    floatIdentity(value) => value
+
+fn floatReason(value: Float) -> Bool
+    FloatBox(value = value) == FloatBox(value = value)
+
+fn nestedFloatReason(value: Float) -> Bool
+    NestedFloat(values = [FloatBox(value = value)]) == NestedFloat(values = [FloatBox(value = value)])

--- a/tests/fixtures/law_reason_filter.av
+++ b/tests/fixtures/law_reason_filter.av
@@ -1,0 +1,44 @@
+module PacketFilter
+    intent = "Retaining packets is a stable filter over their exact key."
+    effects []
+
+type Packet
+    Data(Int, List<Int>)
+    Marker(Int)
+
+fn key(packet: Packet) -> List<Int>
+    match packet
+        Packet.Data(tag, bytes) -> List.prepend(tag, bytes)
+        Packet.Marker(tag) -> [tag]
+
+fn without(packets: List<Packet>, target: List<Int>, acc: List<Packet>) -> List<Packet>
+    match packets
+        [] -> List.reverse(acc)
+        [head, ..tail] -> keep(head, tail, target, acc)
+
+verify without law stableFilter
+    given packets: List<Packet> = [[], [Packet.Marker(81)], [Packet.Data(1, [171]), Packet.Marker(81)]]
+    given target: List<Int> = [[], [1, 171]]
+    given acc: List<Packet> = [[], [Packet.Marker(82)]]
+    because reason(packets, target, acc)
+    using []
+    without(packets, target, acc) => List.concat(List.reverse(acc), retained(packets, target))
+
+fn keep(packet: Packet, rest: List<Packet>, target: List<Int>, acc: List<Packet>) -> List<Packet>
+    match key(packet) == target
+        true -> without(rest, target, acc)
+        false -> without(rest, target, List.prepend(packet, acc))
+
+fn retained(packets: List<Packet>, target: List<Int>) -> List<Packet>
+    match packets
+        [] -> []
+        [head, ..tail] -> match key(head) == target
+            true -> retained(tail, target)
+            false -> List.prepend(head, retained(tail, target))
+
+fn reason(packets: List<Packet>, target: List<Int>, acc: List<Packet>) -> Bool
+    match packets
+        [] -> without(packets, target, acc) == List.concat(List.reverse(acc), retained(packets, target))
+        [head, ..tail] -> match key(head) == target
+            true -> Bool.and(reason(tail, target, acc), without(packets, target, acc) == List.concat(List.reverse(acc), retained(packets, target)))
+            false -> Bool.and(reason(tail, target, List.prepend(head, acc)), without(packets, target, acc) == List.concat(List.reverse(acc), retained(packets, target)))

--- a/tests/proof_spec/recursive_law_reasons.rs
+++ b/tests/proof_spec/recursive_law_reasons.rs
@@ -164,3 +164,94 @@ fn recursive_reason_resolves_imported_helpers_despite_local_name_collisions() {
     );
     let _ = std::fs::remove_dir_all(dir);
 }
+
+#[test]
+fn structural_equality_reasons_preserve_float_nonreflexivity() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-reason-equality");
+    let (summary, run) = run_lean_check_json("tests/fixtures/law_reason_equality.av", &dir, 0, &[]);
+    assert!(!run.status.success(), "NaN reasons must stay open");
+    assert_eq!(summary["build_errors"], 0, "{}", format_output(&run));
+    assert_eq!(summary["universal_laws"], 2, "{summary}");
+    for law in ["identity.recordExplanation", "equalContainers.reflexive"] {
+        assert_eq!(
+            summary["obligations"][format!("{law}.because1")],
+            "universal",
+            "{summary}"
+        );
+    }
+    for law in [
+        "floatIdentity.noNaNReflexivity",
+        "floatIdentity.noNestedNaNReflexivity",
+    ] {
+        assert_eq!(
+            summary["obligations"][format!("{law}.because1")],
+            "failed",
+            "{summary}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn structural_filter_reason_uses_checked_mutual_equations() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-reason-filter");
+    let (summary, run) = run_lean_check_json("tests/fixtures/law_reason_filter.av", &dir, 0, &[]);
+    assert!(run.status.success(), "{}", format_output(&run));
+    assert_eq!(summary["universal_laws"], 1, "{summary}");
+    assert_eq!(
+        summary["obligations"]["without.stableFilter.because1"],
+        "universal"
+    );
+    assert_eq!(
+        summary["obligations"]["without.stableFilter.implication"],
+        "universal"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn imported_structural_equality_and_mutual_equations_keep_their_owner() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-imported-filter-reason");
+    std::fs::create_dir_all(&dir).unwrap();
+    let dependency = include_str!("../fixtures/law_reason_filter.av").replace(
+        "module PacketFilter",
+        "module PacketFilter\n    exposes [Packet, without, retained, reason]",
+    );
+    std::fs::write(dir.join("PacketFilter.av"), dependency).unwrap();
+    let source = dir.join("Consumer.av");
+    std::fs::write(&source, r#"module Consumer
+    depends [PacketFilter]
+    intent = "Imported proof symbols retain their types and owning scopes."
+    effects []
+record Packet
+    value: Float
+fn key(value: Int) -> Int
+    value
+verify key law importedFilter
+    given packets: List<PacketFilter.Packet> = [[], [PacketFilter.Packet.Marker(1)]]
+    given target: List<Int> = [[], [1]]
+    given acc: List<PacketFilter.Packet> = [[]]
+    because PacketFilter.reason(packets, target, acc)
+    using []
+    PacketFilter.without(packets, target, acc) => List.concat(List.reverse(acc), PacketFilter.retained(packets, target))
+"#).unwrap();
+    let (summary, run) = run_lean_check_json_with_args(
+        source.to_str().unwrap(),
+        &dir.join("lean"),
+        0,
+        &[],
+        &["--module-root", dir.to_str().unwrap()],
+    );
+    assert!(run.status.success(), "{}", format_output(&run));
+    assert_eq!(summary["universal_laws"], 2, "{summary}");
+    let _ = std::fs::remove_dir_all(dir);
+}


### PR DESCRIPTION
Executable reasons over lists of user records/variants could remain open even when the argument was a straightforward structural filter proof. Their Boolean equality lacked kernel-derived reflection, and the reason call walk lost tail calls and omitted native mutual-recursion equations.

Derive `ReflBEq`/`LawfulBEq` for supported structural types, preserving Float/NaN behavior including nested containers. Reuse the existing TCO-aware call helper and the exact native mutual-measure gate to expose checked equations; fuel equations remain excluded. No BTC-specific recognition or syntax is added.

Fixes #1299. Fixes #1301.

Validation: 170 Lean codegen unit tests; seven recursive-reason kernel tests, including imported name collisions, false reasons, guard preservation, nondecreasing recursion, and Float/nested-Float counterexamples; `cargo clippy --features wasm --lib -- -D warnings`. BTC ScriptParse's eight new filter/composition laws (including arbitrary-list deletion idempotence and commutativity) all prove universally, with zero sorries or build errors in the selected cone. Full exact parser roundtrip is separate ongoing work.
