### PR TITLE
Bound the wasm-gc suites step so a stalled compile fails fast (#1339)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,11 @@ jobs:
         run: cargo test -p aver-lang --features wasm,wasip2 --test provider_spec --test capability_grammar_spec --test capability_target_manifest_spec
 
       - name: Test wasm-gc suites
+        # The step takes about fifteen minutes on main. It has stalled for
+        # hours more than once right after `Compiling aver-lang` for one of
+        # the test binaries below (jasisz/aver#1339); a bounded step fails
+        # fast and can be re-run instead of holding a pull request.
+        timeout-minutes: 35
         # Run the wasm-gc integration surface explicitly under `wasm`, not
         # the whole package under `wasm,wasip2`. The old package-wide command
         # also built unrelated integration tests and bins with the full


### PR DESCRIPTION
Closes #1339's first item: `timeout-minutes: 35` on the `Test wasm-gc suites` step of the `WASM` job. The step takes about fifteen minutes on main (the whole job took 21 minutes on the last green run) and has stalled for hours seven times since 2026-09-11, each time right after `Compiling aver-lang` for one of its test binaries. A bounded step fails fast and can be re-run with `gh run rerun --failed` instead of holding a pull request.

The second item of the ticket, why that compile can hang on the hosted runner, is not touched here; the ticket stays open for it.