### PR TITLE
Prove K5 truncation bridge and explain actual citation premises

### DIFF
--- a/docs/lean.md
+++ b/docs/lean.md
@@ -367,23 +367,45 @@ tests/fixtures/law_reason_constant_citation.av:39 — product.missingFactorGuard
   To prove: orderedProducts(0, a, b)
   For any a: Int, b: Int
   when a >= 0 [assumed]
-  using orderedProducts.monotone [universal; arguments substituted]
+  using orderedProducts.monotone [universal; source arguments substituted]
     provides orderedProducts(0, a, b) holds
     requires 0 <= a
     requires b >= 0
+  Citation check (isolated): orderedProducts.monotone — direct application succeeded
+    [closed in probe] 0 <= a
+    [open in probe] 0 <= b
 ```
 
 Here the available assumption does not establish `b >= 0`. The requirements
 list describes the cited law; it is not a solver claim that every listed
 condition is missing, or that the checker applied that citation. Unambiguous
 direct call patterns are substituted; other forms retain schematic parameters.
-Automatic law selection is identified as automatic rather than guessed from
-the source. Previous `because` steps carry their audited status: `failed` and
+After a successful counted build, supported direct applications also run in an
+isolated diagnostic copy. This reports the cited law actually tried and the
+premises closed or left open by that application. The actual normalized premise
+may differ in spelling from the source requirement (`0 <= b` versus `b >= 0`
+above). Automatic citations are reported from these observed attempts too.
+Other proof strategies and final implications may have source context only;
+an unsuccessful application does not show that the law is inapplicable.
+
+Every available citation and earlier proof step retains its audited status.
+A probe using a failed, bounded, or unchecked fact is explicitly conditional;
+each closed premise also audits its actual proof's transitive axioms, including
+any additional global lemmas visible in the diagnostic import. Missing audits
+or axioms outside the counted checker's whitelist keep the closure conditional.
+Even closing all its premises awards no proof credit. Unknown backend forms
+are marked unavailable instead of guessed. Probe details are saved separately
+in `proof_citations.log`; the temporary copy never enters the counted build or
+manifest. Previous `because` steps carry their audited status: `failed` and
 `not_checked` steps must not be treated as proved facts. Later steps are never
 listed as assumptions for an earlier step.
 
 `--check-json --explain` exposes the same report in `explanations`, keyed by
-`fn.law` or `fn.law.becauseN` / `fn.law.implication`. A computation limit is
+`fn.law` or `fn.law.becauseN` / `fn.law.implication`. Observed attempts appear in
+`citation_attempts`, with `phase: "diagnostic_direct_application"`, an `outcome`,
+`premises`, `available_laws`, and `established_dependencies`; closed premises
+include `closure_audited` and `proof_axioms`. These describe the
+isolated attempt, not the counted solver's search history. A computation limit is
 reported as `checker_limit`, separately from an unproved step. These reports
 can retain source context even when a hard checker error prevents the final
 axiom audit. Such an error does not establish that the mathematical statement

--- a/projects/k5_fdiv/README.md
+++ b/projects/k5_fdiv/README.md
@@ -1,4 +1,11 @@
-# K5 FDIV — a processor's divider, proven in Aver
+# K5 FDIV — reproducing a processor divider proof in Aver
+
+The executable Fraction truncation now agrees with the normalized model:
+`Kernel.sameTruncation.normalizedModel` proves
+`sameValue(truncFrac(fpValueGeneral(f), n), fpValueGeneral(fpTrunc(f, n)))`
+for `isFp(f)`, `f.width >= 1`, and `n >= 1`. This covers both signs, every
+integer exponent, and target precisions greater than the input width. An
+executable counterexample at `n = 0` records why positive precision is required.
 
 The executable exponent now agrees with the normalized floating-point model:
 `Kernel.normalizedValueExponent.executableExponent` states
@@ -14,14 +21,31 @@ value and proves uniqueness of a binary magnitude interval; `BinadeOrder` reads
 the executable integer bracket as the same rational interval. The Kernel then
 identifies the two exponents through `because` and `using`.
 
-The Kernel export and its imports now contain **82 universal laws**, the same
-**4 bounded laws**, and **105 universal proof steps**, with no `sorry` or build
+`TruncScale` then proves five reusable laws: equal positive-denominator ratios
+have equal floors; the signed exponent scale factors into an ulp and a
+significand scale; floor quotients and restored values respect that change of
+scale; and positive magnitudes preserve a unit sign. `modelSign` identifies the
+executable sign, `modelTruncation` proves the fixed-exponent formula, and
+`truncationFormula` substitutes the established exponent into `truncFrac`.
+The final equality composes those source laws. This argument was developed with
+Aver source and `--explain`, without inspecting the generated Lean.
+
+The source reports identified an open sign implication and a checker limit at a
+nested truncation-formula application. An explicit product-regrouping `because`
+step and a directly citable Bool helper closed those gaps. That is a concrete
+Aver-only proof-author workflow; other open obligations can still require richer
+source diagnostics.
+
+The Kernel export and its imports now contain **91 universal laws**, the same
+**4 bounded laws**, and **142 universal proof steps**, with no `sorry` or build
 errors. The earlier universal laws retain their proof tiers and axiom sets.
 For an open step, `aver proof ... --check --explain` reports its Aver goal,
-assumptions and cited requirements at the source location; see
+assumptions and cited requirements at the source location. Supported direct
+citations also report the actual premises closed or left open in an isolated
+application, with dependency and closure-axiom audits; see
 [proof diagnostics](../../docs/lean.md#step-zero-which-law-failed).
 
-Fraction trunc-sticky composition, sticky-plus, and the complete divider
+The Fraction away/sticky bridges, Fraction trunc-sticky composition, sticky-plus, and the complete divider
 correctness theorem remain open. The wrapper still calls `fpValue`; connecting
 its negative-exponent inputs to `fpValueGeneral` is also outstanding.
 
@@ -32,7 +56,8 @@ Correctness of the Kernel of the AMD5K86 Floating-Point Division Algorithm*
 (Moore, Lynch & Kaufmann, 1996), one of the flagship results of the ACL2 prover and
 a landmark of industrial formal methods.
 
-This project reproduces that proof — **as ordinary Aver code**.
+This project aims to reproduce that proof **as ordinary Aver code**. The audited
+fragments and the remaining end-to-end gap are listed below.
 
 ## The point
 
@@ -49,8 +74,9 @@ the question "is this language a toy?" stops being interesting.
 `.lean` script anyone edits. If K5 were 160 hand-written Lean proofs in disguise, it
 would prove *nothing* — ACL2 already wrote those.
 
-What we write is **clean, provable Aver**: the divider as normal code, the ~160
-intermediate facts as `verify ... law` blocks. **The machine proves them.** Lean's
+What we write is **clean, provable Aver**: the divider as normal code and
+intermediate facts as `verify ... law` blocks. The machine checks the proofs;
+the audited status distinguishes universal results from samples and open claims. Lean's
 kernel and Z3/Dafny are the certifying backends underneath, invisible to the author.
 A helper fact that the prover can't yet close is handled by *stating it as another
 Aver law* (fed to the lemma pool via The Method) or by building a **generic** prover
@@ -97,11 +123,11 @@ Each stage is independently useful as a verified corpus.
 | **1. Float-as-rational (faithful normalized model)** | the paper's representation (Section 5.1, p.10): every value is `sign · s · 2^exp` with `sign` either `+1` or `−1`, a **normalized** rational significand `s ∈ [1,2)` (an n-bit integer `sigBits ∈ [2^(n-1), 2^n)`), an integer exponent, and the width n; the denoted value is the Stage-0 exact `Fraction` | 🟡 **seeded** — `domain/fprep.av`: **Lemma 7.1.2 (p.18)** landed `universal` on the Lean kernel, both halves — the significand is invariant under scaling, `s(x·2^j) = s_x`, and the exponent shifts, `e(x·2^j) = e_x + j` — which hold *definitionally* because `fpScale` renormalizes nothing. Plus the power-of-two homomorphism `pow2(m+n) == pow2(m)·pow2(n)` and the folklore value-of-scaling corollary `fpValue(x·2^j) == fpValue(x)·2^j`, all `universal` (`#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, zero `sorry`). The value corollary is the **laws-as-lemmas composition** end to end, ACROSS the `Domain.Rational` module boundary: it re-proves nothing about powers of two — it *cites* the proven homomorphism and the compiler composes them via one generic strategy, never a per-figure proof. **Lemma 7.1.7 (p.18)** also landed `universal`: *if `x ≠ 0` and `y ≠ 0` then `e_x + e_y ≤ e(x·y) ≤ e_x + e_y + 1`* — the product-exponent range, stated exactly as the paper (a nonzero float is one with a nonzero significand). It is closed by the **generic match-splitting already in the engine**: the keystone's `grind` case-splits `fpMul`'s normalization branch (shift 0 vs 1) and bounds each arm — no new tactic, no per-figure code. **Multiplication's value-preservation** `fpMulValue` also landed `universal` on the Lean kernel (every exponent, `#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, 0 `sorry`). Its obstacle was never the case-split (the same match-splitting that closes 7.1.7 reduces each branch cleanly) but a **pow2 homomorphism *rearrangement***: the product denominator `pow2(w_a+w_b−2)` must be seen as `pow2(w_a−1)·pow2(w_b−1)`, the homomorphism at the rearranged exponent `(w_a−1)+(w_b−1)` — which `grind`'s bare e-matcher misses on the syntactic `+`. The **signed-power-of-two homomorphism normalizer** (the `Fraction`-level companion of the integer pow2 normalizer) supplies exactly that: it canonicalizes `2^(m+n)`/`2^(m+n+1)` through the proven Aver homomorphism law, cited in cross-multiplied form, so `grind` closes the composition — a generic mechanism keyed on the signed-power-of-two cone shape, never a per-figure proof. **Lemma 7.2.12** needs `trunc` plus a strict product bound; then the rounding modes |
 | **2. Newton–Raphson bounds** | the nonlinear error estimates — `domain/estimate.av`: square/product nonneg, monotonicity, the right-factor monotonicity bound, transitivity-through-products, the error-squaring identity, the contraction bound | ✅ **proven** — **all 8 laws `universal` on the Lean kernel** (`#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, 0 sampled, 0 sorries); push-button on Z3/Dafny. Two reusable mechanisms do it, no per-figure tactics. (1) `aver_int_order`, the nonlinear analog of `omega` for the products-and-squares fragment — recurse on a product with `Int.mul_nonneg` (nonnegativity) / `Int.mul_le_mul` (`prod ≤ prod`) / `Int.mul_le_mul_of_nonneg_right` (shared-right-factor bound), sign-split squares — closes the nonneg sub-family (`sqNonneg`, `mulNonneg`, `tripleNonneg`), the monotonicities (`sqMono`, `mulLeMonoRight`), and the contraction bound (`nrContraction`); `grind` closes the error-squaring ring identity. (2) **order-law composition**: the transitivity bound `mulLeTrans` (`a·c ≤ m` when `a ≤ b`, `0 ≤ c`, `b·c ≤ m`) is closed by *citing* `mulLeMonoRight` — the proof composer restates an earlier inequality law as a rewrite trigger over its two comparison sides and chains the instantiated bound `a·c ≤ b·c` with the premise `b·c ≤ m`. Shape-keyed and derived from the cited Aver law (deleting `mulLeMonoRight` breaks it), not a re-proof — the same laws-as-lemmas composition that closes Stage 1, extended from equalities to inequalities |
 | **Rounding — trunc** | Truncation, away/sticky rounding, error bounds and composition laws in `domain/round.av` | **All laws in this module and its imports are universal:** 62 laws, 23 source-proof obligations, no bounded claims or `sorry`. The trunc-sticky argument is source-local: `StickyInt` supplies the low-bit floor law, `StickyScale` cancels the precision scales, and `fpSticky.preservesCoarseTruncation` proves complete record equality for `1 <= m < n`. The public rational-value law follows from it. This result replaces the former manual Lean proof. |
-| **3. Kernel divide** | The 32 straight-line steps and the end-to-end division theorems | **Partial source proofs.** The executable exponent has integer and rational magnitude bounds and agrees with the normalized model for either sign of the exponent. `divide.theorem_2` proves the wrapper equation under the explicit row-32 result-exponent bracket; deriving that bracket remains open. Complete divider correctness still has executable examples rather than a universal proof. Remaining work includes the Fraction rounding bridge, sticky-plus/final-round composition, reciprocal and digit/remainder bounds, the Section 9 bounds, and the wrapper's use of `fpValue` for negative exponents. |
+| **3. Kernel divide** | The 32 straight-line steps and the end-to-end division theorems | **Partial source proofs.** The executable exponent has integer and rational magnitude bounds and agrees with the normalized model for either sign of the exponent. `divide.theorem_2` proves the wrapper equation under the explicit row-32 result-exponent bracket; deriving that bracket remains open. Complete divider correctness still has executable examples rather than a universal proof. Remaining work includes the Fraction away/sticky bridges, sticky-plus/final-round composition, reciprocal and digit/remainder bounds, the Section 9 bounds, and the wrapper's use of `fpValue` for negative exponents. |
 
-Why it's tractable: the algorithm is **straight-line** (two Newton iterations + four
-quotient digits + a rounded sum) — zero unbounded recursion, so no termination/fuel
-problem. Modelling floats as exact rationals sidesteps floating-point/FFI semantics
+The division driver is **straight-line** (two Newton iterations + four
+quotient digits + a rounded sum). Its exponent and rounding helpers still use
+recursion and require termination arguments. Modelling floats as exact rationals sidesteps floating-point/FFI semantics
 entirely. The honest wall is **nonlinear rational arithmetic** (NR error bounds): Z3
 proves it natively; the Lean side gets one reusable generic strategy rather than 160
 bespoke proofs — the first task where the dual backend earns its keep.

--- a/projects/k5_fdiv/domain/kernel.av
+++ b/projects/k5_fdiv/domain/kernel.av
@@ -36,8 +36,8 @@ module Kernel
         "sticky-plus, 7.3.1 final-round-commutes, and the Section 9 exponent/precision"
         "bounds for Theorem 2; plus the remaining bridge from model rounding to the"
         "Fraction operations, using fpValueGeneral for negative exponents."
-    depends [Domain.ModelScale, Domain.BinadeOrder, Domain.Rational, Domain.Fprep, Domain.Round, Domain.Binade]
-    exposes [RoundingMode, fracSign, halve, expoAtLeastOne, twoPow, binadeSig, binadeWindow, fracExpo, fracExpoWindow, normalizedValueExponent, truncFrac, awayFrac, stickyFrac, nearestFrac, posinfFrac, neginfFrac, round, compFrac, reciprocalEstimate, lookup, quotient, divideBang, inField, divide, divideBangCorrect, divideMatchesBang, divideCorrect, finalRoundCommutes_7_3_1, stickyPlus_7_3_2, stickyPerturbStable_7_3_3, truncSticky_rtl, stickySticky_rtl, stickyPlusExact_rtl]
+    depends [Domain.TruncScale, Domain.IntegerOrder, Domain.ModelScale, Domain.BinadeOrder, Domain.Rational, Domain.Fprep, Domain.Round, Domain.Binade]
+    exposes [RoundingMode, fracSign, halve, expoAtLeastOne, twoPow, binadeSig, binadeWindow, fracExpo, fracExpoWindow, normalizedValueExponent, modelSign, sameTruncation, truncFrac, awayFrac, stickyFrac, nearestFrac, posinfFrac, neginfFrac, round, compFrac, reciprocalEstimate, lookup, quotient, divideBang, inField, divide, divideBangCorrect, divideMatchesBang, divideCorrect, finalRoundCommutes_7_3_1, stickyPlus_7_3_2, stickyPerturbStable_7_3_3, truncSticky_rtl, stickySticky_rtl, stickyPlusExact_rtl]
     effects []
 
 // ---------------------------------------------------------------------------
@@ -193,8 +193,9 @@ fn fracExpoWindow(x: Fraction) -> Bool
 // The rounding procedures on rationals (Section 5.2, p.13).
 // Each rounds the rational x to n significant bits: e = fracExpo(x), the ulp is
 // 2^(e-n+1), and the result is sign_x * (integer multiple) * ulp.
-// These AGREE on values with domain/round.av's significand-level fpTrunc /
-// fpAway / fpSticky (which act on the already-normalized Fp model).
+// sameTruncation proves agreement with the significand-level fpTrunc for
+// normalized models, every exponent, and positive target precision.
+// The corresponding fpAway / fpSticky bridges still have concrete examples.
 // ---------------------------------------------------------------------------
 
 verify fracExpoWindow
@@ -211,7 +212,7 @@ verify ceilDiv
     ceilDiv(59, 8) => 8
 
 fn truncFrac(x: Fraction, n: Int) -> Fraction
-    ? "trunc(x,n) (Section 5.2, p.13): round x TOWARD ZERO to n significant bits. The ulp is 2^(e_x - n + 1); the result is sign_x * floor(|x| / ulp) * ulp. Agrees with fpValue(fpTrunc(.)) on the normalized model."
+    ? "trunc(x,n) (Section 5.2, p.13): round x TOWARD ZERO to n significant bits. The ulp is 2^(e_x - n + 1); the result is sign_x * floor(|x| / ulp) * ulp. sameTruncation proves agreement with fpValueGeneral(fpTrunc(.)) on normalized models for every exponent and positive target precision."
     match x.top == 0
         true -> Domain.Rational.zeroFraction()
         false -> Domain.Rational.Fraction(top = fracSign(x) * Domain.Round.floorDiv(Domain.Rational.absInt(x.top) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).bottom, Domain.Rational.absInt(x.bottom) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).top) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).top, bottom = Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).bottom)
@@ -220,6 +221,19 @@ verify truncFrac
     Domain.Rational.sameValue(truncFrac(Domain.Rational.Fraction(top = 13, bottom = 8), 3), Domain.Rational.Fraction(top = 6, bottom = 4)) => true
     Domain.Rational.sameValue(truncFrac(Domain.Rational.Fraction(top = 7, bottom = 2), 24), Domain.Rational.Fraction(top = 7, bottom = 2)) => true
     Domain.Rational.sameValue(truncFrac(Domain.Rational.Fraction(top = -13, bottom = 8), 3), Domain.Rational.Fraction(top = -6, bottom = 4)) => true
+
+fn truncationFormula(x: Fraction, e: Int, n: Int) -> Bool
+    ? "Substitute an established exponent into the executable nonzero truncation formula."
+    truncFrac(x, n) == truncAtExponent(x, e, n)
+
+verify truncationFormula law knownExponent
+    given x: Fraction = [Domain.Rational.Fraction(top = 13, bottom = 8), Domain.Rational.Fraction(top = -9, bottom = 64)]
+    given e: Int = [-3, 0]
+    given n: Int = [1, 2, 7]
+    when x.top != 0
+    when fracExpo(x) == e
+    using []
+    truncationFormula(x, e, n) holds
 
 fn awayFrac(x: Fraction, n: Int) -> Fraction
     ? "away(x,n) (Section 5.2, p.13): round x AWAY FROM ZERO to n significant bits -- the magnitude rounded up (ceiling). The ulp is 2^(e_x - n + 1); the result is sign_x * ceil(|x| / ulp) * ulp. Agrees with fpValue(fpAway(.)) on the normalized model."
@@ -610,3 +624,75 @@ verify normalizedValueExponent law executableExponent
     because Domain.ModelScale.uniqueWindow(Domain.Fprep.fpValueGeneral(f), fracExpo(Domain.Fprep.fpValueGeneral(f)), f.exp)
     using [Domain.ModelScale.nonzeroValue.normalizedValue, fracExpo.rationalMagnitude, Domain.ModelScale.modelWindow.normalizedMagnitude, Domain.ModelScale.uniqueWindow.uniqueExponent]
     normalizedValueExponent(f) holds
+
+fn truncAtExponent(x: Fraction, e: Int, n: Int) -> Fraction
+    ? "The nonzero Fraction truncation formula after its binary exponent has been identified."
+    ulp = Domain.Fprep.pow2Signed(e - n + 1)
+    Domain.Rational.Fraction(top = fracSign(x) * Domain.Round.floorDiv(Domain.Rational.absInt(x.top) * ulp.bottom, Domain.Rational.absInt(x.bottom) * ulp.top) * ulp.top, bottom = ulp.bottom)
+
+verify truncAtExponent
+    truncAtExponent(Domain.Rational.Fraction(top = 13, bottom = 8), 0, 3) => Domain.Rational.Fraction(top = 6, bottom = 4)
+    truncAtExponent(Domain.Rational.Fraction(top = -9, bottom = 64), -3, 2) => Domain.Rational.Fraction(top = -2, bottom = 16)
+
+fn modelSign(f: Fp) -> Bool
+    ? "The executable rational sign agrees with the normalized model's stored sign."
+    fracSign(Domain.Fprep.fpValueGeneral(f)) == f.sign
+
+verify modelSign law normalizedSign
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 9, exp = -3, width = 4)]
+    when Domain.Fprep.isFp(f)
+    because Domain.Fprep.pow2(f.width - 1) >= 1
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.IntegerOrder.positiveProduct(f.sigBits, Domain.Fprep.pow2Signed(f.exp).top)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp).bottom)
+    because Domain.IntegerOrder.positiveProduct(f.sigBits * Domain.Fprep.pow2Signed(f.exp).top, Domain.Fprep.pow2(f.width - 1) * Domain.Fprep.pow2Signed(f.exp).bottom)
+    because Domain.TruncScale.signOfProduct(f.sign, f.sigBits * Domain.Fprep.pow2Signed(f.exp).top, Domain.Fprep.pow2(f.width - 1) * Domain.Fprep.pow2Signed(f.exp).bottom)
+    because Domain.Fprep.fpValueGeneral(f).top * Domain.Fprep.fpValueGeneral(f).bottom == f.sign * ((f.sigBits * Domain.Fprep.pow2Signed(f.exp).top) * (Domain.Fprep.pow2(f.width - 1) * Domain.Fprep.pow2Signed(f.exp).bottom))
+    using [Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.IntegerOrder.positiveProduct.positiveFactors, Domain.TruncScale.signOfProduct.positiveMagnitudes]
+    modelSign(f) holds
+
+fn sameTruncation(f: Fp, n: Int) -> Bool
+    ? "The executable rational truncation and model significand truncation denote the same value, including negative exponents and either sign."
+    Domain.Rational.sameValue(truncFrac(Domain.Fprep.fpValueGeneral(f), n), Domain.Fprep.fpValueGeneral(Domain.Round.fpTrunc(f, n)))
+
+verify sameTruncation
+    sameTruncation(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 0) => false
+    sameTruncation(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 3) => true
+    sameTruncation(Domain.Fprep.Fp(sign = -1, sigBits = 13, exp = -3, width = 4), 3) => true
+    sameTruncation(Domain.Fprep.Fp(sign = 1, sigBits = 9, exp = 5, width = 4), 2) => true
+    sameTruncation(Domain.Fprep.Fp(sign = -1, sigBits = 9, exp = 0, width = 4), 7) => true
+
+verify sameTruncation law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 9, exp = -3, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 9, exp = 5, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because normalizedValueExponent(f)
+    because Domain.ModelScale.nonzeroValue(f)
+    because truncationFormula(Domain.Fprep.fpValueGeneral(f), f.exp, n)
+    because modelTruncation(f, n)
+    using [normalizedValueExponent.executableExponent, Domain.ModelScale.nonzeroValue.normalizedValue, truncationFormula.knownExponent, modelTruncation.normalizedModel]
+    sameTruncation(f, n) holds
+
+fn modelTruncation(f: Fp, n: Int) -> Bool
+    ? "At the stored exponent, the Fraction formula agrees with the truncated model value."
+    Domain.Rational.sameValue(truncAtExponent(Domain.Fprep.fpValueGeneral(f), f.exp, n), Domain.Fprep.fpValueGeneral(Domain.Round.fpTrunc(f, n)))
+
+verify modelTruncation law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 9, exp = -3, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 9, exp = 5, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because Domain.ModelScale.absoluteValue(f)
+    because Domain.ModelScale.nonzeroValue(f)
+    because modelSign(f)
+    because Domain.Fprep.pow2(f.width - 1) >= 1
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.Fprep.pow2SignedPositive(f.exp - n + 1)
+    because Domain.TruncScale.ulpScale(f.exp, n)
+    because Domain.TruncScale.scaledQuotient(f.sigBits, Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp), Domain.Fprep.pow2Signed(f.exp - n + 1), Domain.Fprep.pow2(n - 1))
+    because Domain.TruncScale.restoredValue(f.sign, Domain.Round.fpTrunc(f, n).sigBits, Domain.Fprep.pow2Signed(f.exp), Domain.Fprep.pow2Signed(f.exp - n + 1), Domain.Fprep.pow2(n - 1))
+    using [ Domain.ModelScale.absoluteValue.normalizedMagnitude, Domain.ModelScale.nonzeroValue.normalizedValue, modelSign.normalizedSign, Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.TruncScale.ulpScale.signedExponent, Domain.TruncScale.scaledQuotient.exactScale, Domain.TruncScale.restoredValue.exactScale]
+    modelTruncation(f, n) holds

--- a/projects/k5_fdiv/domain/truncscale.av
+++ b/projects/k5_fdiv/domain/truncscale.av
@@ -1,0 +1,99 @@
+module TruncScale
+    intent = "Transport Euclidean floor quotients across exact rational changes of scale."
+    depends [Domain.StickyInt, Domain.Rational, Domain.Fprep, Domain.IntegerOrder]
+    exposes [equalQuotients, ulpScale, scaledQuotient, restoredValue, signOfProduct]
+    effects []
+
+fn equalQuotients(a: Int, b: Int, c: Int, d: Int) -> Bool
+    ? "Equal rational values with positive denominators have the same Euclidean floor."
+    Domain.StickyInt.floorDiv(a, b) == Domain.StickyInt.floorDiv(c, d)
+
+verify equalQuotients law equalPositiveRatios
+    given a: Int = [-13, 0, 13, 26]
+    given b: Int = [2, 4, 8]
+    given c: Int = [-26, 0, 26, 52]
+    given d: Int = [4, 8, 16]
+    when b > 0
+    when d > 0
+    when a * d == c * b
+    because Domain.StickyInt.floorDiv(d * a, d * b) == Domain.StickyInt.floorDiv(a, b)
+    because Domain.StickyInt.floorDiv(b * c, b * d) == Domain.StickyInt.floorDiv(c, d)
+    using [Domain.StickyInt.floorDiv.cancelCommonFactor]
+    equalQuotients(a, b, c, d) holds
+
+fn ulpScale(e: Int, n: Int) -> Bool
+    ? "The model exponent scale is the truncation ulp multiplied by the n-bit significand scale."
+    scale = Domain.Fprep.pow2Signed(e)
+    ulp = Domain.Fprep.pow2Signed(e - n + 1)
+    scale.top * ulp.bottom == scale.bottom * ulp.top * Domain.Fprep.pow2(n - 1)
+
+verify ulpScale law signedExponent
+    given e: Int = [-5, -1, 0, 3, 8]
+    given n: Int = [1, 2, 4, 9]
+    when n >= 1
+    because Domain.Fprep.pow2SignedHomomorphism(e - n + 1, n - 1)
+    using [Domain.Fprep.pow2SignedHomomorphism.signedHomomorphism]
+    ulpScale(e, n) holds
+
+fn scaledQuotient(a: Int, b: Int, scale: Fraction, ulp: Fraction, p: Int) -> Bool
+    ? "Changing from a model significand to ulp units preserves the integer truncation quotient."
+    Domain.StickyInt.floorDiv(a * scale.top * ulp.bottom, b * scale.bottom * ulp.top) == Domain.StickyInt.floorDiv(a * p, b)
+
+verify scaledQuotient law exactScale
+    given a: Int = [-13, 0, 13]
+    given b: Int = [1, 8]
+    given scale: Fraction = [Domain.Rational.Fraction(top = 1, bottom = 8), Domain.Rational.Fraction(top = 8, bottom = 1)]
+    given ulp: Fraction = [Domain.Rational.Fraction(top = 1, bottom = 32), Domain.Rational.Fraction(top = 2, bottom = 1)]
+    given p: Int = [4]
+    when b > 0
+    when scale.bottom > 0
+    when ulp.top > 0
+    when scale.top * ulp.bottom == scale.bottom * ulp.top * p
+    because Domain.IntegerOrder.positiveProduct(b, scale.bottom)
+    because Domain.IntegerOrder.positiveProduct(b * scale.bottom, ulp.top)
+    because equalQuotients(a * scale.top * ulp.bottom, b * scale.bottom * ulp.top, a * p, b)
+    using [Domain.IntegerOrder.positiveProduct.positiveFactors, equalQuotients.equalPositiveRatios]
+    scaledQuotient(a, b, scale, ulp, p) holds
+
+fn restoredValue(sign: Int, q: Int, scale: Fraction, ulp: Fraction, p: Int) -> Bool
+    ? "Restoring a signed integer quotient in ulp units equals restoring its model significand."
+    Domain.Rational.sameValue(Domain.Rational.Fraction(top = sign * q * ulp.top, bottom = ulp.bottom), Domain.Rational.Fraction(top = scale.top * sign * q, bottom = scale.bottom * p))
+
+verify restoredValue law exactScale
+    given sign: Int = [-1, 1]
+    given q: Int = [0, 1, 6]
+    given scale: Fraction = [Domain.Rational.Fraction(top = 1, bottom = 8), Domain.Rational.Fraction(top = 8, bottom = 1)]
+    given ulp: Fraction = [Domain.Rational.Fraction(top = 1, bottom = 32), Domain.Rational.Fraction(top = 2, bottom = 1)]
+    given p: Int = [4]
+    when scale.top * ulp.bottom == scale.bottom * ulp.top * p
+    using []
+    restoredValue(sign, q, scale, ulp, p) holds
+
+fn signOfProduct(sign: Int, a: Int, b: Int) -> Bool
+    ? "Multiplying two positive magnitudes by a unit sign preserves that sign."
+    match sign * (a * b) >= 0
+        true -> sign == 1
+        false -> sign == -1
+
+verify signOfProduct law positiveMagnitudes
+    given sign: Int = [-1, 1]
+    given a: Int = [1, 9, 13]
+    given b: Int = [1, 8, 32]
+    when Bool.or(sign == 1, sign == -1)
+    when a > 0
+    when b > 0
+    because Domain.IntegerOrder.positiveProduct(a, b)
+    because signOfProductReason(sign, a, b)
+    using [Domain.IntegerOrder.positiveProduct.positiveFactors]
+    signOfProduct(sign, a, b) holds
+
+fn signOfProductReason(sign: Int, a: Int, b: Int) -> Bool
+    ? "Resolve the two unit signs while the unsigned product remains a proved positive integer."
+    match sign == 1
+        true -> signOfProduct(sign, a, b)
+        false -> signOfProduct(sign, a, b)
+
+verify signOfProductReason
+    signOfProductReason(2, 13, 8) => false
+    signOfProductReason(1, 13, 8) => true
+    signOfProductReason(-1, 13, 8) => true

--- a/src/codegen/lean/citation_probe.rs
+++ b/src/codegen/lean/citation_probe.rs
@@ -1,0 +1,186 @@
+//! Isolated, opt-in direct-citation diagnostics. These twins are never part of
+//! the counted build or its axiom audit. They inspect the emitter's actual
+//! citation applications, preserving ordinary generated files byte for byte.
+
+/// Exact emitted namespace and module root for an entry or dependency file.
+/// This shares the emitter's naming rules, including reserved-word escaping.
+pub fn module_name(ctx: &crate::codegen::CodegenContext, scope: Option<&str>) -> String {
+    scope
+        .map(super::syntax::aver_path_to_lean)
+        .unwrap_or_else(|| super::lean_project_name(ctx))
+}
+
+/// Structured diagnostic records, produced only by the isolated probe.
+pub const MARKER: &str = "AVER_CITATION_ATTEMPT:";
+
+/// Append after `untranslate::AVER_DUMP_GOAL_ELAB` and imports, before entering
+/// a generated module namespace. The existing expression serializer gives the
+/// caller the same closed grammar and honest decline as ordinary goal dumps.
+pub const ELAB: &str = r#"
+open Lean Elab Tactic Meta in
+private def averCitationGoalJson (g : MVarId) : TacticM String := g.withContext do
+  let ty ← instantiateMVars (← g.getType)
+  let fvars ← (← getLCtx).foldlM (init := (#[] : Array Expr)) fun acc d => do
+    if d.isImplementationDetail || (← isProp d.type) then return acc
+    return acc.push d.toExpr
+  let closed ← instantiateMVars (← mkForallFVars fvars ty)
+  return averExprJson [] closed
+
+-- Audit the actual assigned term, including values of used local lets and
+-- transitive dependencies of every referenced declaration. Unlike merely
+-- listing _fact names, this catches globally registered grind lemmas too.
+open Lean Elab Tactic Meta in
+private def averCitationProofAudit (g : MVarId) : TacticM (String × Array Name) := do
+  try
+    g.withContext do
+      let some value ← getExprMVarAssignment? g | return ("unavailable", #[])
+      let value ← instantiateMVars value
+      if value.hasMVar then return ("unavailable", #[])
+      let fvars ← (← getLCtx).foldlM (init := (#[] : Array Expr)) fun acc d =>
+        pure (acc.push d.toExpr)
+      -- Keep let values; generalizing them into arbitrary hypotheses would
+      -- erase any axioms carried by a locally bound proof.
+      let closed ← instantiateMVars (← mkLambdaFVars fvars value
+        (usedOnly := true) (generalizeNondepLet := false))
+      if closed.hasMVar || closed.hasFVar || closed.hasLooseBVars then
+        return ("unavailable", #[])
+      let mut axioms : NameSet := {}
+      for name in closed.getUsedConstants do
+        -- collectAxioms tolerates missing declarations; an audit must not.
+        if ((← getEnv).checked.get.find? name).isNone then
+          return ("unavailable", #[])
+        for axiomName in (← collectAxioms name) do
+          axioms := axioms.insert axiomName
+      return ("checked", axioms.toArray.qsort Name.lt)
+  catch _ =>
+    return ("unavailable", #[])
+
+open Lean Elab Tactic Meta in
+elab "aver_probe_citation " claim:str citation:str " prepare_by " preparation:tacticSeq
+    " apply_by " application:tacticSeq
+    " solve_by " solver:tacticSeq : tactic => do
+  let saved ← saveState
+  let mut outcome := "preparation_failed"
+  let mut premises : Array String := #[]
+  try
+    evalTactic preparation
+    outcome := "application_failed"
+    evalTactic application
+    outcome := "matched"
+    -- An implication may carry a conjunction of source guards. Decompose it
+    -- propositionally so diagnostics can report each remaining conjunct.
+    evalTactic (← `(tactic| all_goals repeat' apply And.intro))
+    let goals ← getUnsolvedGoals
+    for g in goals do
+      setGoals [g]
+      let before ← saveState
+      try
+        evalTactic solver
+      catch _ =>
+        before.restore
+      let status := if (← getUnsolvedGoals).isEmpty then "closed" else "open"
+      let goalJson ← averCitationGoalJson g
+      let (audit, axioms) ← if status == "closed" then averCitationProofAudit g
+        else pure ("not_applicable", #[])
+      let axiomsJson := String.intercalate "," (axioms.toList.map fun name =>
+        "\"" ++ averJsonEsc (toString name) ++ "\"")
+      premises := premises.push ("{\"status\":\"" ++ status ++ "\",\"goal\":" ++ goalJson
+        ++ ",\"proof_audit\":\"" ++ audit ++ "\",\"proof_axioms\":[" ++ axiomsJson ++ "]}")
+  catch _ =>
+    if outcome == "matched" then outcome := "probe_error"
+  saved.restore
+  let json := "{\"claim\":\"" ++ averJsonEsc claim.getString
+    ++ "\",\"citation\":\"" ++ averJsonEsc citation.getString
+    ++ "\",\"phase\":\"diagnostic_direct_application\",\"outcome\":\"" ++ outcome
+    ++ "\",\"premises\":[" ++ String.intercalate "," premises.toList ++ "]}"
+  logInfo m!"AVER_CITATION_ATTEMPT:{json}"
+"#;
+
+/// Build a diagnostic twin from one emitted reason-obligation theorem block.
+/// Only the direct application branch has an exact, reusable premise strategy;
+/// other shapes return `None`, rather than inventing a different application.
+/// `claim` is the source identity from the emitter's obligation marker.
+pub fn probe_body(block: &[&str], probe_name: &str, claim: &str) -> Option<String> {
+    let first = block.first()?.trim();
+    let declaration = first.strip_prefix("theorem ")?;
+    let (_, statement) = declaration.split_once(" : ")?;
+    if !statement.ends_with(" := by") {
+        return None;
+    }
+    let mut prefix = Vec::new();
+    let mut facts = std::collections::BTreeMap::new();
+    for line in block.iter().skip(1) {
+        let trimmed = line.trim();
+        if trimmed.starts_with("intro ") || trimmed.starts_with("try simp only ") {
+            prefix.push(*line);
+        } else if let Some(fact) = trimmed.strip_prefix("have ") {
+            let (local, theorem) = fact.split_once(" := ")?;
+            if !local.starts_with("_fact") {
+                break;
+            }
+            facts.insert(local.to_string(), theorem.to_string());
+            prefix.push(*line);
+        } else {
+            break;
+        }
+    }
+    let mut attempts = Vec::new();
+    for line in block {
+        let Some(branch) = line.trim().strip_prefix("| (") else {
+            continue;
+        };
+        let Some((application, solver)) = branch.split_once(" <;> ") else {
+            continue;
+        };
+        let Some((preparation, local)) = application.rsplit_once("; with_reducible apply ") else {
+            continue;
+        };
+        let Some(citation) = facts.get(local) else {
+            continue;
+        };
+        let solver = solver.strip_suffix(')')?;
+        attempts.push(format!(
+            "  aver_probe_citation {} {} prepare_by ({preparation}) apply_by (with_reducible apply {local}) solve_by {solver}",
+            serde_json::to_string(claim).ok()?,
+            serde_json::to_string(citation).ok()?,
+        ));
+    }
+    if attempts.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "theorem {probe_name} : {statement}\n{}\n{}\n  sorry\n",
+        prefix.join("\n"),
+        attempts.join("\n")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::probe_body;
+
+    #[test]
+    fn twin_preserves_actual_citation_and_solver_without_counted_strategy() {
+        let block = [
+            "theorem __aver_reason_demo_because1 : ∀ (a : Int), a = a := by",
+            "  intro a",
+            "  have _fact0 := Source.fact_law_identity",
+            "  try simp only [Bool.and_eq_true] at _fact0",
+            "  first",
+            "  | (simp_all; omega)",
+            "  | (simp only [Bool.and_eq_true] at *; with_reducible apply _fact0 <;> (first | assumption | omega))",
+            "  | sorry",
+        ];
+        let body = probe_body(&block, "_probe", "demo.because1").unwrap();
+        assert!(body.starts_with("theorem _probe : ∀ (a : Int), a = a := by"));
+        assert!(body.contains("\"Source.fact_law_identity\" prepare_by (simp only [Bool.and_eq_true] at *) apply_by (with_reducible apply _fact0) solve_by (first | assumption | omega)"));
+        assert!(!body.contains("| (simp_all; omega)"));
+        assert!(body.ends_with("  sorry\n"));
+    }
+
+    #[test]
+    fn no_direct_application_means_no_invented_probe() {
+        let block = ["theorem foo : True := by", "  trivial"];
+        assert!(probe_body(&block, "_probe", "foo").is_none());
+    }
+}

--- a/src/codegen/lean/lemma_calc.rs
+++ b/src/codegen/lean/lemma_calc.rs
@@ -551,6 +551,7 @@ mod tests {
                 zero_ctor: "Z".to_string(),
                 succ_ctor: "S".to_string(),
             }),
+            ..Default::default()
         }
     }
 

