### PR TITLE
Share proof analysis and expand Dafny proofs on unchanged BTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **Dafny induction follows source recursion through ProofIR.** Guarded integer descent now takes precedence over a growing list accumulator. Ordinary laws and universal citation lemmas carry actual recursive accumulator updates; list and string padding get a shared remaining-length measure consumed by Lean and Dafny. Checked sequence identities close countdown and fold composition examples without additional source proof steps or assumptions.
+
 - **Empty lists take their element type from the other side of equality.** `items == []` and `[] != items` now preserve the checked element type, including nested lists and tuple literals. This reuses the expected-type inference already used for `Option.None`, preventing generated Rust from comparing `AverIntList` with an unresolved generic list.
 
 - **Empty-list equality samples keep their declared element types in Lean.** Imported laws could emit `[] == []` without the `List<Int>` or nested list type supplied by `given`, failing before the proof ran. Equality and inequality now preserve that type when both literals lack an element witness, including comparisons in `when` guards.

--- a/docs/dafny-guidance-spike.md
+++ b/docs/dafny-guidance-spike.md
@@ -418,3 +418,41 @@ counterexample into a quantifier-search timeout.
 Nine of the ten previously omitted ordinary `StackItem.littleEndian` laws
 now check on unchanged BTC source. The readback law and several separate
 citation obligations remain open, so this does not establish the whole module.
+
+
+## Ordinary citation reuse checkpoint
+
+A guided citation of an ordinary source law keeps its checked universal
+restatement, including every given and its `when` premise. When the ordinary
+emitter supplies the same universal signature, that restatement now calls the
+original lemma. It no longer has to reproduce a proof that relied on earlier
+ordinary decomposition laws. Both the original lemma and its caller remain
+obligations in the full checker run.
+
+Availability uses the canonical function cone already carried by ProofIR,
+the emitted recursion boundaries, and the existing signature gate. Finite-Int
+mutual laws, opaque dependencies, omitted laws and specialized signatures do
+not gain universal credit from this reuse. Their citation restatements still
+need independent universal proofs. Ordinary native sequence universals may be
+reused. The backend-specific call decision does not change Lean's proof tactics.
+
+The ordinary decomposition pool now comes from the declaring module's source
+order, even for imported suppliers. It contains only earlier ordinary laws;
+entry-module laws and guided consumers cannot introduce a dependency cycle.
+Owner qualification also keeps an imported lemma distinct from a same-named
+local law.
+
+The independent decimal fixture has nine laws, checked universally from the
+same source by Lean and Dafny. Before reuse its two guided citation suppliers
+failed Dafny verification although all seven ordinary laws passed. Controls
+cover forward citations, an omitted premise, a false unused supplier whose
+samples pass, and an imported false supplier alongside colliding local names. A finite-Int
+law over native mutual lookup remains bounded: its samples pass but its false
+universal citation fails. An ordinary native sequence permutation, which does
+have a universal contract, can be reused successfully.
+
+On unchanged BTC, `StackItem` drops from 15 errors to 6, with four solver
+timeouts still open. `ScriptState` including its imports drops from 22 errors
+to 7; its solver timeouts change from two to four. Strict whole-module credit
+remains 23/104 (`Message` 10, `CompactSize` 6, `ScriptMath` 7). Fewer duplicate
+citation failures do not by themselves establish additional whole modules.

--- a/docs/dafny-guidance-spike.md
+++ b/docs/dafny-guidance-spike.md
@@ -331,3 +331,21 @@ imported functions beside colliding local names, and Bool sequence reversal.
 Missing bounds, false intermediate steps and false unused suppliers all fail
 actual Dafny checking. The remaining BTC modules still have open proofs or
 unsupported operations; this checkpoint does not establish full BTC or K5.
+
+## Sequence composition checkpoint
+
+All six `CompactSize` laws now pass with imports checked, bringing strict
+whole-module BTC coverage to **23/104**. No BTC source or claim changed.
+
+Dafny's checked sequence facts now also expose
+`([head] + prefix) + suffix == [head] + (prefix + suffix)`. This lets a parser's
+head/tail match connect to an already proved payload law at the complete suffix.
+The fact is proved for each concrete element type; it neither assumes a cited
+law nor changes an obligation. This is a Dafny automation hint over existing
+list semantics, so it needs no new source recognizer or ProofIR contract.
+
+An independent decimal framing fixture reproduces two open obligations before
+the change and passes afterwards. Bool and record payloads also check. Incorrect
+reordering of a trailing sequence passes the fixture's empty/singleton samples
+but fails universal verification, both as an intermediate reason and as the
+final claim. A false cited field law is rejected as well.

--- a/docs/dafny-guidance-spike.md
+++ b/docs/dafny-guidance-spike.md
@@ -305,3 +305,29 @@ Move a transformation into the common pipeline when both consumers can retain
 the same source semantics, and check the change with the same-source positive
 and negative controls. Do not require a broad ProofIR refactor to merge this
 validated structural checkpoint.
+
+## Fixed-count unfolding checkpoint
+
+The unchanged BTC `Message` module now passes all ten laws with its imports
+checked, including the 2/4/8-byte read-after-write laws. Strict whole-module
+BTC coverage rises from **7/104 to 17/104** (`Message` plus `ScriptMath`).
+
+ProofIR carries an optional unfolding budget for each `because` step and the
+final claim. It follows small literal arguments through direct forwarding
+wrappers to a checked integer countdown, and records the recursive function
+IDs and concrete sequence-reversal instances in that obligation's source cone.
+The initial strategy accepts Int/Bool givens and countdown literals up to 16;
+arbitrary sequence givens retain citation/induction search. Sample domains and
+range premises do not determine the budget or restrict universal quantifiers.
+
+Dafny renders these hints as local fuel attributes. It avoids introducing broad
+quantified citation facts into the same unfolding context, while still checking
+every cited supplier and every intermediate step. The original premises and
+claim remain unchanged. Lean retains its existing automation; the new ProofIR
+field is a search hint rather than a new semantic assumption.
+
+Regression controls use decimal and hexadecimal digits, widths 3 and 5,
+imported functions beside colliding local names, and Bool sequence reversal.
+Missing bounds, false intermediate steps and false unused suppliers all fail
+actual Dafny checking. The remaining BTC modules still have open proofs or
+unsupported operations; this checkpoint does not establish full BTC or K5.

--- a/docs/dafny-guidance-spike.md
+++ b/docs/dafny-guidance-spike.md
@@ -381,3 +381,40 @@ open obligations, so these four do not yet earn strict whole-module BTC credit.
 This checkpoint does not claim full Lean/Dafny strategy parity: the existing
 Lean ordinary-law lane still bounds one of the independent fixture's two laws,
 while Dafny proves both universally.
+
+## Native floor-division law checkpoint
+
+A checked floor-division recursion no longer makes every ordinary law in its
+cone sample-only. Dafny retains the specialized division-window strategy when
+available and otherwise checks the actual universal obligation. Failure to
+find a proof remains a failed check; native termination alone is not law credit.
+
+Shared source induction now accepts fixed literal arguments in the claim,
+such as the empty seed in `digits(value, [])`. It keeps that seed in the
+statement and recurses on the quantified inputs using the source call's actual
+quotient. A fully quantified anchor still takes priority when one is available.
+Sample values neither choose the seed nor restrict the theorem's quantifiers.
+
+ProofIR also carries the theorem premise instantiated at each recursive call.
+Dafny introduces any list-pattern projections before testing that premise; an
+IH is available only in the branch where its own premise holds. The original
+claim must still be proved in all other branches. Lean continues to consume
+the same source-induction plan with its own functional-induction tactics.
+
+The Dafny sequence-reversal helper now proves preservation of membership in
+addition to length. The quantified element ranges over the input/output union,
+so the contract also supports generic elements containing references. An
+explicit, checked cons decomposition proves the contract from the recursive
+implementation; no sequence property is assumed.
+
+An independent decimal collector has seven universal laws checked by both
+backends; the Dafny controls also use radix seven. Missing guards and an
+incorrect prefix order pass their supplied VM samples but fail universal
+checking. A separate list-accumulator control checks the scope of recursive
+premises in Dafny, which also rejects its false variant. Negative digit laws are
+isolated from unrelated true sibling citations to avoid turning a concrete
+counterexample into a quantifier-search timeout.
+
+Nine of the ten previously omitted ordinary `StackItem.littleEndian` laws
+now check on unchanged BTC source. The readback law and several separate
+citation obligations remain open, so this does not establish the whole module.

--- a/docs/dafny-guidance-spike.md
+++ b/docs/dafny-guidance-spike.md
@@ -349,3 +349,35 @@ the change and passes afterwards. Bool and record payloads also check. Incorrect
 reordering of a trailing sequence passes the fixture's empty/singleton samples
 but fails universal verification, both as an intermediate reason and as the
 final claim. A false cited field law is rejected as well.
+
+## Native mutual sequence laws and shared dependencies
+
+ProofIR now records each law's transitive statically resolved pure function
+cone, including explanations and the guard. Each function body is resolved in
+its owning module; cycles terminate on canonical function IDs, and sample
+expressions do not supply dependencies. Lean's guided equation selection and
+Dafny's ordinary-law unfolding both consume this field. Target equation
+eligibility, termination checks and solver tactics remain backend decisions.
+
+Dafny previously sent even native, termination-checked mutual recursion through
+the finite-sample fallback. Ordinary laws with a list binder now attempt their
+actual universal claim when the cone reaches native mutual recursion and no
+opaque function. Unfolding covers every cycle member, including helpers hidden
+behind wrappers. The moderate fuel setting is a search budget, not a limit on
+list length or quantified values. A checked assertion of the unchanged claim
+also exposes recursive Bool equalities that can remain opaque in an `ensures`
+alone. Unsupported signatures retain their existing
+exclusions; the legacy finite-Int lane remains separate.
+
+Sample assertions instantiate the checked universal theorem. That theorem does
+not call the samples, so a false universal cannot be rescued by a sample cycle.
+An independent permutation fixture checks Int and Bool elements and imported
+lookup functions alongside colliding local names. Incorrect order and omitted
+length/index guards pass the chosen samples but fail actual universal checking.
+
+All four unchanged BTC `ScriptState.rearranged` laws now check without their
+previous axiom fallbacks; their samples check too. Imported modules still have
+open obligations, so these four do not yet earn strict whole-module BTC credit.
+This checkpoint does not claim full Lean/Dafny strategy parity: the existing
+Lean ordinary-law lane still bounds one of the independent fixture's two laws,
+while Dafny proves both universally.

--- a/docs/dafny.md
+++ b/docs/dafny.md
@@ -114,6 +114,8 @@ an exact backend model. These boundaries differ from missing expression syntax.
 Recursive functions fall into three buckets based on the shared classifier in `codegen::recursion::detect`:
 
 **Direct-recursion patterns** — emitted as normal Dafny `function`s with inferred `decreases` clauses:
+- A shared, guarded subtractive countdown takes precedence over sequence-parameter heuristics: a byte accumulator may grow while its width decreases. Both backends consume the same `ProofIR` contract; no caller precondition is added.
+- A list growing under `List.len(xs) < bound`, with a stable integer bound and a statically nonempty prepend/append, uses `decreases bound - |xs|`. Lean uses the same difference converted to `Nat`. The same contract covers strings growing by a nonempty literal under `String.len(text) < bound`. Negative bounds and an append that overshoots the bound remain total.
 - List parameter → `decreases |xs|`
 - String parameter → `decreases |s|`
 - Int countdown (`match n { 0 -> …; _ -> recur(n-1, …) }`) → `requires n >= 0` + `decreases n`. Callers discharge the `requires` via Dafny's auto-inference from surrounding `if`/`match` shapes — `match (n < 0) { false -> worker(n) }` resolves to `n >= 0` automatically.
@@ -231,6 +233,20 @@ have no explicit literal domain (open-`Int` quantifier, oracle
 binding, etc.).
 
 ## Inductive lemma hints
+
+For simple list folds and guarded countdowns, `ProofIR` records the law's
+induction driver and the actual recursive arguments, including accumulator
+updates and extra law givens. Dafny uses those instances in ordinary laws and
+separately checked universal citation lemmas. A law comparing an arbitrary
+accumulator with an empty one receives both recursive instances. Each call must
+prove the original premises and a strict decrease; the plan supplies no axioms.
+Lean also consults the shared driver when choosing functional induction for a
+matching explanation. Unsupported source shapes retain the existing strategies.
+
+The Dafny proof bodies additionally check sequence identities needed to match
+singleton/empty concatenations and reversals. The list reverse helper has a
+checked length-preservation postcondition. See `tests/fixtures/source_recursion/`
+for positive, imported, and false-supplier controls exercised by both checkers.
 
 For `verify law` blocks with a single `given n: Int` where both sides use directly-recursive functions, the codegen generates inductive proof structure:
 

--- a/src/codegen/dafny/expr.rs
+++ b/src/codegen/dafny/expr.rs
@@ -110,6 +110,20 @@ pub fn aver_name_to_dafny(name: &str) -> String {
     crate::codegen::common::escape_reserved_word(&normalized, DAFNY_RESERVED, "_")
 }
 
+/// A declaration is bare in its owning Dafny module and qualified elsewhere.
+pub(super) fn function_name(id: crate::ir::FnId, ctx: &CodegenContext) -> String {
+    let key = &ctx.symbol_table.fn_entry(id).key;
+    let bare = aver_name_to_dafny(&key.name);
+    match key.scope_str() {
+        Some(prefix)
+            if !ctx.modules.is_empty() && ctx.active_module_scope().as_deref() != Some(prefix) =>
+        {
+            format!("{}.{bare}", super::dafny_module_name(prefix))
+        }
+        _ => bare,
+    }
+}
+
 /// Emit a Dafny expression from a resolved Aver expression.
 pub fn emit_expr(expr: &Spanned<ResolvedExpr>, ctx: &CodegenContext) -> String {
     match &expr.node {
@@ -543,9 +557,6 @@ fn emit_fn_call(
             }
         }
         ResolvedCallee::Fn(fn_id) => {
-            let entry = ctx.symbol_table.fn_entry(*fn_id);
-            let bare = entry.key.name.as_str();
-            let module_prefix = entry.key.scope_str();
             let arg_strs: Vec<String> = args.iter().map(|a| emit_expr(a, ctx)).collect();
             // A call to a fn in a DIFFERENT module is qualified with the
             // Dafny module name (`Aver_Domain_Rational.f`). A same-module
@@ -554,17 +565,7 @@ fn emit_fn_call(
             // self-qualification, so `M.f(...)` is an unresolved
             // identifier. Compare the callee's owning scope against the
             // module currently being emitted.
-            let active = ctx.active_module_scope();
-            let func = match module_prefix {
-                Some(prefix) if !ctx.modules.is_empty() && active.as_deref() != Some(prefix) => {
-                    format!(
-                        "{}.{}",
-                        super::dafny_module_name(prefix),
-                        aver_name_to_dafny(bare)
-                    )
-                }
-                _ => aver_name_to_dafny(bare),
-            };
+            let func = function_name(*fn_id, ctx);
             format!("{}({})", func, arg_strs.join(", "))
         }
         ResolvedCallee::LocalSlot { name, .. } => {

--- a/src/codegen/dafny/law_induction.rs
+++ b/src/codegen/dafny/law_induction.rs
@@ -1,0 +1,110 @@
+//! Render the shared source-recursion instances. Dafny checks the original law
+//! premises at every recursive call and verifies the selected strict decrease.
+
+use crate::ast::{VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+use crate::ir::proof_ir::{LawInduction, LawInductionMeasure};
+
+use super::expr::{aver_name_to_dafny, emit_expr};
+
+/// Checked sequence identities give the SMT solver ground-independent rewrite
+/// facts. In particular, recursive calls with `[x] + []` must match calls with
+/// `[x]`; unfolding the worker alone does not reliably expose this equality.
+pub(super) fn sequence_identities(law: &VerifyLaw, ctx: &CodegenContext) -> Vec<String> {
+    let mut elements = std::collections::BTreeSet::new();
+    let scope = ctx.active_module_scope();
+    for expr in [&law.lhs, &law.rhs].into_iter().chain(law.because.iter()) {
+        crate::codegen::expr_walk::walk(expr, &mut |e| {
+            if let Some(crate::ast::Type::List(element)) = e.ty()
+                && crate::types::checker::type_is_fully_concrete(element)
+            {
+                elements.insert(super::toplevel::type_to_dafny_in_scope(
+                    element,
+                    scope.as_deref(),
+                ));
+            }
+        });
+    }
+    elements
+        .into_iter()
+        .flat_map(|element| {
+            [
+                format!("  forall xs: seq<{element}> ensures xs + [] == xs && [] + xs == xs {{ }}"),
+                format!("  forall x: {element} ensures ListReverse([x]) == [x] {{ }}"),
+            ]
+        })
+        .collect()
+}
+
+pub(super) fn plan<'a>(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &'a CodegenContext,
+) -> Option<&'a LawInduction> {
+    let scope = ctx.active_module_scope();
+    let id = ctx
+        .symbol_table
+        .resolve_fn_id_in(&vb.fn_name, scope.as_deref())?;
+    ctx.proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_id == id && t.law_name == law.name)?
+        .induction
+        .as_ref()
+}
+
+pub(super) fn measure(plan: &LawInduction) -> String {
+    let name = aver_name_to_dafny(&plan.driver);
+    match plan.measure {
+        LawInductionMeasure::SequenceLength => format!("|{name}|"),
+        LawInductionMeasure::NonnegativeInt => format!("if {name} >= 0 then {name} else 0"),
+    }
+}
+
+pub(super) fn calls(plan: &LawInduction, name: &str, ctx: &CodegenContext) -> Vec<String> {
+    let mut lines = Vec::new();
+    for call in &plan.calls {
+        lines.push(format!("  if {} {{", emit_expr(&call.guard, ctx)));
+        if let Some(case) = &call.list_case {
+            let list = emit_expr(&case.list, ctx);
+            if let Some(head) = &case.head {
+                lines.push(format!(
+                    "    var {} := ({list})[0];",
+                    aver_name_to_dafny(head)
+                ));
+            }
+            if let Some(tail) = &case.tail {
+                lines.push(format!(
+                    "    var {} := ({list})[1..];",
+                    aver_name_to_dafny(tail)
+                ));
+            }
+            // Expose the exact nil/cons equation used by source recursion.
+            lines.push(format!(
+                "    assert {list} == [({list})[0]] + ({list})[1..];"
+            ));
+            if let Some(ty) = case.list.ty() {
+                let ty = super::toplevel::type_to_dafny_in_scope(
+                    ty,
+                    ctx.active_module_scope().as_deref(),
+                );
+                let mut suffix = "averInductionSuffix".to_string();
+                while list.contains(&suffix) {
+                    suffix.push('_');
+                }
+                // Expose the cons equation underneath append too. The target
+                // checker proves this sequence identity for every suffix.
+                lines.push(format!("    forall {suffix}: {ty} ensures {list} + {suffix} == [({list})[0]] + (({list})[1..] + {suffix}) {{ }}"));
+            }
+        }
+        let args = call
+            .arguments
+            .iter()
+            .map(|a| emit_expr(a, ctx))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(format!("    {name}({args});"));
+        lines.push("  }".to_string());
+    }
+    lines
+}

--- a/src/codegen/dafny/law_induction.rs
+++ b/src/codegen/dafny/law_induction.rs
@@ -107,7 +107,13 @@ pub(super) fn calls(plan: &LawInduction, name: &str, ctx: &CodegenContext) -> Ve
             .map(|a| emit_expr(a, ctx))
             .collect::<Vec<_>>()
             .join(", ");
-        lines.push(format!("    {name}({args});"));
+        if let Some(premise) = &call.premise {
+            lines.push(format!("    if {} {{", emit_expr(premise, ctx)));
+            lines.push(format!("      {name}({args});"));
+            lines.push("    }".to_string());
+        } else {
+            lines.push(format!("    {name}({args});"));
+        }
         lines.push("  }".to_string());
     }
     lines

--- a/src/codegen/dafny/law_induction.rs
+++ b/src/codegen/dafny/law_induction.rs
@@ -10,6 +10,9 @@ use super::expr::{aver_name_to_dafny, emit_expr};
 /// Checked sequence identities give the SMT solver ground-independent rewrite
 /// facts. In particular, recursive calls with `[x] + []` must match calls with
 /// `[x]`; unfolding the worker alone does not reliably expose this equality.
+/// A consumer matching the first element also needs append reassociated under
+/// that cons. Explicitly checking the identity exposes the suffix term at which
+/// a cited payload law applies; it does not assume anything about the payload.
 pub(super) fn sequence_identities(law: &VerifyLaw, ctx: &CodegenContext) -> Vec<String> {
     let mut elements = std::collections::BTreeSet::new();
     let scope = ctx.active_module_scope();
@@ -31,6 +34,7 @@ pub(super) fn sequence_identities(law: &VerifyLaw, ctx: &CodegenContext) -> Vec<
             [
                 format!("  forall xs: seq<{element}> ensures xs + [] == xs && [] + xs == xs {{ }}"),
                 format!("  forall x: {element} ensures ListReverse([x]) == [x] {{ }}"),
+                format!("  forall head: {element}, xs: seq<{element}>, ys: seq<{element}> ensures ([head] + xs) + ys == [head] + (xs + ys) {{ }}"),
             ]
         })
         .collect()

--- a/src/codegen/dafny/law_search.rs
+++ b/src/codegen/dafny/law_search.rs
@@ -6,6 +6,44 @@ use crate::codegen::CodegenContext;
 use crate::ir::FnId;
 use std::collections::HashSet;
 
