### PR TITLE
Share concrete lemma applications for source induction

### DIFF
--- a/docs/dafny.md
+++ b/docs/dafny.md
@@ -243,6 +243,23 @@ prove the original premises and a strict decrease; the plan supplies no axioms.
 Lean also consults the shared driver when choosing functional induction for a
 matching explanation. Unsupported source shapes retain the existing strategies.
 
+The plan also retains the concrete source step when a fixed accumulator seed is
+not a theorem parameter. Shared application search expands that step in the
+claim and matches earlier ordinary laws against its subterms, including terms
+exposed by another lemma's result. It records canonical function identities and
+argument expressions in `ProofIR`. Dafny renders admitted instances as lemma
+calls; Lean's countdown induction consumes the same instances as local facts.
+Both backends still check each supplier through their existing universal-law
+gates. The search currently covers earlier unconditional laws in the declaring
+module and the consumer's function cone, with `Int`, `Bool`, `String`, or list
+givens and a concrete user-function call on the left.
+Its finite search budgets limit hints, never the quantified domain. Unsupported
+terms retain ordinary induction, and normalized reflexive instances are dropped.
+
+[`roundtrip.av`](../tests/fixtures/source_recursion/roundtrip.av) demonstrates an
+unbounded decimal collector/reader roundtrip using only Aver laws. The same
+source passes Lean and Dafny, including a renamed variant using radix 16.
+
 The Dafny proof bodies additionally check sequence identities needed to match
 singleton/empty concatenations and reversals. The list reverse helper has a
 checked length-preservation postcondition. See `tests/fixtures/source_recursion/`

--- a/docs/lean.md
+++ b/docs/lean.md
@@ -218,6 +218,20 @@ The goal is to avoid making the surface language proof-engineer-first.
 
 Invariants still exist as a proof concept, especially for optimized implementations such as tail-recursive helpers, parsers with state, or accumulator-heavy code. But Aver tries to push those invariants down into the proof backend whenever possible, instead of making users write them first.
 
+Countdown induction also consumes concrete lemma applications discovered in
+shared `ProofIR`. The search retains the actual recursive accumulator, expands
+the source step inside the claim, and matches earlier ordinary laws against the
+resulting terms. Lean introduces admitted applications as local facts and
+normalizes sequence composition before unfolding a recursive consumer. It
+splits the source branch before attempting the recursive premise: for example,
+`n >= 0` gives `n - 1 >= 0` only in the positive branch. It
+discards reflexive instances that add no information and can loop as local simp
+rules. Dafny consumes the same applications through its own contract checks;
+see the [shared roundtrip example](../tests/fixtures/source_recursion/roundtrip.av)
+and [application-search limits](dafny.md#inductive-lemma-hints). The
+[Boolean counter](../tests/fixtures/source_recursion/boolean_counter.av) checks
+the same composition with a different list element type and subtractive descent.
+
 In short:
 
 - user-facing Aver should prefer explicit specs

--- a/src/codegen/dafny/law_induction.rs
+++ b/src/codegen/dafny/law_induction.rs
@@ -65,7 +65,12 @@ pub(super) fn measure(plan: &LawInduction) -> String {
     }
 }
 
-pub(super) fn calls(plan: &LawInduction, name: &str, ctx: &CodegenContext) -> Vec<String> {
+pub(super) fn calls(
+    plan: &LawInduction,
+    name: &str,
+    cites: &[(String, &VerifyLaw)],
+    ctx: &CodegenContext,
+) -> Vec<String> {
     let mut lines = Vec::new();
     for call in &plan.calls {
         lines.push(format!("  if {} {{", emit_expr(&call.guard, ctx)));
@@ -113,6 +118,25 @@ pub(super) fn calls(plan: &LawInduction, name: &str, ctx: &CodegenContext) -> Ve
             lines.push("    }".to_string());
         } else {
             lines.push(format!("    {name}({args});"));
+        }
+        for application in &call.applications {
+            let target = &ctx.symbol_table.fn_entry(application.fn_id).key.name;
+            let lemma = format!(
+                "{}_{}",
+                aver_name_to_dafny(target),
+                aver_name_to_dafny(&application.law_name)
+            );
+            // Shared search never decides whether Dafny emitted a universal
+            // supplier. Reuse the same admission gate as the forall hoist.
+            if cites.iter().any(|(name, _)| name == &lemma) {
+                let args = application
+                    .arguments
+                    .iter()
+                    .map(|a| emit_expr(a, ctx))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                lines.push(format!("    {lemma}({args});"));
+            }
         }
         lines.push("  }".to_string());
     }

--- a/src/codegen/dafny/reasons/citations.rs
+++ b/src/codegen/dafny/reasons/citations.rs
@@ -288,7 +288,7 @@ pub(super) fn plain_supplier(
                 ctx,
             ));
             if let Some(plan) = induction {
-                lines.extend(super::super::law_induction::calls(plan, &name, ctx));
+                lines.extend(super::super::law_induction::calls(plan, &name, &[], ctx));
             }
         });
     }

