### PR TITLE
Prove K5 away/sticky bridges through consistent source-law citations

### DIFF
--- a/docs/lean.md
+++ b/docs/lean.md
@@ -179,6 +179,8 @@ The backend uses reason functions' case structure to preserve branch equations, 
 
 `using [function.law, Module.function.law]` selects a set of lemma names. Order within the list is immaterial. Selected lemmas remain available in every explanation obligation and in the final implication. Omitting `using` keeps automatic selection; `using []` selects none. Local forward references are allowed, imported laws must be exposed by their subject's module, and unknown names or dependency cycles are errors. Explicit citations retain theorem scope and the usual transitive axiom audit: samples and `sorry`-tainted theorems cannot grant universal credit.
 
+A law guided by `because` or `using` remains citable when each `given` has only one example. Those examples do not restrict its universal statement; proof credit still depends on the checked theorem and its dependencies.
+
 Typed empty list samples retain their concrete checked element type in Lean, including when nested inside polymorphic list operations. Unresolved generic element types are left for Lean to infer from context.
 
 `aver verify` and `aver verify --hostile` execute every reason under the original guard, using the same sample expansion as the claim. These checks do not require Lean. `aver proof --check-json` and `proof_manifest.json` additionally report separate `obligations`, identified by `<function>.<law>.because1`, `.because2`, and `.implication`. Obligations do not inflate `universal_laws`. `--explain` includes residual goals for failed explanation obligations when the solver provides them; an implication may be universal while its reason and the original law remain failed.
@@ -422,6 +424,8 @@ never `open_goals`. Explanations show the source proof report before usable
 helper suggestions. Unavailable suggestions produce a short notice,
 with technical extraction and translation details in `proof_candidates.log`.
 Generated proof-step theorems are excluded from this legacy helper search.
