### PR TITLE
proof: share checked list descent with singleton recursion

### DIFF
--- a/docs/lean.md
+++ b/docs/lean.md
@@ -187,6 +187,8 @@ For `using` and `because`, nonrecursive functions contribute their full kernel e
 
 Recursive explanations can also supply an induction plan when the function has a checked structural descent on a list. A recursive call contributes an induction hypothesis for the shorter list; its Boolean result must still establish the facts needed by the next step. Original guards and earlier reasons remain premises of that hypothesis, so they must hold at the recursive arguments. If Lean cannot construct a functional induction principle for a local match, the backend falls back to ordinary induction on that same checked list parameter, with the other givens generalized and all original premises retained. The same termination contract serves ordinary functions and explanations: a shrinking list takes precedence over a sibling counter's fuel model.
 
+A single recursive function also reuses the shared cycle analysis for `List.drop` or `List.take` of a known cons-tail: the slice may equal that tail, but it is still shorter than the original list. This uses the existing length contract and native emitter, including when another list accumulator grows. Dafny also prefers this shared checked descent over its fallback parameter ordering. Slicing the whole input does not establish strict decrease. [law_reason_singleton_list.av](../tests/fixtures/law_reason_singleton_list.av) demonstrates direct induction over a chunked traversal without a separate step list, alongside nondecreasing and growing-call controls.
+
 For example, the explanation can establish the property for `rest` before assembling the property for the whole list:
 
 ```aver

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -816,6 +816,14 @@ struct DecreasesInfo {
 
 /// Try to infer a `decreases` clause from the function signature.
 fn infer_decreases(fd: &FnDef) -> Option<DecreasesInfo> {
+    // A checked list descent wins over a growing accumulator or sibling
+    // counter, using the same contract selection as the proof lowerer.
+    if let Some((index, _)) = crate::codegen::recursion::detect::single_list_descent_param(fd) {
+        return Some(DecreasesInfo {
+            expr: format!("|{}|", aver_name_to_dafny(&fd.params[index].0)),
+            requires: vec![],
+        });
+    }
     // Walk the body to learn which params actually change across
     // self-calls. The plain type-priority pick (`prefer List/String,
     // fall back to Int`) emits clauses Dafny rejects when the chosen

--- a/src/codegen/recursion/cycle_measure.rs
+++ b/src/codegen/recursion/cycle_measure.rs
@@ -398,10 +398,10 @@ fn relation(arg: &Spanned<Expr>, caller: &FnDef, scope: &Scope) -> Relation {
     }
     // `List.drop(s, n)` and `List.take(s, n)` never grow `s`. When `s` is
     // the caller's measured list or a cons-tail tracked from it, classify the
-    // result as the same non-strict source. The operation is computed rather
-    // than a structural subterm, so its path is deliberately empty: equality
-    // is possible (`drop 0`, or `take n` with `length s <= n`) and the SCC's
-    // rank must order that edge exactly like a verbatim list pass.
+    // result by its source's path. The slice can equal that source (`drop 0`
+    // or a sufficiently large `take`), but a source that is already a cons-tail
+    // remains strictly smaller than the original list. A slice of the whole
+    // parameter keeps the empty path and still needs a decreasing cycle rank.
     if let Expr::FnCall(callee, args) = &arg.node
         && args.len() == 2
         && matches!(
@@ -426,7 +426,7 @@ fn relation(arg: &Spanned<Expr>, caller: &FnDef, scope: &Scope) -> Relation {
         if is_list_param_or_tail {
             return Relation::Part {
                 param: origin.param,
-                path: Vec::new(),
+                path: origin.path.clone(),
             };
         }
     }

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -1225,6 +1225,37 @@ pub(crate) fn single_list_structural_param(fd: &FnDef) -> Option<(usize, usize)>
         })
 }
 
+/// A checked list-length descent, retaining an exact structural peel when
+/// available and a conservative one-cell bound for slices of known tails.
+/// The literal-tail query stays separate for tactics that inspect that shape.
+pub(crate) fn single_list_descent_param(fd: &FnDef) -> Option<(usize, usize)> {
+    single_list_structural_param(fd).or_else(|| {
+        // The shared cycle analysis also recognizes a non-growing slice
+        // of a cons-tail. One strict self-edge consumes at least one cell;
+        // keep the existing length contract and native proof emitters.
+        use super::cycle_measure::{Candidate, MeasureKind, measure_for_cycle};
+        let names = HashSet::from([fd.name.clone()]);
+        if !collect_calls_from_body(fd.body.as_ref())
+            .iter()
+            .any(|(name, _)| canonical_callee_name(name, &names).is_some())
+        {
+            return None;
+        }
+        fd.params.iter().enumerate().find_map(|(index, (_, ty))| {
+            if !(ty == "List" || ty.starts_with("List<")) {
+                return None;
+            }
+            let candidates = vec![Candidate {
+                index,
+                kind: MeasureKind::Structural,
+            }];
+            measure_for_cycle(&[fd], &[candidates], false)
+                .ok()
+                .map(|_| (index, 1))
+        })
+    })
+}
+
 pub(crate) fn single_list_structural_param_index(fd: &FnDef) -> Option<usize> {
     single_list_structural_param(fd).map(|(param_index, _)| param_index)
 }