--- a/src/codegen/dafny/toplevel.rs
+++ b/src/codegen/dafny/toplevel.rs
@@ -3841,6 +3841,7 @@ pub(super) fn emit_verify_law(
         lines.extend(super::law_induction::calls(
             plan,
             &format!("{}_{}", fn_name, law_name),
+            &cites,
             ctx,
         ));
         lines.push("}\n".to_string());

--- a/src/codegen/lean/law_auto.rs
+++ b/src/codegen/lean/law_auto.rs
@@ -2,6 +2,7 @@
 ///
 /// This module is intentionally isolated from `toplevel.rs` so all heuristic
 /// matching and proof-shape logic lives in one place.
+mod applications;
 mod clique_mono;
 mod container_induction;
 mod decimal;

--- a/src/codegen/lean/law_auto/applications.rs
+++ b/src/codegen/lean/law_auto/applications.rs
@@ -1,0 +1,60 @@
+//! Render ProofIR's concrete applications in the existing fuel-induction step.
+//! Statement admission and transitive axiom auditing stay with the Lean backend.
+
+use crate::ast::{VerifyBlock, VerifyKind, VerifyLaw};
+use crate::codegen::CodegenContext;
+
+pub(super) fn ground(vb: &VerifyBlock, law: &VerifyLaw, ctx: &CodegenContext) -> Vec<String> {
+    let Some(id) = ctx.law_target_fn_id(&vb.fn_name) else {
+        return Vec::new();
+    };
+    let Some(plan) = ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .find(|t| t.fn_id == id && t.law_name == law.name)
+        .and_then(|t| t.induction.as_ref())
+    else {
+        return Vec::new();
+    };
+    let scope = ctx.active_module_scope();
+    let mut out = Vec::new();
+    // List projections have separate backend binder names. Until that mapping
+    // is shared, use only steps whose arguments live in the theorem's scope.
+    for step in plan.calls.iter().filter(|c| c.list_case.is_none()) {
+        for application in &step.applications {
+            for previous in super::shared::same_file_verify_blocks(ctx) {
+                if previous.line == vb.line && previous.fn_name == vb.fn_name {
+                    break;
+                }
+                let VerifyKind::Law(supplier) = &previous.kind else {
+                    continue;
+                };
+                if supplier.name != application.law_name
+                    || ctx
+                        .symbol_table
+                        .resolve_fn_id_in(&previous.fn_name, scope.as_deref())
+                        != Some(application.fn_id)
+                {
+                    continue;
+                }
+                let Some((name, _)) =
+                    crate::codegen::lean::toplevel::law_as_lemma_statement(previous, supplier, ctx)
+                else {
+                    continue;
+                };
+                let args = application
+                    .arguments
+                    .iter()
+                    .map(|a| format!("({})", super::super::expr::emit_expr(a, ctx)))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                let term = format!("{name} {args}");
+                if !out.contains(&term) {
+                    out.push(term);
+                }
+            }
+        }
+    }
+    out
+}

--- a/src/codegen/lean/law_auto/clique_mono.rs
+++ b/src/codegen/lean/law_auto/clique_mono.rs
@@ -22,8 +22,8 @@
 //! member of the same SCC. No function or type name is ever matched.
 //!
 //! The emitter proves ONE conjunction over the whole clique in Prop form by
-//! ordinary `induction fuel` with rank-slotted thresholds (`T s pos rank = (len
-//! - pos.toNat) * R + rank + 1`), then projects the user-named member's conjunct
+//! ordinary `induction fuel` with rank-slotted thresholds
+//! (`T s pos rank = (len - pos.toNat) * R + rank + 1`), then projects the user-named member's conjunct
 //! back through the fuel wrapper (bridging the law's `== / >=` Bool surface via
 //! constructor injection on the `Int` position field and `omega`). Ranks are a
 //! longest-path assignment over the subgraph of same-position / whitespace-weak

--- a/src/codegen/lean/law_auto/wf_fuel.rs
+++ b/src/codegen/lean/law_auto/wf_fuel.rs
@@ -556,6 +556,13 @@ pub(in crate::codegen::lean) fn emit_wf_fuel_induction_law(
         }
     }
 
+    let shared_applications = super::applications::ground(vb, law, ctx);
+    for application in &shared_applications {
+        if !ground.iter().any(|(seen, _)| seen == application) {
+            ground.push((application.clone(), false));
+        }
+    }
+
     // The safe simp set: the blind cone (no countdown fn) plus the earlier
     // laws that are not looping rewrites (the pool is already filtered).
     let mut safe: Vec<String> = law_simp_defs_blind(ctx, vb, law).into_iter().collect();