--- a/src/codegen/lean/mod.rs
+++ b/src/codegen/lean/mod.rs
@@ -6,6 +6,7 @@
 mod builtins;
 mod capability_opaque;
 mod citation_order;
+pub mod citation_probe;
 pub use citation_order::{CitationCycle, order_verify_blocks_for_citation};
 mod crypto;
 mod decl_order;

--- a/src/codegen/lean/tests.rs
+++ b/src/codegen/lean/tests.rs
@@ -5363,3 +5363,7 @@ fn count(n: Int, acc: Int) -> Int
         "certificate emission must not mutate the proof contract"
     );
 }
+
+mod untranslate_context;
+
+mod citation_probe;

--- a/src/codegen/lean/tests/citation_probe.rs
+++ b/src/codegen/lean/tests/citation_probe.rs
@@ -1,0 +1,125 @@
+//! Exercise the actual opt-in elaborator under the same pinned Lean that
+//! checks emitted proofs. These diagnostic twins never supply proof credit.
+
+use crate::codegen::lean::{citation_probe, untranslate};
+
+const SCENARIOS: &str = r#"
+set_option linter.unusedSimpArgs false
+set_option maxHeartbeats 200000
+def ordered (a b factor : Int) : Bool := a * factor <= b * factor
+theorem orderFact (a b factor : Int)
+    (h : (decide (a <= b) && decide (factor >= 0)) = true) : ordered a b factor = true := by
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at h
+  simp [ordered]
+  exact Int.mul_le_mul_of_nonneg_right h.1 h.2
+example (a b : Int) (h : a >= 0) : ordered 0 a b = true := by
+  have _fact0 := orderFact
+  aver_probe_citation "healthy" "orderFact" prepare_by (simp only [Bool.and_eq_true, decide_eq_true_eq] at *) apply_by (with_reducible apply _fact0) solve_by (first | assumption | omega)
+  sorry
+-- The axiom is hidden behind a theorem, never named in the copied _fact list.
+axiom inventedLowerBound (b : Int) : 0 <= b
+theorem laterGlobal (b : Int) : 0 <= b := by
+  exact inventedLowerBound b
+example (a b : Int) (h : a >= 0) : ordered 0 a b = true := by
+  have _fact0 := orderFact
+  aver_probe_citation "foreign_global" "orderFact" prepare_by (simp only [Bool.and_eq_true, decide_eq_true_eq] at *) apply_by (with_reducible apply _fact0) solve_by (first | assumption | omega | exact laterGlobal _)
+  sorry
+theorem laterSorry (b : Int) : 0 <= b := by sorry
+example (a b : Int) (h : a >= 0) : ordered 0 a b = true := by
+  have _fact0 := orderFact
+  let localProof : 0 <= b := laterSorry b
+  aver_probe_citation "sorry_local_let" "orderFact" prepare_by (simp only [Bool.and_eq_true, decide_eq_true_eq] at *) apply_by (with_reducible apply _fact0) solve_by (first | exact localProof | assumption | omega)
+  sorry
+-- A later global grind registration changes the isolated search environment.
+-- Its dependency must be found in the closing term, without guessing sources.
+def mysterious (b : Int) : Int := b
+theorem unrelatedLater (b : Int) : 0 <= mysterious b := by sorry
+grind_pattern unrelatedLater => mysterious b
+example (a b : Int) (h : a >= 0) : ordered 0 a (mysterious b) = true := by
+  have _fact0 := orderFact
+  aver_probe_citation "later_global_pattern" "orderFact" prepare_by (simp only [Bool.and_eq_true, decide_eq_true_eq] at *) apply_by (with_reducible apply _fact0) solve_by (first | assumption | omega | grind)
+  sorry
+-- Clearing the tactic goal list is not an assigned proof. Even this synthetic
+-- apparent closure must fail the audit and cannot get an empty-axiom verdict.
+example (a b : Int) (h : a >= 0) : ordered 0 a b = true := by
+  have _fact0 := orderFact
+  aver_probe_citation "unassigned_goal" "orderFact" prepare_by (simp only [Bool.and_eq_true, decide_eq_true_eq] at *) apply_by (with_reducible apply _fact0) solve_by (run_tac Lean.Elab.Tactic.setGoals [])
+  sorry
+"#;
+
+#[test]
+fn citation_probe_audits_actual_closures_through_globals_and_local_lets() {
+    let dir = tempfile::Builder::new()
+        .prefix("aver-citation-audit-")
+        .tempdir()
+        .unwrap();
+    std::fs::write(
+        dir.path().join("lean-toolchain"),
+        super::super::prelude::generate_toolchain(),
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("Audit.lean"),
+        format!(
+            "{}\n{}\n{}",
+            untranslate::AVER_DUMP_GOAL_ELAB,
+            citation_probe::ELAB,
+            SCENARIOS
+        ),
+    )
+    .unwrap();
+    let output = match std::process::Command::new("lean")
+        .arg("Audit.lean")
+        .current_dir(dir.path())
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return,
+        Err(error) => panic!("run pinned citation probe: {error}"),
+    };
+    let transcript = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "citation probe failed:\n{transcript}"
+    );
+    let records: std::collections::BTreeMap<String, serde_json::Value> = transcript
+        .lines()
+        .filter_map(|line| {
+            let (_, json) = line.split_once(citation_probe::MARKER)?;
+            let record: serde_json::Value =
+                serde_json::from_str(json).expect("structured citation trace");
+            Some((record["claim"].as_str().unwrap().to_string(), record))
+        })
+        .collect();
+    assert_eq!(records.len(), 5);
+    let healthy = &records["healthy"]["premises"];
+    assert_eq!(healthy[0]["status"], "closed");
+    assert_eq!(healthy[0]["proof_audit"], "checked");
+    assert_eq!(healthy[0]["proof_axioms"], serde_json::json!([]));
+    assert_eq!(healthy[1]["status"], "open");
+    for (claim, axiom) in [
+        ("foreign_global", "inventedLowerBound"),
+        ("sorry_local_let", "sorryAx"),
+        ("later_global_pattern", "sorryAx"),
+    ] {
+        let premise = &records[claim]["premises"][1];
+        assert_eq!(premise["status"], "closed", "{claim}");
+        assert_eq!(premise["proof_audit"], "checked", "{claim}");
+        assert!(
+            premise["proof_axioms"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|name| name.as_str() == Some(axiom)),
+            "{claim}: {premise}"
+        );
+    }
+    for premise in records["unassigned_goal"]["premises"].as_array().unwrap() {
+        assert_eq!(premise["status"], "closed");
+        assert_eq!(premise["proof_audit"], "unavailable");
+    }
+}

