### PR TITLE
The inline-take test stops assuming the VM's job is still running at the second take

### DIFF
--- a/tests/wasm_work_spec.rs
+++ b/tests/wasm_work_spec.rs
@@ -143,10 +143,20 @@ fn a_take_right_after_begin_answers_some_on_wasm_gc() {
     let wasm =
         run("work_jobs_inline", &["--wasm-gc"], &[]).unwrap_or_else(|error| panic!("{error}"));
     assert_eq!(wasm, "score 5\nwork: job already taken");
+    // The VM runs the job beside the turn, so what its two takes see is a
+    // race the program cannot win on purpose: usually neither has an answer
+    // yet, but a job this small can settle between the two takes, or before
+    // the first one on a loaded machine. What the VM owes is that no take
+    // ever answers before the job is done and that an answer is given once.
     let vm = run("work_jobs_inline", &[], &[]).unwrap_or_else(|error| panic!("{error}"));
-    assert_eq!(
-        vm, "nothing yet\nnothing yet",
-        "the VM runs the job beside the turn, so neither take has an answer yet"
+    let honest = [
+        "nothing yet\nnothing yet",
+        "nothing yet\nscore 5",
+        "score 5\nwork: job already taken",
+    ];
+    assert!(
+        honest.contains(&vm.as_str()),
+        "the VM's two takes must be a prefix of the job's life, got:\n{vm}"
     );
 }
 


### PR DESCRIPTION
Fixes the `WASM` job failure on main after #1352 (run 34728953701): `a_take_right_after_begin_answers_some_on_wasm_gc` in `tests/wasm_work_spec.rs`, added in #1350, asserted that the VM's two takes both answer "nothing yet". The VM runs the job on its own thread, so a job this small can settle between the two takes (it did on the runner: `nothing yet` then `score 5`), or before the first one. The VM side now accepts the three honest traces of the job's life; the wasm-gc side is unchanged and still asserts `score 5` at once and `work: job already taken` on the second take, which is the property the test exists for.

Ran `cargo test -p aver-lang --features wasm --test wasm_work_spec`: 11 passed.