@@ -579,9 +586,16 @@ pub(in crate::codegen::lean) fn emit_wf_fuel_induction_law(
     let equations = super::induction::equation_grind_arm(vb, law, ctx)
         .map(|arm| format!(" | ({arm})"))
         .unwrap_or_default();
-    let basic_closers = format!(
+    let mut basic_closers = format!(
         "first | (split <;> {simp_all} <;> omega) | ({simp_all} <;> omega) | (split <;> {simp_all} <;> done)"
     );
+    if !shared_applications.is_empty() {
+        // Preserve composed calls long enough for the concrete supplier facts
+        // to rewrite them, before unfolding a recursive reader into matches.
+        basic_closers = format!(
+            "first | ((first | split | skip) <;> simp_all only [{premise_normal}, List.reverse_cons, List.reverse_append, List.reverse_nil, List.reverse_singleton, List.nil_append, List.append_nil, List.cons_append] <;> (first | omega | ({simp_all} <;> omega))) | ({basic_closers})"
+        );
+    }
     let closer = format!("{basic_closers}{equations} | sorry");
     // The BOTTOM rung of a ladder has no rung below it to cite, and its own IH
     // is one step too weak: proving `len(f(v)) <= 1` from `v < 256` leaves
@@ -621,6 +635,18 @@ pub(in crate::codegen::lean) fn emit_wf_fuel_induction_law(
         format!("       | succ {fuel} {ih} =>"),
         format!("         intro {arm_intro}"),
     ];
+    let step_pad = if shared_applications.is_empty() {
+        "         "
+    } else {
+        // The recursive premise may follow only in the source branch: for
+        // subtractive descent, x >= 0 alone does not give x - 1 >= 0. Split
+        // the checked definition before trying the IH, keeping both branches
+        // as obligations. No additional premise is assumed.
+        lines.push(format!("         unfold {}", plan.f_lean));
+        lines.push("         split".to_string());
+        lines.push("         all_goals".to_string());
+        "           "
+    };
     // The fuel-decrease discharge is floored like the closers: the arm runs
     // under `induction`'s error recovery, so a bound `omega` cannot close
     // (never expected — the recognizer admits only inline `p / k` / `p - k`
@@ -636,20 +662,22 @@ pub(in crate::codegen::lean) fn emit_wf_fuel_induction_law(
         // shrunk value, which need not hold there — `try` drops the instance
         // rather than admitting a false premise.
         lines.push(match conditional {
-            true => format!("         try ({have} (by {guard}))"),
-            false => format!("         {have}"),
+            true => format!("{step_pad}try ({have} (by {guard}))"),
+            false => format!("{step_pad}{have}"),
         });
     }
     for (i, (cite, cite_conditional)) in ground.iter().enumerate() {
         let have = format!("have {}{} := {cite}", fresh("l"), i + 1);
         lines.push(match cite_conditional {
-            true => format!("         try ({have})"),
-            false => format!("         {have}"),
+            true => format!("{step_pad}try ({have})"),
+            false => format!("{step_pad}{have}"),
         });
     }
-    lines.push(format!("         clear {ih}"));
-    lines.push(format!("         unfold {}", plan.f_lean));
-    lines.push(format!("         {deep_closer}"));
+    lines.push(format!("{step_pad}clear {ih}"));
+    if shared_applications.is_empty() {
+        lines.push(format!("{step_pad}unfold {}", plan.f_lean));
+    }
+    lines.push(format!("{step_pad}{deep_closer}"));
     let when_arg = if conditional { " h_when" } else { "" };
     lines.push(format!(
         "     exact {key} _ {} (Nat.le_refl _){when_arg})",

--- a/src/codegen/proof_lower/law_applications/mod.rs
+++ b/src/codegen/proof_lower/law_applications/mod.rs
@@ -1,0 +1,165 @@
+//! Bounded, backend-neutral search for concrete earlier-lemma applications.
+//! Source steps and rewrite closure are search data, not evidence. Both targets
+//! must check every supplier and its application through their ordinary gates.
+
+mod terms;
+
+use std::collections::BTreeSet;
+
+use crate::ast::{TopLevel, VerifyKind};
+use crate::ir::proof_ir::{LawApplication, LawTheorem, ProofIR};
+
+use super::ProofLowerInputs;
+use terms::{Bindings, Term};
+
+const ROUNDS: usize = 4;
+const TERMS: usize = 64;
+const NODES: usize = 512;
+const APPLICATIONS: usize = 32;
+
+struct Rule<'a> {
+    theorem: &'a LawTheorem,
+    lhs: Term,
+    rhs: Term,
+    variables: BTreeSet<String>,
+}
+
+fn rewrite(t: &Term, rule: &Rule, applications: &mut Vec<LawApplication>) -> Term {
+    let mut bindings = Bindings::new();
+    if terms::matches(&rule.lhs, t, &rule.variables, &mut bindings) {
+        let args: Option<Vec<_>> = rule
+            .theorem
+            .quantifiers
+            .iter()
+            .map(|q| bindings.get(&q.name).cloned())
+            .collect();
+        if let Some(arguments) = args {
+            let rhs = terms::normalize(&terms::substitute(&rule.rhs, &bindings));
+            // A normalized reflexive instance adds no information. In
+            // particular, an empty-seed identity can be a looping local simp
+            // fact before its empty containers have been normalized by Lean.
+            if &rhs == t {
+                return terms::map(t, &mut |child| rewrite(child, rule, applications));
+            }
+            if !applications.iter().any(|a| {
+                a.fn_id == rule.theorem.fn_id
+                    && a.law_name == rule.theorem.law_name
+                    && a.arguments == arguments
+            }) && applications.len() < APPLICATIONS
+            {
+                applications.push(LawApplication {
+                    fn_id: rule.theorem.fn_id,
+                    law_name: rule.theorem.law_name.clone(),
+                    arguments,
+                });
+            }
+            // Permutation rules may be useful calls, but must not grow the pool.
+            if !terms::matches(&rule.lhs, &rule.rhs, &rule.variables, &mut Bindings::new()) {
+                return rhs;
+            }
+        }
+    }
+    terms::map(t, &mut |child| rewrite(child, rule, applications))
+}
+
+pub(super) fn populate(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
+    // Backend signatures can be specialized; the first supported common lane
+    // is ordinary, unconditional laws with plain scalar/sequence binders.
+    fn plain(ty: &str) -> bool {
+        matches!(ty, "Int" | "Bool" | "String")
+            || ty
+                .strip_prefix("List<")
+                .and_then(|s| s.strip_suffix('>'))
+                .is_some_and(plain)
+    }
+    let mut eligible = BTreeSet::new();
+    let entry = inputs.entry_items.iter().filter_map(|item| match item {
+        TopLevel::Verify(vb) => Some((None, vb)),
+        _ => None,
+    });
+    let deps = inputs.dep_modules.iter().flat_map(|m| {
+        m.verify_blocks
+            .iter()
+            .map(move |vb| (Some(m.prefix.as_str()), vb))
+    });
+    for (scope, vb) in entry.chain(deps) {
+        if let VerifyKind::Law(law) = &vb.kind
+            && law.when.is_none()
+            && law.because.is_empty()
+            && law.using.is_none()
+            && law.givens.iter().all(|g| plain(&g.type_name))
+            && let Some(id) = inputs.symbol_table.resolve_fn_id_in(&vb.fn_name, scope)
+        {
+            eligible.insert((id, law.name.clone()));
+        }
+    }
+    for index in 0..ir.law_theorems.len() {
+        let (earlier, remaining) = ir.law_theorems.split_at_mut(index);
+        let theorem = &mut remaining[0];
+        if !terms::supported(&theorem.claim_lhs) || !terms::supported(&theorem.claim_rhs) {
+            continue;
+        }
+        let Some(induction) = &mut theorem.induction else {
+            continue;
+        };
+        let scope = inputs.symbol_table.fn_entry(theorem.fn_id).key.scope_str();
+        let rules: Vec<_> = earlier
+            .iter()
+            .filter(|t| {
+                eligible.contains(&(t.fn_id, t.law_name.clone()))
+                    // A concrete user-function signature anchors the match's
+                    // argument types. Bare-variable and polymorphic builtin
+                    // roots need a separate typed unifier; never guess there.
+                    && matches!(t.claim_lhs.node, crate::ir::hir::ResolvedExpr::Call(crate::ir::hir::ResolvedCallee::Fn(_), _))
+                    && terms::supported(&t.claim_lhs)
+                    && terms::supported(&t.claim_rhs)
+                    && inputs.symbol_table.fn_entry(t.fn_id).key.scope_str() == scope
+                    && theorem.function_cone.contains(&t.fn_id)
+            })
+            .map(|t| Rule {
+                theorem: t,
+                lhs: terms::normalize(&t.claim_lhs),
+                rhs: terms::normalize(&t.claim_rhs),
+                variables: t.quantifiers.iter().map(|q| q.name.clone()).collect(),
+            })
+            .collect();
+        for step in &mut induction.calls {
+            let Some(source_step) = &step.source_step else {
+                continue;
+            };
+            if !terms::supported(source_step) {
+                continue;
+            }
+            let mut pool: Vec<_> = [&theorem.claim_lhs, &theorem.claim_rhs]
+                .into_iter()
+                .map(|t| terms::normalize(&terms::replace(t, &step.source_call, source_step)))
+                .collect();
+            let mut frontier = pool.clone();
+            'closure: for _ in 0..ROUNDS {
+                let mut next = Vec::new();
+                for term in &frontier {
+                    for rule in &rules {
+                        let candidate =
+                            terms::normalize(&rewrite(term, rule, &mut step.applications));
+                        if terms::size(&candidate) <= NODES
+                            && !pool.contains(&candidate)
+                            && !next.contains(&candidate)
+                        {
+                            next.push(candidate);
+                        }
+                        if pool.len() + next.len() >= TERMS
+                            || step.applications.len() >= APPLICATIONS
+                        {
+                            break 'closure;
+                        }
+                    }
+                }
+                if next.is_empty() {
+                    break;
+                }
+                pool.extend(next.iter().cloned());
+                frontier = next;
+            }
+        }
+    }
+}

--- a/src/codegen/proof_lower/law_applications/terms.rs
+++ b/src/codegen/proof_lower/law_applications/terms.rs
@@ -1,0 +1,171 @@
+//! Small binder-free term language for application search. Names of declarations
+//! are canonical HIR callees; substitutions touch values, never declarations.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::ast::Spanned;
+use crate::ir::hir::{ResolvedCallee as Callee, ResolvedExpr as Expr};
+
+pub(super) type Term = Spanned<Expr>;
+pub(super) type Bindings = BTreeMap<String, Term>;
+
+pub(super) fn variable(t: &Term) -> Option<&str> {
+    match &t.node {
+        Expr::Ident(n) | Expr::Resolved { name: n, .. } => Some(n),
+        _ => None,
+    }
+}
+
+pub(super) fn map(t: &Term, f: &mut impl FnMut(&Term) -> Term) -> Term {
+    let node = match &t.node {
+        Expr::Call(c @ (Callee::Fn(_) | Callee::Builtin(_) | Callee::Intrinsic(_)), args) => {
+            Expr::Call(c.clone(), args.iter().map(f).collect())
+        }
+        Expr::TailCall { target, args } => {
+            Expr::Call(Callee::Fn(*target), args.iter().map(f).collect())
+        }
+        Expr::List(xs) => Expr::List(xs.iter().map(f).collect()),
+        Expr::Tuple(xs) => Expr::Tuple(xs.iter().map(f).collect()),
+        Expr::BinOp(op, a, b) => Expr::BinOp(*op, Box::new(f(a)), Box::new(f(b))),
+        Expr::Neg(a) => Expr::Neg(Box::new(f(a))),
+        _ => return t.clone(),
+    };
+    let out = Spanned::new(node, t.line);
+    if let Some(ty) = t.ty() {
+        out.set_ty(ty.clone());
+    }
+    out
+}
+
+pub(super) fn supported(t: &Term) -> bool {
+    match &t.node {
+        Expr::Literal(_) | Expr::Ident(_) | Expr::Resolved { .. } => true,
+        Expr::Call(Callee::Fn(_) | Callee::Builtin(_) | Callee::Intrinsic(_), args)
+        | Expr::TailCall { args, .. }
+        | Expr::List(args)
+        | Expr::Tuple(args) => args.iter().all(supported),
+        Expr::BinOp(_, a, b) => supported(a) && supported(b),
+        Expr::Neg(a) => supported(a),
+        // A binder or dynamic callee requires a richer scoped term language.
+        _ => false,
+    }
+}
+
+pub(super) fn substitute(t: &Term, bindings: &Bindings) -> Term {
+    if let Some(value) = variable(t).and_then(|n| bindings.get(n)) {
+        return value.clone();
+    }
+    map(t, &mut |child| substitute(child, bindings))
+}
+
+pub(super) fn matches(
+    pattern: &Term,
+    target: &Term,
+    variables: &BTreeSet<String>,
+    bindings: &mut Bindings,
+) -> bool {
+    if let Some(name) = variable(pattern) {
+        if !variables.contains(name) {
+            return variable(target) == Some(name);
+        }
+        return match bindings.get(name) {
+            Some(prior) => prior == target,
+            None => {
+                bindings.insert(name.to_string(), target.clone());
+                true
+            }
+        };
+    }
+    let mut pair = |a: &[Term], b: &[Term]| {
+        a.len() == b.len()
+            && a.iter()
+                .zip(b)
+                .all(|(a, b)| matches(a, b, variables, bindings))
+    };
+    match (&pattern.node, &target.node) {
+        (Expr::Literal(a), Expr::Literal(b)) => a == b,
+        (Expr::Call(a, xs), Expr::Call(b, ys)) => a == b && pair(xs, ys),
+        (Expr::List(xs), Expr::List(ys)) | (Expr::Tuple(xs), Expr::Tuple(ys)) => pair(xs, ys),
+        (Expr::BinOp(a, al, ar), Expr::BinOp(b, bl, br)) => {
+            a == b && matches(al, bl, variables, bindings) && matches(ar, br, variables, bindings)
+        }
+        (Expr::Neg(a), Expr::Neg(b)) => matches(a, b, variables, bindings),
+        _ => false,
+    }
+}
+
+pub(super) fn replace(t: &Term, from: &Term, to: &Term) -> Term {
+    if t == from {
+        to.clone()
+    } else {
+        map(t, &mut |child| replace(child, from, to))
+    }
+}
+
+fn builtin(name: &str, args: Vec<Term>) -> Term {
+    let ty = args.iter().find_map(|a| match a.ty() {
+        Some(ty @ crate::ast::Type::List(_)) => Some(ty.clone()),
+        _ => None,
+    });
+    let result = Spanned::bare(Expr::Call(Callee::Builtin(name.into()), args));
+    if let Some(ty) = ty {
+        result.set_ty(ty);
+    }
+    result
+}
+
+fn is_nil(t: &Term) -> bool {
+    matches!(&t.node, Expr::List(xs) if xs.is_empty())
+}
+
+/// Builtin sequence normal forms only expose candidate terms. No normalized
+/// equality is exported as a fact; the target checker still proves the claim.
+pub(super) fn normalize(t: &Term) -> Term {
+    let result = normalize_inner(t);
+    if let Some(ty) = t.ty() {
+        result.set_ty(ty.clone());
+    }
+    result
+}
+
+fn normalize_inner(t: &Term) -> Term {
+    let t = map(t, &mut normalize);
+    let Expr::Call(Callee::Builtin(name), args) = &t.node else {
+        return t;
+    };
+    match (name.as_str(), args.as_slice()) {
+        ("List.prepend", [head, tail]) => normalize(&builtin(
+            "List.concat",
+            vec![Spanned::bare(Expr::List(vec![head.clone()])), tail.clone()],
+        )),
+        ("List.concat", [a, b]) if is_nil(a) => b.clone(),
+        ("List.concat", [a, b]) if is_nil(b) => a.clone(),
+        ("List.reverse", [a]) => match &a.node {
+            Expr::List(xs) => {
+                let mut result = a.clone();
+                result.node = Expr::List(xs.iter().rev().cloned().collect());
+                result
+            }
+            Expr::Call(Callee::Builtin(n), xs) if n == "List.concat" && xs.len() == 2 => {
+                normalize(&builtin(
+                    "List.concat",
+                    vec![
+                        builtin("List.reverse", vec![xs[1].clone()]),
+                        builtin("List.reverse", vec![xs[0].clone()]),
+                    ],
+                ))
+            }
+            _ => t,
+        },
+        _ => t,
+    }
+}
+
+pub(super) fn size(t: &Term) -> usize {
+    let mut count = 1;
+    map(t, &mut |child| {
+        count += size(child);
+        child.clone()
+    });
+    count
+}

--- a/src/codegen/proof_lower/law_induction.rs
+++ b/src/codegen/proof_lower/law_induction.rs
@@ -62,6 +62,10 @@ fn substitute(
             }
             Expr::FnCall(callee.clone(), args.iter().map(rec).collect::<Option<_>>()?)
         }
+        Expr::TailCall(tc) => Expr::FnCall(
+            Box::new(var(&tc.target)),
+            tc.args.iter().map(rec).collect::<Option<_>>()?,
+        ),
         _ => return None,
     };
     let result = Spanned::new(node, expr.line);