+If a selected theorem cannot be supplied to a proof step, the report identifies
+`citation_unavailable` rather than suggesting a missing mathematical premise.
 Without `--explain`, no new diagnostic fields are emitted.
 The [IR snapshots](transpilation.md#debugging-a-law-that-didnt-auto-prove) and generated output remain useful for
 compiler debugging; ordinary proof-step reports use Aver syntax directly.

--- a/docs/lean.md
+++ b/docs/lean.md
@@ -418,7 +418,11 @@ The existing `sorry_laws` identities, `open_goals` residuals and manifest
 `open_goal` fields remain available for tools that need backend detail. Laws
 without `because` can still use an isolated residual probe and calculated helper
 suggestions; a residual borrowed from a healthy law stays under `probe_of`,
-never `open_goals`. Without `--explain`, no new diagnostic fields are emitted.
+never `open_goals`. Explanations show the source proof report before usable
+helper suggestions. Unavailable suggestions produce a short notice,
+with technical extraction and translation details in `proof_candidates.log`.
+Generated proof-step theorems are excluded from this legacy helper search.
+Without `--explain`, no new diagnostic fields are emitted.
 The [IR snapshots](transpilation.md#debugging-a-law-that-didnt-auto-prove) and generated output remain useful for
 compiler debugging; ordinary proof-step reports use Aver syntax directly.
 

--- a/projects/k5_fdiv/README.md
+++ b/projects/k5_fdiv/README.md
@@ -1,11 +1,22 @@
 # K5 FDIV — reproducing a processor divider proof in Aver
 
-The executable Fraction truncation now agrees with the normalized model:
-`Kernel.sameTruncation.normalizedModel` proves
-`sameValue(truncFrac(fpValueGeneral(f), n), fpValueGeneral(fpTrunc(f, n)))`
-for `isFp(f)`, `f.width >= 1`, and `n >= 1`. This covers both signs, every
-integer exponent, and target precisions greater than the input width. An
-executable counterexample at `n = 0` records why positive precision is required.
+The executable Fraction truncation, away-from-zero rounding and sticky rounding
+now agree with the normalized model. The universal laws
+`Kernel.sameTruncation.normalizedModel`, `Kernel.sameAway.normalizedModel`, and
+`Kernel.sameSticky.normalizedModel` prove, respectively:
+
+```text
+sameValue(truncFrac(fpValueGeneral(f), n), fpValueGeneral(fpTrunc(f, n)))
+sameValue(awayFrac(fpValueGeneral(f), n), fpValueGeneral(fpAway(f, n)))
+sameValue(stickyFrac(fpValueGeneral(f), n), fpValueGeneral(fpSticky(f, n)))
+```
+
+Their guards are `isFp(f)`, `f.width >= 1`, and `n >= 1`. They cover both signs,
+every integer exponent, precision widening, upward carries across an exponent
+boundary, and the one-bit sticky case. Executable counterexamples at `n = 0`
+retain the truncation/sticky precision boundary. Away rounding agrees in that
+zero-precision example but differs at `n = -1`; its positive-precision guard is
+not claimed to be minimal.
 
 The executable exponent now agrees with the normalized floating-point model:
 `Kernel.normalizedValueExponent.executableExponent` states
@@ -30,14 +41,28 @@ executable sign, `modelTruncation` proves the fixed-exponent formula, and
 The final equality composes those source laws. This argument was developed with
 Aver source and `--explain`, without inspecting the generated Lean.
 
-The source reports identified an open sign implication and a checker limit at a
-nested truncation-formula application. An explicit product-regrouping `because`
-step and a directly citable Bool helper closed those gaps. That is a concrete
-Aver-only proof-author workflow; other open obligations can still require richer
-source diagnostics.
+`RoundScale` adds generic integer cancellation, exactness and ceiling laws.
+`AwayModel` proves that a significand carry preserves the value, including the
+negative-exponent boundary. `ValueChain` composes cross-product equalities through
+a positive middle denominator; its zero-denominator counterexample records why
+that premise matters. The sticky argument separately proves the half-precision
+quotient and exactness test, then handles the one-bit case before composing the
+executable operation.
 
-The Kernel export and its imports now contain **91 universal laws**, the same
-**4 bounded laws**, and **142 universal proof steps**, with no `sorry` or build
+The source reports identified open arithmetic implications and checker limits at
+large nested applications. Explicit product-regrouping `because` steps, directly
+citable Bool helpers, and smaller model-level laws closed those gaps. All of these
+arguments were developed through Aver source, `context`, `check`, `verify`, and
+`proof --explain`, without inspecting generated Lean. A universally checked helper
+with singleton sample domains also exposed a generic
+citation-admission inconsistency: its source citation was listed as universal but
+was unavailable to the proof composer. The compiler now admits guided source laws
+consistently with their universal emission. The proof argument stayed in Aver;
+diagnosing that inconsistency still required compiler work. Open obligations can
+still require richer source diagnostics.
+
+The Kernel export and its imports now contain **115 universal laws**, the same
+**4 bounded laws**, and **252 universal proof steps**, with no `sorry` or build
 errors. The earlier universal laws retain their proof tiers and axiom sets.
 For an open step, `aver proof ... --check --explain` reports its Aver goal,
 assumptions and cited requirements at the source location. Supported direct
@@ -45,8 +70,9 @@ citations also report the actual premises closed or left open in an isolated
 application, with dependency and closure-axiom audits; see
 [proof diagnostics](../../docs/lean.md#step-zero-which-law-failed).
 
-The Fraction away/sticky bridges, Fraction trunc-sticky composition, sticky-plus, and the complete divider
-correctness theorem remain open. The wrapper still calls `fpValue`; connecting
+General Fraction trunc-sticky composition, sticky-plus, final-round composition,
+and the complete divider correctness theorem remain open. The wrapper still calls
+`fpValue`; connecting
 its negative-exponent inputs to `fpValueGeneral` is also outstanding.
 
 In 1994 the Pentium FDIV bug — a wrong floating-point division — cost Intel about
@@ -65,7 +91,7 @@ This is **not a new idea.** The proof exists; ACL2 did it in 1996. What this pro
 is, is a **proof of capability**: the same theorem, written the way Aver wants you to
 write everything — normal code plus `verify`/`law` blocks — and discharged by the
 compiler. The grandson reproduces the grandfather's masterpiece. The day
-`aver check` says the divider computes the correctly-rounded quotient for every input,
+`aver proof ... --check` establishes that the divider computes the correctly-rounded quotient for every input,
 the question "is this language a toy?" stops being interesting.
 
 ## The discipline (this is load-bearing)
@@ -76,8 +102,10 @@ would prove *nothing* — ACL2 already wrote those.
 
 What we write is **clean, provable Aver**: the divider as normal code and
 intermediate facts as `verify ... law` blocks. The machine checks the proofs;
-the audited status distinguishes universal results from samples and open claims. Lean's
-kernel and Z3/Dafny are the certifying backends underneath, invisible to the author.
+the audited status distinguishes universal results from samples and open claims.
+Lean currently checks the guided `because`/`using` proofs. Dafny supports other law
+shapes, but declines these guided laws; their portability across proof backends
+has not yet been demonstrated.
 A helper fact that the prover can't yet close is handled by *stating it as another
 Aver law* (fed to the lemma pool via The Method) or by building a **generic** prover
 strategy for its whole class — never a one-off Lean script.
@@ -123,7 +151,7 @@ Each stage is independently useful as a verified corpus.
 | **1. Float-as-rational (faithful normalized model)** | the paper's representation (Section 5.1, p.10): every value is `sign · s · 2^exp` with `sign` either `+1` or `−1`, a **normalized** rational significand `s ∈ [1,2)` (an n-bit integer `sigBits ∈ [2^(n-1), 2^n)`), an integer exponent, and the width n; the denoted value is the Stage-0 exact `Fraction` | 🟡 **seeded** — `domain/fprep.av`: **Lemma 7.1.2 (p.18)** landed `universal` on the Lean kernel, both halves — the significand is invariant under scaling, `s(x·2^j) = s_x`, and the exponent shifts, `e(x·2^j) = e_x + j` — which hold *definitionally* because `fpScale` renormalizes nothing. Plus the power-of-two homomorphism `pow2(m+n) == pow2(m)·pow2(n)` and the folklore value-of-scaling corollary `fpValue(x·2^j) == fpValue(x)·2^j`, all `universal` (`#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, zero `sorry`). The value corollary is the **laws-as-lemmas composition** end to end, ACROSS the `Domain.Rational` module boundary: it re-proves nothing about powers of two — it *cites* the proven homomorphism and the compiler composes them via one generic strategy, never a per-figure proof. **Lemma 7.1.7 (p.18)** also landed `universal`: *if `x ≠ 0` and `y ≠ 0` then `e_x + e_y ≤ e(x·y) ≤ e_x + e_y + 1`* — the product-exponent range, stated exactly as the paper (a nonzero float is one with a nonzero significand). It is closed by the **generic match-splitting already in the engine**: the keystone's `grind` case-splits `fpMul`'s normalization branch (shift 0 vs 1) and bounds each arm — no new tactic, no per-figure code. **Multiplication's value-preservation** `fpMulValue` also landed `universal` on the Lean kernel (every exponent, `#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, 0 `sorry`). Its obstacle was never the case-split (the same match-splitting that closes 7.1.7 reduces each branch cleanly) but a **pow2 homomorphism *rearrangement***: the product denominator `pow2(w_a+w_b−2)` must be seen as `pow2(w_a−1)·pow2(w_b−1)`, the homomorphism at the rearranged exponent `(w_a−1)+(w_b−1)` — which `grind`'s bare e-matcher misses on the syntactic `+`. The **signed-power-of-two homomorphism normalizer** (the `Fraction`-level companion of the integer pow2 normalizer) supplies exactly that: it canonicalizes `2^(m+n)`/`2^(m+n+1)` through the proven Aver homomorphism law, cited in cross-multiplied form, so `grind` closes the composition — a generic mechanism keyed on the signed-power-of-two cone shape, never a per-figure proof. **Lemma 7.2.12** needs `trunc` plus a strict product bound; then the rounding modes |
 | **2. Newton–Raphson bounds** | the nonlinear error estimates — `domain/estimate.av`: square/product nonneg, monotonicity, the right-factor monotonicity bound, transitivity-through-products, the error-squaring identity, the contraction bound | ✅ **proven** — **all 8 laws `universal` on the Lean kernel** (`#print axioms ⊆ {propext, Classical.choice, Quot.sound}`, 0 sampled, 0 sorries); push-button on Z3/Dafny. Two reusable mechanisms do it, no per-figure tactics. (1) `aver_int_order`, the nonlinear analog of `omega` for the products-and-squares fragment — recurse on a product with `Int.mul_nonneg` (nonnegativity) / `Int.mul_le_mul` (`prod ≤ prod`) / `Int.mul_le_mul_of_nonneg_right` (shared-right-factor bound), sign-split squares — closes the nonneg sub-family (`sqNonneg`, `mulNonneg`, `tripleNonneg`), the monotonicities (`sqMono`, `mulLeMonoRight`), and the contraction bound (`nrContraction`); `grind` closes the error-squaring ring identity. (2) **order-law composition**: the transitivity bound `mulLeTrans` (`a·c ≤ m` when `a ≤ b`, `0 ≤ c`, `b·c ≤ m`) is closed by *citing* `mulLeMonoRight` — the proof composer restates an earlier inequality law as a rewrite trigger over its two comparison sides and chains the instantiated bound `a·c ≤ b·c` with the premise `b·c ≤ m`. Shape-keyed and derived from the cited Aver law (deleting `mulLeMonoRight` breaks it), not a re-proof — the same laws-as-lemmas composition that closes Stage 1, extended from equalities to inequalities |
 | **Rounding — trunc** | Truncation, away/sticky rounding, error bounds and composition laws in `domain/round.av` | **All laws in this module and its imports are universal:** 62 laws, 23 source-proof obligations, no bounded claims or `sorry`. The trunc-sticky argument is source-local: `StickyInt` supplies the low-bit floor law, `StickyScale` cancels the precision scales, and `fpSticky.preservesCoarseTruncation` proves complete record equality for `1 <= m < n`. The public rational-value law follows from it. This result replaces the former manual Lean proof. |
-| **3. Kernel divide** | The 32 straight-line steps and the end-to-end division theorems | **Partial source proofs.** The executable exponent has integer and rational magnitude bounds and agrees with the normalized model for either sign of the exponent. `divide.theorem_2` proves the wrapper equation under the explicit row-32 result-exponent bracket; deriving that bracket remains open. Complete divider correctness still has executable examples rather than a universal proof. Remaining work includes the Fraction away/sticky bridges, sticky-plus/final-round composition, reciprocal and digit/remainder bounds, the Section 9 bounds, and the wrapper's use of `fpValue` for negative exponents. |
+| **3. Kernel divide** | The 32 straight-line steps and the end-to-end division theorems | **Partial source proofs.** The executable exponent has integer and rational magnitude bounds and agrees with the normalized model for either sign of the exponent. `divide.theorem_2` proves the wrapper equation under the explicit row-32 result-exponent bracket; deriving that bracket remains open. Complete divider correctness still has executable examples rather than a universal proof. The executable trunc/away/sticky bridges now agree with the normalized model at every positive precision, including one-bit sticky rounding. Remaining work includes general Fraction trunc-sticky and sticky-plus/final-round composition, reciprocal and digit/remainder bounds, the Section 9 bounds, and the wrapper's use of `fpValue` for negative exponents. |
 
 The division driver is **straight-line** (two Newton iterations + four
 quotient digits + a rounded sum). Its exponent and rounding helpers still use
@@ -139,6 +167,8 @@ aver check  projects/k5_fdiv/main.av --module-root projects/k5_fdiv
 aver verify projects/k5_fdiv/domain/rational.av --module-root projects/k5_fdiv
 aver proof  projects/k5_fdiv/domain/rational.av --check          # Lean kernel: 0 sorries, universal
 aver proof  projects/k5_fdiv/domain/rational.av --check --backend dafny
+aver proof  projects/k5_fdiv/domain/kernel.av --module-root projects/k5_fdiv --check --explain
+aver verify projects/k5_fdiv/domain/kernel.av --module-root projects/k5_fdiv
 ```
 
 ## Source

--- a/projects/k5_fdiv/domain/awaymodel.av
+++ b/projects/k5_fdiv/domain/awaymodel.av
@@ -1,0 +1,68 @@
+module AwayModel
+    intent = "Relate the upward significand integer to the renormalized floating-point value."
+    depends [Domain.Round, Domain.Fprep, Domain.ModelScale, Domain.Rational, Domain.IntegerOrder, Domain.ValueChain]
+    exposes [rawValue, normalizedValue, rawValuePositive, transferredValue]
+    effects []
+
+fn rawValue(f: Fp, n: Int) -> Fraction
+    ? "Read the upward-rounded significand at the original exponent before any carry normalization."
+    Domain.Fprep.fpValueGeneral(Domain.Fprep.Fp(sign = f.sign, sigBits = Domain.Round.awaySig(f, n), exp = f.exp, width = n))
+
+verify rawValue
+    rawValue(Domain.Fprep.Fp(sign = 1, sigBits = 15, exp = 0, width = 4), 3) => Domain.Rational.Fraction(top = 8, bottom = 4)
+    rawValue(Domain.Fprep.Fp(sign = -1, sigBits = 13, exp = -3, width = 4), 3) => Domain.Rational.Fraction(top = -7, bottom = 32)
+
+fn normalizedValue(f: Fp, n: Int) -> Bool
+    ? "An upward-rounding carry preserves the exact rational value, including the negative-exponent boundary."
+    Domain.Rational.sameValue(Domain.Fprep.fpValueGeneral(Domain.Round.fpAway(f, n)), rawValue(f, n))
+
+verify normalizedValue law carryPreservesValue
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 15, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = -3, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when n >= 1
+    because Domain.Fprep.pow2(n) == 2 * Domain.Fprep.pow2(n - 1)
+    because Domain.ModelScale.signedDouble(f.exp)
+    because normalizedReason(f, n)
+    using [Domain.Fprep.pow2.homomorphism, Domain.ModelScale.signedDouble.successor]
+    normalizedValue(f, n) holds
+
+fn normalizedReason(f: Fp, n: Int) -> Bool
+    ? "Separate a carry to the next binary exponent from an unchanged significand scale."
+    match Domain.Round.awaySig(f, n) == Domain.Fprep.pow2(n)
+        true -> normalizedValue(f, n)
+        false -> normalizedValue(f, n)
+
+verify normalizedReason
+    normalizedReason(Domain.Fprep.Fp(sign = 1, sigBits = 15, exp = -1, width = 4), 3) => true
+    normalizedReason(Domain.Fprep.Fp(sign = -1, sigBits = 13, exp = -3, width = 4), 3) => true
+
+fn rawValuePositive(f: Fp, n: Int) -> Bool
+    ? "The unnormalized upward value has a positive denominator at every positive precision."
+    rawValue(f, n).bottom > 0
+
+verify rawValuePositive law positivePrecision
+    given f: Fp = [Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4)]
+    given n: Int = [1, 3, 7]
+    when n >= 1
+    because Domain.Fprep.pow2(n - 1) >= 1
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2Signed(f.exp).bottom, Domain.Fprep.pow2(n - 1))
+    using [Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.IntegerOrder.positiveProduct.positiveFactors]
+    rawValuePositive(f, n) holds
+
+fn transferredValue(x: Fraction, f: Fp, n: Int) -> Bool
+    ? "Transport equality with the unnormalized upward value through its value-preserving carry."
+    Domain.Rational.sameValue(x, Domain.Fprep.fpValueGeneral(Domain.Round.fpAway(f, n)))
+
+verify transferredValue law sameRawValue
+    given x: Fraction = [Domain.Rational.Fraction(top = -1, bottom = 1)]
+    given f: Fp = [Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4)]
+    given n: Int = [3]
+    when n >= 1
+    when Domain.Rational.sameValue(x, rawValue(f, n))
+    because rawValuePositive(f, n)
+    because normalizedValue(f, n)
+    because Domain.Rational.sameValue(rawValue(f, n), Domain.Fprep.fpValueGeneral(Domain.Round.fpAway(f, n)))
+    because Domain.ValueChain.sameValueThrough(x, rawValue(f, n), Domain.Fprep.fpValueGeneral(Domain.Round.fpAway(f, n)))
+    using [rawValuePositive.positivePrecision, normalizedValue.carryPreservesValue, Domain.ValueChain.sameValueThrough.positiveMiddle]
+    transferredValue(x, f, n) holds

--- a/projects/k5_fdiv/domain/kernel.av
+++ b/projects/k5_fdiv/domain/kernel.av
@@ -14,11 +14,11 @@ module Kernel
         "final round to the requested mode (step 32). The rounding procedures trunc,"
         "away and sticky (Section 5.2, p.13) and the six-way rounding-mode dispatch"
         "round (Section 5.3, p.14) are reproduced on the rationals; comp is the Newton"
-        "ones-complement 2 - x (Section 1.1, p.3). The rational trunc/away/sticky here"
-        "AGREE on values with the proven significand-level fpTrunc/fpAway/fpSticky of"
-        "domain/round.av (checked: trunc/away/sticky of 13/8 to 3 bits give 6/4, 7/4,"
-        "7/4, matching fpValue of the Fp versions) -- Theorem 1's eventual proof bridges"
-        "the two. The runnable expo (fracExpo) is the binary-exponent function the"
+        "ones-complement 2 - x (Section 1.1, p.3). Source laws relate executable"
+        "Fraction trunc/away/sticky to fpTrunc/fpAway/fpSticky through fpValueGeneral"
+        "for normalized inputs, width >= 1 and precision >= 1. These bridges include"
+        "both signs, every integer exponent, carries, and precision widening."
+        "The runnable expo (fracExpo) is the binary-exponent function the"
         "Stage-1/2 proofs avoid by storing the exponent on the normalized Fp model."
         "Its magnitude bracket is now proved on the executable Fraction functions,"
         "using Domain.Binade and the rounding scale equality, for either exponent sign."
@@ -34,10 +34,10 @@ module Kernel
         "8.1.1 reciprocal bound (Estimate NR bounds + the 128-entry Table 1, by"
         "computation), 8.2.1 digit separation, 8.2.3-4 remainder bounds, 7.3.2"
         "sticky-plus, 7.3.1 final-round-commutes, and the Section 9 exponent/precision"
-        "bounds for Theorem 2; plus the remaining bridge from model rounding to the"
-        "Fraction operations, using fpValueGeneral for negative exponents."
-    depends [Domain.TruncScale, Domain.IntegerOrder, Domain.ModelScale, Domain.BinadeOrder, Domain.Rational, Domain.Fprep, Domain.Round, Domain.Binade]
-    exposes [RoundingMode, fracSign, halve, expoAtLeastOne, twoPow, binadeSig, binadeWindow, fracExpo, fracExpoWindow, normalizedValueExponent, modelSign, sameTruncation, truncFrac, awayFrac, stickyFrac, nearestFrac, posinfFrac, neginfFrac, round, compFrac, reciprocalEstimate, lookup, quotient, divideBang, inField, divide, divideBangCorrect, divideMatchesBang, divideCorrect, finalRoundCommutes_7_3_1, stickyPlus_7_3_2, stickyPerturbStable_7_3_3, truncSticky_rtl, stickySticky_rtl, stickyPlusExact_rtl]
+        "bounds for Theorem 2; plus general Fraction rounding compositions and the"
+        "wrapper's use of fpValue rather than fpValueGeneral for negative exponents."
+    depends [Domain.RoundScale, Domain.AwayModel, Domain.TruncScale, Domain.IntegerOrder, Domain.ModelScale, Domain.BinadeOrder, Domain.Rational, Domain.Fprep, Domain.Round, Domain.Binade]
+    exposes [RoundingMode, fracSign, halve, expoAtLeastOne, twoPow, binadeSig, binadeWindow, fracExpo, fracExpoWindow, normalizedValueExponent, modelSign, sameTruncation, sameAway, sameSticky, truncFrac, awayFrac, stickyFrac, nearestFrac, posinfFrac, neginfFrac, round, compFrac, reciprocalEstimate, lookup, quotient, divideBang, inField, divide, divideBangCorrect, divideMatchesBang, divideCorrect, finalRoundCommutes_7_3_1, stickyPlus_7_3_2, stickyPerturbStable_7_3_3, truncSticky_rtl, stickySticky_rtl, stickyPlusExact_rtl]
     effects []
 
 // ---------------------------------------------------------------------------
@@ -236,7 +236,7 @@ verify truncationFormula law knownExponent
     truncationFormula(x, e, n) holds
 
 fn awayFrac(x: Fraction, n: Int) -> Fraction
-    ? "away(x,n) (Section 5.2, p.13): round x AWAY FROM ZERO to n significant bits -- the magnitude rounded up (ceiling). The ulp is 2^(e_x - n + 1); the result is sign_x * ceil(|x| / ulp) * ulp. Agrees with fpValue(fpAway(.)) on the normalized model."
+    ? "away(x,n) (Section 5.2, p.13): round x AWAY FROM ZERO to n significant bits -- the magnitude rounded up (ceiling). The ulp is 2^(e_x - n + 1); the result is sign_x * ceil(|x| / ulp) * ulp. sameAway proves agreement with fpValueGeneral(fpAway(.)) on normalized models for every exponent and positive target precision."
     match x.top == 0
         true -> Domain.Rational.zeroFraction()
         false -> Domain.Rational.Fraction(top = fracSign(x) * ceilDiv(Domain.Rational.absInt(x.top) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).bottom, Domain.Rational.absInt(x.bottom) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).top) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).top, bottom = Domain.Fprep.pow2Signed(fracExpo(x) - n + 1).bottom)
@@ -247,7 +247,7 @@ verify awayFrac
     Domain.Rational.sameValue(awayFrac(Domain.Rational.Fraction(top = -13, bottom = 8), 3), Domain.Rational.Fraction(top = -7, bottom = 4)) => true
 
 fn stickyFrac(x: Fraction, n: Int) -> Fraction
-    ? "sticky(x,n) in the faithful round-to-odd (RTL/rto) form (domain/round.av, ACL2 RTL lineage): truncate to n-1 bits, then force the n-th bit to 1 unless x already fits in n-1 bits. With h = floor(|x| / 2^(e_x-n+2)) the n-bit multiple is 2*h if x fits exactly in n-1 bits, else 2*h+1. (NOT the draft paper's printed stickyn branch, a known typo.) Agrees with fpValue(fpSticky(.)) on the normalized model."
+    ? "sticky(x,n) in the faithful round-to-odd (RTL/rto) form (domain/round.av, ACL2 RTL lineage): truncate to n-1 bits, then force the n-th bit to 1 unless x already fits in n-1 bits. With h = floor(|x| / 2^(e_x-n+2)) the n-bit multiple is 2*h if x fits exactly in n-1 bits, else 2*h+1. (NOT the draft paper's printed stickyn branch, a known typo.) sameSticky proves agreement with fpValueGeneral(fpSticky(.)) on normalized models for every exponent and positive target precision, including one bit."
     match x.top == 0
         true -> Domain.Rational.zeroFraction()
         false -> stickyFromHalf(x, n, Domain.Round.floorDiv(Domain.Rational.absInt(x.top) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 2).bottom, Domain.Rational.absInt(x.bottom) * Domain.Fprep.pow2Signed(fracExpo(x) - n + 2).top))
@@ -696,3 +696,294 @@ verify modelTruncation law normalizedModel
     because Domain.TruncScale.restoredValue(f.sign, Domain.Round.fpTrunc(f, n).sigBits, Domain.Fprep.pow2Signed(f.exp), Domain.Fprep.pow2Signed(f.exp - n + 1), Domain.Fprep.pow2(n - 1))
     using [ Domain.ModelScale.absoluteValue.normalizedMagnitude, Domain.ModelScale.nonzeroValue.normalizedValue, modelSign.normalizedSign, Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.TruncScale.ulpScale.signedExponent, Domain.TruncScale.scaledQuotient.exactScale, Domain.TruncScale.restoredValue.exactScale]
     modelTruncation(f, n) holds
+
+fn awayAtExponent(x: Fraction, e: Int, n: Int) -> Fraction
+    ? "Read the nonzero upward-rounding formula after identifying the binary exponent."
+    ulp = Domain.Fprep.pow2Signed(e - n + 1)
+    Domain.Rational.Fraction(top = fracSign(x) * ceilDiv(Domain.Rational.absInt(x.top) * ulp.bottom, Domain.Rational.absInt(x.bottom) * ulp.top) * ulp.top, bottom = ulp.bottom)
+
+verify awayAtExponent
+    awayAtExponent(Domain.Rational.Fraction(top = 13, bottom = 8), 0, 3) => Domain.Rational.Fraction(top = 7, bottom = 4)
+    awayAtExponent(Domain.Rational.Fraction(top = -15, bottom = 16), -1, 3) => Domain.Rational.Fraction(top = -8, bottom = 8)
+
+fn awayFormula(x: Fraction, e: Int, n: Int) -> Bool
+    ? "Substitute an established exponent into executable upward rounding."
+    awayFrac(x, n) == awayAtExponent(x, e, n)
+
+verify awayFormula law knownExponent
+    given x: Fraction = [Domain.Rational.Fraction(top = 13, bottom = 8), Domain.Rational.Fraction(top = -9, bottom = 64)]
+    given e: Int = [-3, 0]
+    given n: Int = [1, 2, 7]
+    when x.top != 0
+    when fracExpo(x) == e
+    using []
+    awayFormula(x, e, n) holds
+
+fn modelCeiling(f: Fp, n: Int) -> Bool
+    ? "The exact rational ulp ceiling equals the model's upward significand integer."
+    value = Domain.Fprep.fpValueGeneral(f)
+    ulp = Domain.Fprep.pow2Signed(f.exp - n + 1)
+    ceilDiv(Domain.Rational.absInt(value.top) * ulp.bottom, Domain.Rational.absInt(value.bottom) * ulp.top) == Domain.Round.awaySig(f, n)
+
+verify modelCeiling law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 9, exp = 5, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because Domain.ModelScale.absoluteValue(f)
+    because Domain.Fprep.pow2(f.width - 1) >= 1
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.Fprep.pow2SignedPositive(f.exp - n + 1)
+    because Domain.TruncScale.ulpScale(f.exp, n)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2Signed(f.exp).bottom, Domain.Fprep.pow2Signed(f.exp - n + 1).top)
+    because Domain.Round.truncFitsWindow(f, n)
+    because Domain.RoundScale.scaledCeiling(f.sigBits * Domain.Fprep.pow2(n - 1), Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp).bottom * Domain.Fprep.pow2Signed(f.exp - n + 1).top, Domain.Round.fpTrunc(f, n).sigBits)
+    because Domain.Rational.absInt(Domain.Fprep.fpValueGeneral(f).top) * Domain.Fprep.pow2Signed(f.exp - n + 1).bottom == (f.sigBits * Domain.Fprep.pow2(n - 1)) * (Domain.Fprep.pow2Signed(f.exp).bottom * Domain.Fprep.pow2Signed(f.exp - n + 1).top)
+    because Domain.Rational.absInt(Domain.Fprep.fpValueGeneral(f).bottom) * Domain.Fprep.pow2Signed(f.exp - n + 1).top == Domain.Fprep.pow2(f.width - 1) * (Domain.Fprep.pow2Signed(f.exp).bottom * Domain.Fprep.pow2Signed(f.exp - n + 1).top)
+    because Domain.RoundScale.roundedQuotient(f.sigBits * Domain.Fprep.pow2(n - 1), Domain.Fprep.pow2(f.width - 1), Domain.Round.fpTrunc(f, n).sigBits) == Domain.Round.awaySig(f, n)
+    using [Domain.ModelScale.absoluteValue.normalizedMagnitude, Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.TruncScale.ulpScale.signedExponent, Domain.IntegerOrder.positiveProduct.positiveFactors, Domain.Round.truncFitsWindow.euclideanWindow, Domain.RoundScale.scaledCeiling.positiveScale]
+    modelCeiling(f, n) holds
+
+fn modelAwayRaw(f: Fp, n: Int) -> Bool
+    ? "The fixed-exponent Fraction ceiling denotes the upward significand before carry normalization."
+    Domain.Rational.sameValue(awayAtExponent(Domain.Fprep.fpValueGeneral(f), f.exp, n), Domain.AwayModel.rawValue(f, n))
+
+verify modelAwayRaw law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4)]
+    given n: Int = [1, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because modelSign(f)
+    because modelCeiling(f, n)
+    because Domain.TruncScale.ulpScale(f.exp, n)
+    because Domain.TruncScale.restoredValue(f.sign, Domain.Round.awaySig(f, n), Domain.Fprep.pow2Signed(f.exp), Domain.Fprep.pow2Signed(f.exp - n + 1), Domain.Fprep.pow2(n - 1))
+    using [modelSign.normalizedSign, modelCeiling.normalizedModel, Domain.TruncScale.ulpScale.signedExponent, Domain.TruncScale.restoredValue.exactScale]
+    modelAwayRaw(f, n) holds
+
+fn modelAway(f: Fp, n: Int) -> Bool
+    ? "The fixed-exponent Fraction ceiling denotes the complete renormalized upward-rounded model value."
+    Domain.Rational.sameValue(awayAtExponent(Domain.Fprep.fpValueGeneral(f), f.exp, n), Domain.Fprep.fpValueGeneral(Domain.Round.fpAway(f, n)))
+
+verify modelAway law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 9, exp = 5, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because modelAwayRaw(f, n)
+    because Domain.AwayModel.transferredValue(awayAtExponent(Domain.Fprep.fpValueGeneral(f), f.exp, n), f, n)
+    using [modelAwayRaw.normalizedModel, Domain.AwayModel.transferredValue.sameRawValue]
+    modelAway(f, n) holds
+
+fn sameAway(f: Fp, n: Int) -> Bool
+    ? "Executable Fraction upward rounding and model significand upward rounding denote the same value, including carries and every exponent."
+    Domain.Rational.sameValue(awayFrac(Domain.Fprep.fpValueGeneral(f), n), Domain.Fprep.fpValueGeneral(Domain.Round.fpAway(f, n)))
+
+verify sameAway
+    sameAway(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 0) => true
+    sameAway(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), -1) => false
+    sameAway(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 3) => true
+    sameAway(Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4), 3) => true
+    sameAway(Domain.Fprep.Fp(sign = 1, sigBits = 12, exp = -3, width = 4), 3) => true
+    sameAway(Domain.Fprep.Fp(sign = -1, sigBits = 9, exp = 5, width = 4), 7) => true
+
+verify sameAway law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 15, exp = -1, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 9, exp = 5, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because normalizedValueExponent(f)
+    because Domain.ModelScale.nonzeroValue(f)
+    because awayFormula(Domain.Fprep.fpValueGeneral(f), f.exp, n)
+    because modelAway(f, n)
+    using [normalizedValueExponent.executableExponent, Domain.ModelScale.nonzeroValue.normalizedValue, awayFormula.knownExponent, modelAway.normalizedModel]
+    sameAway(f, n) holds
+
+fn stickyAtExponent(x: Fraction, e: Int, n: Int) -> Fraction
+    ? "Read the nonzero round-to-odd formula after identifying its binary exponent."
+    halfUlp = Domain.Fprep.pow2Signed(e - n + 2)
+    ulp = Domain.Fprep.pow2Signed(e - n + 1)
+    a = Domain.Rational.absInt(x.top) * halfUlp.bottom
+    b = Domain.Rational.absInt(x.bottom) * halfUlp.top
+    h = Domain.Round.floorDiv(a, b)
+    bits = match a == b * h
+        true -> 2 * h
+        false -> 2 * h + 1
+    Domain.Rational.Fraction(top = fracSign(x) * bits * ulp.top, bottom = ulp.bottom)
+
+verify stickyAtExponent
+    stickyAtExponent(Domain.Rational.Fraction(top = 13, bottom = 8), 0, 3) => Domain.Rational.Fraction(top = 7, bottom = 4)
+    stickyAtExponent(Domain.Rational.Fraction(top = -12, bottom = 8), 0, 3) => Domain.Rational.Fraction(top = -6, bottom = 4)
+    stickyAtExponent(Domain.Rational.Fraction(top = -13, bottom = 64), -3, 1) => Domain.Rational.Fraction(top = -1, bottom = 8)
+
+fn stickyFormula(x: Fraction, e: Int, n: Int) -> Bool
+    ? "Substitute an established exponent into executable round-to-odd rounding."
+    stickyFrac(x, n) == stickyAtExponent(x, e, n)
+
+verify stickyFormula law knownExponent
+    given x: Fraction = [Domain.Rational.Fraction(top = 13, bottom = 8), Domain.Rational.Fraction(top = -9, bottom = 64)]
+    given e: Int = [-3, 0]
+    given n: Int = [1, 2, 7]
+    when x.top != 0
+    when fracExpo(x) == e
+    using []
+    stickyFormula(x, e, n) holds
+
+fn modelStickyHalf(f: Fp, n: Int) -> Bool
+    ? "The rational half-precision quotient equals the model's sticky half significand."
+    value = Domain.Fprep.fpValueGeneral(f)
+    halfUlp = Domain.Fprep.pow2Signed(f.exp - n + 2)
+    Domain.Round.floorDiv(Domain.Rational.absInt(value.top) * halfUlp.bottom, Domain.Rational.absInt(value.bottom) * halfUlp.top) == Domain.Round.stickyHalf(f, n)
+
+verify modelStickyHalf law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4)]
+    given n: Int = [2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 2
+    because Domain.ModelScale.absoluteValue(f)
+    because Domain.Fprep.pow2(f.width - 1) >= 1
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.Fprep.pow2SignedPositive(f.exp - n + 2)
+    because Domain.TruncScale.ulpScale(f.exp, n - 1)
+    because Domain.TruncScale.scaledQuotient(f.sigBits, Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp), Domain.Fprep.pow2Signed(f.exp - n + 2), Domain.Fprep.pow2(n - 2))
+    using [Domain.ModelScale.absoluteValue.normalizedMagnitude, Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.TruncScale.ulpScale.signedExponent, Domain.TruncScale.scaledQuotient.exactScale]
+    modelStickyHalf(f, n) holds
+
+fn modelStickyExact(f: Fp, n: Int) -> Bool
+    ? "Changing from rational ulp units to model significand units preserves the sticky exactness test."
+    value = Domain.Fprep.fpValueGeneral(f)
+    halfUlp = Domain.Fprep.pow2Signed(f.exp - n + 2)
+    (Domain.Rational.absInt(value.top) * halfUlp.bottom == Domain.Rational.absInt(value.bottom) * halfUlp.top * Domain.Round.stickyHalf(f, n)) == (f.sigBits * Domain.Fprep.pow2(n - 2) == Domain.Fprep.pow2(f.width - 1) * Domain.Round.stickyHalf(f, n))
+
+verify modelStickyExact law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4)]
+    given n: Int = [2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 2
+    because Domain.ModelScale.absoluteValue(f)
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.Fprep.pow2SignedPositive(f.exp - n + 2)
+    because Domain.TruncScale.ulpScale(f.exp, n - 1)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2Signed(f.exp).bottom, Domain.Fprep.pow2Signed(f.exp - n + 2).top)
+    because Domain.RoundScale.scaledExactness(f.sigBits * Domain.Fprep.pow2(n - 2), Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp).bottom * Domain.Fprep.pow2Signed(f.exp - n + 2).top, Domain.Round.stickyHalf(f, n))
+    because Domain.Rational.absInt(Domain.Fprep.fpValueGeneral(f).top) * Domain.Fprep.pow2Signed(f.exp - n + 2).bottom == (f.sigBits * Domain.Fprep.pow2(n - 2)) * (Domain.Fprep.pow2Signed(f.exp).bottom * Domain.Fprep.pow2Signed(f.exp - n + 2).top)
+    because Domain.Rational.absInt(Domain.Fprep.fpValueGeneral(f).bottom) * Domain.Fprep.pow2Signed(f.exp - n + 2).top == Domain.Fprep.pow2(f.width - 1) * (Domain.Fprep.pow2Signed(f.exp).bottom * Domain.Fprep.pow2Signed(f.exp - n + 2).top)
+    using [Domain.ModelScale.absoluteValue.normalizedMagnitude, Domain.Fprep.pow2SignedPositive.positive, Domain.TruncScale.ulpScale.signedExponent, Domain.IntegerOrder.positiveProduct.positiveFactors, Domain.RoundScale.scaledExactness.positiveScale]
+    modelStickyExact(f, n) holds
+
+fn modelSticky(f: Fp, n: Int) -> Bool
+    ? "The fixed-exponent sticky formula denotes the rounded model value, with separate one-bit and ordinary half-significand proofs."
+    Domain.Rational.sameValue(stickyAtExponent(Domain.Fprep.fpValueGeneral(f), f.exp, n), Domain.Fprep.fpValueGeneral(Domain.Round.fpSticky(f, n)))
+
+verify modelSticky law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4)]
+    given n: Int = [2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 2
+    because modelSign(f)
+    because modelStickyHalf(f, n)
+    because modelStickyExact(f, n)
+    because Domain.TruncScale.ulpScale(f.exp, n)
+    because Domain.TruncScale.restoredValue(f.sign, Domain.Round.fpSticky(f, n).sigBits, Domain.Fprep.pow2Signed(f.exp), Domain.Fprep.pow2Signed(f.exp - n + 1), Domain.Fprep.pow2(n - 1))
+    because modelStickyReason(f, n)
+    using [modelSign.normalizedSign, modelStickyHalf.normalizedModel, modelStickyExact.normalizedModel, Domain.TruncScale.ulpScale.signedExponent, Domain.TruncScale.restoredValue.exactScale]
+    modelSticky(f, n) holds
+
+verify modelSticky law singleBit
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 1, exp = 5, width = 1)]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    because modelSign(f)
+    because singleBitHalf(f)
+    using [modelSign.normalizedSign, singleBitHalf.normalizedModel]
+    modelSticky(f, 1) holds
+
+verify modelSticky law positivePrecision
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because stickyPrecisionReason(f, n)
+    using [modelSticky.normalizedModel, modelSticky.singleBit]
+    modelSticky(f, n) holds
+
+fn modelStickyReason(f: Fp, n: Int) -> Bool
+    ? "Separate exact half-precision values from values whose sticky low bit must be set."
+    match f.sigBits * Domain.Fprep.pow2(n - 2) == Domain.Fprep.pow2(f.width - 1) * Domain.Round.stickyHalf(f, n)
+        true -> modelSticky(f, n)
+        false -> modelSticky(f, n)
+
+verify modelStickyReason
+    modelStickyReason(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 3) => true
+    modelStickyReason(Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4), 3) => true
+
+fn singleBitHalf(f: Fp) -> Bool
+    ? "A normalized magnitude is strictly positive and below the two-binade half unit used by one-bit sticky rounding."
+    value = Domain.Rational.absFraction(Domain.Fprep.fpValueGeneral(f))
+    halfUlp = Domain.Fprep.pow2Signed(f.exp + 1)
+    a = value.top * halfUlp.bottom
+    b = value.bottom * halfUlp.top
+    Bool.and(a > 0, Domain.Round.floorDiv(a, b) == 0)
+
+verify singleBitHalf law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4), Domain.Fprep.Fp(sign = 1, sigBits = 1, exp = 5, width = 1)]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    because Domain.Fprep.pow2(f.width) == 2 * Domain.Fprep.pow2(f.width - 1)
+    because Domain.ModelScale.absoluteValue(f)
+    because Domain.Fprep.pow2(f.width - 1) >= 1
+    because Domain.Fprep.pow2SignedPositive(f.exp)
+    because Domain.Fprep.pow2SignedPositive(f.exp + 1)
+    because Domain.ModelScale.signedDouble(f.exp)
+    because Domain.IntegerOrder.positiveProduct(f.sigBits, Domain.Fprep.pow2Signed(f.exp).top)
+    because Domain.IntegerOrder.positiveProduct(f.sigBits * Domain.Fprep.pow2Signed(f.exp).top, Domain.Fprep.pow2Signed(f.exp + 1).bottom)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp).bottom)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2(f.width - 1) * Domain.Fprep.pow2Signed(f.exp).bottom, Domain.Fprep.pow2Signed(f.exp + 1).top)
+    because Domain.IntegerOrder.positiveProduct(Domain.Fprep.pow2Signed(f.exp).top, Domain.Fprep.pow2Signed(f.exp + 1).bottom)
+    because Domain.IntegerOrder.multiplyLt(f.sigBits, 2 * Domain.Fprep.pow2(f.width - 1), Domain.Fprep.pow2Signed(f.exp).top * Domain.Fprep.pow2Signed(f.exp + 1).bottom)
+    because Domain.Rational.absFraction(Domain.Fprep.fpValueGeneral(f)).top * Domain.Fprep.pow2Signed(f.exp + 1).bottom == f.sigBits * (Domain.Fprep.pow2Signed(f.exp).top * Domain.Fprep.pow2Signed(f.exp + 1).bottom)
+    because Domain.Rational.absFraction(Domain.Fprep.fpValueGeneral(f)).bottom * Domain.Fprep.pow2Signed(f.exp + 1).top == (2 * Domain.Fprep.pow2(f.width - 1)) * (Domain.Fprep.pow2Signed(f.exp).top * Domain.Fprep.pow2Signed(f.exp + 1).bottom)
+    because Domain.RoundScale.remainderQuotient(Domain.Rational.absFraction(Domain.Fprep.fpValueGeneral(f)).bottom * Domain.Fprep.pow2Signed(f.exp + 1).top, 0, Domain.Rational.absFraction(Domain.Fprep.fpValueGeneral(f)).top * Domain.Fprep.pow2Signed(f.exp + 1).bottom)
+    using [Domain.Fprep.pow2.homomorphism, Domain.ModelScale.absoluteValue.normalizedMagnitude, Domain.Fprep.pow2.positive, Domain.Fprep.pow2SignedPositive.positive, Domain.ModelScale.signedDouble.successor, Domain.IntegerOrder.positiveProduct.positiveFactors, Domain.IntegerOrder.multiplyLt.positiveFactor, Domain.RoundScale.remainderQuotient.smallRemainder]
+    singleBitHalf(f) holds
+
+fn stickyPrecisionReason(f: Fp, n: Int) -> Bool
+    ? "Use the dedicated one-bit sticky branch or the ordinary half-significand branch."
+    match n == 1
+        true -> modelSticky(f, n)
+        false -> modelSticky(f, n)
+
+verify stickyPrecisionReason
+    stickyPrecisionReason(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 1) => true
+    stickyPrecisionReason(Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4), 3) => true
+
+fn sameSticky(f: Fp, n: Int) -> Bool
+    ? "Executable Fraction round-to-odd rounding and model significand rounding denote the same value."
+    Domain.Rational.sameValue(stickyFrac(Domain.Fprep.fpValueGeneral(f), n), Domain.Fprep.fpValueGeneral(Domain.Round.fpSticky(f, n)))
+
+verify sameSticky
+    sameSticky(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 0) => false
+    sameSticky(Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), 1) => true
+    sameSticky(Domain.Fprep.Fp(sign = -1, sigBits = 13, exp = -3, width = 4), 3) => true
+    sameSticky(Domain.Fprep.Fp(sign = 1, sigBits = 12, exp = 5, width = 4), 3) => true
+    sameSticky(Domain.Fprep.Fp(sign = -1, sigBits = 9, exp = 0, width = 4), 7) => true
+
+verify sameSticky law normalizedModel
+    given f: Fp = [Domain.Fprep.Fp(sign = 1, sigBits = 13, exp = 0, width = 4), Domain.Fprep.Fp(sign = -1, sigBits = 12, exp = -3, width = 4)]
+    given n: Int = [1, 2, 3, 7]
+    when Domain.Fprep.isFp(f)
+    when f.width >= 1
+    when n >= 1
+    because normalizedValueExponent(f)
+    because Domain.ModelScale.nonzeroValue(f)
+    because stickyFormula(Domain.Fprep.fpValueGeneral(f), f.exp, n)
+    because modelSticky(f, n)
+    using [normalizedValueExponent.executableExponent, Domain.ModelScale.nonzeroValue.normalizedValue, stickyFormula.knownExponent, modelSticky.positivePrecision]
+    sameSticky(f, n) holds

--- a/projects/k5_fdiv/domain/roundscale.av
+++ b/projects/k5_fdiv/domain/roundscale.av
@@ -1,0 +1,146 @@
+module RoundScale
+    intent = "Preserve exactness and upward integer rounding when a positive scale is shared."
+    depends [Domain.StickyInt, Domain.IntegerOrder]
+    exposes [cancelProduct, scaledExactness, roundedQuotient, remainderQuotient, ceilingFromWindow, scaledCeiling]
+    effects []
+
+fn cancelProduct(a: Int, b: Int, c: Int) -> Bool
+    ? "Multiplication by a strictly positive integer preserves and reflects equality."
+    (a * c == b * c) == (a == b)
+
+verify cancelProduct law positiveFactor
+    given a: Int = [-2, 0, 3]
+    given b: Int = [-1, 0, 3]
+    given c: Int = [1, 2, 8]
+    when c > 0
+    because cancelProductReason(a, b, c)
+    using [Domain.IntegerOrder.multiplyLt.positiveFactor]
+    cancelProduct(a, b, c) holds
+
+fn cancelProductReason(a: Int, b: Int, c: Int) -> Bool
+    ? "Unequal integers have a strict order, and a positive factor preserves that order."
+    match a < b
+        true -> Bool.and(Domain.IntegerOrder.multiplyLt(a, b, c), cancelProduct(a, b, c))
+        false -> match b < a
+            true -> Bool.and(Domain.IntegerOrder.multiplyLt(b, a, c), cancelProduct(a, b, c))
+            false -> cancelProduct(a, b, c)
+
+verify cancelProductReason
+    cancelProductReason(1, 2, 3) => true
+    cancelProductReason(2, 1, 3) => true
+    cancelProductReason(2, 2, 3) => true
+
+fn scaledExactness(a: Int, b: Int, c: Int, q: Int) -> Bool
+    ? "A quotient is exact before multiplication by a common positive scale precisely when it is exact afterward."
+    (a * c == b * c * q) == (a == b * q)
+
+verify scaledExactness law positiveScale
+    given a: Int = [-13, 0, 12, 13]
+    given b: Int = [1, 4, 8]
+    given c: Int = [1, 2, 8]
+    given q: Int = [-2, 0, 3]
+    when c > 0
+    because cancelProduct(a, b * q, c)
+    using [cancelProduct.positiveFactor]
+    scaledExactness(a, b, c, q) holds
+
+fn roundedQuotient(a: Int, b: Int, q: Int) -> Int
+    ? "Keep an exact floor quotient; otherwise move up to the next integer."
+    match a == b * q
+        true -> q
+        false -> q + 1
+
+verify roundedQuotient
+    roundedQuotient(12, 4, 3) => 3
+    roundedQuotient(13, 4, 3) => 4
+
+fn remainderQuotient(d: Int, q: Int, r: Int) -> Bool
+    ? "A remainder inside a positive divisor leaves its quotient unchanged."
+    Domain.StickyInt.floorDiv(d * q + r, d) == q
+
+verify remainderQuotient law smallRemainder
+    given d: Int = [2, 4, 8]
+    given q: Int = [-3, 0, 3]
+    given r: Int = [0, 1, 3]
+    when d > 0
+    when r >= 0
+    when r < d
+    because Domain.StickyInt.floorDiv(d * q + r, d) == q
+    using [Domain.StickyInt.floorDiv.absorbRemainder]
+    remainderQuotient(d, q, r) holds
+
+fn ceilingExact(a: Int, b: Int, q: Int) -> Bool
+    ? "An exact quotient remains unchanged by upward rounding."
+    Domain.StickyInt.floorDiv(a + b - 1, b) == q
+
+verify ceilingExact law exactQuotient
+    given a: Int = [-12, 0, 12]
+    given b: Int = [1, 4]
+    given q: Int = [-3, 0, 3]
+    when b > 0
+    when a == b * q
+    because remainderQuotient(b, q, b - 1)
+    using [remainderQuotient.smallRemainder]
+    ceilingExact(a, b, q) holds
+
+fn ceilingInexact(a: Int, b: Int, q: Int) -> Bool
+    ? "A strict floor remainder advances upward rounding by one."
+    Domain.StickyInt.floorDiv(a + b - 1, b) == q + 1
+
+verify ceilingInexact law strictRemainder
+    given a: Int = [-13, 1, 13]
+    given b: Int = [4, 8]
+    given q: Int = [-4, -2, 0, 1, 3]
+    when b > 0
+    when b * q < a
+    when a < b * (q + 1)
+    because remainderQuotient(b, q + 1, a - b * q - 1)
+    using [remainderQuotient.smallRemainder]
+    ceilingInexact(a, b, q) holds
+
+fn ceilingFromWindow(a: Int, b: Int, q: Int) -> Bool
+    ? "The upward integer quotient is determined by the Euclidean floor window and its exactness test."
+    Domain.StickyInt.floorDiv(a + b - 1, b) == roundedQuotient(a, b, q)
+
+verify ceilingFromWindow law euclideanWindow
+    given a: Int = [-13, 0, 12, 13]
+    given b: Int = [1, 4, 8]
+    given q: Int = [-4, -2, 0, 1, 3, 12, 13]
+    when b > 0
+    when b * q <= a
+    when a < b * (q + 1)
+    because ceilingReason(a, b, q)
+    using [ceilingExact.exactQuotient, ceilingInexact.strictRemainder]
+    ceilingFromWindow(a, b, q) holds
+
+fn ceilingReason(a: Int, b: Int, q: Int) -> Bool
+    ? "Express the rounded dividend as a quotient multiple plus a remainder inside its divisor."
+    match a == b * q
+        true -> Bool.and(ceilingExact(a, b, q), ceilingFromWindow(a, b, q))
+        false -> Bool.and(ceilingInexact(a, b, q), ceilingFromWindow(a, b, q))
+
+verify ceilingReason
+    ceilingReason(12, 4, 3) => true
+    ceilingReason(13, 4, 3) => true
+    ceilingReason(-13, 4, -4) => true
+
+fn scaledCeiling(a: Int, b: Int, c: Int, q: Int) -> Bool
+    ? "A positive common numerator-denominator scale leaves upward rounding unchanged."
+    Domain.StickyInt.floorDiv(a * c + b * c - 1, b * c) == roundedQuotient(a, b, q)
+
+verify scaledCeiling law positiveScale
+    given a: Int = [-13, 0, 12, 13]
+    given b: Int = [1, 4, 8]
+    given c: Int = [1, 2, 8]
+    given q: Int = [-4, -2, 0, 1, 3, 12, 13]
+    when b > 0
+    when c > 0
+    when b * q <= a
+    when a < b * (q + 1)
+    because Domain.IntegerOrder.positiveProduct(b, c)
+    because Domain.IntegerOrder.multiplyLe(b * q, a, c)
+    because Domain.IntegerOrder.multiplyLt(a, b * (q + 1), c)
+    because ceilingFromWindow(a * c, b * c, q)
+    because scaledExactness(a, b, c, q)
+    using [Domain.IntegerOrder.positiveProduct.positiveFactors, Domain.IntegerOrder.multiplyLe.nonnegativeFactor, Domain.IntegerOrder.multiplyLt.positiveFactor, ceilingFromWindow.euclideanWindow, scaledExactness.positiveScale]
+    scaledCeiling(a, b, c, q) holds

--- a/projects/k5_fdiv/domain/valuechain.av
+++ b/projects/k5_fdiv/domain/valuechain.av
@@ -1,0 +1,27 @@
+module ValueChain
+    intent = "Compose exact rational equalities through a value with a positive denominator."
+    depends [Domain.Rational, Domain.RoundScale]
+    exposes [sameValueThrough]
+    effects []
+
+fn sameValueThrough(a: Fraction, b: Fraction, c: Fraction) -> Bool
+    ? "Two cross-product equalities compose when the middle denominator is positive."
+    match Bool.and(Domain.Rational.sameValue(a, b), Domain.Rational.sameValue(b, c))
+        true -> Domain.Rational.sameValue(a, c)
+        false -> true
+
+verify sameValueThrough law positiveMiddle
+    given a: Fraction = [Domain.Rational.Fraction(top = 1, bottom = 2), Domain.Rational.Fraction(top = -1, bottom = 2)]
+    given b: Fraction = [Domain.Rational.Fraction(top = 2, bottom = 4), Domain.Rational.Fraction(top = -2, bottom = 4)]
+    given c: Fraction = [Domain.Rational.Fraction(top = 3, bottom = 6), Domain.Rational.Fraction(top = -3, bottom = 6)]
+    when b.bottom > 0
+    when Domain.Rational.sameValue(a, b)
+    when Domain.Rational.sameValue(b, c)
+    because (a.top * c.bottom) * b.bottom == (c.top * a.bottom) * b.bottom
+    because Domain.RoundScale.cancelProduct(a.top * c.bottom, c.top * a.bottom, b.bottom)
+    using [Domain.RoundScale.cancelProduct.positiveFactor]
+    sameValueThrough(a, b, c) holds
+
+verify sameValueThrough
+    sameValueThrough(Domain.Rational.Fraction(top = 1, bottom = 2), Domain.Rational.Fraction(top = 2, bottom = 4), Domain.Rational.Fraction(top = 3, bottom = 6)) => true
+    sameValueThrough(Domain.Rational.Fraction(top = 1, bottom = 1), Domain.Rational.Fraction(top = 0, bottom = 0), Domain.Rational.Fraction(top = 2, bottom = 1)) => false

--- a/src/codegen/lean/toplevel/verify.rs
+++ b/src/codegen/lean/toplevel/verify.rs
@@ -1953,7 +1953,14 @@ pub(crate) fn law_as_lemma_statement(
         && crate::codegen::common::all_givens_are_singletons(law)
         && crate::codegen::common::law_rhs_is_independent_of_givens(law);
     let unclassified = crate::codegen::common::unclassified_fn_names(ctx);
-    if singleton_const_rhs || crate::codegen::common::law_calls_unclassified_fn(law, &unclassified)
+    // Guided laws are emitted as universal statements even when the automatic
+    // sample/fuel heuristics would skip one. Match that emission policy here:
+    // their examples do not restrict citation. A failed proof still propagates
+    // sorryAx through the ordinary transitive credit audit.
+    let guided = !law.because.is_empty() || law.using.is_some();
+    if !guided
+        && (singleton_const_rhs
+            || crate::codegen::common::law_calls_unclassified_fn(law, &unclassified))
     {
         return None;
     }

--- a/src/main/cli.rs
+++ b/src/main/cli.rs
@@ -706,7 +706,8 @@ pub(super) enum Commands {
         /// remaining premises where supported. Check mode only; Lean backend only. JSON adds
         /// `explanations` keyed by law/step. Checker limits are distinguished
         /// from unproved statements; technical output is saved in
-        /// proof_backend.log (citation probes: proof_citations.log).
+        /// proof_backend.log (citation probes: proof_citations.log;
+        /// unavailable helper suggestions: proof_candidates.log).
         /// Existing `open_goals` / manifest `open_goal`
         /// residuals remain available. Laws without because may require an
         /// additional isolated diagnostic build. Explanations never change

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -8558,6 +8558,7 @@ fn run_proof_check(
     // probe artifact is never mistaken for the failing law.
     let mut probe_of: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
+    let mut candidate_goals = None;
     if explain
         && matches!(backend, super::cli::ProofBackend::Lean)
         && output.status.success()
@@ -8582,9 +8583,12 @@ fn run_proof_check(
         let open: Vec<(String, String)> = emitted_main_law_theorems(output_dir)
             .into_iter()
             .filter(|(label, _)| !closed_universal.contains(label.as_str()))
-            // A because law has independently checked source steps. Probing its
-            // final composition theorem adds no explanation of a failed step.
-            .filter(|(label, _)| !proof_sources.is_some_and(|sources| sources.has_reasons(label)))
+            // Only source law identities can receive pasteable suggestions.
+            // Because steps have their own report; generated helper theorems
+            // must never become phantom source laws through the legacy scan.
+            .filter(|(label, _)| {
+                proof_sources.is_none_or(|sources| sources.accepts_residual_suggestion(label))
+            })
             .collect();
         open_goals = lean_residual_goals(output_dir, &open);
         // Attribute residuals to the law that ACTUALLY failed. A proven law
@@ -8626,13 +8630,7 @@ fn run_proof_check(
         // Skipped under `--check-json` so the JSON bytes are unaffected.
         if !check_json {
             let goal_json = lean_goal_json(output_dir, &open);
-            render_explain_candidates(
-                &open,
-                &goal_json,
-                source_items,
-                source_file,
-                source_module_root,
-            );
+            candidate_goals = Some((open, goal_json));
         }
     }
     // `--allow-mathlib` per-law credit (Lean only): tag each law `core` /
@@ -8862,6 +8860,17 @@ fn run_proof_check(
         // diagnostics; we already parsed counts above.
         if explain && matches!(backend, super::cli::ProofBackend::Lean) {
             proof_explain::render(&proof_reports);
+            if let Some((open, goal_json)) = &candidate_goals {
+                let suggestions = proof_explain::render_candidates(
+                    open,
+                    goal_json,
+                    source_items,
+                    source_file,
+                    source_module_root,
+                    output_dir,
+                );
+                print!("{suggestions}");
+            }
         } else {
             print!("{}", stdout);
             eprint!("{}", stderr);
@@ -10238,6 +10247,7 @@ fn emitted_main_law_theorems(dir: &str) -> Vec<(String, String)> {
     };
     let entry_file_name = format!("{entry_root}.lean");
     let mut labels: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut obligations = std::collections::HashSet::new();
     let mut thms: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     if let Ok(rd) = std::fs::read_dir(dir) {
@@ -10260,6 +10270,15 @@ fn emitted_main_law_theorems(dir: &str) -> Vec<(String, String)> {
                 } else if trimmed == "end" || trimmed.starts_with("end ") {
                     namespace_depth = namespace_depth.saturating_sub(1);
                 }
+                if namespace_depth > 1 {
+                    continue;
+                }
+                if let Some(rest) = line.strip_prefix(lean_codegen::LAW_OBLIGATION_MARKER_PREFIX) {
+                    if let Some(theorem) = rest.split_whitespace().next() {
+                        obligations.insert(theorem.to_string());
+                    }
+                    continue;
+                }
                 if let Some(rest) = line.strip_prefix(lean_codegen::LAW_CLASS_MARKER_PREFIX) {
                     let mut parts = rest.split_whitespace();
                     if let (Some(thm), Some(_class)) = (parts.next(), parts.next())
@@ -10267,9 +10286,6 @@ fn emitted_main_law_theorems(dir: &str) -> Vec<(String, String)> {
                     {
                         labels.insert(thm.to_string(), label.to_string());
                     }
-                    continue;
-                }
-                if namespace_depth > 1 {
                     continue;
                 }
                 if let Some(rest) = line.strip_prefix("theorem ") {
@@ -10286,6 +10302,7 @@ fn emitted_main_law_theorems(dir: &str) -> Vec<(String, String)> {
         }
     }
     thms.into_iter()
+        .filter(|thm| !obligations.contains(thm))
         .map(|thm| {
             let label = manifest_label_for(&thm, &labels);
             (label, thm)
@@ -10687,225 +10704,6 @@ enum SampleVerdict {
     /// Aver, or the premise never held on the sample domain) — an engine-form
     /// gap, honestly declined rather than shown as a candidate.
     Gap(String),
-}
-
-/// `aver proof --explain` Aver-space renderer (Lean-only, console). For each
-/// open law with a dumped residual goal: un-translate it back to Aver, and print
-/// EITHER a candidate `law` skeleton gated through the VM sample-check (passed →
-/// add-and-cite; failed → counterexample) OR an honest engine-form-gap verdict.
-/// The agent/user surface is AVER-ONLY here — the raw Lean residual stays in the
-/// internal `open_goal` channel. Pure console output: never affects tiers /
-/// credit / `passed` / the exit code.
-fn render_explain_candidates(
-    open_laws: &[(String, String)],
-    goal_json: &std::collections::BTreeMap<String, GoalDump>,
-    items: &[aver::ast::TopLevel],
-    file: &str,
-    module_root: &str,
-) {
-    use aver::codegen::lean::lemma_calc::{self, CalcVerdict};
-    use aver::codegen::lean::untranslate::{peano_ctx_for_law, untranslate_goal_ctx};
-    use colored::Colorize;
-    if open_laws.is_empty() {
-        return;
-    }
-    // The lemma calculator reads program facts (constructor names, fn return
-    // types) as data; build it once for the whole render.
-    let calc_env = lemma_calc::CalcEnv::from_items(items);
-    println!();
-    println!("{}", "--explain: candidate Aver laws for open goals".bold());
-    // Every OPEN law gets at least one verdict — a law whose residual could not be
-    // extracted (no arm dumped a goal) is reported as an engine-form gap, never
-    // silently skipped. A law's split residual yields several branch goals: each
-    // becomes a candidate, deduped by source; a branch outside the grammar records
-    // its decline reason so a law with no in-grammar branch still gets one honest
-    // gap verdict.
-    for (label, _thm) in open_laws {
-        let Some(dump) = goal_json.get(label) else {
-            println!(
-                "  {label}: {}",
-                "residual not extractable (engine-form gap)".yellow()
-            );
-            continue;
-        };
-        // `fn.law`: the law name is the final segment, the fn everything before.
-        let (fn_name, law_name) = match label.rsplit_once('.') {
-            Some((f, l)) => (f, l),
-            None => ("", label.as_str()),
-        };
-        // Thread a Peano context so a law over a canonical-Peano ADT inverts the
-        // transpiler's `Nat`-lift (`Succ x → x + 1`) back to the ADT's
-        // constructors; a non-Peano law gets the default (pre-V2) behavior.
-        let ctx = peano_ctx_for_law(items, fn_name, law_name);
-        // A calculated lemma is named `_calc` and rendered "calculated law"; a raw
-        // #630 residual fallback keeps `_residual` and "candidate law". The names
-        // must agree with the block the sample-check keys its verdict on.
-        let calc_law_name = format!("{law_name}_calc");
-        let residual_law_name = format!("{law_name}_residual");
-        // The parent law's given names: the fresh lifted variables must dedup
-        // against them (the candidate builder resolves givens by name against the
-        // parent, so a colliding lift clones the wrong domain — name capture).
-        let mut parent_givens: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for it in items {
-            if let aver::ast::TopLevel::Verify(vb) = it
-                && vb.fn_name == fn_name
-                && let aver::ast::VerifyKind::Law(l) = &vb.kind
-                && l.name == law_name
-            {
-                for g in &l.givens {
-                    parent_givens.insert(g.name.clone());
-                }
-            }
-        }
-        // A split residual yields several branch goals. Each becomes a candidate,
-        // deduped by source; the sample-check partitions them. We surface every
-        // branch that PASSES (a forced lemma — prop_73 legitimately yields one per
-        // branch), and fall back to a single honest negative (counterexample, then
-        // gap) only when no branch passes. A branch outside the grammar records its
-        // decline reason so a law with no in-grammar branch still gets a verdict.
-        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-        let mut passed: Vec<(String, bool)> = Vec::new();
-        let mut first_fail: Option<(String, String)> = None;
-        let mut first_gap: Option<String> = None;
-        let mut decline: Option<String> = None;
-        for json in &dump.jsons {
-            let goal = match untranslate_goal_ctx(json, &ctx) {
-                Ok(g) => g,
-                Err(gap) => {
-                    first_gap.get_or_insert(gap.reason);
-                    continue;
-                }
-            };
-            // Prefer the calculator's forced lemma when it sample-checks; else
-            // fall back to the raw residual candidate. The calculator only ever
-            // ADDS a stronger lemma — it never downgrades a raw candidate that
-            // would have passed, so a Lemma that fails the VM defers to the raw.
-            // A `Decline` is an honest verdict of its own: record its reason so it
-            // is surfaced before the fallback, never silently dropped.
-            let mut chosen: Option<(String, SampleVerdict, bool)> = None;
-            match lemma_calc::calculate(&goal, &calc_env, &parent_givens) {
-                CalcVerdict::Lemma(g) => {
-                    if let Ok(src) = build_candidate_law(
-                        fn_name,
-                        law_name,
-                        &calc_law_name,
-                        *g,
-                        items,
-                        ctx.peano.as_ref(),
-                    ) {
-                        let verdict = sample_check_candidate(
-                            &src,
-                            fn_name,
-                            &calc_law_name,
-                            file,
-                            module_root,
-                        );
-                        if matches!(verdict, SampleVerdict::Pass) {
-                            chosen = Some((src, verdict, true));
-                        }
-                    }
-                }
-                CalcVerdict::Decline(reason) => {
-                    decline.get_or_insert(reason);
-                }
-            }
-            let (src, verdict, calculated) = match chosen {
-                Some(c) => c,
-                None => {
-                    let src = match build_candidate_law(
-                        fn_name,
-                        law_name,
-                        &residual_law_name,
-                        goal,
-                        items,
-                        ctx.peano.as_ref(),
-                    ) {
-                        Ok(s) => s,
-                        Err(reason) => {
-                            first_gap.get_or_insert(reason);
-                            continue;
-                        }
-                    };
-                    let verdict = sample_check_candidate(
-                        &src,
-                        fn_name,
-                        &residual_law_name,
-                        file,
-                        module_root,
-                    );
-                    (src, verdict, false)
-                }
-            };
-            if !seen.insert(src.clone()) {
-                continue; // alpha-equivalent branch already accounted for
-            }
-            match verdict {
-                SampleVerdict::Pass => passed.push((src, calculated)),
-                SampleVerdict::Fail { counterexample } => {
-                    first_fail.get_or_insert((counterexample, src));
-                }
-                SampleVerdict::Gap(reason) => {
-                    first_gap.get_or_insert(reason);
-                }
-            }
-        }
-        // The fourth verdict form: an honest calculator decline. Surface its reason
-        // BEFORE the raw fallback candidate it deferred to, so the reason the lemma
-        // was not forced is never silently discarded.
-        if let Some(reason) = &decline {
-            println!(
-                "  {label}: {}",
-                format!("not a forced lemma — {reason}").yellow()
-            );
-        }
-        if !passed.is_empty() {
-            for (src, calculated) in &passed {
-                let head = if *calculated {
-                    "calculated law — sample-check passed, add it and cite:"
-                } else {
-                    "candidate law — sample-check passed, add it and cite:"
-                };
-                println!("  {label}: {}", head.green());
-                // A calculated block is machine-produced, so stamp its
-                // provenance directly above the pasteable `verify …`: when the
-                // user pastes it and it proves, `--check` records the value in
-                // the new law's manifest entry (see `PROVENANCE_MARKER_PREFIX`).
-                // `from=` points back at the stuck law this was calculated from.
-                if *calculated {
-                    println!(
-                        "      {PROVENANCE_MARKER_PREFIX}calculated from={label} tool=explain"
-                    );
-                }
-                for line in src.lines() {
-                    println!("      {line}");
-                }
-            }
-        } else if let Some((counterexample, src)) = first_fail {
-            println!(
-                "  {label}: {}",
-                "law false as stated — sample-check counterexample:".red()
-            );
-            println!("      {counterexample}");
-            for line in src.lines() {
-                println!("      {line}");
-            }
-        } else {
-            let reason = first_gap.unwrap_or_else(|| "no residual branch in grammar".to_string());
-            println!(
-                "  {label}: {}",
-                format!("engine-form gap — {reason}").yellow()
-            );
-        }
-        // The multi-arm caveat applies to any verdict — a single-branch candidate
-        // may not close a many-branch law whether it passed, failed, or gapped.
-        if dump.multi_arm {
-            println!(
-                "      {}",
-                "(the law has more than one open branch — a candidate may not close it alone)"
-                    .yellow()
-            );
-        }
-    }
 }
 
 /// Build a candidate Aver `law` source from an un-translated residual goal:

--- a/src/main/proof_explain/backend.rs
+++ b/src/main/proof_explain/backend.rs
@@ -20,6 +20,16 @@ pub(super) fn failures(dir: &str, output: &str) -> Failures {
     let mut result = Failures::default();
     let lines: Vec<_> = output.lines().collect();
     for (index, line) in lines.iter().enumerate() {
+        if let Some(claim) = line
+            .split_once("AVER_REASON_OPEN:")
+            .and_then(|(_, detail)| detail.strip_suffix(":dependency has no available theorem"))
+        {
+            result.claims.entry(claim.to_string()).or_insert(Failure {
+                status: "citation_unavailable",
+                message: "A selected law could not be made available for citation at this step.",
+            });
+            continue;
+        }
         if !line.trim_start().starts_with("error:") {
             continue;
         }

--- a/src/main/proof_explain/candidates.rs
+++ b/src/main/proof_explain/candidates.rs
@@ -1,0 +1,322 @@
+//! Optional helper-law suggestions follow source proof reports. Failed inverse
+//! translations belong in the diagnostic log, not the proof author's console.
+use super::super::{
+    GoalDump, PROVENANCE_MARKER_PREFIX, SampleVerdict, build_candidate_law, sample_check_candidate,
+};
+
+/// `aver proof --explain` Aver-space renderer (Lean-only, console). For each
+/// open law with a dumped residual goal: un-translate it back to Aver, and print
+/// a candidate `law` skeleton gated through the VM sample-check (passed →
+/// add-and-cite; failed → counterexample). Technical declines are logged.
+/// The agent/user surface is AVER-ONLY here — the raw Lean residual stays in the
+/// internal `open_goal` channel. Pure console output: never affects tiers /
+/// credit / `passed` / the exit code.
+pub(crate) fn render(
+    open_laws: &[(String, String)],
+    goal_json: &std::collections::BTreeMap<String, GoalDump>,
+    items: &[aver::ast::TopLevel],
+    file: &str,
+    module_root: &str,
+    output_dir: &str,
+) -> String {
+    use aver::codegen::lean::lemma_calc::{self, CalcVerdict};
+    use aver::codegen::lean::untranslate::{peano_ctx_for_law, untranslate_goal_ctx};
+    use colored::Colorize;
+    use std::fmt::Write;
+    if open_laws.is_empty() {
+        return String::new();
+    }
+    // The lemma calculator reads program facts (constructor names, fn return
+    // types) as data; build it once for the whole render.
+    let calc_env = lemma_calc::CalcEnv::from_items(items);
+    let mut rendered = String::new();
+    let mut technical = String::new();
+    let mut showed_header = false;
+    // Every open law gets a suggestion or a diagnostic log entry. A law's split
+    // residual yields several branch goals: each
+    // becomes a candidate, deduped by source; a branch outside the grammar records
+    // its decline reason so a law with no in-grammar branch still gets one honest
+    // gap verdict.
+    for (label, _thm) in open_laws {
+        let Some(dump) = goal_json.get(label) else {
+            let _ = writeln!(
+                technical,
+                "{label}: residual not extractable (engine-form gap)"
+            );
+            continue;
+        };
+        // `fn.law`: the law name is the final segment, the fn everything before.
+        let (fn_name, law_name) = match label.rsplit_once('.') {
+            Some((f, l)) => (f, l),
+            None => ("", label.as_str()),
+        };
+        // Thread a Peano context so a law over a canonical-Peano ADT inverts the
+        // transpiler's `Nat`-lift (`Succ x → x + 1`) back to the ADT's
+        // constructors; a non-Peano law gets the default (pre-V2) behavior.
+        let ctx = peano_ctx_for_law(items, fn_name, law_name);
+        // A calculated lemma is named `_calc` and rendered "calculated law"; a raw
+        // #630 residual fallback keeps `_residual` and "candidate law". The names
+        // must agree with the block the sample-check keys its verdict on.
+        let calc_law_name = format!("{law_name}_calc");
+        let residual_law_name = format!("{law_name}_residual");
+        // The parent law's given names: the fresh lifted variables must dedup
+        // against them (the candidate builder resolves givens by name against the
+        // parent, so a colliding lift clones the wrong domain — name capture).
+        let mut parent_givens: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for it in items {
+            if let aver::ast::TopLevel::Verify(vb) = it
+                && vb.fn_name == fn_name
+                && let aver::ast::VerifyKind::Law(l) = &vb.kind
+                && l.name == law_name
+            {
+                for g in &l.givens {
+                    parent_givens.insert(g.name.clone());
+                }
+            }
+        }
+        // A split residual yields several branch goals. Each becomes a candidate,
+        // deduped by source; the sample-check partitions them. We surface every
+        // branch that PASSES (a forced lemma — prop_73 legitimately yields one per
+        // branch), and fall back to a single honest negative (counterexample, then
+        // gap) only when no branch passes. A branch outside the grammar records its
+        // decline reason so a law with no in-grammar branch still gets a verdict.
+        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut passed: Vec<(String, bool)> = Vec::new();
+        let mut first_fail: Option<(String, String)> = None;
+        let mut gaps = Vec::new();
+        let mut decline: Option<String> = None;
+        for json in &dump.jsons {
+            let goal = match untranslate_goal_ctx(json, &ctx) {
+                Ok(g) => g,
+                Err(gap) => {
+                    gaps.push(gap.reason);
+                    continue;
+                }
+            };
+            // Prefer the calculator's forced lemma when it sample-checks; else
+            // fall back to the raw residual candidate. The calculator only ever
+            // ADDS a stronger lemma — it never downgrades a raw candidate that
+            // would have passed, so a Lemma that fails the VM defers to the raw.
+            // A `Decline` is an honest verdict of its own: record its reason so it
+            // is surfaced before the fallback, never silently dropped.
+            let mut chosen: Option<(String, SampleVerdict, bool)> = None;
+            match lemma_calc::calculate(&goal, &calc_env, &parent_givens) {
+                CalcVerdict::Lemma(g) => {
+                    if let Ok(src) = build_candidate_law(
+                        fn_name,
+                        law_name,
+                        &calc_law_name,
+                        *g,
+                        items,
+                        ctx.peano.as_ref(),
+                    ) {
+                        let verdict = sample_check_candidate(
+                            &src,
+                            fn_name,
+                            &calc_law_name,
+                            file,
+                            module_root,
+                        );
+                        if matches!(verdict, SampleVerdict::Pass) {
+                            chosen = Some((src, verdict, true));
+                        }
+                    }
+                }
+                CalcVerdict::Decline(reason) => {
+                    decline.get_or_insert(reason);
+                }
+            }
+            let (src, verdict, calculated) = match chosen {
+                Some(c) => c,
+                None => {
+                    let src = match build_candidate_law(
+                        fn_name,
+                        law_name,
+                        &residual_law_name,
+                        goal,
+                        items,
+                        ctx.peano.as_ref(),
+                    ) {
+                        Ok(s) => s,
+                        Err(reason) => {
+                            gaps.push(reason);
+                            continue;
+                        }
+                    };
+                    let verdict = sample_check_candidate(
+                        &src,
+                        fn_name,
+                        &residual_law_name,
+                        file,
+                        module_root,
+                    );
+                    (src, verdict, false)
+                }
+            };
+            if !seen.insert(src.clone()) {
+                continue; // alpha-equivalent branch already accounted for
+            }
+            match verdict {
+                SampleVerdict::Pass => passed.push((src, calculated)),
+                SampleVerdict::Fail { counterexample } => {
+                    first_fail.get_or_insert((counterexample, src));
+                }
+                SampleVerdict::Gap(reason) => {
+                    gaps.push(reason);
+                }
+            }
+        }
+        // Preserve calculator declines in the log even when the raw residual
+        // fallback succeeds; only usable source suggestions belong on stdout.
+        if let Some(reason) = &decline {
+            let _ = writeln!(technical, "{label}: not a forced lemma — {reason}");
+        }
+        let has_candidate = !passed.is_empty() || first_fail.is_some();
+        if has_candidate && !showed_header {
+            let _ = writeln!(
+                rendered,
+                "\n{}",
+                "--explain: candidate Aver laws for open goals".bold()
+            );
+            showed_header = true;
+        }
+        if !passed.is_empty() {
+            for (src, calculated) in &passed {
+                let head = if *calculated {
+                    "calculated law — sample-check passed, add it and cite:"
+                } else {
+                    "candidate law — sample-check passed, add it and cite:"
+                };
+                let _ = writeln!(rendered, "  {label}: {}", head.green());
+                // A calculated block is machine-produced, so stamp its
+                // provenance directly above the pasteable `verify …`: when the
+                // user pastes it and it proves, `--check` records the value in
+                // the new law's manifest entry (see `PROVENANCE_MARKER_PREFIX`).
+                // `from=` points back at the stuck law this was calculated from.
+                if *calculated {
+                    let _ = writeln!(
+                        rendered,
+                        "      {PROVENANCE_MARKER_PREFIX}calculated from={label} tool=explain"
+                    );
+                }
+                for line in src.lines() {
+                    let _ = writeln!(rendered, "      {line}");
+                }
+            }
+        } else if let Some((counterexample, src)) = first_fail {
+            let _ = writeln!(
+                rendered,
+                "  {label}: {}",
+                "candidate law failed its sample-check:".red()
+            );
+            let _ = writeln!(rendered, "      {counterexample}");
+            for line in src.lines() {
+                let _ = writeln!(rendered, "      {line}");
+            }
+        }
+        if !has_candidate && gaps.is_empty() {
+            gaps.push("no residual branch in grammar".to_string());
+        }
+        // A usable branch must not hide another branch's translation failure.
+        for reason in gaps {
+            let _ = writeln!(technical, "{label}: engine-form gap — {reason}");
+        }
+        // The multi-arm caveat applies to any verdict — a single-branch candidate
+        // may not close a many-branch law whether it passed, failed, or gapped.
+        if has_candidate && dump.multi_arm {
+            let _ = writeln!(
+                rendered,
+                "      {}",
+                "(the law has more than one open branch — a candidate may not close it alone)"
+                    .yellow()
+            );
+        }
+    }
+    let log = std::path::Path::new(output_dir).join("proof_candidates.log");
+    let saved = std::fs::write(log, &technical).is_ok();
+    if !technical.is_empty() {
+        if saved {
+            let _ = writeln!(
+                rendered,
+                "  Some helper suggestions are unavailable; details are in proof_candidates.log."
+            );
+        } else {
+            let _ = writeln!(
+                rendered,
+                "  Some helper suggestions are unavailable; their diagnostic log could not be written."
+            );
+        }
+    }
+    rendered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_helper_suggestions_keep_their_reason_in_a_dedicated_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = render(
+            &[("f.open".into(), "f_law_open".into())],
+            &Default::default(),
+            &[],
+            "unused.av",
+            ".",
+            dir.path().to_str().unwrap(),
+        );
+        let log = std::fs::read_to_string(dir.path().join("proof_candidates.log")).unwrap();
+        assert!(log.contains("f.open: residual not extractable (engine-form gap)"));
+        assert!(output.contains("Some helper suggestions are unavailable"));
+        assert!(!output.contains("engine-form gap"));
+        assert!(!output.contains("residual not extractable"));
+        assert!(!output.contains("candidate Aver laws for open goals"));
+    }
+
+    #[test]
+    fn usable_candidates_and_their_counterexamples_remain_visible() {
+        use serde_json::json;
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("source.av");
+        let source = "fn f(x: Int) -> Int\n    x\nverify f law identity\n    given x: Int = [0, 1]\n    f(x) => x\n";
+        std::fs::write(&file, source).unwrap();
+        let items = aver::source::parse_source(source).unwrap();
+        for (rhs, passes) in [(json!({"var": "x"}), true), (json!({"nat": "7"}), false)] {
+            let goal = json!({"forall": {"name": "x", "ty": {"const": "Int"}, "body": {"app": {"fn": {"const": "Eq"}, "args": [{"const": "Int"}, {"var": "x"}, rhs]}}}});
+            let dump = GoalDump {
+                jsons: vec![
+                    json!({"opaque": "unsupported residual"}).to_string(),
+                    goal.to_string(),
+                ],
+                multi_arm: true,
+            };
+            let goals = std::collections::BTreeMap::from([("f.identity".into(), dump)]);
+            let output = render(
+                &[("f.identity".into(), "f_law_identity".into())],
+                &goals,
+                &items,
+                file.to_str().unwrap(),
+                dir.path().to_str().unwrap(),
+                dir.path().to_str().unwrap(),
+            );
+            let expected = if passes {
+                "sample-check passed, add it and cite"
+            } else {
+                "candidate law failed its sample-check"
+            };
+            assert!(output.contains(expected), "{output}");
+            assert!(
+                output.contains("verify f law identity_residual"),
+                "{output}"
+            );
+            assert!(!output.contains("engine-form gap"), "{output}");
+            let log = std::fs::read_to_string(dir.path().join("proof_candidates.log")).unwrap();
+            assert!(log.contains("f.identity: engine-form gap"), "{log}");
+            assert!(output.contains("more than one open branch"), "{output}");
+            assert!(
+                !output.contains("law false as stated"),
+                "a helper failure is not a parent-law counterexample: {output}"
+            );
+        }
+    }
+}

--- a/src/main/proof_explain/mod.rs
+++ b/src/main/proof_explain/mod.rs
@@ -3,9 +3,12 @@
 
 mod attempt_report;
 mod backend;
+mod candidates;
 mod display;
 mod probe;
 mod source;
+
+pub(super) use candidates::render as render_candidates;
 
 pub(super) fn attach_citation_attempts(
     dir: &str,

--- a/src/main/proof_explain/mod.rs
+++ b/src/main/proof_explain/mod.rs
@@ -133,6 +133,8 @@ pub(super) fn collect(
             "Report the checker error at this source step, with proof_backend.log from the output directory. The error does not identify a missing mathematical premise."
         } else if failure.status == "checker_limit" {
             "Split this step into smaller because expressions or a helper law; the checker did not finish the current proof."
+        } else if failure.status == "citation_unavailable" {
+            "Check that each selected law can be cited at this step. If the cited laws are already universally checked, report this diagnostic with proof_backend.log."
         } else if reason.is_none() && !law.body.because.is_empty() {
             "Connect the earlier because statements to the final claim. A proved intermediate statement does not by itself establish this implication."
         } else if citations

--- a/src/main/proof_explain/source.rs
+++ b/src/main/proof_explain/source.rs
@@ -56,9 +56,10 @@ impl Catalog {
         catalog
     }
 
-    pub(crate) fn has_reasons(&self, identity: &str) -> bool {
-        self.claim(identity)
-            .is_some_and(|(law, _)| !law.body.because.is_empty())
+    pub(crate) fn accepts_residual_suggestion(&self, identity: &str) -> bool {
+        self.laws
+            .get(identity)
+            .is_some_and(|law| law.body.because.is_empty())
     }
 
     pub(super) fn add(&mut self, block: &VerifyBlock, scope: Option<&str>, file: &str) {

--- a/src/main/proof_explain/tests.rs
+++ b/src/main/proof_explain/tests.rs
@@ -1,6 +1,28 @@
 use super::*;
 use aver::ast::TopLevel;
 
+#[test]
+fn residual_candidates_exclude_marked_proof_steps_without_name_guessing() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("lakefile.lean"),
+        "lean_lib Entry where\n  roots := #[`Entry]\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("Entry.lean"), "namespace Entry\n-- aver:law-class f_law_plain universal f.plain\ntheorem f_law_plain : True := by trivial\n-- aver:law-obligation ordinary_law_step universal f.reason.because1\ntheorem ordinary_law_step : True := by trivial\n-- aver:law-class __aver_reason_legitimate_law_name universal f.legitimate\ntheorem __aver_reason_legitimate_law_name : True := by trivial\nnamespace Helpers\n-- aver:law-obligation f_law_plain universal nested.reason.because1\ntheorem f_law_plain : True := by trivial\n-- aver:law-class __aver_reason_legitimate_law_name universal nested.name\ntheorem __aver_reason_legitimate_law_name : True := by trivial\nend Helpers\nend Entry\n").unwrap();
+    let actual = super::super::emitted_main_law_theorems(dir.path().to_str().unwrap());
+    assert_eq!(
+        actual,
+        vec![
+            ("f.plain".into(), "f_law_plain".into()),
+            (
+                "f.legitimate".into(),
+                "__aver_reason_legitimate_law_name".into()
+            )
+        ]
+    );
+}
+
 fn catalog(source: &str, scope: Option<&str>, file: &str) -> Catalog {
     let mut catalog = Catalog::default();
     for item in aver::source::parse_source(source).unwrap() {
@@ -9,6 +31,22 @@ fn catalog(source: &str, scope: Option<&str>, file: &str) -> Catalog {
         }
     }
     catalog
+}
+
+#[test]
+fn helper_suggestions_require_a_source_law_without_explicit_reasons() {
+    let source = "fn f(x: Int) -> Int\n    x\nverify f law plain\n    given x: Int = [1]\n    f(x) => x\nverify f law steps\n    given x: Int = [1]\n    because x > 0\n    f(x) => x\n";
+    let catalog = catalog(source, None, "source.av");
+    assert!(catalog.accepts_residual_suggestion("f.plain"));
+    for identity in [
+        "f.steps",
+        "f.steps.because1",
+        "f.steps.implication",
+        "__aver_reason_f_law_steps_because1",
+        "unknown_law",
+    ] {
+        assert!(!catalog.accepts_residual_suggestion(identity), "{identity}");
+    }
 }
 
 #[test]

--- a/src/main/proof_explain/tests.rs
+++ b/src/main/proof_explain/tests.rs
@@ -50,6 +50,34 @@ fn helper_suggestions_require_a_source_law_without_explicit_reasons() {
 }
 
 #[test]
+fn unavailable_citations_are_not_reported_as_missing_mathematical_premises() {
+    let source = "fn f(x: Int) -> Int\n    x\nverify f law chain\n    given x: Int = [1]\n    because x == x\n    using []\n    f(x) => x\n";
+    let catalog = catalog(source, None, "source.av");
+    let reports = collect(
+        &catalog,
+        None,
+        &["f.chain.because1".into()],
+        "unused",
+        "info: Entry.lean:8:2: AVER_REASON_OPEN:f.chain.because1:dependency has no available theorem\n",
+    );
+    let report = &reports["f.chain.because1"];
+    assert_eq!(report["status"], "citation_unavailable");
+    assert_eq!(report["goal"], "x == x");
+    assert!(
+        report["next"]
+            .as_str()
+            .unwrap()
+            .contains("already universally checked")
+    );
+    assert!(
+        !report["next"]
+            .as_str()
+            .unwrap()
+            .contains("missing intermediate fact")
+    );
+}
+
+#[test]
 fn explanations_show_only_earlier_reasons_and_instantiated_requirements() {
     let source = include_str!("../../../tests/fixtures/law_reason_constant_citation.av");
     let catalog = catalog(source, None, "source.av");

--- a/tests/fixtures/law_reason_singleton_citation/lib.av
+++ b/tests/fixtures/law_reason_singleton_citation/lib.av
@@ -1,0 +1,37 @@
+module Lib
+    exposes [Bounds, inRange, positive]
+    intent = "Singleton examples do not restrict guided universal statements."
+    effects []
+
+record Bounds
+    lower: Int
+
+fn inRange(bounds: Bounds, n: Int) -> Bool
+    match n > bounds.lower
+        true -> n + 1 > bounds.lower + 1
+        false -> false
+
+verify inRange law explained
+    given bounds: Bounds = [Bounds(lower = 0)]
+    given n: Int = [1]
+    when n > bounds.lower
+    because n + 1 > bounds.lower + 1
+    using []
+    inRange(bounds, n) holds
+
+verify inRange law citedOnly
+    given bounds: Bounds = [Bounds(lower = 0)]
+    given n: Int = [1]
+    when n > bounds.lower
+    using [inRange.explained]
+    inRange(bounds, n) holds
+
+fn positive(n: Int) -> Bool
+    n > 0
+
+// The sample passes; the universal statement and its callers must fail.
+verify positive law falseUniversal
+    given n: Int = [1]
+    because n > 0
+    using []
+    positive(n) holds

--- a/tests/fixtures/law_reason_singleton_citation/main.av
+++ b/tests/fixtures/law_reason_singleton_citation/main.av
@@ -1,0 +1,41 @@
+module SingletonCitation
+    depends [Lib]
+    intent = "Imported guided singleton laws remain citable without granting false proof credit."
+    effects []
+
+fn identity(n: Int) -> Int
+    n
+
+verify identity law same
+    given n: Int = [0, 1]
+    using []
+    identity(n) => n
+
+fn checked(n: Int) -> Bool
+    Lib.inRange(Lib.Bounds(lower = 0), n)
+
+verify checked law explainedHelper
+    given n: Int = [1, 2]
+    when n >= 1
+    because identity(n) == n
+    because Lib.inRange(Lib.Bounds(lower = 0), n)
+    using [identity.same, Lib.inRange.explained]
+    checked(n) holds
+
+verify checked law usingOnlyHelper
+    given n: Int = [1, 2]
+    when n >= 1
+    because identity(n) == n
+    because Lib.inRange(Lib.Bounds(lower = 0), n)
+    using [identity.same, Lib.inRange.citedOnly]
+    checked(n) holds
+
+fn asserted(n: Int) -> Bool
+    Lib.positive(n)
+
+verify asserted law taintedHelper
+    given n: Int = [1, 2]
+    because identity(n) == n
+    because Lib.positive(n)
+    using [identity.same, Lib.positive.falseUniversal]
+    asserted(n) holds

--- a/tests/proof_spec/k5_sticky.rs
+++ b/tests/proof_spec/k5_sticky.rs
@@ -39,7 +39,7 @@ fn k5_sticky_composition_has_universal_source_proofs() {
 }
 
 #[test]
-fn k5_fraction_exponent_and_truncation_agree_with_the_normalized_model() {
+fn k5_fraction_exponent_and_rounding_agree_with_the_normalized_model() {
     if Command::new("lake").arg("--version").output().is_err() {
         return;
     }
@@ -123,7 +123,35 @@ fn k5_fraction_exponent_and_truncation_agree_with_the_normalized_model() {
         ("truncationFormula.knownExponent", 0),
         ("modelTruncation.normalizedModel", 9),
         ("sameTruncation.normalizedModel", 4),
+        ("Domain.RoundScale.cancelProduct.positiveFactor", 1),
+        ("Domain.RoundScale.scaledExactness.positiveScale", 1),
+        ("Domain.RoundScale.remainderQuotient.smallRemainder", 1),
+        ("Domain.RoundScale.ceilingExact.exactQuotient", 1),
+        ("Domain.RoundScale.ceilingInexact.strictRemainder", 1),
+        ("Domain.RoundScale.ceilingFromWindow.euclideanWindow", 1),
+        ("Domain.RoundScale.scaledCeiling.positiveScale", 5),
+        ("Domain.AwayModel.normalizedValue.carryPreservesValue", 3),
+        ("Domain.AwayModel.rawValuePositive.positivePrecision", 3),
+        ("Domain.AwayModel.transferredValue.sameRawValue", 4),
+        ("Domain.ValueChain.sameValueThrough.positiveMiddle", 2),
+        ("awayFormula.knownExponent", 0),
+        ("modelCeiling.normalizedModel", 11),
+        ("modelAway.normalizedModel", 2),
+        ("modelAwayRaw.normalizedModel", 4),
+        ("sameAway.normalizedModel", 4),
+        ("stickyFormula.knownExponent", 0),
+        ("modelStickyHalf.normalizedModel", 6),
+        ("modelStickyExact.normalizedModel", 8),
+        ("modelSticky.normalizedModel", 6),
+        ("modelSticky.singleBit", 2),
+        ("modelSticky.positivePrecision", 1),
+        ("singleBitHalf.normalizedModel", 15),
+        ("sameSticky.normalizedModel", 4),
     ] {
+        assert!(
+            laws.iter().any(|claim| claim["law"] == law),
+            "missing source law {law}"
+        );
         for step in (1..=reasons)
             .map(|index| format!("{law}.because{index}"))
             .chain(std::iter::once(format!("{law}.implication")))
@@ -134,17 +162,17 @@ fn k5_fraction_exponent_and_truncation_agree_with_the_normalized_model() {
             );
         }
     }
-    // The checked result currently has 91 universal laws, four previously
-    // bounded laws, and 142 universal steps. Allow additions and promotions.
+    // The checked result currently has 115 universal laws, four previously
+    // bounded laws, and 252 universal steps. Allow additions and promotions.
     assert!(
-        laws.iter().filter(|law| law["tier"] == "universal").count() >= 91,
+        laws.iter().filter(|law| law["tier"] == "universal").count() >= 115,
         "{manifest}"
     );
     assert!(
         laws.iter().filter(|law| law["tier"] == "bounded").count() <= 4,
         "{manifest}"
     );
-    assert!(obligations.len() >= 142, "{manifest}");
+    assert!(obligations.len() >= 252, "{manifest}");
     for claim in laws
         .iter()
         .chain(manifest["obligations"].as_array().unwrap())

--- a/tests/proof_spec/law_reasons.rs
+++ b/tests/proof_spec/law_reasons.rs
@@ -595,3 +595,68 @@ fn explain_locates_private_imported_steps_and_marks_failed_previous_reasons() {
     assert_eq!(report["assumptions"][0]["status"], "failed");
     let _ = std::fs::remove_dir_all(dir);
 }
+
+#[test]
+fn guided_singleton_helpers_remain_citable_without_laundering_false_claims() {
+    if Command::new("lake").arg("--version").output().is_err() {
+        return;
+    }
+    let dir = temp_output_dir("aver-guided-singleton-citation");
+    let (summary, run) = run_lean_check_json_with_args(
+        "tests/fixtures/law_reason_singleton_citation/main.av",
+        &dir,
+        0,
+        &[],
+        &[
+            "--module-root",
+            "tests/fixtures/law_reason_singleton_citation",
+        ],
+    );
+    assert!(!run.status.success(), "the false helper must fail the gate");
+    assert_eq!(summary["build_errors"], 0, "{}", format_output(&run));
+    assert_eq!(summary["bounded_laws"], 0, "{summary}");
+    assert_eq!(summary["universal_laws"], 5, "{summary}");
+    for law in ["checked.explainedHelper", "checked.usingOnlyHelper"] {
+        for step in ["because1", "because2", "implication"] {
+            assert_eq!(
+                summary["obligations"][format!("{law}.{step}")],
+                "universal",
+                "{summary}"
+            );
+        }
+    }
+    // A cited false theorem may taint even a trivially true sibling step when
+    // its local fact remains in the proof term. Never require clean credit in
+    // that context; the false conclusion must retain the failed dependency.
+    assert_eq!(
+        summary["obligations"]["asserted.taintedHelper.because2"], "failed",
+        "{summary}"
+    );
+    let manifest: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dir.join("proof_manifest.json")).unwrap())
+            .unwrap();
+    let law_record = |id: &str| {
+        manifest["laws"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|law| law["law"] == id)
+            .unwrap()
+    };
+    for id in ["Lib.inRange.explained", "Lib.inRange.citedOnly"] {
+        assert_eq!(law_record(id)["tier"], "universal", "{manifest}");
+    }
+    for id in ["Lib.positive.falseUniversal", "asserted.taintedHelper"] {
+        let law = law_record(id);
+        assert_eq!(law["tier"], "failed", "{law}");
+        assert!(
+            law["axioms"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|axiom| axiom == "sorryAx"),
+            "statement admission must preserve transitive failed proof credit: {law}"
+        );
+    }
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/tests/proof_spec/law_reasons.rs
+++ b/tests/proof_spec/law_reasons.rs
@@ -547,7 +547,17 @@ fn explain_reports_source_requirements_without_changing_proof_credit() {
     assert!(output.contains("[closed in probe] 0 <= a"), "{output}");
     assert!(output.contains("[open in probe] 0 <= b"), "{output}");
     assert!(output.contains("when a >= 0 [assumed]"), "{output}");
-    for technical in ["AVER_REASON_OPEN:", "⊢", ".lean:", "simp only", "case "] {
+    for technical in [
+        "AVER_REASON_OPEN:",
+        "⊢",
+        ".lean:",
+        "simp only",
+        "case ",
+        "__aver_reason_",
+        "residual not extractable",
+        "engine-form gap",
+        "candidate Aver laws for open goals",
+    ] {
         assert!(
             !output.contains(technical),
             "raw backend state leaked: {output}"


### PR DESCRIPTION
Guided laws with singleton example domains could be emitted and checked universally, then rejected when another law cited them. One rejected dependency discarded the entire explicit citation set. Match citation admission to guided theorem emission, retain transitive failed-proof auditing, and report unavailable citations at the Aver source step.

K5 now proves that executable Fraction away-from-zero and sticky rounding agree with the normalized Fp model for `isFp(f)`, `width >= 1`, and `n >= 1`. This includes both signs, all integer exponents, carry normalization, precision widening, and one-bit sticky rounding. Generic integer ceiling/exactness laws and positive-denominator equality composition support the bridges. The complete divider theorem remains open.

`--explain` shows the source proof report before helper suggestions, excludes generated obligations from the helper search, and keeps unavailable branch details in `proof_candidates.log`. Candidate counterexamples describe the candidate's failure without claiming to refute its parent law.

Validation:

- Kernel and imports: 115 universal laws, the same 4 bounded laws, all 252 obligations universal, zero sorries/build errors. All 95 previous laws and 142 previous obligations retain their tiers and axiom sets.
- VM: 5213 passing cases; WASM: 5211, with the same two existing unanswered cases and unchanged budgets. No runtime failures.
- 1621 unit tests passed (one existing ignored); 33 proof-reason integration tests passed, including imported guided singleton citations and false-claim propagation.
- The singleton fixture reproduces unavailable healthy citations before the fix; its healthy consumers pass afterward while false claims retain `sorryAx`.
- K5 regression tests pin every new law and proof step. Formatting and compiler Clippy checks pass.

Proof arguments were authored in Aver. Diagnosing the citation-admission inconsistency required compiler work; guided proof portability to Dafny remains open.