--- a/src/codegen/lean/tests/untranslate_context.rs
+++ b/src/codegen/lean/tests/untranslate_context.rs
@@ -1,0 +1,138 @@
+use super::*;
+use crate::codegen::lean::untranslate::{context_for_law, untranslate_premise_json};
+
+fn law_with_type(ty: &str, sample: &str) -> VerifyLaw {
+    let source = format!(
+        "fn f(x: {ty}) -> Bool\n    true\nverify f law identity\n    given x: {ty} = [{sample}]\n    f(x) holds\n"
+    );
+    parse_source(&source)
+        .unwrap()
+        .into_iter()
+        .find_map(|item| {
+            if let TopLevel::Verify(block) = item
+                && let VerifyKind::Law(law) = block.kind
+            {
+                Some(*law)
+            } else {
+                None
+            }
+        })
+        .unwrap()
+}
+
+fn projection(owner: &str, index: usize) -> serde_json::Value {
+    serde_json::json!({"app": {"fn": {"const": "LE.le"}, "args": [
+        {"const": "Int"}, {"const": "Int.instLEInt"}, {"nat": "0"},
+        {"proj": {"struct": owner, "idx": index, "e": {"var": "x"}}}
+    ]}})
+}
+
+#[test]
+fn untranslate_record_context_uses_exact_owner_and_declared_field_order() {
+    let mut ctx = empty_ctx();
+    ctx.items =
+        parse_source("module Entry\n    effects []\nrecord Shared\n    local: Int\n").unwrap();
+    ctx.type_defs = ctx
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let TopLevel::TypeDef(td) = item {
+                Some(td.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+    for (owner, field) in [("Left", "left"), ("Right", "right")] {
+        let source = format!(
+            "module {owner}\n    effects []\nrecord Shared\n    first: Int\n    {field}: Int\n"
+        );
+        ctx.modules.push(crate::codegen::ModuleInfo::from_items(
+            owner.to_string(),
+            &parse_source(&source).unwrap(),
+            None,
+        ));
+    }
+    ctx.symbol_table = crate::ir::SymbolTable::build(&ctx.items, &ctx.modules);
+    let display = context_for_law(&ctx, None, &law_with_type("Shared", "Shared(local = 0)"));
+    for (owner, index, expected) in [
+        ("Entry.Shared", 0, "0 <= x.local"),
+        ("Left.Shared", 1, "0 <= x.left"),
+        ("Right.Shared", 1, "0 <= x.right"),
+    ] {
+        let premise =
+            untranslate_premise_json(&projection(owner, index).to_string(), &display).unwrap();
+        assert_eq!(crate::checker::expr_to_str(&premise.expression), expected);
+        let mut accessor = projection(owner, index);
+        let field = &display.record_fields[owner][index];
+        accessor["app"]["args"][3] = serde_json::json!({"app": {
+            "fn": {"const": format!("{owner}.{}", crate::codegen::lean::aver_name_to_lean(field))},
+            "args": [{"var": "x"}]
+        }});
+        let premise = untranslate_premise_json(&accessor.to_string(), &display).unwrap();
+        assert_eq!(crate::checker::expr_to_str(&premise.expression), expected);
+    }
+    for (owner, index) in [
+        ("Shared", 0),
+        ("Unknown.Shared", 0),
+        ("Left.Shared", 2),
+        ("Subtype", 0),
+    ] {
+        assert!(untranslate_premise_json(&projection(owner, index).to_string(), &display).is_err());
+    }
+    assert!(
+        untranslate_premise_json(
+            &projection("Left.Shared", 1).to_string(),
+            &Default::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn untranslate_record_context_declines_refinement_structure_lifts() {
+    let ctx = ctx_from_source(
+        r#"
+module Carrier
+    effects []
+record Natural
+    value: Int
+fn fromInt(n: Int) -> Result<Natural, String>
+    match n >= 0
+        true -> Result.Ok(Natural(value = n))
+        false -> Result.Err("negative")
+record Held
+    payload: Natural
+    line: Int
+"#,
+        "Carrier",
+    );
+    let display = context_for_law(&ctx, None, &law_with_type("Natural", "Natural(value = 0)"));
+    assert!(!display.record_fields.contains_key("Carrier.Natural"));
+    assert_eq!(display.record_fields["Carrier.Held"], ["payload", "line"]);
+}
+
+#[test]
+fn untranslate_record_context_resolves_imported_peano_by_law_owner() {
+    let mut ctx = empty_ctx();
+    for (owner, zero, succ) in [("Left", "Zero", "Next"), ("Right", "Nil", "More")] {
+        let source =
+            format!("module {owner}\n    effects []\ntype Count\n    {zero}\n    {succ}(Count)\n");
+        ctx.modules.push(crate::codegen::ModuleInfo::from_items(
+            owner.to_string(),
+            &parse_source(&source).unwrap(),
+            None,
+        ));
+    }
+    ctx.symbol_table = crate::ir::SymbolTable::build(&ctx.items, &ctx.modules);
+    for (owner, zero) in [("Left", "Zero"), ("Right", "Nil")] {
+        let display = context_for_law(
+            &ctx,
+            Some(owner),
+            &law_with_type("Count", &format!("Count.{zero}")),
+        );
+        let peano = display.peano.unwrap();
+        assert_eq!(peano.type_name, format!("{owner}.Count"));
+        assert_eq!(peano.zero_ctor, zero);
+    }
+}

--- a/src/codegen/lean/untranslate.rs
+++ b/src/codegen/lean/untranslate.rs
@@ -20,6 +20,9 @@
 
 use serde_json::Value;
 
+mod context;
+pub use context::context_for_law;
+
 use crate::ast::{BinOp, Expr, Literal, Spanned, TopLevel, VerifyKind};
 
 /// The Lean 4 meta-tactic emitted into the `--explain` residual probe file. It
@@ -131,6 +134,9 @@ fn sp(e: Expr) -> Spanned<Expr> {
 #[derive(Debug, Clone, Default)]
 pub struct UntranslateCtx {
     pub peano: Option<PeanoCtx>,
+    /// Exact emitted structure owner/name to declared source fields, in order.
+    /// Empty outside a context built from compiler-owned declaration metadata.
+    pub record_fields: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 /// The canonical-Peano ADT (surface type + constructor names) whose Lean-`Nat`
@@ -174,6 +180,7 @@ pub fn peano_ctx_for_law(items: &[TopLevel], fn_name: &str, law_name: &str) -> U
                                 zero_ctor: p.base_ctor.clone(),
                                 succ_ctor: p.succ_ctor.clone(),
                             }),
+                            ..Default::default()
                         };
                     }
                 }
@@ -237,7 +244,7 @@ pub fn untranslate_goal_ctx(
                     "binder `{name}` has a type outside the grammar (cannot name it in Aver)"
                 ))
             })?;