@@ -344,6 +348,9 @@ pub(super) fn plan(
             None => None,
         };
         calls.push(LawInductionCall {
+            source_call: inputs.resolve_expr(occurrence, scope),
+            source_step: substitute(branch, &bindings).map(|e| inputs.resolve_expr(&e, scope)),
+            applications: Vec::new(),
             guard: inputs.resolve_expr(&guard, scope),
             premise,
             list_case,

--- a/src/codegen/proof_lower/mod.rs
+++ b/src/codegen/proof_lower/mod.rs
@@ -2552,8 +2552,10 @@ pub fn populate_law_theorems(inputs: &ProofLowerInputs, ir: &mut ProofIR) {
             unfolding,
         });
     }
+    law_applications::populate(inputs, ir);
 }
 
+mod law_applications;
 mod law_dependencies;
 mod law_induction;
 mod law_unfolding;

--- a/src/ir/proof_ir.rs
+++ b/src/ir/proof_ir.rs
@@ -530,6 +530,16 @@ pub enum LawInductionMeasure {
 
 #[derive(Debug, Clone)]
 pub struct LawInductionCall {
+    /// The concrete source occurrence and its recursive branch, including fixed
+    /// seeds that are not theorem parameters. Search terms, never equalities
+    /// admitted without the backend checking the source definition.
+    pub source_call: Spanned<crate::ir::hir::ResolvedExpr>,
+    /// Absent when branch syntax exceeds the substitution language; ordinary
+    /// induction remains usable even when application search cannot unfold it.
+    pub source_step: Option<Spanned<crate::ir::hir::ResolvedExpr>>,
+    /// Explicit applications discovered from this step and earlier ordinary
+    /// laws. Backends must independently admit each supplier's full contract.
+    pub applications: Vec<LawApplication>,
     /// Source branch guard, evaluated before introducing pattern projections.
     pub guard: Spanned<crate::ir::hir::ResolvedExpr>,
     /// The theorem premise at the recursive arguments. Evaluated after
@@ -539,6 +549,13 @@ pub struct LawInductionCall {
     /// Nil/cons decomposition under the nonempty guard. Projection names are
     /// fresh in the source/law scope; no partial List.head value is invented.
     pub list_case: Option<LawInductionListCase>,
+    pub arguments: Vec<Spanned<crate::ir::hir::ResolvedExpr>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LawApplication {
+    pub fn_id: FnId,
+    pub law_name: String,
     pub arguments: Vec<Spanned<crate::ir::hir::ResolvedExpr>>,
 }
 

--- a/tests/fixtures/source_recursion/boolean_counter.av
+++ b/tests/fixtures/source_recursion/boolean_counter.av
@@ -1,0 +1,29 @@
+module BooleanCounter
+    intent = "A subtractive collector and a Boolean reader share the same induction applications."
+    effects []
+
+fn read(items: List<Bool>, acc: Int) -> Int
+    match items
+        [] -> acc
+        [_, ..tail] -> read(tail, acc + 1)
+
+verify read law suffix
+    given items: List<Bool> = [[], [true], [false, true]]
+    given bit: Bool = [false, true]
+    given acc: Int = [0, 1, 20]
+    read(List.concat(items, [bit]), acc) => read(items, acc) + 1
+
+fn collect(value: Int, acc: List<Bool>) -> List<Bool>
+    match value > 0
+        true -> collect(value - 1, List.prepend(true, acc))
+        false -> List.reverse(acc)
+
+verify collect law prefix
+    given value: Int = [-1, 0, 1, 4]
+    given acc: List<Bool> = [[], [false], [true, false]]
+    collect(value, acc) => List.concat(List.reverse(acc), collect(value, []))
+
+verify collect law roundtrip
+    given value: Int = [0, 1, 4, 10]
+    when value >= 0
+    read(List.reverse(collect(value, [])), 0) => value

--- a/tests/fixtures/source_recursion/roundtrip.av
+++ b/tests/fixtures/source_recursion/roundtrip.av
@@ -1,0 +1,29 @@
+module Roundtrip
+    intent = "An unbounded decimal roundtrip composes a collector and a reader."
+    effects []
+
+fn read(items: List<Int>, acc: Int) -> Int
+    match items
+        [] -> acc
+        [head, ..tail] -> read(tail, acc * 10 + head)
+
+verify read law suffix
+    given items: List<Int> = [[], [1], [2, 3]]
+    given digit: Int = [0, 4, 9]
+    given acc: Int = [0, 1, 20]
+    read(List.concat(items, [digit]), acc) => read(items, acc) * 10 + digit
+
+fn digits(value: Int, acc: List<Int>) -> List<Int>
+    match value > 0
+        true -> digits(Int.div(value, 10), List.prepend(Int.mod(value, 10), acc))
+        false -> List.reverse(acc)
+
+verify digits law prefix
+    given value: Int = [-1, 0, 1, 10, 123]
+    given acc: List<Int> = [[], [4], [2, 3]]
+    digits(value, acc) => List.concat(List.reverse(acc), digits(value, []))
+
+verify digits law roundtrip
+    given value: Int = [0, 1, 9, 10, 123, 99999]
+    when value >= 0
+    read(List.reverse(digits(value, [])), 0) => value

--- a/tests/proof_ir_diff.rs
+++ b/tests/proof_ir_diff.rs
@@ -29,6 +29,9 @@ use std::path::PathBuf;
 #[path = "proof_ir_diff/bounded_unfolding.rs"]
 mod bounded_unfolding;
 
+#[path = "proof_ir_diff/law_applications.rs"]
+mod law_applications;
+
 fn build_ctx(src: &str) -> CodegenContext {
     let mut items = parse_source(src).expect("parse");
     // Proof-mode minimal pipeline: rewrite stages off (would alter

--- a/tests/proof_ir_diff/law_applications.rs
+++ b/tests/proof_ir_diff/law_applications.rs
@@ -1,0 +1,154 @@
+use super::*;
+use aver::ast::{Literal, Spanned};
+use aver::ir::hir::{ResolvedCallee as Callee, ResolvedExpr as Expr};
+
+const SOURCE: &str = include_str!("../fixtures/source_recursion/roundtrip.av");
+
+#[test]
+fn application_search_does_not_remove_induction_for_unsupported_branch_syntax() {
+    let ctx = build_ctx(
+        r#"module Fallible
+fn depth(value: Int) -> Result<Int, String>
+    match value > 0
+        true -> Result.Ok(depth(Int.div(value, 10))? + 1)
+        false -> Result.Ok(0)
+verify depth law reflexive
+    given value: Int = [0, 1, 10]
+    depth(value) => depth(value)
+"#,
+    );
+    let plan = law_theorem(&ctx, "depth", "reflexive")
+        .unwrap()
+        .induction
+        .as_ref()
+        .expect("application search must not narrow ordinary induction");
+    assert!(
+        plan.calls
+            .iter()
+            .all(|step| step.source_step.is_none() && step.applications.is_empty())
+    );
+}
+
+fn builtin(name: &str, args: Vec<Spanned<Expr>>) -> Spanned<Expr> {
+    Spanned::bare(Expr::Call(Callee::Builtin(name.into()), args))
+}
+
+#[test]
+fn concrete_applications_retain_fixed_seeds_and_compose_distinct_functions() {
+    for radix in [10, 16] {
+        let source = SOURCE.replace("10", &radix.to_string());
+        let ctx = build_ctx(&source);
+        let theorem = law_theorem(&ctx, "digits", "roundtrip").unwrap();
+        let step = &theorem.induction.as_ref().unwrap().calls[0];
+        assert_eq!(
+            step.arguments.len(),
+            1,
+            "only the value is a theorem parameter"
+        );
+        let value = Spanned::bare(Expr::Ident("value".into()));
+        let base = Spanned::bare(Expr::Literal(Literal::Int(radix)));
+        let quotient = Spanned::bare(Expr::Call(
+            Callee::Intrinsic(aver::ir::hir::BuiltinIntrinsic::IntDivEuclid),
+            vec![value.clone(), base.clone()],
+        ));
+        let remainder = Spanned::bare(Expr::Call(
+            Callee::Intrinsic(aver::ir::hir::BuiltinIntrinsic::IntModEuclid),
+            vec![value, base],
+        ));
+        let prefix = step
+            .applications
+            .iter()
+            .find(|a| a.law_name == "prefix")
+            .unwrap();
+        assert_eq!(prefix.fn_id, theorem.fn_id);
+        assert_eq!(
+            prefix.arguments,
+            vec![
+                quotient.clone(),
+                Spanned::bare(Expr::List(vec![remainder.clone()]))
+            ]
+        );
+        let read = law_theorem(&ctx, "read", "suffix").unwrap();
+        let suffix = step
+            .applications
+            .iter()
+            .find(|a| a.law_name == "suffix")
+            .unwrap();
+        assert_eq!(suffix.fn_id, read.fn_id);
+        let rest = Spanned::bare(Expr::Call(
+            Callee::Fn(theorem.fn_id),
+            vec![quotient, Spanned::bare(Expr::List(vec![]))],
+        ));
+        assert_eq!(
+            suffix.arguments,
+            vec![
+                builtin("List.reverse", vec![rest]),
+                remainder,
+                Spanned::bare(Expr::Literal(Literal::Int(0)))
+            ]
+        );
+    }
+}
+
+#[test]
+fn concrete_applications_do_not_use_later_or_guarded_suppliers() {
+    let (before, laws) = SOURCE.split_once("verify digits law prefix").unwrap();
+    let (prefix, roundtrip) = laws.split_once("verify digits law roundtrip").unwrap();
+    let reordered =
+        format!("{before}verify digits law roundtrip{roundtrip}\nverify digits law prefix{prefix}");
+    let conditional = SOURCE.replace(
+        "    digits(value, acc) =>",
+        "    when value >= 0\n    digits(value, acc) =>",
+    );
+    for source in [reordered, conditional] {
+        let ctx = build_ctx(&source);
+        let plan = law_theorem(&ctx, "digits", "roundtrip")
+            .unwrap()
+            .induction
+            .as_ref()
+            .unwrap();
+        assert!(
+            plan.calls
+                .iter()
+                .flat_map(|s| &s.applications)
+                .all(|a| a.law_name != "prefix")
+        );
+    }
+}
+
+#[test]
+fn concrete_applications_keep_import_owner_despite_colliding_local_names() {
+    let left = SOURCE.replace("module Roundtrip", "module Left");
+    let right = SOURCE
+        .replace("module Roundtrip", "module Right")
+        .replace("10", "16");
+    let ctx = build_ctx_with_modules(
+        "module Main\n    depends [Left, Right]\n",
+        &[("Left", &left), ("Right", &right)],
+    );
+    assert_eq!(
+        ctx.proof_ir
+            .law_theorems
+            .iter()
+            .filter(|t| t.law_name == "roundtrip")
+            .count(),
+        2
+    );
+    for theorem in ctx
+        .proof_ir
+        .law_theorems
+        .iter()
+        .filter(|t| t.law_name == "roundtrip")
+    {
+        let owner = ctx.symbol_table.fn_entry(theorem.fn_id).key.scope_str();
+        assert!(matches!(owner, Some("Left" | "Right")));
+        let applications = &theorem.induction.as_ref().unwrap().calls[0].applications;
+        assert!(applications.iter().any(|a| a.law_name == "suffix"));
+        for application in applications {
+            assert_eq!(
+                ctx.symbol_table.fn_entry(application.fn_id).key.scope_str(),
+                owner
+            );
+        }
+    }
+}

--- a/tests/proof_spec.rs
+++ b/tests/proof_spec.rs
@@ -61,6 +61,8 @@ mod floor_window;
 mod fuel_when_cites;
 #[path = "proof_spec/k5_sticky.rs"]
 mod k5_sticky;
+#[path = "proof_spec/law_applications.rs"]
+mod law_applications;
 #[path = "proof_spec/law_reasons.rs"]
 mod law_reasons;
 #[path = "proof_spec/lean_kernel.rs"]

--- a/tests/proof_spec/law_applications.rs
+++ b/tests/proof_spec/law_applications.rs
@@ -1,0 +1,125 @@
+use super::*;
+
+const SOURCE: &str = include_str!("../fixtures/source_recursion/roundtrip.av");
+
+#[test]
+fn concrete_applications_roundtrip_passes_both_checkers_after_renaming_and_radix_change() {
+    for (label, source) in [
+        ("decimal", SOURCE.to_string()),
+        (
+            "booleans",
+            include_str!("../fixtures/source_recursion/boolean_counter.av").to_string(),
+        ),
+        (
+            "renamed",
+            SOURCE
+                .replace("10", "16")
+                .replace("read", "consume")
+                .replace("digits", "collect")
+                .replace("value", "remaining"),
+        ),
+    ] {
+        let dir = temp_output_dir(&format!("aver-concrete-applications-{label}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        for backend in ["dafny", "lean"] {
+            let Some(summary) = super::source_recursion::check(path.to_str().unwrap(), backend)
+            else {
+                continue;
+            };
+            assert_eq!(summary["passed"], true, "{label}/{backend}: {summary}");
+            if backend == "lean" {
+                assert_eq!(summary["universal_laws"], 3);
+            }
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+#[test]
+fn concrete_applications_reject_a_missing_domain_guard_and_a_false_supplier() {
+    let missing_guard = SOURCE.replace("    when value >= 0\n", "");
+    // This false supplier agrees at every retained zero/empty sample. Its
+    // consumer is reflexive, so global rejection must come from the supplier.
+    let false_supplier = SOURCE
+        .replace("[-1, 0, 1, 10, 123]", "[0]")
+        .replace("[[], [4], [2, 3]]", "[[]]")
+        .replace(
+            "List.concat(List.reverse(acc), digits(value, []))",
+            "List.reverse(acc)",
+        )
+        .replace(
+            "read(List.reverse(digits(value, [])), 0) => value",
+            "digits(value, []) => digits(value, [])",
+        );
+    for (label, source) in [
+        ("missing_guard", missing_guard),
+        ("false_supplier", false_supplier),
+    ] {
+        let dir = temp_output_dir(&format!("aver-concrete-applications-{label}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.av");
+        std::fs::write(&path, source).unwrap();
+        let samples = Command::new(env!("CARGO_BIN_EXE_aver"))
+            .args(["verify", path.to_str().unwrap()])
+            .output()
+            .unwrap();
+        assert!(
+            samples.status.success(),
+            "{label}: {}",
+            format_output(&samples)
+        );
+        for backend in ["dafny", "lean"] {
+            let checker = if backend == "lean" { "lake" } else { "dafny" };
+            if Command::new(checker).arg("--version").output().is_err() {
+                continue;
+            }
+            let output = Command::new(env!("CARGO_BIN_EXE_aver"))
+                .args([
+                    "proof",
+                    path.to_str().unwrap(),
+                    "--backend",
+                    backend,
+                    "--check-json",
+                    "-o",
+                ])
+                .arg(dir.join(backend))
+                .output()
+                .unwrap();
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let summary: serde_json::Value = serde_json::from_str(
+                stdout
+                    .lines()
+                    .rev()
+                    .find(|line| line.starts_with('{'))
+                    .unwrap_or_else(|| panic!("{}", format_output(&output))),
+            )
+            .unwrap();
+            assert!(
+                !output.status.success(),
+                "{label}/{backend} must reject a false universal"
+            );
+            assert_eq!(summary["passed"], false, "{summary}");
+            if backend == "lean" {
+                assert_eq!(summary["build_errors"], 0, "{summary}");
+                assert!(!summary["universal"].as_bool().unwrap(), "{summary}");
+            } else {
+                for field in ["axioms", "omitted"] {
+                    assert_eq!(summary[field], 0, "{summary}");
+                }
+                let errors = summary["errors"].as_u64().unwrap();
+                let timeouts = summary["timeouts"].as_u64().unwrap();
+                // On the composed missing-guard claim Z3 may exhaust search
+                // instead of constructing a counterexample. Either outcome
+                // must refuse universal credit, without emission/axiom escapes.
+                assert!(errors + timeouts > 0, "{summary}");
+                if label == "false_supplier" {
+                    assert_eq!(timeouts, 0, "{summary}");
+                    assert!(errors > 0, "{summary}");
+                }
+            }
+        }
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}


### PR DESCRIPTION
A fixed accumulator seed is not a theorem parameter, so source induction previously lost the concrete recursive collector call needed to compose it with a reader. ProofIR now retains that source step and derives explicit earlier-lemma applications from it. The unchanged BTC `littleEndian.readsBackBigEndian` verifies from Aver-generated Dafny output.

The shared search uses canonical function identities, expands the source step inside the claim, and matches earlier ordinary laws against a bounded closure of its subterms. It excludes normalized reflexive instances, preserves expression types, and leaves ordinary induction available when branch syntax exceeds its substitution language. Search limits never restrict the quantified domain. The initial lane admits unconditional laws in the declaring module and function cone, with plain scalar/list givens and a concrete user-function root.

Dafny renders instances through its existing universal-citation gate. Lean consumes the same applications in countdown induction, normalizes sequence composition before unfolding readers, and splits the source branch before checking a recursive premise such as `n - 1 >= 0`. Both checkers remain responsible for supplier proofs and applications.

Validation:

- Independent decimal and renamed radix-16 roundtrips pass unchanged in Lean and Dafny. A Boolean-list counter with subtractive descent passes both too.
- Negative controls retain passing VM samples but reject a false supplier and a missing domain guard. The false supplier requires actual checker errors in Dafny; the composed missing-guard control also permits a rejected solver timeout. No production gates or proof budgets are relaxed.
- ProofIR controls cover concrete arguments, fixed seeds, import/name collisions, exclusion of later/conditional suppliers, and preservation of ordinary induction for unsupported branch syntax.
- 1,680 unit tests (one ignored), 81 ProofIR tests, and 15 selected backend regressions pass; the backend regressions pass together in one run. Clippy (library, CLI and benches with WASM) and formatting pass.

BTC source stays at `a6870c9de7280593d3e5a5928ceb62610a2ba316`. A full StackItem check including imports reports 253 verified obligations, 6 errors, and 3 timeouts (previously 252, 6, and 4). `littleEndian.readsBackBigEndian` is explicitly Correct. Strict whole-module coverage remains 23/104 (Message 10, CompactSize 6, ScriptMath 7), with no outer process timeouts in the full census. Other StackItem obligations remain open, so this does not credit its whole module or establish full BTC/K5.