+/// The ordinary emitter's default universal has exactly the source givens
+/// and `when`. A guided citation may call it, but must not promote a sampled
+/// contract, an opaque dependency or a specialized support-stack signature.
+/// The caller has already checked the entire source citation with `subset`.
+/// Ordinary automatic citations only point to earlier ordinary laws in their
+/// declaring module, so reusing one cannot create a cycle through guidance.
+pub(super) fn reusable_ordinary_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    recursion: &super::toplevel::LawRecursion<'_>,
+) -> bool {
+    let Some(theorem) = ctx.law_target_fn_id(&vb.fn_name).and_then(|id| {
+        ctx.proof_ir
+            .law_theorems
+            .iter()
+            .find(|t| t.fn_id == id && t.law_name == law.name)
+    }) else {
+        return false;
+    };
+    super::toplevel::sample_seed_lemma_available(vb, law, ctx)
+        && !crate::codegen::common::law_lhs_has_trace_projection(&law.lhs)
+        && crate::codegen::common::law_map_order_refusal(vb, law, ctx).is_none()
+        && !matches!(
+            theorem.strategy,
+            crate::ir::ProofStrategy::TailRecFixedBaseFold { .. }
+                | crate::ir::ProofStrategy::FloorDivWindow { .. }
+        )
+        && !theorem.function_cone.iter().any(|id| {
+            recursion.opaque_fns.contains(id) || recursion.termination_opaque.contains(id)
+        })
+        && (!theorem
+            .function_cone
+            .iter()
+            .any(|id| recursion.native_callers.contains(id))
+            || native_sequence_law(vb, law, ctx, recursion.opaque_fns, recursion.native_callers))
+}
+
 fn cone<'a>(vb: &VerifyBlock, law: &VerifyLaw, ctx: &'a CodegenContext) -> &'a [FnId] {
     ctx.law_target_fn_id(&vb.fn_name)
         .and_then(|id| {

--- a/src/codegen/dafny/law_search.rs
+++ b/src/codegen/dafny/law_search.rs
@@ -1,0 +1,67 @@
+//! Target search over the shared source cone. Budgets affect automation only;
+//! admitting an ordinary universal still requires Dafny to check its full claim.
+
+use crate::ast::{Type, VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+use crate::ir::FnId;
+use std::collections::HashSet;
+
+fn cone<'a>(vb: &VerifyBlock, law: &VerifyLaw, ctx: &'a CodegenContext) -> &'a [FnId] {
+    ctx.law_target_fn_id(&vb.fn_name)
+        .and_then(|id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == id && t.law_name == law.name)
+        })
+        .map(|t| t.function_cone.as_slice())
+        .unwrap_or(&[])
+}
+
+/// A list binder makes this disjoint from the legacy finite-Int lane: the
+/// universal never dispatches back to samples which call it. Keep oracle,
+/// refinement and specialized-signature exclusions in the shared seed gate.
+pub(super) fn native_sequence_law(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    opaque: &HashSet<FnId>,
+    native: &HashSet<FnId>,
+) -> bool {
+    law.because.is_empty()
+        && law.using.is_none()
+        && law
+            .givens
+            .iter()
+            .any(|g| matches!(crate::types::parse_type_str(&g.type_name), Type::List(_)))
+        && super::toplevel::sample_seed_lemma_available(vb, law, ctx)
+        && cone(vb, law, ctx).iter().any(|id| native.contains(id))
+        && !cone(vb, law, ctx).iter().any(|id| opaque.contains(id))
+}
+
+pub(super) fn attributes(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+    native_sequence: bool,
+    native: &HashSet<FnId>,
+) -> String {
+    cone(vb, law, ctx)
+        .iter()
+        .map(|id| {
+            // Moderate unfolding of every checked cycle member, including peers
+            // hidden behind wrappers. This is a solver budget, never an input bound.
+            let depth = if native_sequence && native.contains(id) && ctx.recursive_fns.contains(id)
+            {
+                12
+            } else {
+                5
+            };
+            format!(
+                "{{:fuel {}, {depth}}}",
+                super::expr::function_name(*id, ctx)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -8,6 +8,7 @@ mod crypto;
 mod expr;
 mod fuel;
 mod law_induction;
+mod law_search;
 mod lemmas;
 mod propagation;
 mod reasons;

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -7,6 +7,7 @@ mod crypto;
 /// file holding the trust header, top-level items, and verify lemmas.
 mod expr;
 mod fuel;
+mod law_induction;
 mod lemmas;
 mod propagation;
 mod reasons;
@@ -890,6 +891,7 @@ function BranchPath_parse(s: string): Result<BranchPath, string> {
 /// match wins, and `ListAny` is the existential, false on the empty list.
 const DAFNY_HELPER_AVER_LIST: &str = r#"
 function ListReverse<T>(xs: seq<T>): seq<T>
+  ensures |ListReverse(xs)| == |xs|
   decreases |xs|
 {
   if |xs| == 0 then []
@@ -1516,6 +1518,28 @@ verify roll law alwaysSix\n    given rnd: Random.int = [rollMax]\n    roll() => 
             "expected underscore-form call; got:\n{}",
             dfy
         );
+    }
+
+    #[test]
+    fn shared_countdown_measure_wins_over_a_growing_sequence_accumulator() {
+        let ctx = ctx_from_source(
+            r#"module Countdown
+    intent = "The counter, not the growing output, drives termination."
+fn bytes(value: Int, width: Int, acc: List<Int>) -> List<Int>
+    match width <= 0
+        true -> List.reverse(acc)
+        false -> bytes(Int.div(value, 256), width - 1, List.prepend(Int.mod(value, 256), acc))
+"#,
+            "Countdown",
+        );
+        let out = transpile(&ctx);
+        let dfy = dafny_output(&out);
+        assert!(
+            dfy.contains("decreases if width >= 0 then width else 0"),
+            "{dfy}"
+        );
+        assert!(!dfy.contains("decreases |acc|"), "{dfy}");
+        assert!(!dfy.contains("requires width"), "{dfy}");
     }
 
     #[test]

--- a/src/codegen/dafny/mod.rs
+++ b/src/codegen/dafny/mod.rs
@@ -890,13 +890,17 @@ function BranchPath_parse(s: string): Result<BranchPath, string> {
 /// signature. They mirror Lean's model of the same two builtins
 /// (`codegen::lean::builtins` renders `xs.find? p` and `xs.any p`): first
 /// match wins, and `ListAny` is the existential, false on the empty list.
+/// Reversal's membership contract quantifies over the finite input/output
+/// union, so generic elements containing references remain admissible. Its
+/// cons assertion proves the contract from the definition, including absence.
 const DAFNY_HELPER_AVER_LIST: &str = r#"
 function ListReverse<T>(xs: seq<T>): seq<T>
   ensures |ListReverse(xs)| == |xs|
+  ensures forall item | item in xs + ListReverse(xs) :: item in ListReverse(xs) <==> item in xs
   decreases |xs|
 {
   if |xs| == 0 then []
-  else ListReverse(xs[1..]) + [xs[0]]
+  else assert xs == [xs[0]] + xs[1..]; ListReverse(xs[1..]) + [xs[0]]
 }
 
 function ListHead<T>(xs: seq<T>): Option<T> {

--- a/src/codegen/dafny/reasons.rs
+++ b/src/codegen/dafny/reasons.rs
@@ -14,6 +14,7 @@ mod induction;
 mod subset;
 #[cfg(test)]
 mod tests;
+mod unfolding;
 
 fn label(vb: &VerifyBlock, law: &VerifyLaw) -> String {
     format!("{}.{}", vb.fn_name, law.name)
@@ -207,6 +208,11 @@ pub(super) fn emit(
             None => vec![&law.lhs, &law.rhs],
         };
         let driver = induction_driver(&source_expressions, law, ctx);
+        let unfolding = if driver.is_none() {
+            unfolding::attributes(vb, law, index, ctx)
+        } else {
+            None
+        };
         let has_induction = driver.is_some();
         let list_induction = driver
             .as_ref()
@@ -215,7 +221,11 @@ pub(super) fn emit(
             "// aver:dafny-obligation {step_name} {source_id}.{step}"
         ));
         out.push(format!(
-            "lemma {{:induction {}}} {step_name}({params})",
+            "lemma {}{{:induction {}}} {step_name}({params})",
+            unfolding
+                .as_ref()
+                .map(|attrs| format!("{attrs} "))
+                .unwrap_or_default(),
             driver
                 .as_ref()
                 .map(|driver| driver.variables.as_str())
@@ -232,8 +242,12 @@ pub(super) fn emit(
             out.push(format!("  decreases {}", driver.decreases));
         }
         out.push("{".to_string());
-        out.extend(super::law_induction::sequence_identities(law, ctx));
-        for &citation in &citations {
+        if unfolding.is_none() {
+            out.extend(super::law_induction::sequence_identities(law, ctx));
+        }
+        // Suppliers were validated and emitted above even when this obligation
+        // can close directly by unfolding. No `using` declaration is trusted.
+        for &citation in citations.iter().filter(|_| unfolding.is_none()) {
             let dependency = citation.law;
             let cited_name = citations::supplier_name(citation, &name, ctx);
             // The forall range retains the supplier's guard. Calling its

--- a/src/codegen/dafny/reasons.rs
+++ b/src/codegen/dafny/reasons.rs
@@ -232,6 +232,7 @@ pub(super) fn emit(
             out.push(format!("  decreases {}", driver.decreases));
         }
         out.push("{".to_string());
+        out.extend(super::law_induction::sequence_identities(law, ctx));
         for &citation in &citations {
             let dependency = citation.law;
             let cited_name = citations::supplier_name(citation, &name, ctx);

--- a/src/codegen/dafny/reasons.rs
+++ b/src/codegen/dafny/reasons.rs
@@ -27,7 +27,7 @@ fn lemma_name(id: &str) -> String {
     format!("averGuided_{encoded}")
 }
 
-fn local_blocks(ctx: &CodegenContext) -> Vec<&VerifyBlock> {
+pub(super) fn local_blocks(ctx: &CodegenContext) -> Vec<&VerifyBlock> {
     match ctx.active_module_scope().as_deref() {
         Some(scope) => ctx
             .modules
@@ -174,10 +174,10 @@ pub(super) fn emit(
     vb: &VerifyBlock,
     law: &VerifyLaw,
     ctx: &CodegenContext,
-    native_members: &std::collections::HashSet<crate::ir::FnId>,
+    recursion: &super::toplevel::LawRecursion<'_>,
 ) -> Result<String, String> {
     let blocks = local_blocks(ctx);
-    let citations = subset::validate(vb, law, ctx, &blocks, native_members)?;
+    let citations = subset::validate(vb, law, ctx, &blocks, recursion.native_members)?;
     let id = label(vb, law);
     let name = lemma_name(&id);
     let source_id = match ctx.active_module_scope() {
@@ -191,7 +191,7 @@ pub(super) fn emit(
     let goal = conclusion(law, ctx);
     let mut out = Vec::new();
     for &citation in &citations {
-        if let Some(supplier) = citations::plain_supplier(citation, &name, law, ctx)? {
+        if let Some(supplier) = citations::plain_supplier(citation, &name, law, ctx, recursion)? {
             out.push(supplier);
         }
     }

--- a/src/codegen/dafny/reasons/builtins.rs
+++ b/src/codegen/dafny/reasons/builtins.rs
@@ -156,7 +156,14 @@ mod tests {
         let crate::ast::VerifyKind::Law(law) = &block.kind else {
             panic!("expected a law");
         };
-        reasons::emit(block, law, &ctx, &HashSet::new())
+        let empty = HashSet::new();
+        let recursion = crate::codegen::dafny::toplevel::LawRecursion {
+            opaque_fns: &empty,
+            native_members: &empty,
+            native_callers: &empty,
+            termination_opaque: &empty,
+        };
+        reasons::emit(block, law, &ctx, &recursion)
     }
 
     #[test]

--- a/src/codegen/dafny/reasons/citations.rs
+++ b/src/codegen/dafny/reasons/citations.rs
@@ -182,8 +182,9 @@ pub(super) fn conclusion(citation: Citation<'_>, ctx: &CodegenContext) -> String
 }
 
 /// Plain source laws keep their original backend strategy. A selected plain
-/// supplier also gets a separately checked universal restatement in its caller;
-/// no finite-domain or opaque legacy lemma is trusted as a universal contract.
+/// supplier also gets a checked universal restatement in its caller. When the
+/// ordinary emitter supplies the same universal contract, the restatement calls
+/// it; finite-domain and opaque legacy lemmas must still be proved afresh.
 pub(super) fn supplier_name(citation: Citation<'_>, parent: &str, ctx: &CodegenContext) -> String {
     if citation.law.using.is_some() || !citation.law.because.is_empty() {
         return call_name(citation, ctx);
@@ -203,6 +204,7 @@ pub(super) fn plain_supplier(
     parent: &str,
     consumer: &VerifyLaw,
     ctx: &CodegenContext,
+    recursion: &super::super::toplevel::LawRecursion<'_>,
 ) -> Result<Option<String>, String> {
     if citation.law.using.is_some() || !citation.law.because.is_empty() {
         return Ok(None);
@@ -232,9 +234,19 @@ pub(super) fn plain_supplier(
     }
     let params = binders(citation, ctx)?;
     let goal = conclusion(citation, ctx);
-    let induction = ctx.with_module_scope(citation.scope, || {
-        super::super::law_induction::plan(citation.block, citation.law, ctx)
+    let reuse = ctx.with_module_scope(citation.scope, || {
+        super::super::law_search::reusable_ordinary_law(
+            citation.block,
+            citation.law,
+            ctx,
+            recursion,
+        )
     });
+    let induction = ctx
+        .with_module_scope(citation.scope, || {
+            super::super::law_induction::plan(citation.block, citation.law, ctx)
+        })
+        .filter(|_| !reuse);
     let mut lines = vec![
         format!(
             "// Checked universal citation: {}",
@@ -256,15 +268,30 @@ pub(super) fn plain_supplier(
         ));
     }
     lines.push("{".to_string());
-    ctx.with_module_scope(citation.scope, || {
-        lines.extend(super::super::law_induction::sequence_identities(
-            citation.law,
-            ctx,
-        ));
-        if let Some(plan) = induction {
-            lines.extend(super::super::law_induction::calls(plan, &name, ctx));
-        }
-    });
+    if reuse {
+        let ordinary = format!(
+            "{}_{}",
+            super::super::expr::aver_name_to_dafny(&citation.block.fn_name),
+            super::super::expr::aver_name_to_dafny(&citation.law.name),
+        );
+        let ordinary = match citation.scope {
+            Some(owner) if Some(owner) != ctx.active_module_scope().as_deref() => {
+                format!("Aver_{}.{}", owner.replace('.', "_"), ordinary)
+            }
+            _ => ordinary,
+        };
+        lines.push(format!("  {ordinary}({});", super::arguments(citation.law)));
+    } else {
+        ctx.with_module_scope(citation.scope, || {
+            lines.extend(super::super::law_induction::sequence_identities(
+                citation.law,
+                ctx,
+            ));
+            if let Some(plan) = induction {
+                lines.extend(super::super::law_induction::calls(plan, &name, ctx));
+            }
+        });
+    }
     lines.extend([format!("  assert {goal};"), "}".to_string()]);
     Ok(Some(lines.join("\n")))
 }

--- a/src/codegen/dafny/reasons/citations.rs
+++ b/src/codegen/dafny/reasons/citations.rs
@@ -232,6 +232,9 @@ pub(super) fn plain_supplier(
     }
     let params = binders(citation, ctx)?;
     let goal = conclusion(citation, ctx);
+    let induction = ctx.with_module_scope(citation.scope, || {
+        super::super::law_induction::plan(citation.block, citation.law, ctx)
+    });
     let mut lines = vec![
         format!(
             "// Checked universal citation: {}",
@@ -245,11 +248,23 @@ pub(super) fn plain_supplier(
             expression(guard, citation.scope, ctx)
         ));
     }
-    lines.extend([
-        format!("  ensures {goal}"),
-        "{".to_string(),
-        format!("  assert {goal};"),
-        "}".to_string(),
-    ]);
+    lines.push(format!("  ensures {goal}"));
+    if let Some(plan) = induction {
+        lines.push(format!(
+            "  decreases {}",
+            super::super::law_induction::measure(plan)
+        ));
+    }
+    lines.push("{".to_string());
+    ctx.with_module_scope(citation.scope, || {
+        lines.extend(super::super::law_induction::sequence_identities(
+            citation.law,
+            ctx,
+        ));
+        if let Some(plan) = induction {
+            lines.extend(super::super::law_induction::calls(plan, &name, ctx));
+        }
+    });
+    lines.extend([format!("  assert {goal};"), "}".to_string()]);
     Ok(Some(lines.join("\n")))
 }

--- a/src/codegen/dafny/reasons/refinement_tests.rs
+++ b/src/codegen/dafny/reasons/refinement_tests.rs
@@ -14,7 +14,14 @@ fn emit(ctx: &CodegenContext) -> Result<String, String> {
     let crate::ast::VerifyKind::Law(law) = &block.kind else {
         panic!("expected law");
     };
-    reasons::emit(block, law, ctx, &HashSet::new())
+    let empty = HashSet::new();
+    let recursion = crate::codegen::dafny::toplevel::LawRecursion {
+        opaque_fns: &empty,
+        native_members: &empty,
+        native_callers: &empty,
+        termination_opaque: &empty,
+    };
+    reasons::emit(block, law, ctx, &recursion)
 }
 
 #[test]

--- a/src/codegen/dafny/reasons/subset.rs
+++ b/src/codegen/dafny/reasons/subset.rs
@@ -277,6 +277,11 @@ impl<'a> Checker<'a> {
                 && countdown_parameter(fd, ctx).is_none()
                 && list_parameter(fd, ctx).is_none()
                 && super::arithmetic::quotient_parameter(fd, ctx).is_none()
+                && !matches!(
+                    crate::codegen::common::find_fn_contract_for_fn(ctx, fd)
+                        .and_then(|c| c.recursion.as_ref()),
+                    Some(crate::ir::RecursionContract::WellFoundedSequenceGap { .. })
+                )
             {
                 return Err(format!(
                     "recursive function {} requires checked Int or List descent",

--- a/src/codegen/dafny/reasons/tests.rs
+++ b/src/codegen/dafny/reasons/tests.rs
@@ -12,7 +12,14 @@ fn emitted(source: &str, wanted: &str) -> Result<String, String> {
             _ => None,
         })
         .expect("fixture law");
-    emit(block, law, &ctx, &std::collections::HashSet::new())
+    let empty = std::collections::HashSet::new();
+    let recursion = super::super::toplevel::LawRecursion {
+        opaque_fns: &empty,
+        native_members: &empty,
+        native_callers: &empty,
+        termination_opaque: &empty,
+    };
+    emit(block, law, &ctx, &recursion)
 }
 
 const POSITIVE: &str = r#"fn positive(x: Int) -> Bool
@@ -61,7 +68,14 @@ fn mutual_admission_requires_every_native_member_and_checks_its_body() {
         let VerifyKind::Law(law) = &block.kind else {
             panic!("expected law");
         };
-        let result = emit(block, law, &ctx, &native);
+        let empty = std::collections::HashSet::new();
+        let recursion = super::super::toplevel::LawRecursion {
+            opaque_fns: &empty,
+            native_members: &native,
+            native_callers: &native,
+            termination_opaque: &empty,
+        };
+        let result = emit(block, law, &ctx, &recursion);
         assert_eq!(result.is_ok(), admitted, "{native_names:?}: {result:?}");
         if unsupported {
             assert!(result.unwrap_err().contains("String.byteLength"));

--- a/src/codegen/dafny/reasons/unfolding.rs
+++ b/src/codegen/dafny/reasons/unfolding.rs
@@ -1,0 +1,41 @@
+//! Render an obligation-local search budget from shared ProofIR. Keeping
+//! universal citation lifts out of this context prevents their quantified
+//! calls from multiplying the cost of deeper recursive unfolding.
+
+use crate::ast::{VerifyBlock, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+pub(super) fn attributes(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    index: usize,
+    ctx: &CodegenContext,
+) -> Option<String> {
+    let id = ctx.law_target_fn_id(&vb.fn_name)?;
+    let plan = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_id == id && t.law_name == law.name)?
+        .unfolding
+        .get(index)?
+        .as_ref()?;
+    let mut targets: Vec<_> = plan
+        .functions
+        .iter()
+        .map(|id| super::super::expr::function_name(*id, ctx))
+        .collect();
+    targets.extend(plan.reverse_elements.iter().map(|t| {
+        format!(
+            "ListReverse<{}>",
+            super::super::toplevel::type_to_dafny_in_scope(t, None)
+        )
+    }));
+    Some(
+        targets
+            .iter()
+            .map(|name| format!("{{:fuel {name}, {}}}", plan.depth))
+            .collect::<Vec<_>>()
+            .join(" "),
+    )
+}

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1669,7 +1669,11 @@ fn verify_subject_fn_id(vb: &VerifyBlock, ctx: &CodegenContext) -> Option<crate:
     ctx.symbol_table.fn_id_of(&key)
 }
 
-fn sample_seed_lemma_available(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> bool {
+pub(super) fn sample_seed_lemma_available(
+    vb: &VerifyBlock,
+    law: &VerifyLaw,
+    ctx: &CodegenContext,
+) -> bool {
     // Mirror of the issue-#128 "universal lemma omitted" gate in
     // `emit_verify_law` — keep in sync.
     let vb_fn_id = verify_subject_fn_id(vb, ctx);
@@ -1855,7 +1859,9 @@ pub fn emit_law_samples(
             law_refs_opaque_fn(l, ctx, native_emitted) || law_refs_opaque_fn(r, ctx, native_emitted)
         })
         .unwrap_or(false);
-    let needs_bounded_form = any_opaque || any_native_mutual;
+    let native_sequence =
+        super::law_search::native_sequence_law(vb, law, ctx, opaque_fns, native_emitted);
+    let needs_bounded_form = any_opaque || (any_native_mutual && !native_sequence);
 
     // Only lift the sample cap when the universal lemma will *also*
     // emit as bounded-∀ (every given Int + Explicit literal-int
@@ -2065,28 +2071,8 @@ pub fn emit_law_samples(
         // `length([1, 0]) == S(length([1]))` spuriously fails to verify even
         // though the universal law (which carries `{:fuel}`) proves — masking
         // a genuinely-closed proof behind a sample error.
-        let mut sample_fns = std::collections::BTreeSet::new();
-        crate::codegen::proof_recognize::collect_called_fns(&law.lhs, &mut sample_fns);
-        crate::codegen::proof_recognize::collect_called_fns(&law.rhs, &mut sample_fns);
-        let mut transitive = std::collections::BTreeSet::new();
-        for f in &sample_fns {
-            if let Some(fd) = ctx.fn_def_by_name(f, ctx.active_module_scope().as_deref()) {
-                crate::codegen::proof_recognize::collect_called_fns_in_body(
-                    &fd.body,
-                    &mut transitive,
-                );
-            }
-        }
-        sample_fns.extend(transitive);
-        let sample_fuel: String = sample_fns
-            .iter()
-            .filter(|f| {
-                ctx.fn_def_by_name(f, ctx.active_module_scope().as_deref())
-                    .is_some()
-            })
-            .map(|f| format!("{{:fuel {}, 5}}", aver_name_to_dafny(f)))
-            .collect::<Vec<_>>()
-            .join(" ");
+        let sample_fuel =
+            super::law_search::attributes(vb, law, ctx, native_sequence, native_emitted);
         let fuel_prefix = if sample_fuel.is_empty() {
             String::new()
         } else {
@@ -3740,36 +3726,9 @@ pub(super) fn emit_verify_law(
     } = super::lemmas::algebra_lemmas(law, ctx, &law_uid);
 
     let mut lines = Vec::new();
-    // Collect all functions used in the law for fuel annotations
-    let mut law_fns = std::collections::BTreeSet::new();
-    crate::codegen::proof_recognize::collect_called_fns(&law.lhs, &mut law_fns);
-    crate::codegen::proof_recognize::collect_called_fns(&law.rhs, &mut law_fns);
-    // Add transitive callees
-    let mut transitive_fns = std::collections::BTreeSet::new();
-    for f in &law_fns {
-        if let Some(fd) = ctx.fn_def_by_name(f, ctx.active_module_scope().as_deref()) {
-            crate::codegen::proof_recognize::collect_called_fns_in_body(
-                &fd.body,
-                &mut transitive_fns,
-            );
-        }
-    }
-    law_fns.extend(transitive_fns);
-
-    // Oracle v1: fuel attrs only for names that resolve to top-level
-    // functions. Callees collected from lifted effectful bodies can
-    // include oracle / capability params (e.g. `rnd_Random_int`,
-    // `oracle`) that Dafny sees as lambda variables — emitting
-    // `{:fuel oracle, 5}` makes Dafny reject the lemma.
-    let fuel_attrs: String = law_fns
-        .iter()
-        .filter(|f| {
-            ctx.fn_def_by_name(f, ctx.active_module_scope().as_deref())
-                .is_some()
-        })
-        .map(|f| format!("{{:fuel {}, 5}}", aver_name_to_dafny(f)))
-        .collect::<Vec<_>>()
-        .join(" ");
+    let native_sequence =
+        super::law_search::native_sequence_law(vb, law, ctx, opaque_fns, native_emitted);
+    let fuel_attrs = super::law_search::attributes(vb, law, ctx, native_sequence, native_emitted);
 
     lines.push(format!("// Law: {}.{}", fn_name, law_name));
     if fuel_attrs.is_empty() {
@@ -3835,14 +3794,16 @@ pub(super) fn emit_verify_law(
     let is_opaque = law_refs_opaque_fn(&law.lhs, ctx, opaque_fns)
         || law_refs_opaque_fn(&law.rhs, ctx, opaque_fns);
     // Native-decreases mutual recursion isn't opaque (Dafny unfolds
-    // it), but the universal `add_commutative(a, b: int)` over
+    // it). Open sequence laws now try a real universal with shared-cone
+    // unfolding; the legacy finite-Int lane below remains separate.
+    // The universal `add_commutative(a, b: int)` over
     // `int × int` still doesn't close as a true ∀ without a domain
     // restriction. Route through the bounded-∀ form the same way
     // opaque does — the case-split body composes per-pair sample
     // lemmas that Dafny *can* close from `{}` on the native path.
     let is_native_mutual = law_refs_opaque_fn(&law.lhs, ctx, native_emitted)
         || law_refs_opaque_fn(&law.rhs, ctx, native_emitted);
-    let needs_bounded_form = is_opaque || is_native_mutual;
+    let needs_bounded_form = is_opaque || (is_native_mutual && !native_sequence);
     let all_explicit_int = !law.givens.is_empty()
         && law.givens.iter().all(|g| {
             (g.type_name == "Int" || lifted_vars.contains_key(&g.name))
@@ -4208,6 +4169,11 @@ pub(super) fn emit_verify_law(
         }
     }
 
+    if native_sequence {
+        // An explicit VC also exposes recursive Bool equalities which Z3 can
+        // leave opaque when they appear only in the method postcondition.
+        lines.push(format!("  assert {} == {};", lhs, rhs));
+    }
     lines.push("}\n".to_string());
 
     // Prepend the proved additive-op lemmas the `forall`-lift above refers

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -474,27 +474,37 @@ pub fn emit_fn_def(
         lines.push(format!("  requires {requirement}.Ok?"));
     }
 
-    // Guard-validated floor-division countdown (shared classifier —
-    // `RecursionContract::WellFoundedToNat { floor_div: Some(_) }`):
+    // Guard-validated integer descent comes from ProofIR for both subtractive
+    // and floor-division countdowns. It must precede signature heuristics:
+    // an output accumulator can grow while this checked counter decreases.
     // the classifier proved every self-call site's guard chain
     // implies the shrinking param is >= 1, so the total guarded
     // measure verifies WITHOUT a synthesized `requires` — total
     // callers stay wellformed (a synthesized precondition on a
     // recursive fn breaks every caller that can't prove it).
-    let floor_div_param = crate::codegen::common::find_fn_contract_for_fn(ctx, fd).and_then(
+    let native_int_param = crate::codegen::common::find_fn_contract_for_fn(ctx, fd).and_then(
         |contract| match &contract.recursion {
-            Some(crate::ir::RecursionContract::WellFoundedToNat {
-                param,
-                floor_div: Some(_),
-            }) => Some(param.clone()),
+            Some(crate::ir::RecursionContract::WellFoundedToNat { param, .. }) => {
+                Some(param.clone())
+            }
             _ => None,
         },
     );
-    if needs_decreases && let Some(param) = floor_div_param {
+    if needs_decreases && let Some(param) = native_int_param {
         let dname = aver_name_to_dafny(&param);
         lines.push(format!(
             "  decreases if {} >= 0 then {} else 0",
             dname, dname
+        ));
+    } else if needs_decreases
+        && let Some(crate::ir::RecursionContract::WellFoundedSequenceGap { sequence, bound }) =
+            crate::codegen::common::find_fn_contract_for_fn(ctx, fd)
+                .and_then(|c| c.recursion.as_ref())
+    {
+        lines.push(format!(
+            "  decreases {} - |{}|",
+            aver_name_to_dafny(bound),
+            aver_name_to_dafny(sequence)
         ));
     } else if needs_decreases && let Some(info) = infer_decreases(fd) {
         for req in &info.requires {
@@ -1428,17 +1438,17 @@ pub(super) fn termination_guess_unjustified(fd: &FnDef, ctx: &CodegenContext) ->
     if !body_has_recursive_call(fd.body.as_ref(), &fd.name) {
         return false;
     }
-    // Guard-validated floor-division countdown — the shared
+    // Guard-validated integer countdown — the shared
     // classifier proved the measure, so the fn emits with a native
     // total-guard `decreases` (see `emit_fn_def`) instead of
     // declining to an opaque `{:axiom}`.
     if crate::codegen::common::find_fn_contract_for_fn(ctx, fd).is_some_and(|contract| {
         matches!(
             &contract.recursion,
-            Some(crate::ir::RecursionContract::WellFoundedToNat {
-                floor_div: Some(_),
-                ..
-            })
+            Some(
+                crate::ir::RecursionContract::WellFoundedToNat { .. }
+                    | crate::ir::RecursionContract::WellFoundedSequenceGap { .. }
+            )
         )
     }) {
         return false;
@@ -3859,13 +3869,34 @@ pub(super) fn emit_verify_law(
     }
 
     lines.push(format!("  ensures {} == {}", lhs, rhs));
+    let source_induction = if needs_bounded_form || !lifted_vars.is_empty() {
+        None
+    } else {
+        super::law_induction::plan(vb, law, ctx)
+    };
+    if let Some(plan) = source_induction {
+        // Explicit source calls supply the induction instances; suppress the
+        // target's unrelated parameter-order heuristic.
+        if let Some(header) = lines
+            .iter_mut()
+            .rev()
+            .find(|line| line.starts_with("lemma "))
+        {
+            *header = header.replacen("lemma ", "lemma {:induction false} ", 1);
+        }
+        lines.push(format!(
+            "  decreases {}",
+            super::law_induction::measure(plan)
+        ));
+    }
     // Datatype accumulator-generalization: the structurally-shrinking driver
     // given may not be the lemma's FIRST param (givens can be declared in any
     // order), so Dafny's default lexicographic measure — which tries params
     // left-to-right and would hit the GROWING accumulator first — fails. Pin the
     // measure to the driver. (The datatype-induction hint below recurses on its
     // field predecessor, which decreases this driver.)
-    if law.when.is_none()
+    if source_induction.is_none()
+        && law.when.is_none()
         && crate::codegen::common::accumulator_fold_fn_names(ctx).contains(&vb.fn_name)
         && let Some(fd) = ctx.fn_def_by_name(&vb.fn_name, ctx.active_module_scope().as_deref())
         && let Some(driver) = datatype_driver_given_name(fd, law)
@@ -3878,6 +3909,9 @@ pub(super) fn emit_verify_law(
     // `forall` hoist (here) and the explicit-instantiation engine (list-induction
     // step, below).
     let cites = eligible_cites(vb, law, ctx, opaque_fns, native_emitted);
+    if !needs_bounded_form {
+        lines.extend(super::law_induction::sequence_identities(law, ctx));
+    }
 
     // Hoist additive-op facts at the top of the body (inductive paths only;
     // bounded-form bodies dispatch to samples and never reach the universal).
@@ -3932,6 +3966,20 @@ pub(super) fn emit_verify_law(
         lines.push(format!("  assume {{:axiom}} {} == {};", lhs, rhs));
         lines.push("}\n".to_string());
         return lines.join("\n");
+    }
+
+    if let Some(plan) = source_induction {
+        lines.extend(super::law_induction::calls(
+            plan,
+            &format!("{}_{}", fn_name, law_name),
+            ctx,
+        ));
+        lines.push("}\n".to_string());
+        return op_lemma_defs
+            .into_iter()
+            .chain(lines)
+            .collect::<Vec<_>>()
+            .join("\n");
     }
 
     // Generate inductive proof body for Int-parameterized laws

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -1725,18 +1725,6 @@ pub(super) fn sample_seed_lemma_available(
     ) {
         return false;
     }
-    // Mirror of the floor-division omitted-universal gate in
-    // `emit_verify_law`: a law whose cone reaches a guard-validated
-    // floor-division countdown fn gets NO universal lemma unless its
-    // `FloorDivWindow` figure is pinned — seeding a sample with a
-    // call to a lemma that was never emitted would be a parse error.
-    if !matches!(
-        pinned_strategy,
-        Some(crate::ir::ProofStrategy::FloorDivWindow { .. })
-    ) && law_reaches_floor_div_fn(law, ctx)
-    {
-        return false;
-    }
     law.givens.iter().all(|g| {
         oracle_predicate_for(&g.type_name).is_none()
             && crate::codegen::common::refinement_lift_for_given(
@@ -2700,49 +2688,6 @@ fn emit_tailrec_fixed_base_support_stack(
     Some(lines.join("\n"))
 }
 
-/// True when the law's call cone (lhs + rhs, transitively expanded
-/// through fn bodies) reaches a fn carrying the guard-validated
-/// floor-division countdown contract
-/// (`RecursionContract::WellFoundedToNat { floor_div: Some(_) }`).
-/// Such a fn verifies its own termination natively, but a DEFAULT
-/// empty-body universal lemma over it still hands Z3 an unbounded
-/// symbolic unfolding — a guaranteed error or timeout on a law that
-/// may well hold — so `emit_verify_law` keeps the honest
-/// omitted-universal decline unless the law carries a
-/// `FloorDivWindow` strategy (whose support stack proves it).
-pub(super) fn law_reaches_floor_div_fn(law: &VerifyLaw, ctx: &CodegenContext) -> bool {
-    let mut cone = std::collections::BTreeSet::new();
-    crate::codegen::proof_recognize::collect_called_fns(&law.lhs, &mut cone);
-    crate::codegen::proof_recognize::collect_called_fns(&law.rhs, &mut cone);
-    let mut changed = true;
-    while changed {
-        changed = false;
-        let snapshot: Vec<String> = cone.iter().cloned().collect();
-        for name in snapshot {
-            if let Some(fd) = ctx.fn_def_by_name(&name, ctx.active_module_scope().as_deref()) {
-                let before = cone.len();
-                crate::codegen::proof_recognize::collect_called_fns_in_body(&fd.body, &mut cone);
-                if cone.len() != before {
-                    changed = true;
-                }
-            }
-        }
-    }
-    cone.iter().any(|name| {
-        crate::codegen::common::fn_id_for_dotted_name(ctx, name)
-            .and_then(|id| ctx.proof_ir.fn_contracts.get(&id))
-            .is_some_and(|contract| {
-                matches!(
-                    &contract.recursion,
-                    Some(crate::ir::RecursionContract::WellFoundedToNat {
-                        floor_div: Some(_),
-                        ..
-                    })
-                )
-            })
-    })
-}
-
 /// Render the `FloorDivWindow` support stack + main lemma for one
 /// pinned figure. The lemma text was validated end-to-end on the
 /// emitted artifact (`dafny verify`: everything PROVED, no `assume`,
@@ -3443,16 +3388,9 @@ pub(super) fn emit_verify_law(
         );
     }
 
-    // Floor-division window family. A law whose cone reaches a
-    // guard-validated floor-division countdown fn either carries a
-    // recognized `FloorDivWindow` figure — then its validated support
-    // stack (division-window prelude + power algebra + branch-split
-    // helper lemmas, all PROVED in the emitted file) closes the
-    // universal — or it stays an honestly omitted universal: the fn
-    // is in the proof subset now, but Z3 cannot close an arbitrary
-    // universal over its unbounded symbolic unfolding, and the
-    // default empty-body lemma would manufacture a guaranteed error
-    // on a law that may well hold.
+    // Prefer the shared division-window support plan when available. Other
+    // laws over native floor-division recursion still receive real universal
+    // obligations: a missing specialized tactic is not a language omission.
     let pinned_floor_window_figure = vb_fn_id
         .and_then(|fn_id| {
             ctx.proof_ir
@@ -3470,35 +3408,6 @@ pub(super) fn emit_verify_law(
     if let Some(body) = super::lemmas::floor_arith_law(law, ctx, &fn_name, &law_name) {
         return body;
     }
-    // The omission applies only where the default path would state an
-    // OPEN universal with an empty body. The bounded-∀ form (mutual /
-    // opaque cone over all-literal-Int given domains — the same
-    // predicates the default path evaluates below) dispatches to
-    // per-sample lemmas instead and keeps working exactly as it did
-    // before this family existed, so it is excluded here.
-    let bounded_form_applies = {
-        let is_opaque_cone = law_refs_opaque_fn(&law.lhs, ctx, opaque_fns)
-            || law_refs_opaque_fn(&law.rhs, ctx, opaque_fns)
-            || law_refs_opaque_fn(&law.lhs, ctx, native_emitted)
-            || law_refs_opaque_fn(&law.rhs, ctx, native_emitted);
-        let all_literal_int_domains = !law.givens.is_empty()
-            && law.givens.iter().all(|g| {
-                g.type_name == "Int"
-                    && matches!(
-                        &g.domain,
-                        VerifyGivenDomain::Explicit(vs)
-                            if vs.iter().all(|v| literal_int_value(v).is_some())
-                    )
-            });
-        is_opaque_cone && all_literal_int_domains
-    };
-    if !bounded_form_applies && law_reaches_floor_div_fn(law, ctx) {
-        return format!(
-            "// Law {}.{}{}: reaches a floor-division recursion whose universal Z3 cannot close push-button, sample-only (universal lemma omitted)",
-            fn_name, law_name, suffix,
-        );
-    }
-
     // IR-pinned `LinearRecurrence2SpecEquivalence` — emit a full
     // support-theorem stack (Nat helper + worker_nat_shift +
     // helper_nat + helper_seed + spec_nat_bridge + main lemma)

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -3042,10 +3042,9 @@ fn eligible_cites<'a>(
     };
 
     let mut out = Vec::new();
-    for item in &ctx.items {
-        let TopLevel::Verify(prev) = item else {
-            continue;
-        };
+    // Use the declaring module's order, including when this is an imported
+    // supplier. Entry blocks must never enter a dependency's citation pool.
+    for prev in super::reasons::local_blocks(ctx) {
         // Only blocks earlier in source are eligible; stop at the consumer.
         if prev.line == vb.line && prev.fn_name == vb.fn_name {
             break;
@@ -3187,7 +3186,7 @@ pub(super) fn emit_verify_law(
 ) -> String {
     let LawRecursion {
         opaque_fns,
-        native_members,
+        native_members: _,
         native_callers: native_emitted,
         termination_opaque,
     } = *recursion;
@@ -3195,7 +3194,7 @@ pub(super) fn emit_verify_law(
     let law_name = aver_name_to_dafny(&law.name);
     if !law.because.is_empty() || law.using.is_some() {
         let claim = format!("{}.{}", vb.fn_name, law.name);
-        let reason = match super::reasons::emit(vb, law, ctx, native_members) {
+        let reason = match super::reasons::emit(vb, law, ctx, recursion) {
             Ok(emitted) => return emitted,
             Err(reason) => format!("Dafny guided-law pilot declined: {reason}"),
         };

--- a/src/codegen/lean/law_auto/reasons.rs
+++ b/src/codegen/lean/law_auto/reasons.rs
@@ -168,7 +168,7 @@ pub(in crate::codegen::lean) fn emit_reason_law(
         .iter()
         .map(|r| induction::plan(r, law, ctx))
         .collect::<Vec<_>>();
-    let definitions = induction::definitions(law, ctx);
+    let definitions = induction::definitions(vb, law, ctx);
     let params = claim
         .binders
         .iter()

--- a/src/codegen/lean/law_auto/reasons/induction.rs
+++ b/src/codegen/lean/law_auto/reasons/induction.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
-use crate::ast::{Expr, FnDef, Spanned, Stmt, VerifyLaw};
+use crate::ast::{Expr, FnDef, Spanned, VerifyBlock, VerifyLaw};
 use crate::codegen::lean::expr::{aver_name_to_lean, emit_expr, resolve_rewrite_output};
 use crate::codegen::{CodegenContext, common};
 
@@ -145,73 +145,51 @@ pub(super) struct Definitions {
     pub(super) unfold_once: Vec<(String, bool)>,
 }
 
-pub(super) fn definitions(law: &VerifyLaw, ctx: &CodegenContext) -> Definitions {
-    fn visit(
-        expr: &Spanned<Expr>,
-        scope: Option<&str>,
-        ctx: &CodegenContext,
-        seen: &mut HashSet<crate::ir::FnId>,
-        out: &mut BTreeMap<String, bool>,
-        unfold_once: &mut Vec<String>,
-    ) {
-        if let Some(fd) = callee(expr, ctx, scope)
-            && fd.effects.is_empty()
-            && let Some(id) = common::fn_id_for_decl(ctx, fd)
-            && seen.insert(id)
-        {
-            let recursive = ctx.recursive_fns.contains(&id);
-            // Subtractive countdown equations expose fixed-width steps. Keep
-            // floor-division recursion opaque: its equations recursively grow
-            // the arithmetic search even when cited laws already summarize it.
-            let subtractive = matches!(
-                common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref()),
-                Some(crate::ir::RecursionContract::WellFoundedToNat {
-                    floor_div: None,
-                    ..
-                })
-            );
-            if matches!(
-                common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref()),
-                Some(
-                    crate::ir::RecursionContract::WellFoundedToNat {
-                        floor_div: Some(_),
-                        ..
-                    } | crate::ir::RecursionContract::WellFoundedSequenceGap { .. }
-                )
-            ) {
-                unfold_once.push(lean_name(fd, ctx));
-            }
-            if !recursive || list_measure(fd, ctx).is_some() || subtractive {
-                out.insert(lean_name(fd, ctx), recursive);
-            }
-            let owner = common::fn_owning_scope_for(ctx, fd);
-            for stmt in fd.body.stmts() {
-                let (Stmt::Expr(body) | Stmt::Binding(_, _, body)) = stmt;
-                visit(body, owner, ctx, seen, out, unfold_once);
-            }
-        }
-        crate::codegen::expr_walk::for_each_child(expr, &mut |child| {
-            visit(child, scope, ctx, seen, out, unfold_once)
-        });
-    }
+pub(super) fn definitions(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> Definitions {
     let scope = ctx.active_module_scope();
-    let mut seen = HashSet::new();
+    let cone = ctx
+        .law_target_fn_id(&vb.fn_name)
+        .and_then(|id| {
+            ctx.proof_ir
+                .law_theorems
+                .iter()
+                .find(|t| t.fn_id == id && t.law_name == law.name)
+        })
+        .map(|t| t.function_cone.as_slice())
+        .unwrap_or(&[]);
+    let seen: HashSet<_> = cone.iter().copied().collect();
     let mut out = BTreeMap::new();
     let mut unfold_once = Vec::new();
-    for expr in law
-        .because
-        .iter()
-        .chain([&law.lhs, &law.rhs])
-        .chain(law.when.iter())
-    {
-        visit(
-            expr,
-            scope.as_deref(),
-            ctx,
-            &mut seen,
-            &mut out,
-            &mut unfold_once,
+    for &id in cone {
+        let key = &ctx.symbol_table.fn_entry(id).key;
+        let Some(fd) = ctx.fn_def_by_name(&key.name, key.scope_str()) else {
+            continue;
+        };
+        let recursive = ctx.recursive_fns.contains(&id);
+        // Subtractive countdown equations expose fixed-width steps. Keep
+        // floor-division recursion opaque: its equations recursively grow
+        // the arithmetic search even when cited laws already summarize it.
+        let subtractive = matches!(
+            common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref()),
+            Some(crate::ir::RecursionContract::WellFoundedToNat {
+                floor_div: None,
+                ..
+            })
         );
+        if matches!(
+            common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref()),
+            Some(
+                crate::ir::RecursionContract::WellFoundedToNat {
+                    floor_div: Some(_),
+                    ..
+                } | crate::ir::RecursionContract::WellFoundedSequenceGap { .. }
+            )
+        ) {
+            unfold_once.push(lean_name(fd, ctx));
+        }
+        if !recursive || list_measure(fd, ctx).is_some() || subtractive {
+            out.insert(lean_name(fd, ctx), recursive);
+        }
     }
     // A mutual helper's original equation is available only when the same
     // checked measure that emits its native definition succeeds. Fuel remains opaque.

--- a/src/codegen/lean/law_auto/reasons/induction.rs
+++ b/src/codegen/lean/law_auto/reasons/induction.rs
@@ -44,6 +44,43 @@ pub(super) fn plan(expr: &Spanned<Expr>, law: &VerifyLaw, ctx: &CodegenContext) 
     if !fd.effects.is_empty() {
         return None;
     }
+    // LawLower records the canonical source call and its checked input once.
+    // Reuse that plan when this explanation is the law's anchored call;
+    // backend-specific functional/measure tactics still prove every branch.
+    if let Some(id) = common::fn_id_for_decl(ctx, fd)
+        && let Some(shared) = ctx
+            .proof_ir
+            .law_theorems
+            .iter()
+            .find(|t| t.fn_id == id && t.law_name == law.name)
+            .and_then(|t| t.induction.as_ref())
+        && shared.source_call.node == resolve_rewrite_output(expr, ctx, None).node
+    {
+        let call = emit_expr(&shared.source_call, ctx);
+        return Some(match shared.measure {
+            crate::ir::proof_ir::LawInductionMeasure::NonnegativeInt => {
+                format!("fun_induction {call}")
+            }
+            crate::ir::proof_ir::LawInductionMeasure::SequenceLength => {
+                let others = law
+                    .givens
+                    .iter()
+                    .filter(|g| g.name != shared.driver)
+                    .map(|g| aver_name_to_lean(&g.name))
+                    .collect::<Vec<_>>();
+                let generalizing = if others.is_empty() {
+                    String::new()
+                } else {
+                    format!(" generalizing {}", others.join(" "))
+                };
+                format!(
+                    "first | fun_induction {call} | (induction {} using (measure List.length).wf.induction{generalizing} <;> dsimp only [WellFoundedRelation.rel, measure, invImage, InvImage, Nat.lt_wfRel] at * <;> rw [{}.eq_def])",
+                    aver_name_to_lean(&shared.driver),
+                    lean_name(fd, ctx)
+                )
+            }
+        });
+    }
     let measure = list_measure(fd, ctx);
     let native_integer = matches!(
         common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref()),
@@ -135,10 +172,12 @@ pub(super) fn definitions(law: &VerifyLaw, ctx: &CodegenContext) -> Definitions 
             );
             if matches!(
                 common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref()),
-                Some(crate::ir::RecursionContract::WellFoundedToNat {
-                    floor_div: Some(_),
-                    ..
-                })
+                Some(
+                    crate::ir::RecursionContract::WellFoundedToNat {
+                        floor_div: Some(_),
+                        ..
+                    } | crate::ir::RecursionContract::WellFoundedSequenceGap { .. }
+                )
             ) {
                 unfold_once.push(lean_name(fd, ctx));
             }

--- a/src/codegen/lean/toplevel/fn_def.rs
+++ b/src/codegen/lean/toplevel/fn_def.rs
@@ -85,6 +85,43 @@ pub fn emit_fn_def_proof(fd: &FnDef, ctx: &CodegenContext) -> Option<String> {
         return None;
     }
 
+    if let Some(crate::ir::RecursionContract::WellFoundedSequenceGap { sequence, bound }) =
+        crate::codegen::common::find_fn_contract_for_fn(ctx, fd).and_then(|c| c.recursion.as_ref())
+    {
+        let mut lines = Vec::new();
+        if let Some(desc) = &fd.desc {
+            lines.push(format!("/-- {} -/", sanitize_doc(desc)));
+        }
+        lines.push(format!(
+            "def {} {} : {} :=",
+            aver_name_to_lean(&fd.name),
+            emit_fn_params(&fd.params),
+            type_annotation_to_lean(&fd.return_type)
+        ));
+        let lowered = lower_pure_question_bang_for_emit(fd);
+        let body = lowered
+            .as_ref()
+            .map(|f| f.body.as_ref())
+            .unwrap_or(fd.body.as_ref());
+        lines.push(emit_fn_body_for(fd, body, ctx));
+        lines.push(format!(
+            "termination_by ({} - ({}.length : Int)).toNat",
+            aver_name_to_lean(bound),
+            aver_name_to_lean(sequence)
+        ));
+        let simplify = if fd
+            .params
+            .iter()
+            .any(|(name, ty)| name == sequence && ty == "String")
+        {
+            "simp_all [String.add_eq_append, String.length, String.toList_append]"
+        } else {
+            "simp_all only [List.length_append, List.length_cons, List.length_nil]"
+        };
+        lines.push(format!("decreasing_by\n  all_goals ({simplify}; omega)"));
+        return Some(lines.join("\n"));
+    }
+
     // LinearRecurrence2 — dedicated `RecursionContract::LinearRecurrence2`
     // marker. Backend still calls `detect_second_order_int_linear_
     // recurrence` to extract base cases + coefficients; the contract

--- a/src/codegen/proof_lower/law_dependencies.rs
+++ b/src/codegen/proof_lower/law_dependencies.rs
@@ -1,0 +1,60 @@
+//! One canonical source dependency walk for both proof backends. This collects
+//! available equations; it neither proves a claim nor bounds its input domain.
+
+use std::collections::HashSet;
+
+use crate::ast::{Expr, Spanned, Stmt, VerifyLaw};
+use crate::ir::FnId;
+use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
+
+use super::ProofLowerInputs;
+
+pub(super) fn collect(
+    law: &VerifyLaw,
+    inputs: &ProofLowerInputs,
+    scope: Option<&str>,
+) -> Vec<FnId> {
+    fn visit(
+        expr: &Spanned<Expr>,
+        scope: Option<&str>,
+        inputs: &ProofLowerInputs,
+        seen: &mut HashSet<FnId>,
+        out: &mut Vec<FnId>,
+    ) {
+        let id = match inputs.resolve_expr(expr, scope).node {
+            ResolvedExpr::Call(ResolvedCallee::Fn(id), _)
+            | ResolvedExpr::TailCall { target: id, .. } => Some(id),
+            _ => None,
+        };
+        if let Some(id) = id
+            && seen.insert(id)
+        {
+            let key = &inputs.symbol_table.fn_entry(id).key;
+            if let Some(fd) = inputs
+                .pure_fns_in_scope(key.scope_str())
+                .into_iter()
+                .find(|fd| fd.name == key.name)
+            {
+                out.push(id);
+                for stmt in fd.body.stmts() {
+                    let (Stmt::Expr(body) | Stmt::Binding(_, _, body)) = stmt;
+                    visit(body, key.scope_str(), inputs, seen, out);
+                }
+            }
+        }
+        crate::codegen::expr_walk::for_each_child(expr, &mut |child| {
+            visit(child, scope, inputs, seen, out)
+        });
+    }
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for expr in law
+        .because
+        .iter()
+        .chain([&law.lhs, &law.rhs])
+        .chain(law.when.iter())
+    {
+        visit(expr, scope, inputs, &mut seen, &mut out);
+    }
+    out
+}

--- a/src/codegen/proof_lower/law_induction.rs
+++ b/src/codegen/proof_lower/law_induction.rs
@@ -191,15 +191,38 @@ pub(super) fn plan(
             }
         });
     }
-    let anchor = occurrences.iter().copied().find(|e| {
+    // A fixed seed is not a quantified induction parameter. Recurse on the
+    // varying givens while retaining that seed in the theorem statement; the
+    // backend must prove the resulting equation (often using an accumulator
+    // decomposition law). Never infer a bound from concrete sample values.
+    fn fixed(expr: &Spanned<Expr>) -> bool {
+        match &expr.node {
+            Expr::Literal(_) => true,
+            Expr::List(xs) | Expr::Tuple(xs) => xs.iter().all(fixed),
+            _ => false,
+        }
+    }
+    let full_anchor = occurrences.iter().copied().find(|e| {
         let args = self_args(e, id, inputs, scope).unwrap();
-        let names: Option<Vec<_>> = args.iter().map(ident).collect();
-        names.is_some_and(|names| {
-            names.len() == fd.params.len()
-                && names
-                    .iter()
-                    .all(|n| law.givens.iter().any(|g| g.name == *n))
-                && names.iter().collect::<BTreeSet<_>>().len() == names.len()
+        let mut names = BTreeSet::new();
+        args.len() == fd.params.len()
+            && args.iter().all(|arg| {
+                ident(arg).is_some_and(|name| {
+                    law.givens.iter().any(|g| g.name == name) && names.insert(name)
+                })
+            })
+    });
+    let anchor = full_anchor.or_else(|| {
+        occurrences.iter().copied().find(|e| {
+            let args = self_args(e, id, inputs, scope).unwrap();
+            if args.len() != fd.params.len() || ident(&args[driver_index]).is_none() {
+                return false;
+            }
+            let mut names = BTreeSet::new();
+            args.iter().all(|arg| match ident(arg) {
+                Some(name) => law.givens.iter().any(|g| g.name == name) && names.insert(name),
+                None => fixed(arg),
+            })
         })
     })?;
     let anchor_args = self_args(anchor, id, inputs, scope)?;
@@ -310,13 +333,19 @@ pub(super) fn plan(
             .map(|g| (g.name.clone(), var(&g.name)))
             .collect();
         for (anchor_arg, recursive_arg) in anchor_args.iter().zip(recursive_args) {
-            given_args.insert(
-                ident(anchor_arg)?.to_string(),
-                substitute(recursive_arg, &bindings)?,
-            );
+            if let Some(name) = ident(anchor_arg) {
+                given_args.insert(name.to_string(), substitute(recursive_arg, &bindings)?);
+            }
         }
+        // A conditional theorem supplies an IH only where its recursive
+        // premise holds. Other branches remain independent proof obligations.
+        let premise = match &law.when {
+            Some(premise) => Some(inputs.resolve_expr(&substitute(premise, &given_args)?, scope)),
+            None => None,
+        };
         calls.push(LawInductionCall {
             guard: inputs.resolve_expr(&guard, scope),
+            premise,
             list_case,
             arguments: law
                 .givens

--- a/src/codegen/proof_lower/law_induction.rs
+++ b/src/codegen/proof_lower/law_induction.rs
@@ -1,0 +1,334 @@
+//! Law induction follows a checked source input and the actual recursive
+//! arguments. Both targets receive resolved expressions and canonical IDs.
+//! The emitted recursive lemma calls remain obligations of the target checker.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ast::{BinOp, Expr, FnDef, Literal, Pattern, Spanned, Stmt, VerifyLaw};
+use crate::ir::proof_ir::{
+    FuelMetric, LawInduction, LawInductionCall, LawInductionListCase, LawInductionMeasure, ProofIR,
+    RecursionContract,
+};
+
+use super::ProofLowerInputs;
+
+fn ident(expr: &Spanned<Expr>) -> Option<&str> {
+    match &expr.node {
+        Expr::Ident(name) | Expr::Resolved { name, .. } => Some(name),
+        _ => None,
+    }
+}
+
+fn var(name: &str) -> Spanned<Expr> {
+    Spanned::new(Expr::Ident(name.to_string()), 0)
+}
+
+fn int(value: i64) -> Spanned<Expr> {
+    Spanned::new(Expr::Literal(Literal::Int(value)), 0)
+}
+
+fn call(name: &str, args: Vec<Spanned<Expr>>) -> Spanned<Expr> {
+    Spanned::new(Expr::FnCall(Box::new(var(name)), args), 0)
+}
+
+/// Simultaneous value substitution; callees and fields are not value names.
+/// Binder-bearing expressions are omitted until their scopes are represented
+/// here. Preserving types matters for discharged division and empty containers.
+fn substitute(
+    expr: &Spanned<Expr>,
+    bindings: &BTreeMap<String, Spanned<Expr>>,
+) -> Option<Spanned<Expr>> {
+    let rec = |e| substitute(e, bindings);
+    let node = match &expr.node {
+        Expr::Ident(name) | Expr::Resolved { name, .. } => {
+            let replacement = bindings.get(name)?;
+            return Some(if ident(replacement) == Some(name.as_str()) {
+                expr.clone()
+            } else {
+                replacement.clone()
+            });
+        }
+        Expr::Literal(_) => return Some(expr.clone()),
+        Expr::BinOp(op, a, b) => Expr::BinOp(*op, Box::new(rec(a)?), Box::new(rec(b)?)),
+        Expr::Neg(e) => Expr::Neg(Box::new(rec(e)?)),
+        Expr::List(xs) => Expr::List(xs.iter().map(rec).collect::<Option<_>>()?),
+        Expr::Tuple(xs) => Expr::Tuple(xs.iter().map(rec).collect::<Option<_>>()?),
+        Expr::Attr(base, field) => Expr::Attr(Box::new(rec(base)?), field.clone()),
+        Expr::FnCall(callee, args) => {
+            // A parameter used as a callable needs a callback substitution
+            // contract; do not mistake it for a static source declaration.
+            if ident(callee).is_some_and(|name| bindings.contains_key(name)) {
+                return None;
+            }
+            Expr::FnCall(callee.clone(), args.iter().map(rec).collect::<Option<_>>()?)
+        }
+        _ => return None,
+    };
+    let result = Spanned::new(node, expr.line);
+    if let Some(ty) = expr.ty() {
+        result.set_ty(ty.clone());
+    }
+    Some(result)
+}
+
+fn self_args<'a>(
+    expr: &'a Spanned<Expr>,
+    id: crate::ir::FnId,
+    inputs: &ProofLowerInputs,
+    scope: Option<&str>,
+) -> Option<&'a [Spanned<Expr>]> {
+    let (name, args) = match &expr.node {
+        Expr::FnCall(callee, args) => (crate::checker::expr_to_str(callee), args.as_slice()),
+        Expr::TailCall(tc) => (tc.target.clone(), tc.args.as_slice()),
+        _ => return None,
+    };
+    (inputs.symbol_table.resolve_fn_id_in(&name, scope) == Some(id)).then_some(args)
+}
+
+struct SourceBranch<'a> {
+    guard: Spanned<Expr>,
+    body: &'a Spanned<Expr>,
+    list_bindings: Option<(String, String)>,
+}
+
+/// A single outer branch exposes an unambiguous source guard and substitution.
+/// Nested matches/local bindings stay with existing strategies, never guessed.
+fn recursive_branch<'a>(
+    fd: &'a FnDef,
+    driver: &str,
+    measure: LawInductionMeasure,
+    id: crate::ir::FnId,
+    inputs: &ProofLowerInputs,
+    scope: Option<&str>,
+) -> Option<SourceBranch<'a>> {
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    if arms.len() != 2 {
+        return None;
+    }
+    match measure {
+        LawInductionMeasure::SequenceLength => {
+            if ident(subject)? != driver {
+                return None;
+            }
+            arms.iter()
+                .find(|arm| matches!(arm.pattern, Pattern::EmptyList))?;
+            let arm = arms
+                .iter()
+                .find(|arm| matches!(arm.pattern, Pattern::Cons(_, _)))?;
+            let Pattern::Cons(head, tail) = &arm.pattern else {
+                return None;
+            };
+            let guard = Spanned::new(
+                Expr::BinOp(
+                    BinOp::Gt,
+                    Box::new(call("List.len", vec![var(driver)])),
+                    Box::new(int(0)),
+                ),
+                body.line,
+            );
+            Some(SourceBranch {
+                guard,
+                body: &arm.body,
+                list_bindings: Some((head.clone(), tail.clone())),
+            })
+        }
+        LawInductionMeasure::NonnegativeInt => {
+            // The function contract has checked positivity at every call.
+            // Keep the actual branch test, including its orientation.
+            let recursive = arms.iter().find(|arm| {
+                crate::codegen::expr_walk::any(&arm.body, &mut |e| {
+                    self_args(e, id, inputs, scope).is_some()
+                })
+            })?;
+            let guard = match recursive.pattern {
+                Pattern::Literal(Literal::Bool(true)) => (**subject).clone(),
+                Pattern::Literal(Literal::Bool(false)) => {
+                    call("Bool.not", vec![(**subject).clone()])
+                }
+                _ => return None,
+            };
+            Some(SourceBranch {
+                guard,
+                body: &recursive.body,
+                list_bindings: None,
+            })
+        }
+    }
+}
+
+pub(super) fn plan(
+    law: &VerifyLaw,
+    id: crate::ir::FnId,
+    inputs: &ProofLowerInputs,
+    ir: &ProofIR,
+    scope: Option<&str>,
+) -> Option<LawInduction> {
+    let (param, measure) = match ir.fn_contracts.get(&id)?.recursion.as_ref()? {
+        RecursionContract::WellFoundedToNat { param, .. } => {
+            (param, LawInductionMeasure::NonnegativeInt)
+        }
+        RecursionContract::Fuel {
+            fuel_metric: FuelMetric::SeqLenPlusOne { param },
+        } => (param, LawInductionMeasure::SequenceLength),
+        _ => return None,
+    };
+    let name = &inputs.symbol_table.fn_entry(id).key.name;
+    let fd = inputs
+        .pure_fns_in_scope(scope)
+        .into_iter()
+        .find(|fd| fd.name == *name)?;
+    let driver_index = fd.params.iter().position(|(p, _)| p == param)?;
+    let mut occurrences = Vec::new();
+    for expr in [&law.lhs, &law.rhs] {
+        crate::codegen::expr_walk::walk(expr, &mut |e| {
+            if self_args(e, id, inputs, scope).is_some() {
+                occurrences.push(e);
+            }
+        });
+    }
+    let anchor = occurrences.iter().copied().find(|e| {
+        let args = self_args(e, id, inputs, scope).unwrap();
+        let names: Option<Vec<_>> = args.iter().map(ident).collect();
+        names.is_some_and(|names| {
+            names.len() == fd.params.len()
+                && names
+                    .iter()
+                    .all(|n| law.givens.iter().any(|g| g.name == *n))
+                && names.iter().collect::<BTreeSet<_>>().len() == names.len()
+        })
+    })?;
+    let anchor_args = self_args(anchor, id, inputs, scope)?;
+    let driver = ident(&anchor_args[driver_index])?.to_string();
+    let SourceBranch {
+        guard,
+        body: branch,
+        list_bindings: pattern,
+    } = recursive_branch(fd, param, measure, id, inputs, scope)?;
+    if crate::codegen::expr_walk::any(branch, &mut |e| matches!(e.node, Expr::Match { .. })) {
+        return None;
+    }
+    let mut recursive_calls = Vec::new();
+    crate::codegen::expr_walk::walk(branch, &mut |e| {
+        if let Some(args) = self_args(e, id, inputs, scope) {
+            recursive_calls.push(args);
+        }
+    });
+    if recursive_calls.len() != 1 {
+        return None;
+    }
+    let recursive_args = recursive_calls[0];
+    if recursive_args.len() != fd.params.len() {
+        return None;
+    }
+    // A plain structural homomorphism already has its own decomposition
+    // strategy. This plan is needed when a list fold changes another input;
+    // selecting an arbitrary occurrence in e.g. f(x ++ y) = f(y) ++ f(x)
+    // would choose an unrelated driver and discard useful algebraic support.
+    if matches!(measure, LawInductionMeasure::SequenceLength)
+        && fd
+            .params
+            .iter()
+            .zip(recursive_args)
+            .enumerate()
+            .all(|(index, ((name, _), arg))| index == driver_index || ident(arg) == Some(name))
+    {
+        return None;
+    }
+    let mut occupied: BTreeSet<String> = law
+        .givens
+        .iter()
+        .map(|g| g.name.clone())
+        .chain(fd.params.iter().map(|(n, _)| n.clone()))
+        .chain(
+            inputs
+                .pure_fns_in_scope(scope)
+                .iter()
+                .map(|f| f.name.clone()),
+        )
+        .collect();
+    for expr in [&law.lhs, &law.rhs, branch] {
+        crate::codegen::expr_walk::walk(expr, &mut |e| {
+            if let Some(name) = ident(e) {
+                occupied.insert(name.to_string());
+            }
+        });
+    }
+    let mut fresh = || {
+        for index in 0.. {
+            let name = format!("averInductionPart{index}");
+            if occupied.insert(name.clone()) {
+                return name;
+            }
+        }
+        unreachable!()
+    };
+    let mut calls = Vec::new();
+    for occurrence in occurrences {
+        let args = self_args(occurrence, id, inputs, scope)?;
+        if args.len() != fd.params.len() || ident(&args[driver_index]) != Some(driver.as_str()) {
+            continue;
+        }
+        let mut bindings: BTreeMap<_, _> = fd
+            .params
+            .iter()
+            .zip(args)
+            .map(|((name, _), arg)| (name.clone(), arg.clone()))
+            .collect();
+        let guard = substitute(
+            &guard,
+            &fd.params
+                .iter()
+                .zip(args)
+                .map(|((n, _), a)| (n.clone(), a.clone()))
+                .collect(),
+        )?;
+        let list_case = pattern.as_ref().map(|(head, tail)| {
+            let head_name = (head != "_").then(&mut fresh);
+            let tail_name = (tail != "_").then(&mut fresh);
+            // Pattern binders shadow function formals. Fresh IR projections
+            // are substituted simultaneously, so law names cannot be captured.
+            if let Some(name) = &head_name {
+                bindings.insert(head.clone(), var(name));
+            }
+            if let Some(name) = &tail_name {
+                bindings.insert(tail.clone(), var(name));
+            }
+            LawInductionListCase {
+                list: inputs.resolve_expr(&args[driver_index], scope),
+                head: head_name,
+                tail: tail_name,
+            }
+        });
+        let mut given_args: BTreeMap<_, _> = law
+            .givens
+            .iter()
+            .map(|g| (g.name.clone(), var(&g.name)))
+            .collect();
+        for (anchor_arg, recursive_arg) in anchor_args.iter().zip(recursive_args) {
+            given_args.insert(
+                ident(anchor_arg)?.to_string(),
+                substitute(recursive_arg, &bindings)?,
+            );
+        }
+        calls.push(LawInductionCall {
+            guard: inputs.resolve_expr(&guard, scope),
+            list_case,
+            arguments: law
+                .givens
+                .iter()
+                .map(|g| inputs.resolve_expr(&given_args[&g.name], scope))
+                .collect(),
+        });
+    }
+    (!calls.is_empty()).then(|| LawInduction {
+        driver,
+        measure,
+        calls,
+        source_call: inputs.resolve_expr(anchor, scope),
+    })
+}

--- a/src/codegen/proof_lower/law_unfolding.rs
+++ b/src/codegen/proof_lower/law_unfolding.rs
@@ -1,0 +1,195 @@
+//! Small literal countdowns suggest bounded unfolding of an obligation's cone.
+//! This is a search hint, not a proof of a runtime bound. In particular, no
+//! `given` samples or `when` bounds participate in choosing the budget.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ast::{Expr, FnDef, Literal, Spanned, Stmt, Type, VerifyLaw};
+use crate::ir::FnId;
+use crate::ir::hir::{ResolvedCallee, ResolvedExpr};
+use crate::ir::proof_ir::{LawUnfolding, ProofIR, RecursionContract};
+
+use super::ProofLowerInputs;
+
+fn definition<'a>(inputs: &ProofLowerInputs<'a>, id: FnId) -> Option<&'a FnDef> {
+    let key = &inputs.symbol_table.fn_entry(id).key;
+    inputs
+        .pure_fns_in_scope(key.scope_str())
+        .into_iter()
+        .find(|f| f.name == key.name)
+}
+
+fn literal(e: &Spanned<Expr>, bindings: &BTreeMap<String, Option<i64>>) -> Option<i64> {
+    match &e.node {
+        Expr::Literal(Literal::Int(n)) => Some(*n),
+        Expr::Ident(name) | Expr::Resolved { name, .. } => bindings.get(name).copied().flatten(),
+        _ => None,
+    }
+}
+
+/// Follow only direct forwarding wrappers. Branches, local bindings and
+/// callbacks need richer substitution; they keep the existing search strategy.
+fn countdown(
+    e: &Spanned<Expr>,
+    bindings: &BTreeMap<String, Option<i64>>,
+    scope: Option<&str>,
+    inputs: &ProofLowerInputs,
+    ir: &ProofIR,
+    remaining: u32,
+) -> Option<u32> {
+    if remaining == 0 {
+        return None;
+    }
+    let Expr::FnCall(callee, args) = &e.node else {
+        return None;
+    };
+    let name = crate::checker::expr_to_str(callee);
+    if bindings.contains_key(&name) {
+        return None;
+    }
+    let id = inputs.symbol_table.resolve_fn_id_in(&name, scope)?;
+    let fd = definition(inputs, id)?;
+    if fd.params.len() != args.len() {
+        return None;
+    }
+    let actuals: BTreeMap<_, _> = fd
+        .params
+        .iter()
+        .zip(args)
+        .map(|(p, a)| (p.0.clone(), literal(a, bindings)))
+        .collect();
+    if let Some(RecursionContract::WellFoundedToNat {
+        param,
+        floor_div: None,
+    }) = ir.fn_contracts.get(&id).and_then(|c| c.recursion.as_ref())
+    {
+        let n = actuals.get(param).copied().flatten()?;
+        return (0..=16).contains(&n).then_some(n as u32);
+    }
+    if inputs.recursive_fns.contains(&id) {
+        return None;
+    }
+    let [Stmt::Expr(body)] = fd.body.stmts() else {
+        return None;
+    };
+    countdown(
+        body,
+        &actuals,
+        inputs.symbol_table.fn_entry(id).key.scope_str(),
+        inputs,
+        ir,
+        remaining - 1,
+    )
+}
+
+/// Until named-type substitution is represented here, only closed structural
+/// types can name a helper instance without carrying an owning module scope.
+fn closed_type(ty: &Type) -> bool {
+    match ty {
+        Type::Int | Type::Bool | Type::Str => true,
+        Type::List(t) => closed_type(t),
+        Type::Tuple(ts) => ts.iter().all(closed_type),
+        _ => false,
+    }
+}
+
+pub(super) fn plan(
+    law: &VerifyLaw,
+    expressions: &[&Spanned<Expr>],
+    inputs: &ProofLowerInputs,
+    ir: &ProofIR,
+    scope: Option<&str>,
+) -> Option<LawUnfolding> {
+    // A fixed countdown does not bound an independently quantified sequence.
+    // Keep citation/induction search for those obligations: deeper unfolding
+    // alone can lose proofs about an arbitrary suffix or accumulator.
+    if !law.givens.iter().all(|g| {
+        matches!(
+            crate::types::parse_type_str(&g.type_name),
+            Type::Int | Type::Bool
+        )
+    }) {
+        return None;
+    }
+    let mut width = None;
+    for e in expressions {
+        crate::codegen::expr_walk::walk(e, &mut |node| {
+            if let Some(n) = countdown(node, &BTreeMap::new(), scope, inputs, ir, 8) {
+                width = Some(width.unwrap_or(0).max(n));
+            }
+        });
+    }
+    let depth = width? + 4;
+    let mut pending = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut functions = Vec::new();
+    let mut reverse_elements = Vec::new();
+    let mut supported = true;
+    let mut collect = |e: &Spanned<Expr>,
+                       owner: Option<&str>,
+                       parameters: &[(String, String)],
+                       pending: &mut Vec<FnId>| {
+        crate::codegen::expr_walk::walk(
+            e,
+            &mut |node| match inputs.resolve_expr(node, owner).node {
+                ResolvedExpr::Call(ResolvedCallee::Fn(id), _)
+                | ResolvedExpr::TailCall { target: id, .. } => pending.push(id),
+                ResolvedExpr::Call(ResolvedCallee::Builtin(name), args)
+                    if name == "List.reverse" =>
+                {
+                    // Imported source views may lack expression stamps. A
+                    // directly named parameter still has its checked signature.
+                    let parameter_type = args.first().and_then(|arg| match &arg.node {
+                        ResolvedExpr::Ident(name) | ResolvedExpr::Resolved { name, .. } => {
+                            parameters
+                                .iter()
+                                .find(|(p, _)| p == name)
+                                .map(|(_, ty)| crate::types::parse_type_str(ty))
+                        }
+                        _ => None,
+                    });
+                    if let Some(Type::List(element)) = node.ty().or(parameter_type.as_ref()) {
+                        if closed_type(element) {
+                            if !reverse_elements.contains(element.as_ref()) {
+                                reverse_elements.push((**element).clone());
+                            }
+                        } else {
+                            supported = false;
+                        }
+                    } else {
+                        supported = false;
+                    }
+                }
+                _ => {}
+            },
+        );
+    };
+    for e in expressions {
+        collect(e, scope, &[], &mut pending);
+    }
+    while let Some(id) = pending.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        if seen.len() > 128 {
+            return None;
+        }
+        let fd = definition(inputs, id)?;
+        if inputs.recursive_fns.contains(&id) {
+            functions.push(id);
+        }
+        let owner = inputs.symbol_table.fn_entry(id).key.scope_str();
+        for stmt in fd.body.stmts() {
+            let e = match stmt {
+                Stmt::Expr(e) | Stmt::Binding(_, _, e) => e,
+            };
+            collect(e, owner, &fd.params, &mut pending);
+        }
+    }
+    functions.sort();
+    supported.then_some(LawUnfolding {
+        depth,
+        functions,
+        reverse_elements,
+    })
+}

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -2530,6 +2530,13 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
         );
 
         let induction = law_induction::plan(law, fn_id, inputs, ir, law_scope_ref);
+        let unfolding = law
+            .because
+            .iter()
+            .map(|e| vec![e])
+            .chain(std::iter::once(vec![&law.lhs, &law.rhs]))
+            .map(|expressions| law_unfolding::plan(law, &expressions, inputs, ir, law_scope_ref))
+            .collect();
 
         ir.law_theorems.push(LawTheorem {
             fn_id,
@@ -2540,11 +2547,13 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             claim_rhs: inputs.resolve_expr(&law.rhs, law_scope_ref),
             strategy,
             induction,
+            unfolding,
         });
     }
 }
 
 mod law_induction;
+mod law_unfolding;
 
 /// Pick the strategy `LawLower` should pin on a `(fn, law)` pair.
 ///

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -2530,6 +2530,7 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
         );
 
         let induction = law_induction::plan(law, fn_id, inputs, ir, law_scope_ref);
+        let function_cone = law_dependencies::collect(law, inputs, law_scope_ref);
         let unfolding = law
             .because
             .iter()
@@ -2547,11 +2548,13 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             claim_rhs: inputs.resolve_expr(&law.rhs, law_scope_ref),
             strategy,
             induction,
+            function_cone,
             unfolding,
         });
     }
 }
 
+mod law_dependencies;
 mod law_induction;
 mod law_unfolding;
 

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -2142,6 +2142,24 @@ fn populate_fn_contracts_for_scope(
             continue;
         };
 
+        if let RecursionPlan::SequenceGrowthBound {
+            sequence_index,
+            bound_index,
+        } = plan
+        {
+            ir.fn_contracts.insert(
+                canonical_key,
+                FnContract {
+                    source_name: fn_name.clone(),
+                    recursion: Some(RecursionContract::WellFoundedSequenceGap {
+                        sequence: fd.params[*sequence_index].0.clone(),
+                        bound: fd.params[*bound_index].0.clone(),
+                    }),
+                },
+            );
+            continue;
+        }
+
         // A subtractive countdown with a positive guard at every self-call
         // has a total native measure. Reuse the same shrink and guard checks
         // as the recursion classifier, independently of the laws present.
@@ -2511,6 +2529,8 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             law_scope_ref,
         );
 
+        let induction = law_induction::plan(law, fn_id, inputs, ir, law_scope_ref);
+
         ir.law_theorems.push(LawTheorem {
             fn_id,
             law_name: law.name.clone(),
@@ -2519,9 +2539,12 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             claim_lhs: inputs.resolve_expr(&law.lhs, law_scope_ref),
             claim_rhs: inputs.resolve_expr(&law.rhs, law_scope_ref),
             strategy,
+            induction,
         });
     }
 }
+
+mod law_induction;
 
 /// Pick the strategy `LawLower` should pin on a `(fn, law)` pair.
 ///

--- a/src/codegen/recursion/detect.rs
+++ b/src/codegen/recursion/detect.rs
@@ -2580,6 +2580,14 @@ pub fn analyze_plans_in_scope(
                     helper_fn,
                 },
             );
+        } else if let Some((sequence_index, bound_index)) = super::sequence_growth::detect(fd) {
+            plans.insert(
+                fd.name.clone(),
+                RecursionPlan::SequenceGrowthBound {
+                    sequence_index,
+                    bound_index,
+                },
+            );
         } else if supports_single_sizeof_structural(fd, inputs)
             || (list_structural.is_none()
                 && single_adt_structural_param_index(fd, inputs).is_some())

--- a/src/codegen/recursion/mod.rs
+++ b/src/codegen/recursion/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod cycle_measure;
 pub mod detect;
+mod sequence_growth;
 
 use std::collections::HashSet;
 
@@ -30,6 +31,12 @@ pub use detect::analyze_plans_in_scope;
 /// sees (pattern matching, `matches!`, equality via `.eq`).
 #[derive(Clone, Debug, PartialEq)]
 pub enum RecursionPlan {
+    /// A list or string grows strictly toward a preserved integer bound; every self-call
+    /// is guarded by its current length being below that bound.
+    SequenceGrowthBound {
+        sequence_index: usize,
+        bound_index: usize,
+    },
     /// Single-fn recursion where an `Int` parameter decreases by 1.
     /// The wrapper supplies `n.natAbs + 1` fuel so the helper terminates.
     IntCountdown { param_index: usize },

--- a/src/codegen/recursion/sequence_growth.rs
+++ b/src/codegen/recursion/sequence_growth.rs
@@ -1,0 +1,121 @@
+//! Strict list/string growth under a stable length bound. This source fact feeds
+//! ProofIR, so Lean and Dafny use the same remaining-length measure.
+
+use crate::ast::{BinOp, Expr, FnDef, Literal, Pattern, Spanned, Stmt};
+
+fn ident(e: &Spanned<Expr>, name: &str) -> bool {
+    matches!(&e.node, Expr::Ident(n) | Expr::Resolved { name: n, .. } if n == name)
+}
+
+fn length(e: &Spanned<Expr>, name: &str, string: bool) -> bool {
+    matches!(&e.node, Expr::FnCall(f, args)
+        if crate::checker::expr_to_str(f) == if string { "String.len" } else { "List.len" }
+            && args.len() == 1 && ident(&args[0], name))
+}
+
+fn grows(e: &Spanned<Expr>, name: &str, string: bool) -> bool {
+    if string {
+        let Expr::BinOp(BinOp::Add, a, b) = &e.node else {
+            return false;
+        };
+        let nonempty =
+            |e: &Spanned<Expr>| matches!(&e.node, Expr::Literal(Literal::Str(s)) if !s.is_empty());
+        return (ident(a, name) && nonempty(b)) || (nonempty(a) && ident(b, name));
+    }
+    let Expr::FnCall(f, args) = &e.node else {
+        return false;
+    };
+    match (crate::checker::expr_to_str(f).as_str(), args.as_slice()) {
+        ("List.prepend", [_, tail]) => ident(tail, name),
+        ("List.concat", [a, b]) => {
+            let nonempty = |e: &Spanned<Expr>| matches!(&e.node, Expr::List(xs) if !xs.is_empty());
+            (ident(a, name) && nonempty(b)) || (nonempty(a) && ident(b, name))
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn detect(fd: &FnDef) -> Option<(usize, usize)> {
+    let stmts = fd.body.stmts();
+    let (alias, body) = match stmts {
+        [Stmt::Expr(body)] => (None, body),
+        [Stmt::Binding(name, _, value), Stmt::Expr(body)] => (Some((name.as_str(), value)), body),
+        _ => return None,
+    };
+    let Expr::Match { subject, arms } = &body.node else {
+        return None;
+    };
+    let Expr::BinOp(op, left, right) = &subject.node else {
+        return None;
+    };
+    if arms.len() != 2 {
+        return None;
+    }
+    if !arms
+        .iter()
+        .any(|a| matches!(a.pattern, Pattern::Literal(Literal::Bool(true))))
+        || !arms
+            .iter()
+            .any(|a| matches!(a.pattern, Pattern::Literal(Literal::Bool(false))))
+        || arms.iter().any(|a| {
+            crate::codegen::expr_walk::any(&a.body, &mut |e| matches!(e.node, Expr::Match { .. }))
+        })
+    {
+        return None;
+    }
+    for (sequence_index, (sequence, ty)) in fd.params.iter().enumerate() {
+        let string = ty == "String";
+        if !string && !ty.starts_with("List<") {
+            continue;
+        }
+        for (bound_index, (bound, ty)) in fd.params.iter().enumerate() {
+            if ty != "Int" {
+                continue;
+            }
+            // A local binding may name the length, but cannot shadow either
+            // parameter on which the termination fact depends.
+            if alias.is_some_and(|(name, value)| {
+                name == sequence || name == bound || !length(value, sequence, string)
+            }) {
+                continue;
+            }
+            let is_length = |e: &Spanned<Expr>| {
+                length(e, sequence, string) || alias.is_some_and(|(name, _)| ident(e, name))
+            };
+            let recursive_when = match op {
+                BinOp::Lt if is_length(left) && ident(right, bound) => true,
+                BinOp::Gt if ident(left, bound) && is_length(right) => true,
+                BinOp::Gte if is_length(left) && ident(right, bound) => false,
+                BinOp::Lte if ident(left, bound) && is_length(right) => false,
+                _ => continue,
+            };
+            let mut found = false;
+            let mut valid = true;
+            for arm in arms {
+                let Pattern::Literal(Literal::Bool(value)) = arm.pattern else {
+                    valid = false;
+                    break;
+                };
+                let mut calls = Vec::new();
+                super::detect::collect_calls_from_expr(&arm.body, &mut calls);
+                for (target, args) in calls {
+                    if !super::detect::call_matches(&target, &fd.name) {
+                        continue;
+                    }
+                    found = true;
+                    if value != recursive_when
+                        || args.len() != fd.params.len()
+                        || !grows(args[sequence_index], sequence, string)
+                        || !ident(args[bound_index], bound)
+                    {
+                        valid = false;
+                    }
+                }
+            }
+            if found && valid {
+                return Some((sequence_index, bound_index));
+            }
+        }
+    }
+    None
+}

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -291,6 +291,10 @@ pub struct FnContract {
 /// the lowerer having proved preservation + decrease.
 #[derive(Debug, Clone)]
 pub enum RecursionContract {
+    /// A list or string grows by at least one element at every self-call while its length
+    /// is strictly below an unchanged integer bound. The natural part of the
+    /// remaining gap decreases, including calls that overshoot the bound.
+    WellFoundedSequenceGap { sequence: String, bound: String },
     /// Fuel-encoded fallback. No side-conditions to prove; works
     /// for any shape the classifier accepted as recursive.
     Fuel {
@@ -484,6 +488,42 @@ pub struct LawTheorem {
     pub claim_lhs: Spanned<crate::ir::hir::ResolvedExpr>,
     pub claim_rhs: Spanned<crate::ir::hir::ResolvedExpr>,
     pub strategy: ProofStrategy,
+    /// Source-recursion instances for an induction over a checked input.
+    /// These are proof candidates, never assumptions: each backend must prove
+    /// the recursive call's premises and strict decrease.
+    pub induction: Option<LawInduction>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LawInduction {
+    pub driver: String,
+    pub measure: LawInductionMeasure,
+    /// A call whose distinct source arguments map function parameters to givens.
+    pub source_call: Spanned<crate::ir::hir::ResolvedExpr>,
+    /// Recursive instances in the law's given order, including updated accumulators.
+    pub calls: Vec<LawInductionCall>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LawInductionMeasure {
+    SequenceLength,
+    NonnegativeInt,
+}
+
+#[derive(Debug, Clone)]
+pub struct LawInductionCall {
+    pub guard: Spanned<crate::ir::hir::ResolvedExpr>,
+    /// Nil/cons decomposition under the nonempty guard. Projection names are
+    /// fresh in the source/law scope; no partial List.head value is invented.
+    pub list_case: Option<LawInductionListCase>,
+    pub arguments: Vec<Spanned<crate::ir::hir::ResolvedExpr>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LawInductionListCase {
+    pub list: Spanned<crate::ir::hir::ResolvedExpr>,
+    pub head: Option<String>,
+    pub tail: Option<String>,
 }
 
 /// A universally-quantified variable in a law theorem. Carries

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -492,6 +492,20 @@ pub struct LawTheorem {
     /// These are proof candidates, never assumptions: each backend must prove
     /// the recursive call's premises and strict decrease.
     pub induction: Option<LawInduction>,
+    /// Optional unfolding budgets, in `because` order followed by the claim.
+    /// These guide proof search only; they neither restrict the quantified
+    /// domain nor replace any source premise, supplier, or proof obligation.
+    pub unfolding: Vec<Option<LawUnfolding>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LawUnfolding {
+    /// Small literal countdown plus headroom for wrappers and the base case.
+    pub depth: u32,
+    /// Canonical recursive declarations in this obligation's source cone.
+    pub functions: Vec<FnId>,
+    /// Concrete instances of the recursive sequence reversal operation.
+    pub reverse_elements: Vec<crate::ast::Type>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -530,7 +530,12 @@ pub enum LawInductionMeasure {
 
 #[derive(Debug, Clone)]
 pub struct LawInductionCall {
+    /// Source branch guard, evaluated before introducing pattern projections.
     pub guard: Spanned<crate::ir::hir::ResolvedExpr>,
+    /// The theorem premise at the recursive arguments. Evaluated after
+    /// `list_case` bindings, since it may mention the projected head or tail.
+    /// Where it is false, the original claim still needs an independent proof.
+    pub premise: Option<Spanned<crate::ir::hir::ResolvedExpr>>,
     /// Nil/cons decomposition under the nonempty guard. Projection names are
     /// fresh in the source/law scope; no partial List.head value is invented.
     pub list_case: Option<LawInductionListCase>,

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -492,6 +492,10 @@ pub struct LawTheorem {
     /// These are proof candidates, never assumptions: each backend must prove
     /// the recursive call's premises and strict decrease.
     pub induction: Option<LawInduction>,
+    /// Transitive statically resolved pure declarations used by the claim,
+    /// explanations and guard, in discovery order. Samples do not contribute.
+    /// Search data only: callbacks and builtin implementations are not expanded.
+    pub function_cone: Vec<FnId>,
     /// Optional unfolding budgets, in `because` order followed by the claim.
     /// These guide proof search only; they neither restrict the quantified
     /// domain nor replace any source premise, supplier, or proof obligation.

--- a/src/main/commands.rs
+++ b/src/main/commands.rs
@@ -4939,6 +4939,13 @@ fn render_proof_ir_dump(ir: &aver::ir::ProofIR, symbols: &aver::ir::SymbolTable)
             Some(RecursionContract::LinearRecurrence2) => {
                 writeln!(out, "LinearRecurrence2 (pair-state Nat worker)").unwrap();
             }
+            Some(RecursionContract::WellFoundedSequenceGap { sequence, bound }) => {
+                writeln!(
+                    out,
+                    "WellFoundedSequenceGap {{ measure: toNat({bound} - List.len({sequence})) }}"
+                )
+                .unwrap();
+            }
             Some(RecursionContract::WellFoundedToNat { param, floor_div }) => match floor_div {
                 Some(shrink) => writeln!(
                     out,

--- a/tests/fixtures/source_recursion/README.md
+++ b/tests/fixtures/source_recursion/README.md
@@ -1,0 +1,22 @@
+# Source recursion across proof backends
+
+`proof_spec::source_recursion` sends identical Aver sources to Lean and Dafny.
+Positive runs require all laws to verify, no omitted claims or trust escapes,
+and Lean universal credit with only the approved kernel axioms.
+
+- `../guarded_countdown_digits.av`: four laws for a decreasing width and growing
+  digit accumulator, including a cited accumulator-prefix lemma.
+- `list_fold.av`: three laws for a fold whose accumulator changes; the append law
+  carries an extra given that is not a source function parameter. A length-only
+  empty list also exercises the absence of an inferred element type.
+- `imported/main.av`: the same append argument through an imported supplier,
+  beside an unrelated local function with the supplier's bare name.
+- `sequence_growth.av`: three guarded base equations and executable examples for
+  list padding with one or two elements and string padding with a nonempty literal. Both kernels check the shared termination
+  measure, including negative bounds and overshoot.
+- `false_accumulator.av`: the zero-valued samples pass, but the universal law
+  drops its accumulator. Both checkers must reject it and its consumer.
+
+ProofIR tests also reject non-growing steps, moving bounds, and invalid guards,
+and check fresh projection names and both recursive accumulator instances.
+These fixtures test compiler behavior; they do not establish full BTC coverage.

--- a/tests/fixtures/source_recursion/bounded_unfolding.av
+++ b/tests/fixtures/source_recursion/bounded_unfolding.av
@@ -1,0 +1,39 @@
+module BoundedUnfolding
+    intent = "Fixed digit counts guide unfolding while values remain universally quantified."
+    effects []
+
+fn digits(value: Int, width: Int) -> List<Int>
+    digitsInto(value, width, [])
+
+fn digitsInto(value: Int, width: Int, acc: List<Int>) -> List<Int>
+    match width <= 0
+        true -> List.reverse(acc)
+        false -> digitsInto(Int.div(value, 10), width - 1, List.prepend(Int.mod(value, 10), acc))
+
+fn read(items: List<Int>) -> Int
+    readFrom(List.reverse(items), 0)
+
+fn readFrom(items: List<Int>, acc: Int) -> Int
+    match items
+        [] -> acc
+        [head, ..tail] -> readFrom(tail, acc * 10 + head)
+
+fn identity(value: Int) -> Int
+    value
+
+verify identity law unchanged
+    given value: Int = [0, 1]
+    identity(value) => value
+
+verify digits law threeDigits
+    given value: Int = [0, 1, 999]
+    when Bool.and(value >= 0, value < 1000)
+    using [identity.unchanged]
+    read(digits(value, 3)) => value
+
+verify digits law fiveDigits
+    given value: Int = [0, 1, 99999]
+    when Bool.and(value >= 0, value < 100000)
+    because read(digits(value, 5)) == value
+    using [identity.unchanged]
+    read(digits(value, 5)) => value

--- a/tests/fixtures/source_recursion/false_accumulator.av
+++ b/tests/fixtures/source_recursion/false_accumulator.av
@@ -1,0 +1,17 @@
+module FalseAccumulator
+    intent = "Samples at zero hide an omitted accumulator; a universal proof must reject it."
+fn count(xs: List<Int>, acc: Int) -> Int
+    match xs
+        [] -> acc
+        [_, ..tail] -> count(tail, acc + 1)
+verify count law droppedAccumulator
+    given acc: Int = [0]
+    given xs: List<Int> = [[], [1], [2, 3]]
+    count(xs, acc) => List.len(xs)
+fn size(xs: List<Int>, initial: Int) -> Int
+    count(xs, initial)
+verify size law failedSupplier
+    given xs: List<Int> = [[], [1]]
+    given initial: Int = [0]
+    using [count.droppedAccumulator]
+    size(xs, initial) => List.len(xs)

--- a/tests/fixtures/source_recursion/floor_citation.av
+++ b/tests/fixtures/source_recursion/floor_citation.av
@@ -1,0 +1,57 @@
+module FloorCitation
+    intent = "A decimal digit collector preserves its arbitrary prefix and range."
+    effects []
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    match value > 0
+        true -> digits(Int.div(value, 10), List.prepend(Int.mod(value, 10), acc))
+        false -> List.reverse(acc)
+
+verify digits law prefix
+    given value: Int = [-1, 0, 1, 10, 123]
+    given acc: List<Int> = [[], [4], [2, 3]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))
+
+verify digits law outsideRange
+    given value: Int = [-1, 0, 123]
+    given acc: List<Int> = [[], [-1, 10], [2, 3]]
+    given item: Int = [-1, 10]
+    when Bool.or(item < 0, item >= 10)
+    List.contains(digits(value, acc), item) => List.contains(acc, item)
+
+verify digits law noNewDigits
+    given value: Int = [-1, 0, 1, 123]
+    given acc: List<Int> = [[], [2, 3]]
+    List.len(digits(value, acc)) <= List.len(acc) => value <= 0
+
+verify digits law singletonPrefix
+    given value: Int = [-1, 0, 123]
+    given item: Int = [2, 3]
+    digits(value, [item]) => List.prepend(item, digits(value, []))
+
+verify digits law oneDigit
+    given value: Int = [1, 9]
+    when Bool.and(value > 0, value < 10)
+    digits(value, []) => [value]
+
+verify digits law positive
+    given value: Int = [1, 10, 123]
+    when value > 0
+    List.len(digits(value, [])) > 0 holds
+
+verify digits law nonpositive
+    given value: Int = [-1, 0]
+    when value <= 0
+    digits(value, []) => []
+
+verify digits law citedPrefix
+    given value: Int = [-1, 0, 123]
+    given item: Int = [2, 3]
+    using [digits.singletonPrefix]
+    digits(value, [item]) => List.prepend(item, digits(value, []))
+
+verify digits law citedPositive
+    given value: Int = [1, 10, 123]
+    when value > 0
+    using [digits.positive]
+    List.len(digits(value, [])) > 0 holds

--- a/tests/fixtures/source_recursion/floor_digits.av
+++ b/tests/fixtures/source_recursion/floor_digits.av
@@ -1,0 +1,45 @@
+module FloorDigits
+    intent = "A decimal digit collector preserves its arbitrary prefix and range."
+    effects []
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    match value > 0
+        true -> digits(Int.div(value, 10), List.prepend(Int.mod(value, 10), acc))
+        false -> List.reverse(acc)
+
+verify digits law prefix
+    given value: Int = [-1, 0, 1, 10, 123]
+    given acc: List<Int> = [[], [4], [2, 3]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))
+
+verify digits law outsideRange
+    given value: Int = [-1, 0, 123]
+    given acc: List<Int> = [[], [-1, 10], [2, 3]]
+    given item: Int = [-1, 10]
+    when Bool.or(item < 0, item >= 10)
+    List.contains(digits(value, acc), item) => List.contains(acc, item)
+
+verify digits law noNewDigits
+    given value: Int = [-1, 0, 1, 123]
+    given acc: List<Int> = [[], [2, 3]]
+    List.len(digits(value, acc)) <= List.len(acc) => value <= 0
+
+verify digits law singletonPrefix
+    given value: Int = [-1, 0, 123]
+    given item: Int = [2, 3]
+    digits(value, [item]) => List.prepend(item, digits(value, []))
+
+verify digits law oneDigit
+    given value: Int = [1, 9]
+    when Bool.and(value > 0, value < 10)
+    digits(value, []) => [value]
+
+verify digits law positive
+    given value: Int = [1, 10, 123]
+    when value > 0
+    List.len(digits(value, [])) > 0 holds
+
+verify digits law nonpositive
+    given value: Int = [-1, 0]
+    when value <= 0
+    digits(value, []) => []

--- a/tests/fixtures/source_recursion/framing/codec.av
+++ b/tests/fixtures/source_recursion/framing/codec.av
@@ -1,0 +1,50 @@
+module Codec
+    exposes [digits, read]
+    intent = "Fixed digit counts guide unfolding while values remain universally quantified."
+    effects []
+
+fn digits(value: Int, width: Int) -> List<Int>
+    digitsInto(value, width, [])
+
+fn digitsInto(value: Int, width: Int, acc: List<Int>) -> List<Int>
+    match width <= 0
+        true -> List.reverse(acc)
+        false -> digitsInto(Int.div(value, 10), width - 1, List.prepend(Int.mod(value, 10), acc))
+
+fn read(items: List<Int>) -> Int
+    readFrom(List.reverse(items), 0)
+
+fn readFrom(items: List<Int>, acc: Int) -> Int
+    match items
+        [] -> acc
+        [head, ..tail] -> readFrom(tail, acc * 10 + head)
+
+fn identity(value: Int) -> Int
+    value
+
+verify identity law unchanged
+    given value: Int = [0, 1]
+    identity(value) => value
+
+verify digits law threeDigits
+    given value: Int = [0, 1, 999]
+    when Bool.and(value >= 0, value < 1000)
+    using [identity.unchanged]
+    read(digits(value, 3)) => value
+
+verify digits law fiveDigits
+    given value: Int = [0, 1, 99999]
+    when Bool.and(value >= 0, value < 100000)
+    because read(digits(value, 5)) == value
+    using [identity.unchanged]
+    read(digits(value, 5)) => value
+
+verify digits law threeLength
+    given value: Int = [0, 999]
+    using []
+    List.len(digits(value, 3)) => 3
+
+verify digits law fiveLength
+    given value: Int = [0, 99999]
+    using []
+    List.len(digits(value, 5)) => 5

--- a/tests/fixtures/source_recursion/framing/main.av
+++ b/tests/fixtures/source_recursion/framing/main.av
@@ -1,0 +1,54 @@
+module Framing
+    intent = "Compose independently verified fields behind a marker and preserve arbitrary trailing data."
+    depends [Codec]
+    effects []
+
+record Packet
+    value: Int
+    rest: List<Int>
+    consumed: Int
+
+fn field(width: Int, items: List<Int>) -> Packet
+    Packet(value = Codec.read(List.take(items, width)), rest = List.drop(items, width), consumed = width + 1)
+
+verify field law shortField
+    given value: Int = [0, 999]
+    given suffix: List<Int> = [[], [7]]
+    when Bool.and(0 <= value, value < 1000)
+    using [Codec.digits.threeDigits, Codec.digits.threeLength]
+    field(3, List.concat(Codec.digits(value, 3), suffix)) => Packet(value = value, rest = suffix, consumed = 4)
+
+verify field law longField
+    given value: Int = [0, 99999]
+    given suffix: List<Int> = [[], [7]]
+    when Bool.and(0 <= value, value < 100000)
+    using [Codec.digits.fiveDigits, Codec.digits.fiveLength]
+    field(5, List.concat(Codec.digits(value, 5), suffix)) => Packet(value = value, rest = suffix, consumed = 6)
+
+fn dispatch(tag: Int, items: List<Int>) -> Packet
+    match tag
+        17 -> field(3, items)
+        _ -> field(5, items)
+
+fn receive(items: List<Int>) -> Packet
+    match items
+        [] -> Packet(value = 0, rest = [], consumed = 0)
+        [head, ..tail] -> dispatch(head, tail)
+
+fn send(value: Int) -> List<Int>
+    match value < 1000
+        true -> List.prepend(17, Codec.digits(value, 3))
+        false -> List.prepend(23, Codec.digits(value, 5))
+
+fn roundtrip(value: Int, suffix: List<Int>) -> Bool
+    match value < 1000
+        true -> receive(List.concat(send(value), suffix)) == Packet(value = value, rest = suffix, consumed = 4)
+        false -> receive(List.concat(send(value), suffix)) == Packet(value = value, rest = suffix, consumed = 6)
+
+verify send law receivesBack
+    given value: Int = [0, 999, 1000, 99999]
+    given suffix: List<Int> = [[], [7]]
+    when Bool.and(0 <= value, value < 100000)
+    because roundtrip(value, suffix)
+    using [field.shortField, field.longField, Codec.digits.threeLength, Codec.digits.fiveLength]
+    receive(List.concat(send(value), suffix)) => Packet(value = value, rest = suffix, consumed = List.len(send(value)))

--- a/tests/fixtures/source_recursion/framing/typed.av
+++ b/tests/fixtures/source_recursion/framing/typed.av
@@ -1,0 +1,30 @@
+module TypedFraming
+    intent = "Framing preserves the ordered payload for primitive and record elements."
+    effects []
+
+record Entry
+    value: Int
+
+fn dropBool(items: List<Bool>) -> List<Bool>
+    match items
+        [] -> []
+        [_, ..tail] -> tail
+
+verify dropBool law keepsPayload
+    given marker: Bool = [false, true]
+    given prefix: List<Bool> = [[], [true]]
+    given suffix: List<Bool> = [[], [false]]
+    using []
+    dropBool(List.concat(List.prepend(marker, prefix), suffix)) => List.concat(prefix, suffix)
+
+fn dropEntry(items: List<Entry>) -> List<Entry>
+    match items
+        [] -> []
+        [_, ..tail] -> tail
+
+verify dropEntry law keepsPayload
+    given marker: Entry = [Entry(value = 1)]
+    given prefix: List<Entry> = [[], [Entry(value = 2)]]
+    given suffix: List<Entry> = [[], [Entry(value = 3)]]
+    using []
+    dropEntry(List.concat(List.prepend(marker, prefix), suffix)) => List.concat(prefix, suffix)

--- a/tests/fixtures/source_recursion/guarded_list_seed.av
+++ b/tests/fixtures/source_recursion/guarded_list_seed.av
@@ -1,0 +1,14 @@
+module GuardedListSeed
+    intent = "An induction premise is evaluated after binding the recursive head."
+    effects []
+
+fn grow(items: List<Int>, acc: Int) -> Int
+    match items
+        [] -> acc
+        [head, ..tail] -> grow(tail, acc + Int.abs(head))
+
+verify grow law nonnegative
+    given items: List<Int> = [[], [1, 2], [3]]
+    given acc: Int = [0, 4]
+    when acc >= 0
+    grow(items, acc) >= 0 holds

--- a/tests/fixtures/source_recursion/imported/main.av
+++ b/tests/fixtures/source_recursion/imported/main.av
@@ -1,0 +1,12 @@
+module ImportedFold
+    depends [Worker]
+    intent = "An unrelated local function cannot capture the imported induction."
+fn read(xs: List<Int>, acc: Int) -> Int
+    acc - List.len(xs)
+fn finish(prefix: List<Int>, digit: Int) -> Int
+    Worker.read(List.concat(prefix, [digit]), 0)
+verify finish law importedSnoc
+    given prefix: List<Int> = [[], [1], [2, 3]]
+    given digit: Int = [-1, 0, 15]
+    using [Worker.read.snoc]
+    finish(prefix, digit) => Worker.read(prefix, 0) * 16 + digit

--- a/tests/fixtures/source_recursion/imported/worker.av
+++ b/tests/fixtures/source_recursion/imported/worker.av
@@ -1,0 +1,12 @@
+module Worker
+    exposes [read]
+    intent = "Induction follows the tail and updates the accumulator; digit is an extra law given."
+fn read(xs: List<Int>, acc: Int) -> Int
+    match xs
+        [] -> acc
+        [head, ..tail] -> read(tail, acc * 16 + head)
+verify read law snoc
+    given acc: Int = [0, -1, 17]
+    given prefix: List<Int> = [[], [1], [2, 3]]
+    given digit: Int = [-1, 0, 15]
+    read(List.concat(prefix, [digit]), acc) => read(prefix, acc) * 16 + digit

--- a/tests/fixtures/source_recursion/list_fold.av
+++ b/tests/fixtures/source_recursion/list_fold.av
@@ -1,0 +1,25 @@
+module ListFold
+    intent = "Induction follows the tail and updates the accumulator; digit is an extra law given."
+fn read(xs: List<Int>, acc: Int) -> Int
+    match xs
+        [] -> acc
+        [head, ..tail] -> read(tail, acc * 16 + head)
+verify read law snoc
+    given acc: Int = [0, -1, 17]
+    given prefix: List<Int> = [[], [1], [2, 3]]
+    given digit: Int = [-1, 0, 15]
+    read(List.concat(prefix, [digit]), acc) => read(prefix, acc) * 16 + digit
+fn finish(prefix: List<Int>, digit: Int) -> Int
+    read(List.concat(prefix, [digit]), 0)
+verify finish law composed
+    given prefix: List<Int> = [[], [1], [2, 3]]
+    given digit: Int = [-1, 0, 15]
+    using [read.snoc]
+    finish(prefix, digit) => read(prefix, 0) * 16 + digit
+
+fn emptyLength(n: Int) -> Int
+    List.len([]) + n
+verify emptyLength law inferredEmpty
+    given n: Int = [-1, 0, 1]
+    using []
+    emptyLength(n) => List.len([]) + n

--- a/tests/fixtures/source_recursion/native_sequence.av
+++ b/tests/fixtures/source_recursion/native_sequence.av
@@ -1,0 +1,30 @@
+module NativeSequence
+    intent = "Fixed permutations through a mutually recursive list lookup."
+    effects []
+
+fn at(items: List<Int>, index: Int) -> Int
+    match items
+        [] -> 0
+        [head, ..tail] -> select(head, tail, index)
+
+fn select(head: Int, tail: List<Int>, index: Int) -> Int
+    match index == 0
+        true -> head
+        false -> at(tail, index - 1)
+
+fn shuffle(items: List<Int>) -> List<Int>
+    [at(items, 2), at(items, 0), at(items, 1)]
+
+verify shuffle law threeTurns
+    given items: List<Int> = [[4, 4, 4], [9, 9, 9, 9]]
+    when List.len(items) >= 3
+    shuffle(shuffle(shuffle(items))) => List.take(items, 3)
+
+fn project(items: List<Int>, index: Int) -> Int
+    at(items, index)
+
+verify project law firstThree
+    given items: List<Int> = [[4, 4, 4], [9, 9, 9, 9]]
+    given index: Int = [0, 1, 2]
+    when Bool.and(index >= 0, index < 3)
+    project(List.take(items, 3), index) => project(items, index)

--- a/tests/fixtures/source_recursion/sequence_growth.av
+++ b/tests/fixtures/source_recursion/sequence_growth.av
@@ -1,0 +1,43 @@
+module SequenceGrowth
+    intent = "The stable length bound proves termination, including negative bounds and overshoot."
+fn pad(xs: List<Int>, width: Int) -> List<Int>
+    count = List.len(xs)
+    match count >= width
+        true -> List.take(xs, width)
+        false -> pad(List.concat(xs, [0]), width)
+verify pad
+    pad([], -1) => []
+    pad([7], 3) => [7, 0, 0]
+verify pad law stop
+    given xs: List<Int> = [[], [1], [1, 2]]
+    given width: Int = [-1, 0, 1, 2]
+    when List.len(xs) >= width
+    using []
+    pad(xs, width) => List.take(xs, width)
+fn padPairs(xs: List<Int>, width: Int) -> List<Int>
+    match width > List.len(xs)
+        true -> padPairs(List.concat([0, 0], xs), width)
+        false -> xs
+verify padPairs
+    padPairs([], 3) => [0, 0, 0, 0]
+    padPairs([7], -1) => [7]
+verify padPairs law stop
+    given xs: List<Int> = [[], [1], [1, 2]]
+    given width: Int = [-1, 0, 1, 2]
+    when List.len(xs) >= width
+    using []
+    padPairs(xs, width) => xs
+
+fn padLeft(text: String, width: Int) -> String
+    match String.len(text) >= width
+        true -> text
+        false -> padLeft("0" + text, width)
+verify padLeft
+    padLeft("7", 3) => "007"
+    padLeft("long", -1) => "long"
+verify padLeft law stop
+    given text: String = ["", "7", "long"]
+    given width: Int = [-1, 0, 1, 3]
+    when String.len(text) >= width
+    using []
+    padLeft(text, width) => text

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -3120,3 +3120,78 @@ fn pad(text: String, width: Int) -> String
         );
     }
 }
+
+#[test]
+fn law_induction_retains_fixed_seeds_and_guards_the_recursive_premise() {
+    let source = include_str!("fixtures/source_recursion/floor_digits.av");
+    let flipped = source.replace(
+        "digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))",
+        "List.concat(List.reverse(acc), digits(value, [])) => digits(value, acc)",
+    );
+    let flipped_ctx = build_ctx(&flipped);
+    let plan = law_theorem(&flipped_ctx, "digits", "prefix")
+        .unwrap()
+        .induction
+        .as_ref()
+        .unwrap();
+    assert!(
+        plan.calls
+            .iter()
+            .all(|call| !matches!(&call.arguments[1].node,
+        aver::ir::hir::ResolvedExpr::Ident(name) if name == "acc")),
+        "Prefer the fully quantified anchor even when the fixed seed appears first"
+    );
+    let ctx = build_ctx(source);
+    for name in ["oneDigit", "positive", "nonpositive"] {
+        let plan = law_theorem(&ctx, "digits", name)
+            .unwrap()
+            .induction
+            .as_ref()
+            .unwrap();
+        assert_eq!(plan.driver, "value");
+        assert_eq!(plan.calls.len(), 1);
+        let call = &plan.calls[0];
+        assert_eq!(
+            call.arguments.len(),
+            1,
+            "The fixed [] seed is not a theorem parameter"
+        );
+        assert!(
+            matches!(
+                &call.arguments[0].node,
+                aver::ir::hir::ResolvedExpr::Call(
+                    aver::ir::hir::ResolvedCallee::Intrinsic(
+                        aver::ir::hir::BuiltinIntrinsic::IntDivEuclid
+                    ),
+                    _
+                )
+            ),
+            "{:?}",
+            call.arguments[0]
+        );
+        let premise = call
+            .premise
+            .as_ref()
+            .expect("Keep the recursive theorem premise");
+        assert!(
+            format!("{premise:?}").contains("IntDivEuclid"),
+            "Use the recursive premise, not the original one"
+        );
+    }
+}
+
+#[test]
+fn recursive_list_premises_live_inside_the_projection_scope() {
+    let ctx = build_ctx(include_str!(
+        "fixtures/source_recursion/guarded_list_seed.av"
+    ));
+    let plan = law_theorem(&ctx, "grow", "nonnegative")
+        .unwrap()
+        .induction
+        .as_ref()
+        .unwrap();
+    let call = &plan.calls[0];
+    let head = call.list_case.as_ref().unwrap().head.as_ref().unwrap();
+    assert!(!format!("{:?}", call.guard).contains(head));
+    assert!(format!("{:?}", call.premise).contains(head));
+}

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -26,6 +26,9 @@ use aver::ir::proof_ir::{
 use aver::source::{LoadedModule, parse_source};
 use std::path::PathBuf;
 
+#[path = "proof_ir_diff/bounded_unfolding.rs"]
+mod bounded_unfolding;
+
 fn build_ctx(src: &str) -> CodegenContext {
     let mut items = parse_source(src).expect("parse");
     // Proof-mode minimal pipeline: rewrite stages off (would alter
@@ -86,15 +89,27 @@ fn build_ctx_with_modules(entry_src: &str, deps: &[(&str, &str)]) -> CodegenCont
     let mut items = parse_source(entry_src).expect("entry parse");
     let loaded: Vec<LoadedModule> = deps
         .iter()
-        .map(|(name, source)| LoadedModule {
-            dep_name: (*name).to_string(),
-            items: parse_source(source).unwrap_or_else(|error| panic!("{name} parse: {error}")),
-            path: PathBuf::from(format!("{name}.av")),
+        .map(|(name, source)| {
+            let mut items =
+                parse_source(source).unwrap_or_else(|error| panic!("{name} parse: {error}"));
+            // Module loading performs TCO before assembling the codegen view.
+            aver::tco::transform_program(&mut items);
+            LoadedModule {
+                dep_name: (*name).to_string(),
+                items,
+                path: PathBuf::from(format!("{name}.av")),
+            }
         })
         .collect();
     let modules: Vec<aver::codegen::ModuleInfo> = loaded
         .iter()
-        .map(aver::codegen::ModuleInfo::from_loaded)
+        .map(|module| {
+            aver::codegen::ModuleInfo::from_items(
+                module.dep_name.clone(),
+                &module.items,
+                Some(aver::ir::analyze(&module.items, None)),
+            )
+        })
         .collect();
     let mut pipeline_result = aver::ir::pipeline::run(
         &mut items,

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -2957,3 +2957,151 @@ fn native_subtractive_measure_requires_positive_guards_at_every_call() {
         );
     }
 }
+
+#[test]
+fn law_induction_tracks_the_countdown_and_both_accumulator_instances() {
+    let ctx = build_ctx(include_str!("fixtures/guarded_countdown_digits.av"));
+    let law = law_theorem(&ctx, "digitsInto", "accumulatorPrefix").unwrap();
+    let plan = law.induction.as_ref().expect("source induction planned");
+    assert_eq!(plan.driver, "width");
+    assert!(matches!(
+        plan.measure,
+        aver::ir::proof_ir::LawInductionMeasure::NonnegativeInt
+    ));
+    assert_eq!(
+        plan.calls.len(),
+        2,
+        "the arbitrary and empty accumulators both recur"
+    );
+    for call in &plan.calls {
+        assert_eq!(call.arguments.len(), 3);
+        assert!(call.list_case.is_none());
+        assert!(matches!(
+            call.arguments[1].node,
+            aver::ir::hir::ResolvedExpr::BinOp(aver::ast::BinOp::Sub, _, _)
+        ));
+    }
+    assert_ne!(
+        plan.calls[0].arguments[2].node,
+        plan.calls[1].arguments[2].node
+    );
+}
+
+#[test]
+fn law_induction_uses_fresh_list_projections_and_preserves_extra_givens() {
+    let source = r#"module Fold
+    intent = "The induction carries the actual accumulator update."
+fn read(xs: List<Int>, acc: Int) -> Int
+    match xs
+        [] -> acc
+        [head, ..tail] -> read(tail, acc * 256 + head)
+verify read law snoc
+    given averInductionPart0: Int = [0]
+    given prefix: List<Int> = [[], [1]]
+    given digit: Int = [0]
+    read(List.concat(prefix, [digit]), averInductionPart0) => read(prefix, averInductionPart0) * 256 + digit
+"#;
+    let ctx = build_ctx(source);
+    let plan = law_theorem(&ctx, "read", "snoc")
+        .unwrap()
+        .induction
+        .as_ref()
+        .unwrap();
+    assert_eq!(plan.driver, "prefix");
+    assert_eq!(plan.calls.len(), 1);
+    let call = &plan.calls[0];
+    let case = call.list_case.as_ref().unwrap();
+    assert_ne!(case.head.as_deref(), Some("averInductionPart0"));
+    assert_ne!(case.tail.as_deref(), Some("averInductionPart0"));
+    assert_ne!(case.head, case.tail);
+    assert!(
+        matches!(&call.arguments[2].node, aver::ir::hir::ResolvedExpr::Ident(n) if n == "digit")
+    );
+    assert!(matches!(
+        call.arguments[0].node,
+        aver::ir::hir::ResolvedExpr::BinOp(aver::ast::BinOp::Add, _, _)
+    ));
+}
+
+#[test]
+fn sequence_growth_measure_requires_strict_growth_and_a_stable_guarded_bound() {
+    for (condition, growth, bound, accepted) in [
+        (
+            "List.len(xs) < width",
+            "List.concat(xs, [0])",
+            "width",
+            true,
+        ),
+        ("width > List.len(xs)", "List.prepend(0, xs)", "width", true),
+        (
+            "List.len(xs) < width",
+            "List.concat([0, 0], xs)",
+            "width",
+            true,
+        ),
+        (
+            "List.len(xs) < width",
+            "List.concat(xs, [])",
+            "width",
+            false,
+        ),
+        ("List.len(xs) < width", "xs", "width", false),
+        (
+            "List.len(xs) < width",
+            "List.concat(xs, [0])",
+            "width + 1",
+            false,
+        ),
+        (
+            "List.len(xs) > width",
+            "List.concat(xs, [0])",
+            "width",
+            false,
+        ),
+        (
+            "List.len(xs) <= width",
+            "List.concat(xs, [0])",
+            "width",
+            false,
+        ),
+    ] {
+        let source = format!(
+            "module Grow\n    intent = \"Guarded growth\"\nfn pad(xs: List<Int>, width: Int) -> List<Int>\n    match {condition}\n        true -> pad({growth}, {bound})\n        false -> xs\n"
+        );
+        let ctx = build_ctx(&source);
+        let contract = fn_contract(&ctx, "pad");
+        assert_eq!(
+            matches!(contract.and_then(|c| c.recursion.as_ref()), Some(RecursionContract::WellFoundedSequenceGap { sequence, bound }) if sequence == "xs" && bound == "width"),
+            accepted,
+            "{source}: {contract:?}"
+        );
+    }
+}
+
+#[test]
+fn string_growth_requires_a_nonempty_literal_and_an_unchanged_bound() {
+    for (growth, bound, expected) in [
+        (r#""0" + text"#, "width", true),
+        (r#"text + "xy""#, "width", true),
+        (r#""" + text"#, "width", false),
+        (r#""0" + text"#, "width + 1", false),
+        ("text + text", "width", false),
+    ] {
+        let source = format!(
+            r#"module Pad
+    intent = "The sequence must grow strictly."
+fn pad(text: String, width: Int) -> String
+    match String.len(text) >= width
+        true -> text
+        false -> pad({growth}, {bound})
+"#
+        );
+        let ctx = build_ctx(&source);
+        let contract = fn_contract(&ctx, "pad");
+        assert_eq!(
+            matches!(contract.and_then(|c| c.recursion.as_ref()), Some(RecursionContract::WellFoundedSequenceGap { sequence, bound }) if sequence == "text" && bound == "width"),
+            expected,
+            "{source}: {contract:?}"
+        );
+    }
+}

--- a/tests/proof_ir_diff/bounded_unfolding.rs
+++ b/tests/proof_ir_diff/bounded_unfolding.rs
@@ -147,6 +147,15 @@ verify identity law fixedWidth
                 ctx.proof_ir.fn_contracts, ctx.recursive_fns
             )
         });
+    let cone = &ctx.proof_ir.law_theorems[0].function_cone;
+    assert!(
+        cone.len() >= 4,
+        "Include wrappers and both recursive helpers"
+    );
+    assert!(
+        cone.iter()
+            .all(|id| ctx.symbol_table.fn_entry(*id).key.scope_str() == Some("Codec"))
+    );
     assert_eq!(plan.functions.len(), 2);
     for id in &plan.functions {
         assert_eq!(
@@ -154,4 +163,35 @@ verify identity law fixedWidth
             Some("Codec")
         );
     }
+}
+
+#[test]
+fn law_function_cone_tracks_cycles_guards_and_reasons_but_not_samples() {
+    let source = include_str!("../fixtures/source_recursion/native_sequence.av")
+        .replace("fn shuffle(", "fn sample() -> List<Int>\n    [4, 4, 4]\n\nfn guard(items: List<Int>) -> Bool\n    List.len(items) >= 3\n\nfn reason(items: List<Int>) -> Bool\n    true\n\nfn shuffle(")
+        .replace("[[4, 4, 4], [9, 9, 9, 9]]", "[sample()]")
+        .replace("when List.len(items) >= 3", "when guard(items)\n    because reason(items)");
+    let ctx = build_ctx(&source);
+    let law = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.law_name == "threeTurns")
+        .unwrap();
+    let names: std::collections::BTreeSet<_> = law
+        .function_cone
+        .iter()
+        .map(|id| ctx.symbol_table.fn_entry(*id).key.name.as_str())
+        .collect();
+    assert_eq!(
+        names,
+        ["shuffle", "at", "select", "guard", "reason"]
+            .into_iter()
+            .collect()
+    );
+    assert_eq!(
+        law.function_cone.len(),
+        names.len(),
+        "Cycles terminate without duplicate declarations"
+    );
 }

--- a/tests/proof_ir_diff/bounded_unfolding.rs
+++ b/tests/proof_ir_diff/bounded_unfolding.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+const SOURCE: &str = include_str!("../fixtures/source_recursion/bounded_unfolding.av");
+
+#[test]
+fn literal_countdowns_are_obligation_local_search_hints() {
+    let ctx = build_ctx(SOURCE);
+    let three = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.law_name == "threeDigits")
+        .unwrap();
+    let five = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.law_name == "fiveDigits")
+        .unwrap();
+    assert_eq!(three.unfolding.len(), 1);
+    assert_eq!(five.unfolding.len(), 2);
+    for (theorem, depth) in [(three, 7), (five, 9)] {
+        for plan in &theorem.unfolding {
+            let plan = plan.as_ref().unwrap();
+            assert_eq!(plan.depth, depth);
+            let names: std::collections::BTreeSet<_> = plan
+                .functions
+                .iter()
+                .map(|id| ctx.symbol_table.fn_entry(*id).key.name.as_str())
+                .collect();
+            assert_eq!(names, ["digitsInto", "readFrom"].into_iter().collect());
+            assert_eq!(plan.reverse_elements, [aver::ast::Type::Int]);
+        }
+        assert_eq!(theorem.quantifiers.len(), 1);
+        assert_eq!(theorem.premises.len(), 1);
+    }
+}
+
+#[test]
+fn samples_and_range_guards_do_not_supply_unfolding_widths() {
+    for width in ["width", "17"] {
+        let source = SOURCE
+            .replace(
+                "read(digits(value, 3))",
+                &format!("read(digits(value, {width}))"),
+            )
+            .replace(
+                "verify digits law threeDigits\n",
+                "verify digits law threeDigits\n    given width: Int = [2, 4, 8]\n",
+            );
+        let ctx = build_ctx(&source);
+        let law = ctx
+            .proof_ir
+            .law_theorems
+            .iter()
+            .find(|t| t.law_name == "threeDigits")
+            .unwrap();
+        assert!(law.unfolding[0].is_none(), "{width}: {:?}", law.unfolding);
+    }
+    let source = SOURCE
+        .replace("[0, 1, 999]", "[123456789]")
+        .replace("    when Bool.and(value >= 0, value < 1000)\n", "");
+    let ctx = build_ctx(&source);
+    let law = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.law_name == "threeDigits")
+        .unwrap();
+    assert_eq!(law.unfolding[0].as_ref().unwrap().depth, 7);
+    assert!(law.premises.is_empty()); // Search hints do not invent the missing bound.
+
+    let source = SOURCE
+        .replace(
+            "verify digits law threeDigits\n",
+            "verify digits law threeDigits\n    given suffix: List<Int> = [[], [1]]\n",
+        )
+        .replace(
+            "read(digits(value, 3)) => value",
+            "List.concat(digits(value, 3), suffix) => List.concat(digits(value, 3), suffix)",
+        );
+    let ctx = build_ctx(&source);
+    let law = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.law_name == "threeDigits")
+        .unwrap();
+    assert!(
+        law.unfolding[0].is_none(),
+        "An arbitrary suffix must retain citation search"
+    );
+}
+
+#[test]
+fn imported_unfolding_cones_keep_canonical_function_identity() {
+    let dep = SOURCE.split("verify identity").next().unwrap().replace(
+        "module BoundedUnfolding",
+        "module Codec\n    exposes [digits, read]",
+    );
+    let ctx = build_ctx_with_modules(
+        r#"module Consumer
+    depends [Codec]
+fn digitsInto(n: Int) -> Int
+    n + 100
+fn readFrom(n: Int) -> Int
+    n + 200
+fn roundtrip(n: Int) -> Int
+    Codec.read(Codec.digits(n, 3))
+verify roundtrip law fixedWidth
+    given n: Int = [1]
+    when Bool.and(n >= 0, n < 1000)
+    using []
+    roundtrip(n) => n
+"#,
+        &[("Codec", &dep)],
+    );
+    let law = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.law_name == "fixedWidth")
+        .unwrap();
+    // A wrapper containing a composed call is deliberately outside the small
+    // direct-forwarding recognizer. Put the literal call in the claim instead.
+    assert!(law.unfolding[0].is_none());
+    let entry = r#"module Consumer
+    depends [Codec]
+fn digitsInto(n: Int) -> Int
+    n + 100
+fn readFrom(n: Int) -> Int
+    n + 200
+fn identity(n: Int) -> Int
+    n
+verify identity law fixedWidth
+    given n: Int = [1]
+    when Bool.and(n >= 0, n < 1000)
+    using []
+    Codec.read(Codec.digits(n, 3)) => n
+"#;
+    let ctx = build_ctx_with_modules(entry, &[("Codec", &dep)]);
+    let plan = ctx.proof_ir.law_theorems[0].unfolding[0]
+        .as_ref()
+        .unwrap_or_else(|| {
+            panic!(
+                "contracts: {:?}; recursive: {:?}",
+                ctx.proof_ir.fn_contracts, ctx.recursive_fns
+            )
+        });
+    assert_eq!(plan.functions.len(), 2);
+    for id in &plan.functions {
+        assert_eq!(
+            ctx.symbol_table.fn_entry(*id).key.scope_str(),
+            Some("Codec")
+        );
+    }
+}

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -85,6 +85,8 @@ mod recursive_law_reasons;
 mod scc_list_drop;
 #[path = "proof_spec/source_only.rs"]
 mod source_only;
+#[path = "proof_spec/source_recursion.rs"]
+mod source_recursion;
 #[path = "proof_spec/wf_fuel.rs"]
 mod wf_fuel;
 #[path = "proof_spec/when_lane.rs"]

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -25,6 +25,8 @@ mod check_gates;
 mod citation_attempts;
 #[path = "proof_spec/citation_order.rs"]
 mod citation_order;
+#[path = "proof_spec/citation_reuse.rs"]
+mod citation_reuse;
 #[path = "proof_spec/conditional_split_omega.rs"]
 mod conditional_split_omega;
 #[path = "proof_spec/container_induction.rs"]

--- a/tests/proof_spec/citation_reuse.rs
+++ b/tests/proof_spec/citation_reuse.rs
@@ -2,16 +2,34 @@ use super::*;
 
 const SOURCE: &str = include_str!("../fixtures/source_recursion/floor_citation.av");
 
+// The positive corpus needs its decomposition pool. For a false supplier,
+// isolate the counterexample from unrelated quantified sibling facts: otherwise
+// Z3 can exhaust its search budget instead of reporting the false statement.
+// Keep the same source function, false claim and misleading zero samples.
+fn isolated_false_supplier() -> String {
+    let definitions = SOURCE.split_once("verify digits law prefix").unwrap().0;
+    let law = SOURCE
+        .split_once("verify digits law singletonPrefix")
+        .unwrap()
+        .1
+        .split_once("verify digits law oneDigit")
+        .unwrap()
+        .0;
+    format!("{definitions}verify digits law singletonPrefix{law}")
+        .replace("given item: Int = [2, 3]", "given item: Int = [0]")
+        .replace(
+            "digits(value, [item]) => List.prepend(item, digits(value, []))",
+            "digits(value, [item]) => List.prepend(0, digits(value, []))",
+        )
+}
+
 #[test]
 fn dafny_citation_reuse_keeps_guards_and_checks_false_unused_suppliers() {
     let (ordinary, guided) = SOURCE.split_once("verify digits law citedPrefix").unwrap();
     let (before_positive, positive) = guided
         .split_once("verify digits law citedPositive")
         .unwrap();
-    let false_ordinary = ordinary.replace(
-        "digits(value, [item]) => List.prepend(item, digits(value, []))",
-        "digits(value, [item]) => List.prepend(0, digits(value, []))",
-    );
+    let false_ordinary = isolated_false_supplier();
     for (name, source, expected) in [
         ("positive", SOURCE.to_string(), true),
         (
@@ -35,7 +53,7 @@ fn dafny_citation_reuse_keeps_guards_and_checks_false_unused_suppliers() {
             "false_unused_supplier",
             format!(
                 "{false_ordinary}\nverify digits law citedPrefix{}",
-                guided.replace(
+                before_positive.replace(
                     "digits(value, [item]) => List.prepend(item, digits(value, []))",
                     "digits(value, [item]) => digits(value, [item])"
                 )
@@ -78,17 +96,12 @@ fn dafny_citation_reuse_retains_import_owner_and_module_local_earlier_laws() {
     for false_supplier in [false, true] {
         let dir = temp_output_dir("aver-citation-reuse-import");
         std::fs::create_dir_all(&dir).unwrap();
-        let source = SOURCE.replace("module FloorCitation", "module Codec\n    exposes [digits]");
         let source = if false_supplier {
-            source
-                .replace("given item: Int = [2, 3]", "given item: Int = [0]")
-                .replace(
-                    "digits(value, [item]) => List.prepend(item, digits(value, []))",
-                    "digits(value, [item]) => List.prepend(0, digits(value, []))",
-                )
+            isolated_false_supplier()
         } else {
-            source
-        };
+            SOURCE.to_string()
+        }
+        .replace("module FloorCitation", "module Codec\n    exposes [digits]");
         std::fs::write(dir.join("codec.av"), source).unwrap();
         let entry = dir.join("main.av");
         std::fs::write(

--- a/tests/proof_spec/citation_reuse.rs
+++ b/tests/proof_spec/citation_reuse.rs
@@ -1,0 +1,184 @@
+use super::*;
+
+const SOURCE: &str = include_str!("../fixtures/source_recursion/floor_citation.av");
+
+#[test]
+fn dafny_citation_reuse_keeps_guards_and_checks_false_unused_suppliers() {
+    let (ordinary, guided) = SOURCE.split_once("verify digits law citedPrefix").unwrap();
+    let (before_positive, positive) = guided
+        .split_once("verify digits law citedPositive")
+        .unwrap();
+    let false_ordinary = ordinary.replace(
+        "digits(value, [item]) => List.prepend(item, digits(value, []))",
+        "digits(value, [item]) => List.prepend(0, digits(value, []))",
+    );
+    for (name, source, expected) in [
+        ("positive", SOURCE.to_string(), true),
+        (
+            "forward_supplier",
+            format!(
+                "{}verify digits law citedPrefix{guided}{}",
+                ordinary.split_once("verify digits law prefix").unwrap().0,
+                &ordinary[ordinary.find("verify digits law prefix").unwrap()..]
+            ),
+            true,
+        ),
+        (
+            "missing_premise",
+            format!(
+                "{ordinary}verify digits law citedPrefix{before_positive}verify digits law citedPositive{}",
+                positive.replace("    when value > 0\n", "")
+            ),
+            false,
+        ),
+        (
+            "false_unused_supplier",
+            format!(
+                "{false_ordinary}\nverify digits law citedPrefix{}",
+                guided.replace(
+                    "digits(value, [item]) => List.prepend(item, digits(value, []))",
+                    "digits(value, [item]) => digits(value, [item])"
+                )
+            ),
+            false,
+        ),
+    ] {
+        let dir = temp_output_dir(&format!("aver-citation-reuse-{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        let source = if name == "false_unused_supplier" {
+            source.replace("given item: Int = [2, 3]", "given item: Int = [0]")
+        } else {
+            source
+        };
+        std::fs::write(&path, source).unwrap();
+        // Zero-valued samples conceal the false arbitrary-item supplier.
+        let samples = Command::new(env!("CARGO_BIN_EXE_aver"))
+            .arg("verify")
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(
+            samples.status.success(),
+            "{name}: {}",
+            format_output(&samples)
+        );
+        let Some(summary) = super::source_recursion::check(path.to_str().unwrap(), "dafny") else {
+            return;
+        };
+        assert_eq!(summary["passed"], expected, "{name}: {summary}");
+        if !expected {
+            assert!(summary["errors"].as_u64().unwrap() > 0, "{name}: {summary}");
+        }
+    }
+}
+
+#[test]
+fn dafny_citation_reuse_retains_import_owner_and_module_local_earlier_laws() {
+    for false_supplier in [false, true] {
+        let dir = temp_output_dir("aver-citation-reuse-import");
+        std::fs::create_dir_all(&dir).unwrap();
+        let source = SOURCE.replace("module FloorCitation", "module Codec\n    exposes [digits]");
+        let source = if false_supplier {
+            source
+                .replace("given item: Int = [2, 3]", "given item: Int = [0]")
+                .replace(
+                    "digits(value, [item]) => List.prepend(item, digits(value, []))",
+                    "digits(value, [item]) => List.prepend(0, digits(value, []))",
+                )
+        } else {
+            source
+        };
+        std::fs::write(dir.join("codec.av"), source).unwrap();
+        let entry = dir.join("main.av");
+        std::fs::write(
+            &entry,
+            r#"module Main
+    depends [Codec]
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    acc
+verify digits law singletonPrefix
+    given value: Int = [0, 1]
+    given acc: List<Int> = [[], [8]]
+    digits(value, acc) => acc
+verify digits law importedPrefix
+    given value: Int = [0, 123]
+    given item: Int = [0]
+    using [Codec.digits.singletonPrefix]
+    Codec.digits(value, [item]) => List.prepend(item, Codec.digits(value, []))
+"#,
+        )
+        .unwrap();
+        let Some(summary) = super::source_recursion::check(entry.to_str().unwrap(), "dafny") else {
+            return;
+        };
+        assert_eq!(summary["passed"], !false_supplier, "{summary}");
+        if false_supplier {
+            assert!(summary["errors"].as_u64().unwrap() > 0, "{summary}");
+        }
+    }
+}
+
+#[test]
+fn dafny_citation_reuse_does_not_promote_a_finite_mutual_law() {
+    let dir = temp_output_dir("aver-citation-reuse-finite");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.av");
+    std::fs::write(
+        &path,
+        r#"module FiniteCitation
+fn at(items: List<Int>, index: Int) -> Int
+    match items
+        [] -> 0
+        [head, ..tail] -> select(head, tail, index)
+fn select(head: Int, tail: List<Int>, index: Int) -> Int
+    match index == 0
+        true -> head
+        false -> at(tail, index - 1)
+verify at law sampled
+    given n: Int = [0, 1]
+    at([n], 0) => Int.abs(n)
+verify at law reflexiveConsumer
+    given n: Int = [0, 1]
+    using [at.sampled]
+    at([n], 0) => at([n], 0)
+"#,
+    )
+    .unwrap();
+    let samples = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .arg("verify")
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(samples.status.success(), "{}", format_output(&samples));
+    let Some(summary) = super::source_recursion::check(path.to_str().unwrap(), "dafny") else {
+        return;
+    };
+    assert_eq!(summary["passed"], false, "{summary}");
+    assert!(summary["errors"].as_u64().unwrap() > 0, "{summary}");
+}
+
+#[test]
+fn dafny_citation_reuse_supports_an_ordinary_native_sequence_universal() {
+    let dir = temp_output_dir("aver-citation-reuse-native-sequence");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.av");
+    let source = include_str!("../fixtures/source_recursion/native_sequence.av");
+    std::fs::write(
+        &path,
+        format!(
+            "{source}\n{}",
+            r#"verify shuffle law citedPermutation
+    given items: List<Int> = [[4, 4, 4], [9, 9, 9, 9]]
+    when List.len(items) >= 3
+    using [shuffle.threeTurns]
+    shuffle(shuffle(shuffle(items))) => List.take(items, 3)
+"#
+        ),
+    )
+    .unwrap();
+    let Some(summary) = super::source_recursion::check(path.to_str().unwrap(), "dafny") else {
+        return;
+    };
+    assert_eq!(summary["passed"], true, "{summary}");
+}

--- a/tests/proof_spec/source_recursion.rs
+++ b/tests/proof_spec/source_recursion.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+fn check(source: &str, backend: &str) -> Option<serde_json::Value> {
+    let checker = if backend == "lean" { "lake" } else { "dafny" };
+    if Command::new(checker).arg("--version").output().is_err() {
+        return None;
+    }
+    let dir = temp_output_dir("aver-source-recursion");
+    let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .args(["proof", source, "--backend", backend, "--check-json", "-o"])
+        .arg(&dir)
+        .arg("--module-root")
+        .arg(std::path::Path::new(source).parent().unwrap())
+        .output()
+        .expect("run source-recursion proof");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let summary: serde_json::Value = serde_json::from_str(
+        stdout
+            .lines()
+            .rev()
+            .find(|l| l.starts_with('{'))
+            .unwrap_or_else(|| panic!("{source}/{backend}: {}", format_output(&output))),
+    )
+    .unwrap();
+    assert_eq!(summary["passed"], output.status.success(), "{summary}");
+    for field in if backend == "lean" {
+        &["build_errors"][..]
+    } else {
+        &["axioms", "omitted", "timeouts"][..]
+    } {
+        assert_eq!(summary[field], 0, "{source}/{backend}: {summary}; {dir:?}");
+    }
+    assert_eq!(summary["declined"].as_u64().unwrap_or(0), 0, "{summary}");
+    if backend == "lean" {
+        let manifest: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.join("proof_manifest.json")).unwrap(),
+        )
+        .unwrap();
+        for law in manifest["laws"].as_array().unwrap() {
+            assert_eq!(
+                law["tier"],
+                if output.status.success() {
+                    "universal"
+                } else {
+                    "failed"
+                },
+                "{law}"
+            );
+            assert!(
+                !output.status.success()
+                    || law["axioms"].as_array().unwrap().iter().all(|a| matches!(
+                        a.as_str(),
+                        Some("propext" | "Classical.choice" | "Quot.sound")
+                    )),
+                "{law}"
+            );
+        }
+    }
+    Some(summary)
+}
+
+#[test]
+fn source_recursion_identical_positive_sources_pass_both_checkers() {
+    for (source, laws) in [
+        ("tests/fixtures/guarded_countdown_digits.av", 4),
+        ("tests/fixtures/source_recursion/list_fold.av", 3),
+        ("tests/fixtures/source_recursion/imported/main.av", 2),
+        ("tests/fixtures/source_recursion/sequence_growth.av", 3),
+    ] {
+        for backend in ["dafny", "lean"] {
+            let Some(summary) = check(source, backend) else {
+                continue;
+            };
+            assert_eq!(summary["passed"], true, "{source}/{backend}: {summary}");
+            if backend == "lean" {
+                assert_eq!(summary["universal_laws"], laws, "{summary}");
+            }
+        }
+    }
+}
+
+#[test]
+fn source_recursion_rejects_dropped_accumulator_and_failed_supplier() {
+    for backend in ["dafny", "lean"] {
+        let Some(summary) = check(
+            "tests/fixtures/source_recursion/false_accumulator.av",
+            backend,
+        ) else {
+            continue;
+        };
+        assert_eq!(summary["passed"], false, "{backend}: {summary}");
+        let failures = if backend == "lean" {
+            "sorries"
+        } else {
+            "errors"
+        };
+        assert!(
+            summary[failures].as_u64().unwrap() >= if backend == "lean" { 1 } else { 2 },
+            "{summary}"
+        );
+    }
+}

--- a/tests/proof_spec/source_recursion.rs
+++ b/tests/proof_spec/source_recursion.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn check(source: &str, backend: &str) -> Option<serde_json::Value> {
+pub(super) fn check(source: &str, backend: &str) -> Option<serde_json::Value> {
     let checker = if backend == "lean" { "lake" } else { "dafny" };
     if Command::new(checker).arg("--version").output().is_err() {
         return None;
@@ -58,6 +58,95 @@ fn check(source: &str, backend: &str) -> Option<serde_json::Value> {
         }
     }
     Some(summary)
+}
+
+#[test]
+fn dafny_bounded_unfolding_keeps_universal_values_and_checks_every_supplier_and_reason() {
+    let source = include_str!("../fixtures/source_recursion/bounded_unfolding.av");
+    for (name, source, expected) in [
+        ("positive", source.to_string(), true),
+        (
+            "different_radix",
+            source
+                .replace(", 10)", ", 16)")
+                .replace("acc * 10", "acc * 16")
+                .replace("< 1000)", "< 4096)")
+                .replace("< 100000)", "< 1048576)"),
+            true,
+        ),
+        (
+            "missing_guard",
+            source.replace("    when Bool.and(value >= 0, value < 1000)\n", ""),
+            false,
+        ),
+        (
+            "false_reason",
+            source.replace(
+                "because read(digits(value, 5)) == value",
+                "because read(digits(value, 5)) == value + 1",
+            ),
+            false,
+        ),
+        (
+            "false_unused_supplier",
+            source.replace("identity(value) => value", "identity(value) => value + 1"),
+            false,
+        ),
+    ] {
+        let dir = temp_output_dir(&format!("aver-bounded-unfolding-{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        let Some(summary) = check(path.to_str().unwrap(), "dafny") else {
+            return;
+        };
+        assert_eq!(summary["passed"], expected, "{name}: {summary}");
+        if !expected {
+            assert!(summary["errors"].as_u64().unwrap() > 0, "{name}: {summary}");
+        }
+    }
+}
+
+#[test]
+fn dafny_bounded_unfolding_handles_imported_names_and_typed_reverse_helpers() {
+    let dir = temp_output_dir("aver-bounded-import");
+    std::fs::create_dir_all(&dir).unwrap();
+    let source = include_str!("../fixtures/source_recursion/bounded_unfolding.av").replace(
+        "module BoundedUnfolding",
+        "module Codec\n    exposes [digits, read]",
+    );
+    std::fs::write(dir.join("codec.av"), source).unwrap();
+    let entry = dir.join("main.av");
+    std::fs::write(
+        &entry,
+        r#"module Main
+    depends [Codec]
+fn readFrom(n: Int) -> Int
+    n + 100
+fn digitsInto(n: Int) -> Int
+    n + 200
+fn identity(n: Int) -> Int
+    n
+verify identity law importedDigits
+    given n: Int = [0, 999]
+    when Bool.and(n >= 0, n < 1000)
+    using []
+    Codec.read(Codec.digits(n, 3)) => n
+fn repeat(value: Bool, width: Int, acc: List<Bool>) -> List<Bool>
+    match width <= 0
+        true -> List.reverse(acc)
+        false -> repeat(value, width - 1, List.prepend(value, acc))
+verify repeat law threeValues
+    given value: Bool = [true, false]
+    using []
+    repeat(value, 3, []) => [value, value, value]
+"#,
+    )
+    .unwrap();
+    let Some(summary) = check(entry.to_str().unwrap(), "dafny") else {
+        return;
+    };
+    assert_eq!(summary["passed"], true, "{summary}");
 }
 
 #[test]

--- a/tests/proof_spec/source_recursion.rs
+++ b/tests/proof_spec/source_recursion.rs
@@ -254,3 +254,79 @@ fn source_recursion_rejects_dropped_accumulator_and_failed_supplier() {
         );
     }
 }
+
+#[test]
+fn dafny_native_mutual_sequence_laws_prove_universally_and_reject_sample_blind_spots() {
+    let source = include_str!("../fixtures/source_recursion/native_sequence.av");
+    for (name, source, expected) in [
+        ("positive", source.to_string(), true),
+        (
+            "wrong_order",
+            source.replace(
+                "shuffle(shuffle(shuffle(items)))",
+                "shuffle(shuffle(items))",
+            ),
+            false,
+        ),
+        (
+            "missing_length",
+            source.replace("    when List.len(items) >= 3\n", ""),
+            false,
+        ),
+        (
+            "missing_index",
+            source.replace("    when Bool.and(index >= 0, index < 3)\n", ""),
+            false,
+        ),
+    ] {
+        let dir = temp_output_dir(&format!("aver-native-sequence-{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        // Symmetric samples deliberately miss the permutation error; all
+        // supplied lists/indices also satisfy the guards removed above.
+        let vm = Command::new(env!("CARGO_BIN_EXE_aver"))
+            .args(["verify", path.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(vm.status.success(), "{name}: {}", format_output(&vm));
+        if let Some(summary) = check(path.to_str().unwrap(), "dafny") {
+            assert_eq!(summary["passed"], expected, "{name}: {summary}");
+            if !expected {
+                assert!(summary["errors"].as_u64().unwrap() > 0, "{name}: {summary}");
+            }
+        }
+    }
+}
+
+#[test]
+fn dafny_native_sequence_search_preserves_import_owners_and_boolean_elements() {
+    let source = include_str!("../fixtures/source_recursion/native_sequence.av");
+    let (definitions, claims) = source.split_once("fn shuffle").unwrap();
+    let dir = temp_output_dir("aver-native-sequence-import");
+    std::fs::create_dir_all(&dir).unwrap();
+    let dependency =
+        definitions.replace("module NativeSequence", "module Lookup\n    exposes [at]");
+    std::fs::write(dir.join("lookup.av"), dependency).unwrap();
+    let entry = format!(
+        "module Consumer\n    depends [Lookup]\n\nfn at(n: Int) -> Int\n    n + 99\n\nfn select(n: Int) -> Int\n    n + 77\n\nfn shuffle{}",
+        claims.replace("at(items,", "Lookup.at(items,")
+    );
+    let path = dir.join("main.av");
+    std::fs::write(&path, entry).unwrap();
+    if let Some(summary) = check(path.to_str().unwrap(), "dafny") {
+        assert_eq!(summary["passed"], true, "{summary}");
+    }
+    let bool_source = source
+        .replace("List<Int>", "List<Bool>")
+        .replace("head: Int", "head: Bool")
+        .replace(") -> Int", ") -> Bool")
+        .replace("[] -> 0", "[] -> false")
+        .replace("[4, 4, 4]", "[true, true, true]")
+        .replace("[9, 9, 9, 9]", "[false, false, false, false]");
+    let path = dir.join("bool.av");
+    std::fs::write(&path, bool_source).unwrap();
+    if let Some(summary) = check(path.to_str().unwrap(), "dafny") {
+        assert_eq!(summary["passed"], true, "{summary}");
+    }
+}

--- a/tests/proof_spec/source_recursion.rs
+++ b/tests/proof_spec/source_recursion.rs
@@ -150,6 +150,70 @@ verify repeat law threeValues
 }
 
 #[test]
+fn dafny_sequence_composition_preserves_order_and_checks_cited_fields() {
+    let main = include_str!("../fixtures/source_recursion/framing/main.av");
+    let codec = include_str!("../fixtures/source_recursion/framing/codec.av");
+    let (before, reason_and_law) = main.split_once("fn roundtrip").unwrap();
+    let (reason, law) = reason_and_law.split_once("verify send law").unwrap();
+    let false_reason = format!(
+        "{before}fn roundtrip{}verify send law{law}",
+        reason.replace("rest = suffix", "rest = List.reverse(suffix)")
+    );
+    for (name, source, expected) in [
+        ("positive", main.to_string(), true),
+        ("reordered_reason", false_reason, false),
+        (
+            "reordered_claim",
+            main.replace(
+                "rest = suffix, consumed = List.len",
+                "rest = List.reverse(suffix), consumed = List.len",
+            ),
+            false,
+        ),
+        (
+            "false_supplier",
+            main.replacen(
+                "Packet(value = value, rest = suffix, consumed = 4)",
+                "Packet(value = value + 1, rest = suffix, consumed = 4)",
+                1,
+            ),
+            false,
+        ),
+    ] {
+        let dir = temp_output_dir(&format!("aver-framing-{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("codec.av"), codec).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        if name.starts_with("reordered") {
+            // Empty/singleton samples cannot distinguish either reordering.
+            // The universal checker must still reject the incorrect law.
+            let sampled = Command::new(env!("CARGO_BIN_EXE_aver"))
+                .args([
+                    "verify",
+                    path.to_str().unwrap(),
+                    "--module-root",
+                    dir.to_str().unwrap(),
+                ])
+                .output()
+                .unwrap();
+            assert!(sampled.status.success(), "{}", format_output(&sampled));
+        }
+        let Some(summary) = check(path.to_str().unwrap(), "dafny") else {
+            return;
+        };
+        assert_eq!(summary["passed"], expected, "{name}: {summary}");
+        if !expected {
+            assert!(summary["errors"].as_u64().unwrap() > 0, "{name}: {summary}");
+        }
+    }
+    let Some(summary) = check("tests/fixtures/source_recursion/framing/typed.av", "dafny") else {
+        return;
+    };
+    assert_eq!(summary["passed"], true, "{summary}");
+}
+
+#[test]
 fn source_recursion_identical_positive_sources_pass_both_checkers() {
     for (source, laws) in [
         ("tests/fixtures/guarded_countdown_digits.av", 4),

--- a/tests/proof_spec/source_recursion.rs
+++ b/tests/proof_spec/source_recursion.rs
@@ -221,6 +221,7 @@ fn source_recursion_identical_positive_sources_pass_both_checkers() {
         ("tests/fixtures/source_recursion/imported/main.av", 2),
         ("tests/fixtures/source_recursion/sequence_growth.av", 3),
         ("tests/fixtures/source_recursion/floor_digits.av", 7),
+        ("tests/fixtures/source_recursion/floor_citation.av", 9),
     ] {
         for backend in ["dafny", "lean"] {
             let Some(summary) = check(source, backend) else {
@@ -249,10 +250,10 @@ fn source_recursion_rejects_dropped_accumulator_and_failed_supplier() {
         } else {
             "errors"
         };
-        assert!(
-            summary[failures].as_u64().unwrap() >= if backend == "lean" { 1 } else { 2 },
-            "{summary}"
-        );
+        // A citation may reuse the ordinary supplier instead of failing a
+        // second proof of the same false statement. The original supplier
+        // must still fail and keep the entire file outside universal credit.
+        assert!(summary[failures].as_u64().unwrap() > 0, "{summary}");
     }
 }
 

--- a/tests/proof_spec/source_recursion.rs
+++ b/tests/proof_spec/source_recursion.rs
@@ -220,6 +220,7 @@ fn source_recursion_identical_positive_sources_pass_both_checkers() {
         ("tests/fixtures/source_recursion/list_fold.av", 3),
         ("tests/fixtures/source_recursion/imported/main.av", 2),
         ("tests/fixtures/source_recursion/sequence_growth.av", 3),
+        ("tests/fixtures/source_recursion/floor_digits.av", 7),
     ] {
         for backend in ["dafny", "lean"] {
             let Some(summary) = check(source, backend) else {
@@ -328,5 +329,103 @@ fn dafny_native_sequence_search_preserves_import_owners_and_boolean_elements() {
     std::fs::write(&path, bool_source).unwrap();
     if let Some(summary) = check(path.to_str().unwrap(), "dafny") {
         assert_eq!(summary["passed"], true, "{summary}");
+    }
+}
+
+#[test]
+fn dafny_floor_division_laws_keep_fixed_seeds_and_require_real_universal_proofs() {
+    let source = include_str!("../fixtures/source_recursion/floor_digits.av");
+    for (name, source, expected) in [
+        ("positive", source.to_string(), true),
+        (
+            "radix_seven",
+            source.replace("10", "7").replace("[1, 9]", "[1, 6]"),
+            true,
+        ),
+        (
+            "missing_digit_guard",
+            source.replace("    when Bool.and(value > 0, value < 10)\n", ""),
+            false,
+        ),
+        (
+            "missing_range_guard",
+            source.replace("    when Bool.or(item < 0, item >= 10)\n", ""),
+            false,
+        ),
+        (
+            "missing_positive_guard",
+            source.replace("    when value > 0\n", ""),
+            false,
+        ),
+        (
+            "wrong_prefix",
+            source.replace("[2, 3]", "[2, 2]").replace(
+                "List.concat(List.reverse(acc), digits(value, []))",
+                "List.concat(acc, digits(value, []))",
+            ),
+            false,
+        ),
+    ] {
+        // A counterexample to one law does not need the automatic pool of
+        // other true laws. Isolate it so quantified citations do not turn
+        // a concrete rejection into a search timeout.
+        let source = if expected {
+            source
+        } else {
+            let target = match name {
+                "missing_digit_guard" => "oneDigit",
+                "missing_range_guard" => "outsideRange",
+                "missing_positive_guard" => "positive",
+                "wrong_prefix" => "prefix",
+                _ => unreachable!(),
+            };
+            let mut blocks = source.split("verify digits law ");
+            let definitions = blocks.next().unwrap();
+            let law = blocks
+                .find(|b| b.starts_with(&format!("{target}\n")))
+                .unwrap();
+            format!("{definitions}verify digits law {law}")
+        };
+        let dir = temp_output_dir(&format!("aver-floor-laws-{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        let sampled = Command::new(env!("CARGO_BIN_EXE_aver"))
+            .args(["verify", path.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(
+            sampled.status.success(),
+            "{name}: {}",
+            format_output(&sampled)
+        );
+        if let Some(summary) = check(path.to_str().unwrap(), "dafny") {
+            assert_eq!(summary["passed"], expected, "{name}: {summary}");
+            if !expected {
+                assert!(summary["errors"].as_u64().unwrap() > 0, "{summary}");
+            }
+        }
+    }
+}
+
+#[test]
+fn dafny_recursive_premise_guards_bind_list_projections_without_excusing_a_false_law() {
+    let source = include_str!("../fixtures/source_recursion/guarded_list_seed.av");
+    for (name, source, expected) in [
+        ("positive", source.to_string(), true),
+        ("false", source.replace("Int.abs(head)", "head"), false),
+    ] {
+        let dir = temp_output_dir(&format!("aver-list-premise-{name}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        let vm = Command::new(env!("CARGO_BIN_EXE_aver"))
+            .args(["verify", path.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(vm.status.success(), "{}", format_output(&vm));
+        if let Some(summary) = check(path.to_str().unwrap(), "dafny") {
+            assert_eq!(summary["passed"], expected, "{name}: {summary}");
+        }
     }
 }


### PR DESCRIPTION
BTC byte encoders previously used their growing accumulator as a termination measure, and their law proofs recursed with the wrong accumulator. This PR fixes the shared analysis and closes all ten `Message` laws and all six `CompactSize` laws on unchanged BTC source. Strict whole-module coverage rises from **7/104 to 23/104**, including `ScriptMath`. The four `ScriptState.rearranged` laws also verify without their former axiom fallbacks; open imported obligations keep them outside the strict total.

ProofIR carries checked induction drivers, actual recursive arguments, remaining-length measures, obligation-local countdown hints, recursive premises and canonical transitive function dependencies. Lean's guided equation selection and Dafny's ordinary-law unfolding consume the shared dependency field, preserving declaration ownership and including mutual peers hidden behind wrappers.

Dafny checks the sequence identities needed to compose header, payload and suffix. It attempts ordinary laws over native mutual recursion with list binders universally, separately from its legacy finite-Int lane. Native floor-division recursion no longer causes blanket ordinary-law omissions: shared induction accepts fixed literal seeds and recurses on the actual source quotient. Nine of ten formerly omitted `littleEndian` laws check; readback remains open.

Guided citations now reuse an ordinary lemma when it has the same universal signature and premises. The checked restatement calls that original lemma instead of losing its decomposition facts and proving it again. Availability uses the shared ProofIR cone and Dafny's emission boundaries; bounded, opaque, omitted and specialized contracts are not promoted. Imported ordinary lemmas draw earlier facts from their own module. Both the original supplier and its caller remain obligations in the full checker run.

Validation:

- 1,680 unit tests and 77 ProofIR tests pass; formatting and CI-scope Clippy pass.
- All 124 selected integration tests have passing results: 123 in the broad run and the remaining test after updating its expectation of duplicate failures. Citation reuse leaves one failed original supplier instead of two copies; the test still requires rejection of the whole file. No proof budgets or production checker gates were relaxed.
- The same independent nine-law decimal fixture passes universally in Lean and Dafny. Controls cover forward and imported citations, colliding local names, missing premises, false unused suppliers with passing VM samples, and refusal to promote a finite-Int mutual law. An ordinary native sequence universal remains reusable. False-supplier controls isolate their counterexample from unrelated quantified sibling laws, so they require actual verification errors with zero timeouts.
- Existing framing, radix, typed-sequence, accumulator, explanation and false-reason controls retain their checks.
- BTC revision `a6870c9de7280593d3e5a5928ceb62610a2ba316` is unchanged. The census verifies imports and requires zero errors, axioms, omissions, declines and timeouts for whole-module credit. Compiler SHA-256: `fd0832cab2afe8fea8db4fe2b5631dabd93443c094adec04df8e9390ae123e45`.

Current diagnostics: `StackItem` has 6 errors and four solver timeouts (previous checkpoint: 15 and four). `ScriptState` including imports has 7 errors and four timeouts (previously 22 and two). These modules still earn no strict credit. Other modules retain open proofs and unsupported `String.toLower`. This does not establish full BTC, historical K5, or complete backend strategy parity.