@@ -2479,7 +2510,7 @@ pub fn analyze_plans_in_scope(
         }
 
         let fd = component[0];
-        let list_structural = single_list_structural_param(fd);
+        let list_structural = single_list_descent_param(fd);
         if crate::codegen::lean::recurrence::detect_second_order_int_linear_recurrence(fd).is_some()
         {
             plans.insert(fd.name.clone(), RecursionPlan::LinearRecurrence2);

--- a/tests/fixtures/law_reason_singleton_list.av
+++ b/tests/fixtures/law_reason_singleton_list.av
@@ -1,0 +1,96 @@
+module SingletonListReason
+    intent = "A recursive explanation follows a chunked list traversal, retaining each branch condition."
+    effects []
+
+fn score(values: List<Int>) -> Int
+    match values
+        [] -> 0
+        [head, ..tail] -> match head < 0
+            false -> head + score(tail)
+            true -> match List.take(tail, 0 - head)
+                chunk -> match List.len(chunk) == 0 - head
+                    false -> 0
+                    true -> score(List.drop(tail, 0 - head))
+
+verify score law nonnegative
+    given values: List<Int> = [[], [2, 3], [-2, 8, 9, 4]]
+    because reason(values)
+    using []
+    score(values) >= 0 holds
+
+verify score law rejectsPositiveScore
+    given values: List<Int> = [[2, 3]]
+    when List.len(values) > 0
+    because falseReason(values)
+    using []
+    score(values) > 0 holds
+
+fn reason(values: List<Int>) -> Bool
+    match values
+        [] -> score(values) >= 0
+        [head, ..tail] -> match head < 0
+            false -> Bool.and(reason(tail), score(values) >= 0)
+            true -> match List.take(tail, 0 - head)
+                chunk -> match List.len(chunk) == 0 - head
+                    false -> score(values) >= 0
+                    true -> Bool.and(reason(List.drop(tail, 0 - head)), score(values) >= 0)
+
+fn falseReason(values: List<Int>) -> Bool
+    match values
+        [] -> Bool.or(List.len(values) == 0, score(values) > 0)
+        [head, ..tail] -> match head < 0
+            false -> Bool.and(falseReason(tail), Bool.or(List.len(values) == 0, score(values) > 0))
+            true -> match List.take(tail, 0 - head)
+                chunk -> match List.len(chunk) == 0 - head
+                    false -> Bool.or(List.len(values) == 0, score(values) > 0)
+                    true -> Bool.and(falseReason(List.drop(tail, 0 - head)), Bool.or(List.len(values) == 0, score(values) > 0))
+
+fn selected(acc: List<Int>, values: List<Int>, count: Int) -> List<Int>
+    match values
+        [] -> List.reverse(acc)
+        [head, ..tail] -> selected(List.prepend(head, acc), List.take(tail, count), count - 1)
+
+verify selected
+    selected([], [1, 2, 3, 4], 2) => [1, 2, 3]
+    selected([9], [1, 2], -1) => [9, 1]
+
+fn sameList(values: List<Int>, count: Int) -> Int
+    match values
+        [] -> 0
+        [head, ..tail] -> sameList(List.drop(values, count), count)
+
+verify sameList
+    sameList([], 0) => 0
+
+verify sameList law rejectsUnchangedInput
+    given values: List<Int> = [[]]
+    given count: Int = [0]
+    using []
+    sameList(values, count) => 0
+
+fn growing(values: List<Int>) -> Int
+    match values
+        [] -> 0
+        [head, ..tail] -> growing(List.concat(values, [head]))
+
+verify growing
+    growing([]) => 0
+
+verify growing law rejectsGrowth
+    given values: List<Int> = [[]]
+    using []
+    growing(values) => 0
+
+fn samePrefix(values: List<Int>, count: Int) -> Int
+    match values
+        [] -> 0
+        [head, ..tail] -> samePrefix(List.take(values, count), count)
+
+verify samePrefix
+    samePrefix([1], 0) => 0
+
+verify samePrefix law rejectsUnchangedPrefix
+    given values: List<Int> = [[1]]
+    given count: Int = [0]
+    using []
+    samePrefix(values, count) => 0

--- a/tests/proof_spec/recursive_law_reasons.rs
+++ b/tests/proof_spec/recursive_law_reasons.rs
@@ -36,6 +36,90 @@ fn guided_laws_see_all_nonrecursive_match_alternatives() {
 }
 
 #[test]
+fn dafny_prefers_checked_list_descent_over_a_growing_accumulator() {
+    if Command::new("dafny").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-dafny-singleton-list");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join("selection.av");
+    std::fs::write(
+        &file,
+        r#"module Selection
+    intent = "A computed list tail decreases while its accumulator grows."
+    effects []
+fn selected(acc: List<Int>, values: List<Int>, count: Int) -> List<Int>
+    match values
+        [] -> List.reverse(acc)
+        [head, ..tail] -> selected(List.prepend(head, acc), List.take(tail, count), count - 1)
+verify selected law emptyInput
+    given acc: List<Int> = [[], [1, 2]]
+    given count: Int = [-1, 0, 3]
+    selected(acc, [], count) => List.reverse(acc)
+"#,
+    )
+    .unwrap();
+    let output = dir.join("out");
+    let run = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("proof")
+        .arg(&file)
+        .args(["--backend", "dafny", "--check-json", "-o"])
+        .arg(&output)
+        .output()
+        .unwrap();
+    assert!(run.status.success(), "{}", format_output(&run));
+    let dafny = std::fs::read_to_string(output.join("Selection.dfy")).unwrap();
+    assert!(dafny.contains("decreases |values|"), "{dafny}");
+    assert!(!dafny.contains("decreases |acc|"), "{dafny}");
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn singleton_computed_lists_reuse_checked_length_descent() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let file = "tests/fixtures/law_reason_singleton_list.av";
+    let samples = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .args(["verify", file])
+        .output()
+        .unwrap();
+    assert!(samples.status.success(), "{}", format_output(&samples));
+    let dir = temp_output_dir("aver-singleton-list-reasons");
+    let (summary, run) = run_lean_check_json(file, &dir, 0, &[]);
+    assert!(
+        !run.status.success(),
+        "false and nonterminating claims must remain open"
+    );
+    assert_eq!(summary["build_errors"], 0, "{}", format_output(&run));
+    assert_eq!(summary["universal_laws"], 1, "{summary}");
+    for step in ["because1", "implication"] {
+        assert_eq!(
+            summary["obligations"][format!("score.nonnegative.{step}")],
+            "universal",
+            "{summary}"
+        );
+    }
+    let lean = std::fs::read_to_string(dir.join("SingletonListReason.lean")).unwrap();
+    for name in ["score", "reason", "selected"] {
+        assert!(!lean.contains(&format!("partial def {name}")), "{lean}");
+        assert!(!lean.contains(&format!("{name}__fuel")), "{lean}");
+    }
+    for name in ["sameList", "samePrefix", "growing"] {
+        assert!(lean.contains(&format!("partial def {name}")), "{lean}");
+    }
+    assert!(
+        !lean.contains("termination_by acc.length"),
+        "growing accumulator must not be measured: {lean}"
+    );
+    assert_eq!(
+        summary["obligations"]["score.rejectsPositiveScore.because1"], "failed",
+        "{summary}"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
 fn nested_reason_cases_preserve_branch_premises_before_ordered_facts() {
     if Command::new("lake").arg("--version").output().is_err() {
         return;


### PR DESCRIPTION
A recursive traversal of `List.drop(tail, n)` or `List.take(tail, n)` previously became `partial def` even though extracting a helper allowed equivalent mutual recursion to use a checked length measure. It now reuses the shared cycle analysis and existing native list emitter. A recursive `because` function can follow the actual remaining input without a separate list of proof steps.

Preserve the known cons-tail path when classifying slices, and share checked list-descent selection with singleton proof lowering and Dafny. This also lets Dafny choose the shrinking input when an earlier list accumulator grows. Whole-input slices and growing calls retain conservative fallback; the literal-tail query used by existing induction tactics stays separate. No Lean emitter or tactic changes.

Validation:
- 1,587 library tests passed; one ignored.
- All 15 recursive-law-reason integration tests passed, including real Lean and Dafny checks.
- Existing two SCC slice tests passed.
- The new fixture proves both obligations of the positive law, rejects the false explanation, and keeps nondecreasing/growing recursion partial.
- BTC interpreter: 97 universal laws, 2 bounded, 0 open proofs, 0 build errors; 130 explicitly budgeted non-law refusals unchanged.
- Formatting and clippy passed.

`because`/`using` remain Lean-only; the Dafny change concerns termination selection.

Closes #1311.