-            givens.push((name.to_string(), tn));
+            givens.push((untranslate_local_name(name)?, tn));
         }
         cur = body;
     }
@@ -248,6 +255,44 @@ pub fn untranslate_goal_ctx(
         givens,
         premises,
         claim: (lhs?, rhs?),
+    })
+}
+
+/// One actual application premise, abstracted only over data variables by the
+/// citation probe. This is display syntax, not a new proof or a source guard.
+#[derive(Debug, Clone)]
+pub struct UntranslatedPremise {
+    pub givens: Vec<(String, String)>,
+    pub expression: Spanned<Expr>,
+}
+
+/// Render a structured citation premise without requiring the final Prop to
+/// be an equality. Higher-order binders and unsupported terms decline honestly.
+pub fn untranslate_premise_json(
+    json: &str,
+    ctx: &UntranslateCtx,
+) -> Result<UntranslatedPremise, EngineGap> {
+    let value: Value = serde_json::from_str(json)
+        .map_err(|e| EngineGap::new(format!("malformed premise JSON: {e}")))?;
+    let mut current = &value;
+    let mut givens = Vec::new();
+    while let Some(binder) = current.get("forall") {
+        let name = binder
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| EngineGap::new("premise binder without a name"))?;
+        let ty = binder
+            .get("ty")
+            .and_then(|ty| aver_type_name(ty, ctx))
+            .ok_or_else(|| EngineGap::new("premise binder is not a supported data type"))?;
+        givens.push((untranslate_local_name(name)?, ty));
+        current = binder
+            .get("body")
+            .ok_or_else(|| EngineGap::new("premise binder without a body"))?;
+    }
+    Ok(UntranslatedPremise {
+        givens,
+        expression: untranslate_bool(current, ctx)?,
     })
 }
 
@@ -305,6 +350,22 @@ fn untranslate_eq(
     ))
 }
 
