### PR TITLE
Lean export: derive equality of types with a refined field from DecidableEq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Aver are documented here. Starting with 0.10.0, minor rel
 
 ### Fixed
 
+- **A record or sum type with a `Bytes` or `Digest32` field now exports to Lean without an unsolved goal.** Such a type derived its own `BEq` and then asked Lean to derive `LawfulBEq` for it; the derived comparison goes through the subtype instance and the derivation stopped at the type declaration. A non-recursive type with a refinement directly in a field now derives no `BEq` of its own, so `==` is the `DecidableEq` comparison Lean already knows to be lawful; a refinement under `List`, `Option` or `Map` and every recursive type keep their previous derivation, which builds.
 - **Dafny induction follows source recursion through ProofIR.** Guarded integer descent now takes precedence over a growing list accumulator. Ordinary laws and universal citation lemmas carry actual recursive accumulator updates; list and string padding get a shared remaining-length measure consumed by Lean and Dafny. Checked sequence identities close countdown and fold composition examples without additional source proof steps or assumptions.
 
 - **Empty lists take their element type from the other side of equality.** `items == []` and `[] != items` now preserve the checked element type, including nested lists and tuple literals. This reuses the expected-type inference already used for `Option.None`, preventing generated Rust from comparing `AverIntList` with an unresolved generic list.

--- a/src/codegen/lean/toplevel/type_def.rs
+++ b/src/codegen/lean/toplevel/type_def.rs
@@ -430,20 +430,72 @@ fn emit_sum_type(
             .all(|field| field_is_inhabitable(field, ctx, scope, &mut Vec::new()))
     });
     // #14: Recursive types cannot derive DecidableEq automatically
-    lines.push(derives_line(inhabited, !is_recursive));
-    if equality::reflects_equality(&crate::types::Type::named(name), ctx, scope) {
+    lines.extend(equality_lines(
+        name,
+        variants
+            .iter()
+            .flat_map(|v| v.fields.iter().map(String::as_str)),
+        inhabited,
+        is_recursive,
+        ctx,
+        scope,
+    ));
+    lines.join("\n")
+}
+
+/// The `deriving` clause and, when the type reflects equality, the line that
+/// proves the derived `BEq` lawful.
+///
+/// A non-recursive type with a refinement (`Bytes`, `Digest32` — a `Subtype`
+/// in Lean) directly in a field takes the other route: it derives no `BEq` of
+/// its own, so `==` on it is the `DecidableEq` comparison, and Lean's
+/// `instBEqOfDecidableEq` already carries `ReflBEq` and `LawfulBEq`. The
+/// derived `BEq` handler compares such a field through the subtype's own
+/// instance and the `LawfulBEq` deriving handler then cannot connect the two
+/// (`(x == y) = true → Delta.header s x = Delta.header s y` stays an unsolved
+/// goal, a hard build error). A refinement nested under `List`/`Option`/`Map`
+/// is compared through that container's instance and derives fine.
+fn equality_lines<'a>(
+    name: &str,
+    mut fields: impl Iterator<Item = &'a str>,
+    inhabited: bool,
+    is_recursive: bool,
+    ctx: &CodegenContext,
+    scope: Option<&str>,
+) -> Vec<String> {
+    let reflects = equality::reflects_equality(&crate::types::Type::named(name), ctx, scope);
+    let direct_refined = fields.any(|field| is_direct_refined_field(field, ctx, scope));
+    if !is_recursive && reflects && direct_refined {
+        return vec![derives_line(inhabited, true, false)];
+    }
+    let mut lines = vec![derives_line(inhabited, !is_recursive, true)];
+    if reflects {
         lines.push(format!(
             "deriving instance ReflBEq, LawfulBEq for {}",
             aver_name_to_lean(name)
         ));
     }
-    lines.join("\n")
+    lines
 }
 