+/// Undo only the emitter's known keyword guard. Other Lean-local decorations
+/// have no source identifier spelling and must not be presented as Aver.
+fn untranslate_local_name(name: &str) -> Result<String, EngineGap> {
+    let source = super::expr::lean_name_to_aver(name);
+    let mut chars = source.chars();
+    if !chars.next().is_some_and(|c| c.is_alphabetic() || c == '_')
+        || !chars.all(|c| c.is_alphanumeric() || c == '_')
+        || super::expr::aver_name_to_lean(&source) != name
+    {
+        return Err(EngineGap::new(
+            "local variable has no exact source identifier spelling",
+        ));
+    }
+    Ok(source)
+}
+
 /// Recursive descent JSON node → `ast::Expr`, declining on any out-of-grammar
 /// shape.
 fn untranslate_expr(v: &Value, ctx: &UntranslateCtx) -> Result<Spanned<Expr>, EngineGap> {
@@ -318,7 +379,7 @@ fn untranslate_expr(v: &Value, ctx: &UntranslateCtx) -> Result<Spanned<Expr>, En
         return Ok(sp(Expr::Literal(Literal::Str(s.to_string()))));
     }
     if let Some(name) = v.get("var").and_then(Value::as_str) {
-        return Ok(sp(Expr::Ident(name.to_string())));
+        return Ok(sp(Expr::Ident(untranslate_local_name(name)?)));
     }
     if let Some(name) = v.get("const").and_then(Value::as_str) {
         return Ok(sp(const_to_expr(name)));
@@ -332,14 +393,58 @@ fn untranslate_expr(v: &Value, ctx: &UntranslateCtx) -> Result<Spanned<Expr>, En
     if v.get("forall").is_some() {
         return Err(EngineGap::new("nested quantifier in the goal claim"));
     }
-    if v.get("proj").is_some() {
-        return Err(EngineGap::new("field projection outside the grammar"));
+    if let Some(projection) = v.get("proj") {
+        let owner = projection
+            .get("struct")
+            .and_then(Value::as_str)
+            .ok_or_else(|| EngineGap::new("field projection without a structure owner"))?;
+        let index = projection
+            .get("idx")
+            .and_then(Value::as_u64)
+            .and_then(|index| usize::try_from(index).ok())
+            .ok_or_else(|| EngineGap::new("field projection without a valid index"))?;
+        let field = ctx
+            .record_fields
+            .get(owner)
+            .and_then(|fields| fields.get(index))
+            .ok_or_else(|| EngineGap::new("field projection has no exact source record mapping"))?;
+        let receiver = projection
+            .get("e")
+            .ok_or_else(|| EngineGap::new("field projection without a receiver"))?;
+        return Ok(sp(Expr::Attr(
+            Box::new(untranslate_expr(receiver, ctx)?),
+            field.clone(),
+        )));
     }
     Err(EngineGap::new("unrecognised goal node"))
 }
 
 fn untranslate_app(app: &Value, ctx: &UntranslateCtx) -> Result<Spanned<Expr>, EngineGap> {
     let head = head_const(app);
+    // Before reduction Lean represents a record projection as its generated
+    // accessor constant applied to the receiver, rather than Expr.proj. Both
+    // forms need the same exact declaration-backed inverse.
+    if let Some((owner, accessor)) = head.and_then(|name| name.rsplit_once('.'))
+        && let Some(fields) = ctx.record_fields.get(owner)
+        && let Some(field) = fields
+            .iter()
+            .find(|field| super::expr::aver_name_to_lean(field) == accessor)
+    {
+        let args = app
+            .get("args")
+            .and_then(Value::as_array)
+            .filter(|args| args.len() == 1)
+            .ok_or_else(|| EngineGap::new("record accessor has no unique source receiver"))?;
+        return Ok(sp(Expr::Attr(
+            Box::new(untranslate_expr(&args[0], ctx)?),
+            field.clone(),
+        )));
+    }
+    if matches!(head, Some("Subtype.val" | "Subtype.property")) {
+        return Err(EngineGap::new(
+            "refinement projection outside the source record grammar",
+        ));
+    }
     // Numeric literal: `@OfNat.ofNat _ n _` — the middle arg carries the nat.
     if head == Some("OfNat.ofNat") {
         let nat = app
@@ -717,6 +822,66 @@ fn peano_numeral_from_str(p: &PeanoCtx, nat: &str) -> Result<Expr, EngineGap> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn citation_premise_restores_reserved_source_variables_and_rejects_decorations() {
+        let make = |name: &str| {
+            serde_json::json!({"forall": {
+                "name": name, "ty": {"const": "Int"}, "body": {"app": {
+                    "fn": {"const": "LE.le"}, "args": [
+                        {"const": "Int"}, {"const": "Int.instLEInt"},
+                        {"nat": "0"}, {"var": name}
+                    ]
+                }}
+            }})
+        };
+        let actual = super::untranslate_premise_json(
+            &make("by'").to_string(),
+            &super::UntranslateCtx::default(),
+        )
+        .unwrap();
+        assert_eq!(actual.givens, [("by".to_string(), "Int".to_string())]);
+        assert_eq!(crate::checker::expr_to_str(&actual.expression), "0 <= by");
+        for name in ["value'", "value✝", "a.b", "by"] {
+            assert!(
+                super::untranslate_premise_json(
+                    &make(name).to_string(),
+                    &super::UntranslateCtx::default(),
+                )
+                .is_err(),
+                "must decline {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn citation_premise_renders_comparison_and_declines_higher_order_context() {
+        let premise = serde_json::json!({"forall": {
+            "name": "b", "ty": {"const": "Int"}, "body": {"app": {
+                "fn": {"const": "GE.ge"}, "args": [
+                    {"const": "Int"}, {"const": "Int.instLEInt"},
+                    {"var": "b"}, {"nat": "0"}
+                ]
+            }}
+        }});
+        let actual = super::untranslate_premise_json(
+            &premise.to_string(),
+            &super::UntranslateCtx::default(),
+        )
+        .unwrap();
+        assert_eq!(actual.givens, [("b".to_string(), "Int".to_string())]);
+        assert_eq!(crate::checker::expr_to_str(&actual.expression), "b >= 0");
+        let foreign = serde_json::json!({"forall": {
+            "name": "proof", "ty": {"forall": {}}, "body": premise
+        }});
+        assert!(
+            super::untranslate_premise_json(
+                &foreign.to_string(),
+                &super::UntranslateCtx::default(),
+            )
+            .is_err()
+        );
+    }
+
     use super::*;
     use crate::ast::unparse;
 
@@ -953,6 +1118,7 @@ mod tests {
                 zero_ctor: "Z".to_string(),
                 succ_ctor: "S".to_string(),
             }),
+            ..Default::default()
         }
     }
 
@@ -1002,20 +1168,52 @@ mod tests {
         assert!(!r.contains("hAppend") && !r.contains("List.cons"), "{r}");
     }
 
+    // These saved probes contain one inaccessible Lean-generated local name.
+    // First assert that real input declines there; then alpha-rename only that
+    // fixture binder and its occurrences to exercise the independent blocked
+    // match boundary that the original tests were written to guard.
+    fn fixture_without_hygienic_local(dump: &str) -> String {
+        let error = untranslate_goal_ctx(dump, &peano_nat()).expect_err("hygienic local");
+        assert!(
+            error.reason.contains("exact source identifier"),
+            "{}",
+            error.reason
+        );
+        let value: Value = serde_json::from_str(dump).unwrap();
+        let mut current = &value;
+        let mut result = dump.to_string();
+        let mut renamed = 0;
+        while let Some(binder) = current.get("forall") {
+            let name = binder["name"].as_str().unwrap();
+            if name.contains("._hygCtx.") {
+                result = result.replace(
+                    &serde_json::to_string(name).unwrap(),
+                    &format!("\"fixtureLocal{renamed}\""),
+                );
+                renamed += 1;
+            }
+            current = &binder["body"];
+        }
+        assert_eq!(renamed, 1, "fixture must keep its one hygienic local");
+        result
+    }
+
     #[test]
     fn peano_66_2_declines_on_blocked_match() {
         // p66_2 still has the unreduced blocked `if isZ … then … else …`: its
         // `ite` decidability condition (`false = true`) is a nested equality and
         // its `isZ.match_1` args are opaque (Wall B, cleaned in step 1's Lean-side
         // re-strip). Descent hits the nested-`Eq` condition first — honest decline.
-        let err = untranslate_goal_ctx(DUMP_P66_2, &peano_nat()).expect_err("blocked match");
+        let err = untranslate_goal_ctx(&fixture_without_hygienic_local(DUMP_P66_2), &peano_nat())
+            .expect_err("blocked match");
         assert!(err.reason.contains("equality nested"), "{}", err.reason);
     }
 
     #[test]
     fn peano_73_1_declines_on_blocked_match() {
         // p73_1 likewise carries the unreduced `ite`/`isZ.match_1` residual.
-        let err = untranslate_goal_ctx(DUMP_P73_1, &peano_nat()).expect_err("blocked match");
+        let err = untranslate_goal_ctx(&fixture_without_hygienic_local(DUMP_P73_1), &peano_nat())
+            .expect_err("blocked match");
         assert!(err.reason.contains("equality nested"), "{}", err.reason);
     }
 

--- a/src/codegen/lean/untranslate/context.rs
+++ b/src/codegen/lean/untranslate/context.rs
@@ -1,0 +1,80 @@
+//! Source-backed inverse metadata. Owner-qualified emitted names are display
+//! keys, derived from declarations and the emitter's naming functions; bare
+//! names are never used to choose between records from different modules.
+
+use super::{PeanoCtx, UntranslateCtx};
+use crate::ast::{TypeDef, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+/// Build inverse display metadata for a law in its actual defining module.
+/// `scope = None` denotes the entry file. Projection metadata excludes the
+/// exact refinements that the emitter lowers to `Subtype`, whose indices no
+/// longer denote source record fields. Peano inversion is enabled only when
+/// the law's givens resolve to one unambiguous canonical-Peano declaration.
+pub fn context_for_law(
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+    law: &VerifyLaw,
+) -> UntranslateCtx {
+    let mut result = UntranslateCtx::default();
+    let mut peanos = Vec::new();
+    let mut register = |types: &[TypeDef], owner: Option<&str>, namespace: &str| {
+        for td in types {
+            if let TypeDef::Product { name, fields, .. } = td
+                && crate::codegen::common::find_refined_type_scoped(ctx, name, owner).is_none()
+            {
+                let emitted = format!(
+                    "{namespace}.{}",
+                    super::super::expr::aver_name_to_lean(name)
+                );
+                result.record_fields.insert(
+                    emitted,
+                    fields.iter().map(|(field, _)| field.clone()).collect(),
+                );
+            }
+            if let Some(peano) = crate::codegen::proof_recognize::detect_canonical_peano(td)
+                && let Some(id) = ctx.symbol_table.resolve_type_id_in(&peano.type_name, owner)
+            {
+                let source_type = owner
+                    .map(|owner| format!("{owner}.{}", peano.type_name))
+                    .unwrap_or(peano.type_name);
+                peanos.push((
+                    id,
+                    PeanoCtx {
+                        type_name: source_type,
+                        zero_ctor: peano.base_ctor,
+                        succ_ctor: peano.succ_ctor,
+                    },
+                ));
+            }
+        }
+    };
+    register(&ctx.type_defs, None, &super::super::lean_project_name(ctx));
+    for module in &ctx.modules {
+        register(
+            &module.type_defs,
+            Some(&module.prefix),
+            &super::super::syntax::aver_path_to_lean(&module.prefix),
+        );
+    }
+    let mut found = None;
+    for given in &law.givens {
+        for token in super::type_name_tokens(&given.type_name) {
+            let Some(id) = ctx.symbol_table.resolve_type_id_in(&token, scope) else {
+                continue;
+            };
+            let Some((_, peano)) = peanos.iter().find(|(candidate, _)| *candidate == id) else {
+                continue;
+            };
+            if let Some((previous, _)) = &found {
+                if *previous != id {
+                    return result;
+                }
+            } else {
+                found = Some((id, peano.clone()));
+            }
+        }
+    }
+    result.peano = found.map(|(_, peano)| peano);
+    result
+}

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -702,10 +702,12 @@ pub(super) enum Commands {
         check_json: bool,
         /// Explain open proof steps in Aver: source locations, goals,
         /// assumptions, previous because results, and explicit using
-        /// requirements. Check mode only; Lean backend only. JSON adds
+        /// requirements, plus isolated citation applications and their
+        /// remaining premises where supported. Check mode only; Lean backend only. JSON adds
         /// `explanations` keyed by law/step. Checker limits are distinguished
         /// from unproved statements; technical output is saved in
-        /// proof_backend.log. Existing `open_goals` / manifest `open_goal`
+        /// proof_backend.log (citation probes: proof_citations.log).
+        /// Existing `open_goals` / manifest `open_goal`
         /// residuals remain available. Laws without because may require an
         /// additional isolated diagnostic build. Explanations never change
         /// proof credit, budgets, or exit codes; absent this flag, no new

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -8698,7 +8698,7 @@ fn run_proof_check(
         write_proof_manifest(output_dir, m);
     }
 
-    let proof_reports = proof_sources
+    let mut proof_reports = proof_sources
         .map(|sources| {
             proof_explain::collect(
                 sources,
@@ -8709,6 +8709,17 @@ fn run_proof_check(
             )
         })
         .unwrap_or_default();
+    if output.status.success()
+        && model_panic_hits == 0
+        && let Some(sources) = proof_sources
+    {
+        proof_explain::attach_citation_attempts(
+            output_dir,
+            sources,
+            manifest.as_ref(),
+            &mut proof_reports,
+        );
+    }
     if proof_sources.is_some() {
         let _ = std::fs::write(
             std::path::Path::new(output_dir).join("proof_backend.log"),

--- a/src/main/proof_explain/attempt_report.rs
+++ b/src/main/proof_explain/attempt_report.rs
@@ -1,0 +1,88 @@
+//! Present observed citation attempts separately from source requirements.
+
+use serde_json::{Value, json};
+
+pub(super) fn finish(report: &mut Value) {
+    let Some(attempts) = report["citation_attempts"].as_array() else {
+        return;
+    };
+    let matched: Vec<_> = attempts
+        .iter()
+        .filter(|a| a["outcome"] == "matched")
+        .collect();
+    if matched.is_empty() {
+        return;
+    }
+    let established: Vec<_> = matched
+        .iter()
+        .filter(|a| a["established_dependencies"] == true)
+        .collect();
+    let next = if established.is_empty() {
+        "The citation probe has unproved dependencies or an unaudited closure. Resolve failed, bounded, or unchecked dependencies before relying on its closed premises."
+    } else if established.iter().any(|a| {
+        a["premises"]
+            .as_array()
+            .is_some_and(|ps| ps.iter().all(|p| p["status"] == "closed"))
+    }) {
+        "An isolated direct application closed all its premises, while the counted proof remains open. Report a proof-strategy gap at this source step."
+    } else {
+        "The isolated citation check left open premises. Establish them in earlier because steps or a helper law; the probe does not prove that those premises are false."
+    };
+    report["next"] = json!(next);
+}
+
+pub(super) fn render(report: &Value) {
+    if report["citation_probe"]["status"] == "unavailable" {
+        println!("  Citation check unavailable; technical details are in proof_citations.log.");
+    }
+    let Some(attempts) = report["citation_attempts"].as_array() else {
+        return;
+    };
+    for attempt in attempts {
+        let outcome = match attempt["outcome"].as_str() {
+            Some("matched") => "direct application succeeded",
+            Some("application_failed") => "direct application unsuccessful",
+            Some("preparation_failed") => "normalization did not complete",
+            _ => "diagnostic attempt did not complete",
+        };
+        println!(
+            "  Citation check (isolated): {} — {outcome}",
+            attempt["law"].as_str().unwrap_or("")
+        );
+        if attempt["established_dependencies"] != true {
+            println!(
+                "    Unproved dependencies or unaudited closure; closed premises are conditional."
+            );
+            if let Some(laws) = attempt["available_laws"].as_array() {
+                for law in laws.iter().filter(|law| law["status"] != "universal") {
+                    println!(
+                        "    available {} [{}]",
+                        law["law"]
+                            .as_str()
+                            .unwrap_or("<source citation unavailable>"),
+                        law["status"].as_str().unwrap_or("not_checked")
+                    );
+                }
+            }
+        }
+        if attempt["outcome"] == "matched"
+            && let Some(premises) = attempt["premises"].as_array()
+        {
+            for premise in premises {
+                println!(
+                    "    [{} in probe] {}",
+                    premise["status"].as_str().unwrap_or("open"),
+                    premise["expression"]
+                        .as_str()
+                        .unwrap_or("<this premise cannot yet be displayed in Aver>")
+                );
+                if premise["status"] == "closed" && premise["closure_audited"] != true {
+                    println!("      This closure has not passed the proof-axiom audit.");
+                }
+            }
+            if premises.is_empty() {
+                println!("    No remaining premises in this isolated application.");
+            }
+        }
+    }
+}

--- a/src/main/proof_explain/display.rs
+++ b/src/main/proof_explain/display.rs
@@ -1,0 +1,55 @@
+//! Readable source expressions, retaining explicit arithmetic grouping. The
+//! general unparser handles uncommon forms and literal escaping.
+use aver::ast::{BinOp, Expr, Spanned};
+
+pub(super) fn expression(expr: &Spanned<Expr>) -> String {
+    let Ok(text) = grouped(expr) else {
+        return "<source expression unavailable>".into();
+    };
+    let text = text.trim();
+    if matches!(expr.node, Expr::BinOp(..)) {
+        text.strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .unwrap_or(text)
+            .to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+fn grouped(expr: &Spanned<Expr>) -> Result<String, aver::ast::unparse::UnparseError> {
+    match &expr.node {
+        Expr::Attr(receiver, name)
+            if matches!(
+                receiver.node,
+                Expr::Ident(_) | Expr::Attr(..) | Expr::FnCall(..)
+            ) =>
+        {
+            Ok(format!("{}.{name}", grouped(receiver)?))
+        }
+        Expr::FnCall(callee, args) => {
+            let args = args.iter().map(grouped).collect::<Result<Vec<_>, _>>()?;
+            Ok(format!("{}({})", grouped(callee)?, args.join(", ")))
+        }
+        Expr::BinOp(op, lhs, rhs) => {
+            let op = match op {
+                BinOp::Add => "+",
+                BinOp::Sub => "-",
+                BinOp::Mul => "*",
+                BinOp::Div => "/",
+                BinOp::Eq => "==",
+                BinOp::Neq => "!=",
+                BinOp::Lt => "<",
+                BinOp::Gt => ">",
+                BinOp::Lte => "<=",
+                BinOp::Gte => ">=",
+            };
+            Ok(format!("({} {op} {})", grouped(lhs)?, grouped(rhs)?))
+        }
+        _ => {
+            let mut text = String::new();
+            aver::ast::unparse::write_expr_public(&mut text, expr, 0)?;
+            Ok(text)
+        }
+    }
+}

--- a/src/main/proof_explain/mod.rs
+++ b/src/main/proof_explain/mod.rs
@@ -1,8 +1,20 @@
 //! Explanations of failed proof steps in the source language. This report is
 //! diagnostic metadata only; the existing backend audit remains authoritative.
 
+mod attempt_report;
 mod backend;
+mod display;
+mod probe;
 mod source;
+
+pub(super) fn attach_citation_attempts(
+    dir: &str,
+    catalog: &Catalog,
+    manifest: Option<&ProofManifest>,
+    reports: &mut BTreeMap<String, Value>,
+) {
+    probe::attach(dir, catalog, manifest, reports);
+}
 
 use super::{LawTier, ProofManifest};
 use serde_json::{Value, json};
@@ -118,6 +130,8 @@ pub(super) fn collect(
             "Report the checker error at this source step, with proof_backend.log from the output directory. The error does not identify a missing mathematical premise."
         } else if failure.status == "checker_limit" {
             "Split this step into smaller because expressions or a helper law; the checker did not finish the current proof."
+        } else if reason.is_none() && !law.body.because.is_empty() {
+            "Connect the earlier because statements to the final claim. A proved intermediate statement does not by itself establish this implication."
         } else if citations
             .iter()
             .any(|c| c["requires"].as_array().is_some_and(|r| !r.is_empty()))
@@ -206,7 +220,7 @@ pub(super) fn render(reports: &BTreeMap<String, Value>) {
         if let Some(citations) = report["citations"].as_array() {
             for citation in citations {
                 let scope = if citation["instantiated"] == true {
-                    "arguments substituted"
+                    "source arguments substituted"
                 } else {
                     "schematic parameters"
                 };
@@ -225,6 +239,7 @@ pub(super) fn render(reports: &BTreeMap<String, Value>) {
                 }
             }
         }
+        attempt_report::render(report);
         println!("  Next: {}", text("next"));
     }
 }

--- a/src/main/proof_explain/probe.rs
+++ b/src/main/proof_explain/probe.rs
@@ -1,0 +1,378 @@
+//! Run isolated twins of open source obligations. Probe output never enters
+//! the counted build, residual audit, or proof manifest.
+
+use super::{Catalog, ProofManifest, source, tier};
+use aver::codegen::lean::{citation_probe, untranslate};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct Attempt {
+    claim: String,
+    citation: String,
+    phase: String,
+    outcome: String,
+    premises: Vec<Premise>,
+}
+
+#[derive(Deserialize)]
+struct Premise {
+    status: String,
+    goal: Value,
+    #[serde(default)]
+    proof_audit: Option<String>,
+    #[serde(default)]
+    proof_axioms: Option<Vec<String>>,
+}
+
+fn audited_closure(premise: &Premise) -> bool {
+    premise.proof_audit.as_deref() == Some("checked")
+        && premise.proof_axioms.as_ref().is_some_and(|axioms| {
+            axioms.iter().all(|axiom| {
+                matches!(
+                    axiom.as_str(),
+                    "propext" | "Classical.choice" | "Quot.sound"
+                )
+            })
+        })
+}
+
+struct Module {
+    name: String,
+    source: String,
+}
+
+struct Context {
+    module: String,
+    citations: Vec<String>,
+}
+
+pub(super) fn attach(
+    dir: &str,
+    catalog: &Catalog,
+    manifest: Option<&ProofManifest>,
+    reports: &mut BTreeMap<String, Value>,
+) {
+    let wanted: BTreeSet<_> = reports
+        .iter()
+        .filter(|(_, report)| report["status"] == "unproved")
+        .map(|(claim, _)| claim.clone())
+        .collect();
+    if wanted.is_empty() {
+        return;
+    }
+    let mut modules = Vec::new();
+    read_modules(Path::new(dir), Path::new(dir), &mut modules);
+    modules.retain(|module| {
+        catalog
+            .laws
+            .values()
+            .any(|law| law.emitted_module == module.name)
+    });
+    modules.sort_by(|a, b| a.name.cmp(&b.name));
+    let labels = unique_markers(catalog, &modules);
+    let mut bodies = String::new();
+    let mut owners = BTreeMap::new();
+    let mut imports = BTreeSet::new();
+    for module in &modules {
+        let lines: Vec<_> = module.source.lines().collect();
+        let mut found = String::new();
+        for (index, line) in lines.iter().enumerate() {
+            let Some((theorem, claim)) = marker(line) else {
+                continue;
+            };
+            if !wanted.contains(claim)
+                || labels
+                    .get(&format!("{}.{theorem}", module.name))
+                    .map(String::as_str)
+                    != Some(claim)
+                || !catalog
+                    .claim(claim)
+                    .is_some_and(|(law, _)| law.emitted_module == module.name)
+            {
+                continue;
+            }
+            let Some(start) = (index + 1..lines.len()).find(|&i| !lines[i].trim().is_empty())
+            else {
+                continue;
+            };
+            if lines[start]
+                .trim()
+                .strip_prefix("theorem ")
+                .and_then(|declaration| declaration.split_once(" : "))
+                .map(|(name, _)| name)
+                != Some(theorem)
+            {
+                continue;
+            }
+            let end = (start + 1..lines.len())
+                .find(|&i| {
+                    marker(lines[i]).is_some()
+                        || lines[i].starts_with("theorem ")
+                        || lines[i].starts_with("private theorem ")
+                        || lines[i].starts_with("end ")
+                        || lines[i].starts_with("def ")
+                        || lines[i].starts_with("namespace ")
+                })
+                .unwrap_or(lines.len());
+            let name = format!("_aver_citation_{}", owners.len());
+            let Some(body) = citation_probe::probe_body(&lines[start..end], &name, claim) else {
+                continue;
+            };
+            let citations = body
+                .lines()
+                .filter_map(|line| {
+                    line.trim()
+                        .strip_prefix("have _fact")?
+                        .split_once(" := ")
+                        .map(|(_, name)| name.to_string())
+                })
+                .collect();
+            found.push_str(&body);
+            owners.insert(
+                claim.to_string(),
+                Context {
+                    module: module.name.clone(),
+                    citations,
+                },
+            );
+        }
+        if found.is_empty() {
+            continue;
+        }
+        imports.insert(module.name.clone());
+        bodies.push_str("section\n");
+        for line in &lines {
+            if line.starts_with("namespace ") {
+                break;
+            }
+            if line.starts_with("open ") || line.starts_with("set_option ") {
+                bodies.push_str(line);
+                bodies.push('\n');
+            }
+        }
+        bodies.push_str(&format!(
+            "namespace {}\n{found}end {}\nend\n",
+            module.name, module.name
+        ));
+    }
+    if owners.is_empty() {
+        return;
+    }
+    let mut text = String::from("import Lean\n");
+    for module in imports {
+        text.push_str(&format!("import {module}\n"));
+    }
+    text.push_str(untranslate::AVER_DUMP_GOAL_ELAB.trim_start_matches("import Lean\n"));
+    text.push_str(citation_probe::ELAB);
+    text.push_str(&bodies);
+    let name = "_aver_citation_probe.lean";
+    let file = Path::new(dir).join(name);
+    if std::fs::write(&file, text).is_err() {
+        return;
+    }
+    let output = std::process::Command::new("lake")
+        .args(["env", "lean", name])
+        .current_dir(dir)
+        .output();
+    let _ = std::fs::remove_file(&file);
+    let Ok(output) = output else { return };
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let _ = std::fs::write(Path::new(dir).join("proof_citations.log"), &text);
+    if !output.status.success() {
+        for claim in owners.keys() {
+            if let Some(report) = reports.get_mut(claim) {
+                report["citation_probe"] = json!({"status": "unavailable"});
+            }
+        }
+        return;
+    }
+    attach_output(catalog, manifest, reports, &owners, &labels, &text);
+    for report in reports.values_mut() {
+        super::attempt_report::finish(report);
+    }
+}
+
+/// A claim and its emitted theorem must identify each other uniquely. Even
+/// identical repeated markers are refused: two candidate source blocks must
+/// never compete to supply one reported diagnostic context.
+fn unique_markers(catalog: &Catalog, modules: &[Module]) -> BTreeMap<String, String> {
+    let mut candidates = Vec::new();
+    for module in modules {
+        for line in module.source.lines() {
+            let Some((theorem, claim)) = marker(line) else {
+                continue;
+            };
+            if catalog
+                .claim(claim)
+                .is_some_and(|(law, _)| law.emitted_module == module.name)
+            {
+                candidates.push((format!("{}.{theorem}", module.name), claim.to_string()));
+            }
+        }
+    }
+    let mut theorem_counts = BTreeMap::<&str, usize>::new();
+    let mut claim_counts = BTreeMap::<&str, usize>::new();
+    for (theorem, claim) in &candidates {
+        *theorem_counts.entry(theorem).or_default() += 1;
+        *claim_counts.entry(claim).or_default() += 1;
+    }
+    candidates
+        .iter()
+        .filter(|(theorem, claim)| {
+            theorem_counts.get(theorem.as_str()) == Some(&1)
+                && claim_counts.get(claim.as_str()) == Some(&1)
+        })
+        .cloned()
+        .collect()
+}
+
+fn read_modules(root: &Path, dir: &Path, modules: &mut Vec<Module>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') {
+            continue;
+        }
+        let Ok(kind) = entry.file_type() else {
+            continue;
+        };
+        if kind.is_dir() {
+            read_modules(root, &entry.path(), modules);
+        } else if kind.is_file() && entry.path().extension().is_some_and(|ext| ext == "lean") {
+            let path = entry.path();
+            let Ok(relative) = path.strip_prefix(root) else {
+                continue;
+            };
+            let Some(relative) = relative.to_str() else {
+                continue;
+            };
+            let Ok(source) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if source.lines().any(|line| marker(line).is_some()) {
+                modules.push(Module {
+                    name: relative
+                        .trim_end_matches(".lean")
+                        .replace(std::path::MAIN_SEPARATOR, "."),
+                    source,
+                });
+            }
+        }
+    }
+}
+
+fn marker(line: &str) -> Option<(&str, &str)> {
+    let marker = line
+        .strip_prefix(aver::codegen::lean::LAW_CLASS_MARKER_PREFIX)
+        .or_else(|| line.strip_prefix(aver::codegen::lean::LAW_OBLIGATION_MARKER_PREFIX))?;
+    let mut fields = marker.split_whitespace();
+    let name = fields.next()?;
+    fields.next()?;
+    Some((name, fields.next()?))
+}
+
+fn attach_output(
+    catalog: &Catalog,
+    manifest: Option<&ProofManifest>,
+    reports: &mut BTreeMap<String, Value>,
+    owners: &BTreeMap<String, Context>,
+    labels: &BTreeMap<String, String>,
+    text: &str,
+) {
+    for line in text.lines() {
+        let Some((_, text)) = line.split_once(citation_probe::MARKER) else {
+            continue;
+        };
+        let Ok(attempt) = serde_json::from_str::<Attempt>(text) else {
+            continue;
+        };
+        if attempt.phase != "diagnostic_direct_application"
+            || !matches!(
+                attempt.outcome.as_str(),
+                "matched" | "application_failed" | "preparation_failed" | "probe_error"
+            )
+        {
+            continue;
+        }
+        let Some(owner) = owners.get(&attempt.claim) else {
+            continue;
+        };
+        if !owner.citations.contains(&attempt.citation) {
+            continue;
+        }
+        let Some(report) = reports.get_mut(&attempt.claim) else {
+            continue;
+        };
+        let Some((law, _)) = catalog.claim(&attempt.claim) else {
+            continue;
+        };
+        let Some(citation) = labels
+            .get(&format!("{}.{}", owner.module, attempt.citation))
+            .or_else(|| labels.get(&attempt.citation))
+        else {
+            continue;
+        };
+        let available_laws: Vec<_> = owner.citations.iter().map(|name| {
+            let label = labels.get(&format!("{}.{name}", owner.module)).or_else(|| labels.get(name));
+            json!({"law": label, "status": label.map_or("not_checked", |label| tier(manifest, label))})
+        }).collect();
+        let established_dependencies = attempt
+            .premises
+            .iter()
+            .all(|p| p.status != "closed" || audited_closure(p))
+            && available_laws
+                .iter()
+                .all(|law| law["status"] == "universal")
+            && report["assumptions"].as_array().is_none_or(|assumptions| {
+                assumptions
+                    .iter()
+                    .all(|a| a["kind"] != "because" || a["status"] == "universal")
+            });
+        if attempt
+            .premises
+            .iter()
+            .any(|p| !matches!(p.status.as_str(), "closed" | "open"))
+        {
+            continue;
+        }
+        let premises: Vec<_> = if attempt.outcome == "matched" {
+            attempt.premises.iter().map(|premise| {
+                let mut rendered = match untranslate::untranslate_premise_json(&premise.goal.to_string(), &law.untranslate) {
+                    Ok(goal) => json!({"status": premise.status, "expression": source::expression(&goal.expression), "variables": goal.givens, "source_form": "aver"}),
+                    Err(_) => json!({"status": premise.status, "source_form": "unavailable"}),
+                };
+                if premise.status == "closed" {
+                    rendered["closure_audited"] = json!(audited_closure(premise));
+                    rendered["proof_axioms"] = json!(premise.proof_axioms);
+                }
+                rendered
+            }).collect()
+        } else {
+            Vec::new()
+        };
+        if report["citation_attempts"].is_null() {
+            report["citation_attempts"] = json!([]);
+        }
+        report["citation_attempts"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({
+            "law": citation, "phase": attempt.phase, "outcome": attempt.outcome,
+            "law_status": tier(manifest, citation), "available_laws": available_laws,
+            "established_dependencies": established_dependencies, "premises": premises,
+            }));
+        report["citation_probe"] = json!({"status": "completed"});
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/main/proof_explain/probe/tests.rs
+++ b/src/main/proof_explain/probe/tests.rs
@@ -1,0 +1,323 @@
+use super::*;
+
+const CLAIM: &str = "p.target.because1";
+
+fn catalog() -> Catalog {
+    let source = "fn p(by: Int) -> Bool\n    by > 0\nverify p law selected\n    given by: Int = [1]\n    p(by) holds\nverify p law sibling\n    given by: Int = [1]\n    p(by) holds\nverify p law target\n    given by: Int = [1]\n    because p(by)\n    using [p.selected, p.sibling]\n    p(by) holds\n";
+    let mut catalog = Catalog::default();
+    for item in aver::source::parse_source(source).unwrap() {
+        if let aver::ast::TopLevel::Verify(block) = item {
+            catalog.add(&block, None, "source.av");
+        }
+    }
+    catalog
+}
+
+fn reports() -> BTreeMap<String, Value> {
+    BTreeMap::from([(
+        CLAIM.to_string(),
+        json!({
+            "claim": CLAIM, "status": "unproved", "assumptions": [],
+        }),
+    )])
+}
+
+fn owners() -> BTreeMap<String, Context> {
+    BTreeMap::from([(
+        CLAIM.to_string(),
+        Context {
+            module: "Entry".to_string(),
+            citations: vec!["p_law_selected".to_string(), "p_law_sibling".to_string()],
+        },
+    )])
+}
+
+fn labels() -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("Entry.p_law_selected".to_string(), "p.selected".to_string()),
+        ("Entry.p_law_sibling".to_string(), "p.sibling".to_string()),
+    ])
+}
+
+fn manifest(selected: Option<&str>, sibling: Option<&str>) -> ProofManifest {
+    let laws: Vec<_> = [("p.selected", selected), ("p.sibling", sibling)]
+        .into_iter()
+        .filter_map(|(law, tier)| tier.map(|tier| json!({"law": law, "tier": tier})))
+        .collect();
+    super::super::super::parse_proof_manifest(&json!({"backend": "lean", "laws": laws}).to_string())
+        .unwrap()
+}
+
+fn goal() -> Value {
+    json!({"forall": {
+        "name": "by'", "ty": {"const": "Int"}, "body": {"app": {
+            "fn": {"const": "LE.le"}, "args": [
+                {"const": "Int"}, {"const": "Int.instLEInt"}, {"nat": "0"}, {"var": "by'"}
+            ]
+        }}
+    }})
+}
+
+fn attempt() -> Value {
+    json!({"claim": CLAIM, "citation": "p_law_selected",
+        "phase": "diagnostic_direct_application", "outcome": "matched",
+        "premises": [{"status": "closed", "goal": goal(), "proof_audit": "checked", "proof_axioms": ["propext"]}],
+    })
+}
+
+fn trace(attempt: &Value) -> String {
+    format!("{}{}\n", citation_probe::MARKER, attempt)
+}
+
+#[test]
+fn unknown_claims_and_citations_cannot_attach_attempts() {
+    let catalog = catalog();
+    let manifest = manifest(Some("universal"), Some("universal"));
+    for (key, unknown) in [
+        ("claim", "unknown.target.because1"),
+        ("citation", "unknown_law"),
+    ] {
+        let mut output = attempt();
+        output[key] = json!(unknown);
+        let mut reports = reports();
+        let original = reports.clone();
+        attach_output(
+            &catalog,
+            Some(&manifest),
+            &mut reports,
+            &owners(),
+            &labels(),
+            &trace(&output),
+        );
+        assert_eq!(reports, original, "must ignore an unknown {key}");
+    }
+}
+
+#[test]
+fn closed_premises_are_conditional_on_every_available_law() {
+    let catalog = catalog();
+    for (selected, sibling, expected) in [
+        (Some("universal"), Some("universal"), true),
+        (Some("failed"), Some("universal"), false),
+        (Some("universal"), Some("failed"), false),
+        (Some("universal"), None, false),
+        (Some("bounded"), Some("universal"), false),
+    ] {
+        let manifest = manifest(selected, sibling);
+        let mut reports = reports();
+        attach_output(
+            &catalog,
+            Some(&manifest),
+            &mut reports,
+            &owners(),
+            &labels(),
+            &trace(&attempt()),
+        );
+        let actual = &reports[CLAIM]["citation_attempts"][0];
+        assert_eq!(actual["established_dependencies"], expected);
+        assert_eq!(actual["law_status"], selected.unwrap_or("not_checked"));
+        assert_eq!(
+            actual["available_laws"][1]["status"],
+            sibling.unwrap_or("not_checked")
+        );
+        assert_eq!(actual["premises"][0]["status"], "closed");
+        assert_eq!(
+            reports[CLAIM]["status"], "unproved",
+            "probe must not upgrade proof status"
+        );
+    }
+}
+
+#[test]
+fn closure_requires_its_own_complete_axiom_audit_even_with_healthy_citations() {
+    let catalog = catalog();
+    let manifest = manifest(Some("universal"), Some("universal"));
+    for (audit, axioms) in [
+        (json!("checked"), json!(["sorryAx"])),
+        (json!("checked"), json!(["foreignAxiom"])),
+        (json!("unavailable"), json!([])),
+        (Value::Null, Value::Null),
+        (json!("checked"), Value::Null),
+    ] {
+        let mut output = attempt();
+        output["premises"][0]["proof_audit"] = audit;
+        output["premises"][0]["proof_axioms"] = axioms;
+        let mut reports = reports();
+        attach_output(
+            &catalog,
+            Some(&manifest),
+            &mut reports,
+            &owners(),
+            &labels(),
+            &trace(&output),
+        );
+        let actual = &reports[CLAIM]["citation_attempts"][0];
+        assert_eq!(actual["established_dependencies"], false, "{actual}");
+        assert_eq!(actual["premises"][0]["closure_audited"], false, "{actual}");
+    }
+}
+
+#[test]
+fn failed_prior_reason_keeps_a_closed_attempt_conditional() {
+    let catalog = catalog();
+    let manifest = manifest(Some("universal"), Some("universal"));
+    let mut reports = reports();
+    reports.get_mut(CLAIM).unwrap()["assumptions"] = json!([
+        {"kind": "when", "status": "assumed", "expression": "by > 0"},
+        {"kind": "because", "status": "failed", "expression": "p(by)"},
+    ]);
+    attach_output(
+        &catalog,
+        Some(&manifest),
+        &mut reports,
+        &owners(),
+        &labels(),
+        &trace(&attempt()),
+    );
+    assert_eq!(
+        reports[CLAIM]["citation_attempts"][0]["established_dependencies"],
+        false
+    );
+    assert_eq!(
+        reports[CLAIM]["citation_attempts"][0]["law_status"],
+        "universal"
+    );
+}
+
+#[test]
+fn unrecognized_record_premise_never_becomes_fabricated_aver() {
+    let catalog = catalog();
+    let mut output = attempt();
+    output["premises"][0]["goal"]["forall"]["body"]["app"]["args"][3] = json!({"proj": {
+        "struct": "Unknown.Record", "idx": 0, "e": {"var": "by'"},
+    }});
+    let mut reports = reports();
+    attach_output(
+        &catalog,
+        None,
+        &mut reports,
+        &owners(),
+        &labels(),
+        &trace(&output),
+    );
+    let premise = &reports[CLAIM]["citation_attempts"][0]["premises"][0];
+    assert_eq!(premise["source_form"], "unavailable");
+    assert!(premise.get("expression").is_none());
+    assert!(!reports[CLAIM].to_string().contains("Unknown.Record"));
+}
+
+#[test]
+fn actual_premise_restores_the_source_variable_spelling() {
+    let catalog = catalog();
+    let mut reports = reports();
+    attach_output(
+        &catalog,
+        None,
+        &mut reports,
+        &owners(),
+        &labels(),
+        &trace(&attempt()),
+    );
+    let premise = &reports[CLAIM]["citation_attempts"][0]["premises"][0];
+    assert_eq!(premise["source_form"], "aver");
+    assert_eq!(premise["expression"], "0 <= by");
+    assert_eq!(premise["variables"], json!([["by", "Int"]]));
+}
+
+#[test]
+fn unsuccessful_application_does_not_claim_partial_premise_results() {
+    let catalog = catalog();
+    for outcome in ["application_failed", "preparation_failed", "probe_error"] {
+        let mut output = attempt();
+        output["outcome"] = json!(outcome);
+        let mut reports = reports();
+        attach_output(
+            &catalog,
+            None,
+            &mut reports,
+            &owners(),
+            &labels(),
+            &trace(&output),
+        );
+        let actual = &reports[CLAIM]["citation_attempts"][0];
+        assert_eq!(actual["outcome"], outcome);
+        assert_eq!(actual["premises"], json!([]));
+    }
+}
+
+#[test]
+fn invalid_phase_outcome_or_premise_status_is_ignored() {
+    let catalog = catalog();
+    for invalid in ["phase", "outcome", "premise"] {
+        let mut output = attempt();
+        match invalid {
+            "premise" => output["premises"][0]["status"] = json!("universal"),
+            key => output[key] = json!("counted_proof"),
+        }
+        let mut reports = reports();
+        let original = reports.clone();
+        attach_output(
+            &catalog,
+            None,
+            &mut reports,
+            &owners(),
+            &labels(),
+            &trace(&output),
+        );
+        assert_eq!(reports, original);
+    }
+}
+
+#[test]
+fn duplicated_theorem_or_claim_markers_have_no_attribution_winner() {
+    let mut catalog = catalog();
+    for law in catalog.laws.values_mut() {
+        law.emitted_module = "Entry".to_string();
+    }
+    let prefix = aver::codegen::lean::LAW_CLASS_MARKER_PREFIX;
+    let source = |rows: &[(&str, &str)]| {
+        rows.iter()
+            .map(|(theorem, claim)| format!("{prefix}{theorem} universal {claim}\n"))
+            .collect::<String>()
+    };
+    for conflict in [
+        vec![("same", "p.selected"), ("same", "p.sibling")],
+        vec![("first", "p.selected"), ("second", "p.selected")],
+        vec![("same", "p.selected"), ("same", "p.selected")],
+    ] {
+        let mut rows = conflict;
+        rows.push(("unrelated", "p.target"));
+        let modules = [Module {
+            name: "Entry".to_string(),
+            source: source(&rows),
+        }];
+        let actual = unique_markers(&catalog, &modules);
+        assert_eq!(
+            actual,
+            BTreeMap::from([("Entry.unrelated".to_string(), "p.target".to_string())])
+        );
+    }
+}
+
+#[test]
+fn wrong_owner_markers_do_not_contaminate_unique_source_attribution() {
+    let mut catalog = catalog();
+    for law in catalog.laws.values_mut() {
+        law.emitted_module = "Entry".to_string();
+    }
+    let prefix = aver::codegen::lean::LAW_CLASS_MARKER_PREFIX;
+    let modules = [
+        Module {
+            name: "Entry".to_string(),
+            source: format!("{prefix}real universal p.selected\n"),
+        },
+        Module {
+            name: "StaleCopy".to_string(),
+            source: format!("{prefix}other universal p.selected\n"),
+        },
+    ];
+    assert_eq!(
+        unique_markers(&catalog, &modules),
+        BTreeMap::from([("Entry.real".to_string(), "p.selected".to_string())])
+    );
+}

--- a/src/main/proof_explain/source.rs
+++ b/src/main/proof_explain/source.rs
@@ -13,6 +13,8 @@ pub(super) struct Law {
     pub line: usize,
     pub function: String,
     pub body: VerifyLaw,
+    pub untranslate: aver::codegen::lean::untranslate::UntranslateCtx,
+    pub emitted_module: String,
 }
 
 #[derive(Default)]
@@ -42,6 +44,15 @@ impl Catalog {
                 catalog.add(block, Some(&module.prefix), &file);
             }
         }
+        for law in catalog.laws.values_mut() {
+            law.emitted_module =
+                aver::codegen::lean::citation_probe::module_name(ctx, law.scope.as_deref());
+            law.untranslate = aver::codegen::lean::untranslate::context_for_law(
+                ctx,
+                law.scope.as_deref(),
+                &law.body,
+            );
+        }
         catalog
     }
 
@@ -65,6 +76,8 @@ impl Catalog {
                 line: block.line,
                 function: qualify(scope, &block.fn_name),
                 body: *body.clone(),
+                untranslate: Default::default(),
+                emitted_module: scope.unwrap_or_default().to_string(),
             },
         );
     }
@@ -98,24 +111,7 @@ fn qualify(scope: Option<&str>, name: &str) -> String {
 }
 
 pub(super) fn expression(expr: &Spanned<Expr>) -> String {
-    let mut out = String::new();
-    // This printer preserves precedence, string escaping, and match scopes.
-    if aver::ast::unparse::write_expr_public(&mut out, expr, 0).is_ok() {
-        let out = out.trim();
-        // The unparser fully parenthesizes binary expressions. The outermost
-        // pair is redundant when an expression is displayed on its own.
-        if matches!(expr.node, Expr::BinOp(..)) {
-            out.strip_prefix('(')
-                .and_then(|s| s.strip_suffix(')'))
-                .unwrap_or(out)
-                .to_string()
-        } else {
-            out.to_string()
-        }
-    } else {
-        // An unavailable source form is explicit, never a guessed Lean translation.
-        "<source expression unavailable>".to_string()
-    }
+    super::display::expression(expr)
 }
 
 pub(super) fn assertion(law: &VerifyLaw) -> String {

--- a/src/main/proof_explain/tests.rs
+++ b/src/main/proof_explain/tests.rs
@@ -80,6 +80,34 @@ fn expression_rendering_preserves_grouping() {
 }
 
 #[test]
+fn expression_rendering_keeps_dotted_names_and_escaped_literals_readable() {
+    let source = r#"fn f(x: Int) -> Int
+    x
+verify f law display
+    given x: Int = [1]
+    because Domain.Fprep.value(x).exp > x.exp + 1
+    because String.len("quote: \" and slash: \\") > 0
+    f(x) => x
+"#;
+    let catalog = catalog(source, None, "source.av");
+    let reports = collect(
+        &catalog,
+        None,
+        &["f.display.because1".into(), "f.display.because2".into()],
+        "unused",
+        "",
+    );
+    assert_eq!(
+        reports["f.display.because1"]["goal"],
+        "Domain.Fprep.value(x).exp > (x.exp + 1)"
+    );
+    assert_eq!(
+        reports["f.display.because2"]["goal"],
+        r#"String.len("quote: \" and slash: \\") > 0"#
+    );
+}
+
+#[test]
 fn unrelated_checker_errors_are_not_hidden_by_an_open_source_step() {
     let source = "fn f(x: Int) -> Int\n    x\nverify f law chain\n    given x: Int = [1]\n    because x > 0\n    f(x) => x\n";
     let catalog = catalog(source, None, "source.av");

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -21,6 +21,8 @@ mod capability;
 mod capability_opaque;
 #[path = "proof_spec/check_gates.rs"]
 mod check_gates;
+#[path = "proof_spec/citation_attempts.rs"]
+mod citation_attempts;
 #[path = "proof_spec/citation_order.rs"]
 mod citation_order;
 #[path = "proof_spec/conditional_split_omega.rs"]

--- a/tests/proof_spec/citation_attempts.rs
+++ b/tests/proof_spec/citation_attempts.rs
@@ -1,0 +1,281 @@
+use super::*;
+
+#[test]
+fn citation_attempt_decodes_a_private_imported_record_in_its_own_scope() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-citation-private-record");
+    std::fs::create_dir_all(&dir).unwrap();
+    let library = dir.join("lib.av");
+    std::fs::write(
+        &library,
+        r#"module Lib
+    exposes [identity]
+    intent = "Cite an order law before simplification erases its zero argument."
+    effects []
+
+fn orderedProducts(a: Int, b: Int, factor: Int) -> Bool
+    a * factor <= b * factor
+
+verify orderedProducts law monotone
+    given a: Int = [-2, 0, 1]
+    given b: Int = [-1, 0, 3]
+    given factor: Int = [0, 1, 4]
+    when a <= b
+    when factor >= 0
+    because orderReason(a, b, factor)
+    using []
+    orderedProducts(a, b, factor) holds
+
+fn orderReason(a: Int, b: Int, factor: Int) -> Bool
+    match factor <= 0
+        true -> orderedProducts(a, b, factor)
+        false -> Bool.and(orderReason(a, b, factor - 1), orderedProducts(a, b, factor))
+
+record Count
+    value: Int
+fn identity(value: Int) -> Int
+    value
+fn checked(a: Int, x: Count) -> Int
+    x.value
+verify checked law missingGuard
+    given a: Int = [0, 1]
+    given x: Count = [Count(value = -1), Count(value = 0)]
+    when a >= 0
+    because orderedProducts(0, a, x.value)
+    using [orderedProducts.monotone]
+    checked(a, x) => checked(a, x)
+"#,
+    )
+    .unwrap();
+    let entry = dir.join("entry.av");
+    std::fs::write(
+        &entry,
+        r#"module Entry
+    depends [Lib]
+    intent = "Conflicting entry record metadata."
+    effects []
+record Count
+    text: String
+fn orderedProducts(a: Int, b: Int, x: Count) -> Bool
+    x.text == "entry"
+fn copy(value: Int) -> Int
+    Lib.identity(value)
+"#,
+    )
+    .unwrap();
+    let (summary, run) = run_lean_check_json_with_args(
+        entry.to_str().unwrap(),
+        &dir.join("lean"),
+        0,
+        &[],
+        &["--explain", "--module-root", dir.to_str().unwrap()],
+    );
+    assert!(!run.status.success(), "the missing record guard must fail");
+    assert_eq!(summary["passed"], false, "{summary}");
+    assert_eq!(summary["build_errors"], 0, "{}", format_output(&run));
+    let report = &summary["explanations"]["Lib.checked.missingGuard.because1"];
+    assert_eq!(report["file"], library.to_str().unwrap(), "{summary}");
+    let attempt = report["citation_attempts"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing citation attempts: {summary}"))
+        .iter()
+        .find(|attempt| attempt["law"] == "Lib.orderedProducts.monotone")
+        .unwrap_or_else(|| panic!("missing private citation: {report}"));
+    assert_eq!(attempt["phase"], "diagnostic_direct_application");
+    assert_eq!(attempt["outcome"], "matched", "{attempt}");
+    assert_eq!(attempt["law_status"], "universal", "{attempt}");
+    assert_eq!(attempt["established_dependencies"], true, "{attempt}");
+    assert!(
+        attempt["premises"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|premise| {
+                premise["status"] == "open"
+                    && premise["source_form"] == "aver"
+                    && premise["expression"] == "0 <= x.value"
+            }),
+        "the actual premise must use Lib.Count.value, not Entry.Count.text: {attempt}"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn automatic_citation_attempt_keeps_a_sorry_tainted_pool_unestablished() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-citation-automatic-tainted");
+    std::fs::create_dir_all(&dir).unwrap();
+    let entry = dir.join("entry.av");
+    std::fs::write(
+        &entry,
+        r#"module AutomaticTainted
+    intent = "Cite an order law before simplification erases its zero argument."
+    effects []
+
+fn orderedProducts(a: Int, b: Int, factor: Int) -> Bool
+    a * factor <= b * factor
+
+verify orderedProducts law monotone
+    given a: Int = [-2, 0, 1]
+    given b: Int = [-1, 0, 3]
+    given factor: Int = [0, 1, 4]
+    when a <= b
+    when factor >= 0
+    because false
+    using []
+    orderedProducts(a, b, factor) holds
+
+fn orderReason(a: Int, b: Int, factor: Int) -> Bool
+    match factor <= 0
+        true -> orderedProducts(a, b, factor)
+        false -> Bool.and(orderReason(a, b, factor - 1), orderedProducts(a, b, factor))
+
+fn product(a: Int, b: Int) -> Int
+    a * b
+
+verify product law missingFactorGuard
+    given a: Int = [0, 1, 3]
+    given b: Int = [-1, 0, 4]
+    when a >= 0
+    because orderedProducts(0, a, b)
+    product(a, b) => product(a, b)
+"#,
+    )
+    .unwrap();
+    let (summary, run) = run_lean_check_json_with_args(
+        entry.to_str().unwrap(),
+        &dir.join("lean"),
+        0,
+        &[],
+        &["--explain"],
+    );
+    assert!(!run.status.success(), "the false source reason must fail");
+    assert_eq!(summary["passed"], false, "{summary}");
+    assert_eq!(summary["build_errors"], 0, "{}", format_output(&run));
+    assert_eq!(
+        summary["obligations"]["product.missingFactorGuard.because1"], "failed",
+        "the diagnostic must not award counted credit: {summary}"
+    );
+    let report = &summary["explanations"]["product.missingFactorGuard.because1"];
+    assert_eq!(report["citation_mode"], "automatic", "{summary}");
+    let attempts = report["citation_attempts"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing automatic attempts: {summary}"));
+    let attempt = attempts
+        .iter()
+        .find(|attempt| attempt["law"] == "orderedProducts.monotone")
+        .unwrap_or_else(|| panic!("missing automatically selected law: {report}"));
+    assert_eq!(attempt["phase"], "diagnostic_direct_application");
+    assert_eq!(attempt["outcome"], "matched", "{attempt}");
+    assert_eq!(attempt["law_status"], "failed", "{attempt}");
+    assert_eq!(attempt["established_dependencies"], false, "{attempt}");
+    assert!(
+        attempt["premises"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|premise| {
+                premise["status"] == "open"
+                    && premise["source_form"] == "aver"
+                    && premise["expression"] == "0 <= b"
+            }),
+        "a matching failed law must still expose its actual missing premise: {attempt}"
+    );
+    assert!(
+        attempt["available_laws"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|law| law["law"] == "orderedProducts.monotone" && law["status"] == "failed"),
+        "the whole available citation pool must retain audit status: {attempt}"
+    );
+    for attempt in attempts {
+        assert_eq!(attempt["established_dependencies"], false, "{attempt}");
+    }
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn automatic_citation_attempt_reports_the_actual_missing_premise() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-citation-automatic-healthy");
+    std::fs::create_dir_all(&dir).unwrap();
+    let entry = dir.join("entry.av");
+    std::fs::write(
+        &entry,
+        r#"module AutomaticHealthy
+    intent = "Cite an order law before simplification erases its zero argument."
+    effects []
+
+fn orderedProducts(a: Int, b: Int, factor: Int) -> Bool
+    a * factor <= b * factor
+
+verify orderedProducts law monotone
+    given a: Int = [-2, 0, 1]
+    given b: Int = [-1, 0, 3]
+    given factor: Int = [0, 1, 4]
+    when a <= b
+    when factor >= 0
+    because orderReason(a, b, factor)
+    using []
+    orderedProducts(a, b, factor) holds
+
+fn orderReason(a: Int, b: Int, factor: Int) -> Bool
+    match factor <= 0
+        true -> orderedProducts(a, b, factor)
+        false -> Bool.and(orderReason(a, b, factor - 1), orderedProducts(a, b, factor))
+
+fn product(a: Int, b: Int) -> Int
+    a * b
+
+verify product law missingFactorGuard
+    given a: Int = [0, 1, 3]
+    given b: Int = [-1, 0, 4]
+    when a >= 0
+    because orderedProducts(0, a, b)
+    product(a, b) => product(a, b)
+"#,
+    )
+    .unwrap();
+    let (summary, run) = run_lean_check_json_with_args(
+        entry.to_str().unwrap(),
+        &dir.join("lean"),
+        0,
+        &[],
+        &["--explain"],
+    );
+    assert!(!run.status.success(), "the missing premise must fail");
+    assert_eq!(summary["passed"], false, "{summary}");
+    assert_eq!(summary["build_errors"], 0, "{}", format_output(&run));
+    let report = &summary["explanations"]["product.missingFactorGuard.because1"];
+    assert_eq!(report["citation_mode"], "automatic", "{summary}");
+    let attempt = report["citation_attempts"]
+        .as_array()
+        .unwrap_or_else(|| panic!("missing automatic attempts: {summary}"))
+        .iter()
+        .find(|attempt| attempt["law"] == "orderedProducts.monotone")
+        .unwrap_or_else(|| panic!("missing automatic citation: {report}"));
+    assert_eq!(attempt["phase"], "diagnostic_direct_application");
+    assert_eq!(attempt["outcome"], "matched", "{attempt}");
+    assert_eq!(attempt["law_status"], "universal", "{attempt}");
+    assert_eq!(attempt["established_dependencies"], true, "{attempt}");
+    assert!(
+        attempt["premises"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|premise| {
+                premise["status"] == "open"
+                    && premise["source_form"] == "aver"
+                    && premise["expression"] == "0 <= b"
+            }),
+        "{attempt}"
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/tests/proof_spec/k5_sticky.rs
+++ b/tests/proof_spec/k5_sticky.rs
@@ -39,7 +39,7 @@ fn k5_sticky_composition_has_universal_source_proofs() {
 }
 
 #[test]
-fn k5_fraction_exponent_has_a_universal_magnitude_window() {
+fn k5_fraction_exponent_and_truncation_agree_with_the_normalized_model() {
     if Command::new("lake").arg("--version").output().is_err() {
         return;
     }
@@ -67,6 +67,15 @@ fn k5_fraction_exponent_has_a_universal_magnitude_window() {
         "fracExpo.executableMagnitude",
         "fracExpo.rationalMagnitude",
         "normalizedValueExponent.executableExponent",
+        "modelSign.normalizedSign",
+        "truncationFormula.knownExponent",
+        "modelTruncation.normalizedModel",
+        "sameTruncation.normalizedModel",
+        "Domain.TruncScale.equalQuotients.equalPositiveRatios",
+        "Domain.TruncScale.ulpScale.signedExponent",
+        "Domain.TruncScale.scaledQuotient.exactScale",
+        "Domain.TruncScale.restoredValue.exactScale",
+        "Domain.TruncScale.signOfProduct.positiveMagnitudes",
         "Domain.ModelScale.modelWindow.normalizedMagnitude",
         "Domain.ModelScale.uniqueWindow.uniqueExponent",
         "Domain.BinadeOrder.fractionWindow.integerMagnitude",
@@ -98,9 +107,44 @@ fn k5_fraction_exponent_has_a_universal_magnitude_window() {
             assert_eq!(law["tier"], "universal", "{law}");
         }
     }
-    for obligation in manifest["obligations"].as_array().unwrap() {
+    let obligations = manifest["obligations"].as_array().unwrap();
+    for obligation in obligations {
         assert_eq!(obligation["tier"], "universal", "{obligation}");
     }
+    // Pin every new source step as well as its parent law: a missing or
+    // unaudited because/implication must not silently reduce the proof surface.
+    for (law, reasons) in [
+        ("Domain.TruncScale.equalQuotients.equalPositiveRatios", 2),
+        ("Domain.TruncScale.ulpScale.signedExponent", 1),
+        ("Domain.TruncScale.scaledQuotient.exactScale", 3),
+        ("Domain.TruncScale.restoredValue.exactScale", 0),
+        ("Domain.TruncScale.signOfProduct.positiveMagnitudes", 2),
+        ("modelSign.normalizedSign", 7),
+        ("truncationFormula.knownExponent", 0),
+        ("modelTruncation.normalizedModel", 9),
+        ("sameTruncation.normalizedModel", 4),
+    ] {
+        for step in (1..=reasons)
+            .map(|index| format!("{law}.because{index}"))
+            .chain(std::iter::once(format!("{law}.implication")))
+        {
+            assert!(
+                obligations.iter().any(|claim| claim["law"] == step),
+                "missing source obligation {step}"
+            );
+        }
+    }
+    // The checked result currently has 91 universal laws, four previously
+    // bounded laws, and 142 universal steps. Allow additions and promotions.
+    assert!(
+        laws.iter().filter(|law| law["tier"] == "universal").count() >= 91,
+        "{manifest}"
+    );
+    assert!(
+        laws.iter().filter(|law| law["tier"] == "bounded").count() <= 4,
+        "{manifest}"
+    );
+    assert!(obligations.len() >= 142, "{manifest}");
     for claim in laws
         .iter()
         .chain(manifest["obligations"].as_array().unwrap())

--- a/tests/proof_spec/law_reasons.rs
+++ b/tests/proof_spec/law_reasons.rs
@@ -477,7 +477,12 @@ fn explain_reports_source_requirements_without_changing_proof_credit() {
     let fixture = "tests/fixtures/law_reason_constant_citation.av";
     let (plain, _) = run_lean_check_json_with_args(fixture, &dir, 0, &[], &[]);
     assert!(plain.get("explanations").is_none());
+    let counted_source = std::fs::read(dir.join("ConstantCitation.lean")).unwrap();
     let (explained, run) = run_lean_check_json_with_args(fixture, &dir, 0, &[], &["--explain"]);
+    assert_eq!(
+        counted_source,
+        std::fs::read(dir.join("ConstantCitation.lean")).unwrap()
+    );
     assert!(!run.status.success());
     for (key, value) in plain.as_object().unwrap() {
         assert_eq!(&explained[key], value, "counted field {key} changed");
@@ -495,6 +500,31 @@ fn explain_reports_source_requirements_without_changing_proof_credit() {
         report["citations"][0]["requires"],
         serde_json::json!(["0 <= a", "b >= 0"])
     );
+    let attempt = &report["citation_attempts"][0];
+    assert_eq!(
+        attempt["phase"], "diagnostic_direct_application",
+        "{report}"
+    );
+    assert_eq!(attempt["law"], "orderedProducts.monotone", "{report}");
+    assert_eq!(attempt["outcome"], "matched", "{report}");
+    assert_eq!(attempt["law_status"], "universal", "{report}");
+    assert_eq!(attempt["established_dependencies"], true, "{report}");
+    assert_eq!(attempt["premises"][0]["expression"], "0 <= a", "{report}");
+    assert_eq!(attempt["premises"][0]["status"], "closed", "{report}");
+    assert_eq!(attempt["premises"][0]["closure_audited"], true, "{report}");
+    assert!(
+        attempt["premises"][0]["proof_axioms"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|axiom| matches!(
+                axiom.as_str(),
+                Some("propext" | "Classical.choice" | "Quot.sound")
+            )),
+        "{report}"
+    );
+    assert_eq!(attempt["premises"][1]["expression"], "0 <= b", "{report}");
+    assert_eq!(attempt["premises"][1]["status"], "open", "{report}");
     assert!(
         std::fs::read_to_string(dir.join("proof_backend.log"))
             .unwrap()
@@ -514,6 +544,8 @@ fn explain_reports_source_requirements_without_changing_proof_credit() {
         "{output}"
     );
     assert!(output.contains("requires b >= 0"), "{output}");
+    assert!(output.contains("[closed in probe] 0 <= a"), "{output}");
+    assert!(output.contains("[open in probe] 0 <= b"), "{output}");
     assert!(output.contains("when a >= 0 [assumed]"), "{output}");
     for technical in ["AVER_REASON_OPEN:", "⊢", ".lean:", "simp only", "case "] {
         assert!(


### PR DESCRIPTION
The executable K5 Fraction truncation now agrees universally with the normalized `Fp` model for either sign, every integer exponent, and positive precision. The proof lives in ordinary Aver `because`/`using` steps, with five reusable scale laws in `Domain.TruncScale`; its author completed it without reading generated Lean. Kernel and imports now have 91 universal laws and 142 universal source obligations, retaining the same four bounded laws and the previous axiom sets. The whole divider theorem remains open.

`aver proof --check --explain` now tries supported direct citations in an isolated copy and reports the actual premises closed or left open in Aver syntax. For example, a missing multiplication guard reports `0 <= a` as closed and `0 <= b` as open, separately from the source requirement list. Imported record fields use their defining module's metadata. Available facts retain their audited tiers, and each closed premise's actual proof receives a transitive axiom audit; incomplete or untrusted context stays conditional. Duplicate/stale source attribution is rejected. Counted files, proof credit, budgets, and exit codes are unchanged.

Validation: 1,615 unit tests plus the new pinned-Lean closure-audit regression passed (one existing ignored test); 32 reason regressions, four explanation CLI tests, three citation CLI tests, and both K5 proof regressions passed. VM: 4,017 passing cases; WASM: 4,015 plus the same two pre-existing budget refusals, with unchanged budgets. Compiler Clippy, formatting, and whitespace checks passed. Regression coverage includes unchanged counted output with `--explain`, automatic and private imported citations, conditional closures, unsupported source forms, and all new K5 laws/obligations. Direct citation probes are diagnostic attempts, not a trace of the counted solver's search, and other proof strategies may still have source context only.