-/// The `deriving` clause: `Repr` and `BEq` always, then the two that a shape
-/// can decline.
-fn derives_line(inhabited: bool, decidable_eq: bool) -> String {
-    let mut derives = vec!["Repr", "BEq"];
+/// Is this field annotation a refined type itself, not merely one mentioned
+/// under a container?
+fn is_direct_refined_field(field: &str, ctx: &CodegenContext, scope: Option<&str>) -> bool {
+    match crate::types::parse_type_str(field.trim()) {
+        crate::types::Type::Named { name, .. } => {
+            crate::codegen::common::find_refined_type_scoped(ctx, &name, scope).is_some()
+        }
+        _ => false,
+    }
+}
+
+/// The `deriving` clause: `Repr` always, then the three that a shape can
+/// decline.
+fn derives_line(inhabited: bool, decidable_eq: bool, beq: bool) -> String {
+    let mut derives = vec!["Repr"];
+    if beq {
+        derives.push("BEq");
+    }
     if inhabited {
         derives.push("Inhabited");
     }
@@ -492,13 +544,14 @@ fn emit_product_type(
     let inhabited = fields
         .iter()
         .all(|(_, field)| field_is_inhabitable(field, ctx, scope, &mut Vec::new()));
-    lines.push(derives_line(inhabited, !is_recursive));
-    if equality::reflects_equality(&crate::types::Type::named(name), ctx, scope) {
-        lines.push(format!(
-            "deriving instance ReflBEq, LawfulBEq for {}",
-            aver_name_to_lean(name)
-        ));
-    }
+    lines.extend(equality_lines(
+        name,
+        fields.iter().map(|(_, field)| field.as_str()),
+        inhabited,
+        is_recursive,
+        ctx,
+        scope,
+    ));
     lines.join("\n")
 }
 

--- a/src/codegen/lean/toplevel/type_def.rs
+++ b/src/codegen/lean/toplevel/type_def.rs
@@ -481,9 +481,13 @@ fn equality_lines<'a>(
 /// Is this field annotation a refined type itself, not merely one mentioned
 /// under a container?
 fn is_direct_refined_field(field: &str, ctx: &CodegenContext, scope: Option<&str>) -> bool {
-    match crate::types::parse_type_str(field.trim()) {
-        crate::types::Type::Named { name, .. } => {
-            crate::codegen::common::find_refined_type_scoped(ctx, &name, scope).is_some()
+    let ty = crate::types::parse_type_str(field.trim());
+    match &ty {
+        crate::types::Type::Named { id: Some(_), .. } => {
+            crate::codegen::common::find_refined_type_for_named(ctx, &ty).is_some()
+        }
+        crate::types::Type::Named { id: None, name } => {
+            crate::codegen::common::find_refined_type_scoped(ctx, name, scope).is_some()
         }
         _ => false,
     }

--- a/tests/fixtures/refined_field_equality.av
+++ b/tests/fixtures/refined_field_equality.av
@@ -1,0 +1,49 @@
+module RefinedFieldEquality
+    intent =
+        "Types that carry a refinement (Bytes, Digest32) directly in a field,"
+        "recursive and not, so the Lean export can be checked to build."
+    depends [Bytes, Crypto.Digest32]
+    exposes [Sealed, Fact, Chain, sameSealed, sameFact, chainLength]
+    effects []
+
+record Sealed
+    name: String
+    payload: Bytes
+
+type Fact
+    Note(String)
+    Digest(Digest32)
+
+type Chain
+    End
+    Link(Bytes, Chain)
+
+fn sameSealed(a: Sealed, b: Sealed) -> Bool
+    ? "Structural equality of two sealed records."
+    a == b
+
+fn sameFact(a: Fact, b: Fact) -> Bool
+    ? "Structural equality of two facts."
+    a == b
+
+fn chainLength(chain: Chain) -> Int
+    ? "How many links the chain has."
+    match chain
+        Chain.End -> 0
+        Chain.Link(_, rest) -> 1 + chainLength(rest)
+
+verify sameSealed
+    sameSealed(Sealed(name = "a", payload = Bytes.fromList([1])), Sealed(name = "a", payload = Bytes.fromList([1]))) => true
+    sameSealed(Sealed(name = "a", payload = Bytes.fromList([1])), Sealed(name = "a", payload = Bytes.fromList([2]))) => false
+
+verify sameFact
+    sameFact(Fact.Note("a"), Fact.Note("a")) => true
+    sameFact(Fact.Note("a"), Fact.Note("b")) => false
+
+verify sameFact law reflexive
+    given a: Fact = [Fact.Note("a"), Fact.Note("b")]
+    sameFact(a, a) holds
+
+verify chainLength
+    chainLength(Chain.End) => 0
+    chainLength(Chain.Link(Bytes.fromList([1]), Chain.Link(Bytes.fromList([2]), Chain.End))) => 2

--- a/tests/proof_spec/export_structure.rs
+++ b/tests/proof_spec/export_structure.rs
@@ -1575,3 +1575,100 @@ fn proof_export_two_cons_peel_gets_a_dafny_decreases_not_an_axiom() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn proof_export_types_with_a_refined_field_take_the_decidable_eq_route() {
+    // A record or sum type with a `Bytes` or `Digest32` field used to derive
+    // its own `BEq` and then ask Lean to derive `LawfulBEq` for it. The
+    // derived `BEq` compares the field through the subtype instance and the
+    // `LawfulBEq` handler cannot connect the two: the export stopped with an
+    // unsolved goal at the type declaration. Such a type now derives no `BEq`
+    // of its own, so `==` is the `DecidableEq` comparison, which Lean already
+    // knows to be lawful.
+    //
+    // A recursive type with a refinement directly in a field keeps the old
+    // route (derived `BEq`, opaque `DecidableEq`); it never asked for
+    // `LawfulBEq`, because equality reflection declines every recursive
+    // type, so the derivation that failed is not emitted for it either.
+    let aver_bin = env!("CARGO_BIN_EXE_aver");
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let root = temp_output_dir("aver-proof-refined-field-equality");
+    let mut command = Command::new(aver_bin);
+    command
+        .current_dir(&repo_root)
+        .arg("proof")
+        .arg("tests/fixtures/refined_field_equality.av")
+        .arg("--module-root")
+        .arg(root.join("no-project-modules"))
+        .arg("--backend")
+        .arg("lean")
+        .arg("-o")
+        .arg(&root);
+    let lake = Command::new("lake").arg("--version").output().is_ok();
+    if lake {
+        command.arg("--check").arg("--check-json");
+    } else {
+        eprintln!("skipping the lake build: `lake` not available");
+    }
+    let output = command
+        .output()
+        .expect("aver proof for types with a refined field");
+    assert!(
+        output.status.success(),
+        "the export of types with a refined field failed:\n{}",
+        format_output(&output)
+    );
+    let lean = std::fs::read_to_string(root.join("RefinedFieldEquality.lean"))
+        .expect("read RefinedFieldEquality.lean");
+
+    // The non-recursive shapes: `DecidableEq` in the deriving line, no
+    // `BEq` there, and no `LawfulBEq` derivation for them anywhere.
+    assert!(
+        lean.contains(
+            "structure Sealed where\n  name : String\n  payload : Bytes.Bytes\n  deriving Repr, DecidableEq\n"
+        ),
+        "a record with a Bytes field must derive DecidableEq and no BEq of its own:\n{lean}"
+    );
+    assert!(
+        lean.contains(
+            "inductive Fact where\n  | note (_ : String)\n  | digest (_ : Crypto.Digest32.Digest32)\n  deriving Repr, Inhabited, DecidableEq\n"
+        ),
+        "a sum type with a Digest32 variant must derive DecidableEq and no BEq of its own:\n{lean}"
+    );
+    assert!(
+        !lean.contains("deriving instance ReflBEq, LawfulBEq"),
+        "no type in this module may ask for a derived LawfulBEq:\n{lean}"
+    );
+
+    // The recursive shape: the old route, and no `LawfulBEq` line either.
+    assert!(
+        lean.contains(
+            "inductive Chain where\n  | end'\n  | link (_ : Bytes.Bytes) (_ : Chain)\n  deriving Repr, BEq, Inhabited\n"
+        ) && lean.contains("instance : DecidableEq Chain := Chain.compDecEq"),
+        "a recursive sum type with a Bytes field keeps the derived BEq and the opaque DecidableEq:\n{lean}"
+    );
+
+    if lake {
+        let json_line = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .rev()
+            .find(|l| l.starts_with('{'))
+            .map(str::to_owned)
+            .unwrap_or_else(|| {
+                panic!(
+                    "`aver proof --check --check-json` produced no JSON line:\n{}",
+                    format_output(&output)
+                )
+            });
+        let summary: serde_json::Value =
+            serde_json::from_str(&json_line).expect("summary line parses as JSON");
+        assert_eq!(
+            summary["build_errors"].as_u64(),
+            Some(0),
+            "every type declaration with a refined field must build:\n{}",
+            format_output(&output)
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## What

A record or sum type with a refined type (`Bytes`, `Digest32`, or a user-defined refinement) directly in a field derived its own `BEq` and then asked Lean to derive `LawfulBEq` for it. The derived `BEq` compares the field through the subtype instance and the `LawfulBEq` handler cannot connect the two, so the export stopped with an unsolved goal at the type declaration. Any module with such a type could not be exported to Lean at all.

A non-recursive type with a refinement directly in a field now derives no `BEq` of its own: `==` is the `DecidableEq` comparison, and Lean already carries `ReflBEq` and `LawfulBEq` for that instance. A refinement nested under `List`, `Option` or `Map` keeps the previous derivation, which works. Recursive types never asked for the failing derivation (`reflects_equality` is false for them) and are unchanged; the test pins that.

## Test

`tests/proof_spec/export_structure.rs::proof_export_types_with_a_refined_field_take_the_decidable_eq_route` exports `tests/fixtures/refined_field_equality.av` (a record with a `Bytes` field, a sum with a `Digest32` variant, a recursive sum with a `Bytes` field), asserts the emitted `deriving` lines, and with `lake` available builds the module and requires zero build errors. On `main` the string assertion fails and the build has an unsolved goal.

Found while writing `examples/formal/knowledge.av` for #1329, which is the first module in the corpus with a sum type carrying `Bytes` directly.
